### PR TITLE
use obs-studio-node v0.0.47 instead of v0.0.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.0/iojs-v2.0.5-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.3/iojs-v2.0.5-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.1/iojs-v2.0.5-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.48/iojs-v2.0.4-signed.tar.gz",
+    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.47/iojs-v2.0.4-signed.tar.gz",
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6930,9 +6930,9 @@ object.values@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
-"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.48/iojs-v2.0.4-signed.tar.gz":
+"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.47/iojs-v2.0.4-signed.tar.gz":
   version "0.0.1"
-  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.48/iojs-v2.0.4-signed.tar.gz#2e8d301423f96dfff41fc442f2da4dda4f86dcbd"
+  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.47/iojs-v2.0.4-signed.tar.gz#02a38622755a1a896b1b64d401aa0d7839c5981e"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
fixes #7.
**このpull requestが解決する内容**
コメジェネが動かなかったのでStreamlabs-obs側の巻き戻しに追従し、obs-studio-node v0.0.48ではなく v0.0.47を使うように変更しました

**動作確認手順**
1. KILINBOXさんの [HTML5コメントジェネレーター](https://www.kilinbox.net/2016/01/HCG.html)をダウンロードし、展開する
2. CommentGenerator.htmlの `DemoMode = 0` 行を  `DemoMode = 1` に書き換えて保存する
3. ソース - ソース追加 - Webページソース - ローカルファイルにチェックし、上記の CommentGenerator.html を追加する
4. デモコメントが流れたら成功。初期画面のままなら失敗

![image](https://user-images.githubusercontent.com/864587/43876175-d0a02718-9bce-11e8-87d5-4b42e5c2953e.png)
