### PR TITLE
ニコニコヘルプのURLをN Airのヘルプトップに修正

### DIFF
--- a/app/components/TopNav.vue.ts
+++ b/app/components/TopNav.vue.ts
@@ -57,7 +57,7 @@ export default class TopNav extends Vue {
   }
 
   openHelp() {
-    electron.remote.shell.openExternal('https://qa.nicovideo.jp');
+    electron.remote.shell.openExternal('https://qa.nicovideo.jp/faq/show/11856');
   }
 
   get isDevMode() {


### PR DESCRIPTION
**このpull requestが解決する内容**
アプリケーションのNAVメニューのヘルプのURLが正しくN Airのヘルプのトップに変更される

**動作確認手順**
アプリケーションを起動してナビゲーションメニューから`ヘルプ`の遷移先を確認する