### PR TITLE
ResolutionInputで選択した値を選択解除できないように修正

### DIFF
--- a/app/components/shared/forms/ResolutionInput.vue
+++ b/app/components/shared/forms/ResolutionInput.vue
@@ -12,6 +12,7 @@
       :close-on-select="true"
       :placeholder="placeholder || $t('settings.resolutionPlaceholder')"
       :allow-custom="getCustomResolution"
+      :allow-empty="false"
       label="description"
       @input="onInputHandler"
       @search-change="onSearchChange">


### PR DESCRIPTION
**このpull requestが解決する内容**

`ResolutionInput.onInputHandler`  に渡される値は常に `null` や `undefined` でないことが期待されています。

https://github.com/n-air-app/n-air-app/blob/v0.1.20180809-1/app/components/shared/forms/ResolutionInput.vue.ts#L23

しかし現状では、選択していた値をもう一度選択すると選択解除され、`ResolutionInput.onInputHandler` に `null` が渡される結果エラーになってしまいます。

そこで `multiselect` に `:allow-empty="false"` を設定し、一度値が設定されたら選択解除できないように修正します（解除できないだけで変更は可能です）。

**動作確認手順**

ResolutionInputを使用している箇所すべてが確認対象になりますが、ここでは例として`配信映像の解像度` を例にします。

1. Developer Toolsを開いておく
1. `設定` ダイアログを開く
1. `映像` タブを選択
1. `配信映像の解像度` の選択しから、現在設定されている値と同じ選択肢を選ぶ
1. Developer Toolsでエラーが発生しないことを確認する