### PR TITLE
ニコ生配信開始時に設定を自動で最適化する仕組みを実装

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -1,17 +1,41 @@
 <template>
 <div>
-  <div class="section">
-    <p>{{ $t('settings.cacheClearDescription')}}</p>
-    <div class="margin-bot--20">
-      <a class="button button--action" @click="showCacheDir">
-        {{ $t('settings.showCacheDirectory')}}
-      </a>
-      <a class="button button--action" @click="deleteCacheDir">
-        {{ $t('settings.deleteCacheAndRestart') }}
-      </a>
+  <div class="section" v-if="isNiconicoLoggedIn()">
+    <div class="input-label">
+      <label>{{ $t('settings.optimizationForNiconicoLiveService')}}</label>
     </div>
+    <BoolInput
+      :value="optimizeForNiconicoModel"
+      @input="setOptimizeForNiconico" />
+    <BoolInput
+      :value="showOptimizationDialogForNiconicoModel"
+      v-show="optimizeForNiconicoModel.value"
+      @input="setShowOptimizationDialogForNiconico"
+      class="optional-item" />
+  </div>
+
+  <div class="section">
+    <div class="input-label">
+      <label>{{ $t('settings.cacheManagement')}}</label>
+    </div>
+
+    <p>{{ $t('settings.cacheClearDescription')}}</p>
+
+    <a class="button button--action" @click="showCacheDir">
+      {{ $t('settings.showCacheDirectory')}}
+    </a>
+
+    <a class="button button--action" @click="deleteCacheDir">
+      {{ $t('settings.deleteCacheAndRestart') }}
+    </a>
   </div>
 </div>
 </template>
 
 <script lang="ts" src="./ExtraSettings.vue.ts"></script>
+
+<style lang="less" scoped>
+.optional-item {
+  margin-left: 24px;
+}
+</style>

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -25,6 +25,30 @@ export default class ExtraSettings extends Vue {
 
   cacheUploading = false;
 
+  get optimizeForNiconicoModel(): IFormInput<boolean> {
+    return {
+      name: 'optimize_for_niconico',
+      description: $t('settings.optimizeForNiconico'),
+      value: this.customizationService.state.optimizeForNiconico
+    };
+  }
+
+  setOptimizeForNiconico(model: IFormInput<boolean>) {
+    this.customizationService.setOptimizeForNiconico(model.value);
+  }
+
+  get showOptimizationDialogForNiconicoModel(): IFormInput<boolean> {
+    return {
+      name: 'show_optimization_dialog_for_niconico',
+      description: $t('settings.showOptimizationDialogForNiconico'),
+      value: this.customizationService.state.showOptimizationDialogForNiconico
+    };
+  }
+
+  setShowOptimizationDialogForNiconico(model: IFormInput<boolean>) {
+    this.customizationService.setShowOptimizationDialogForNiconico(model.value);
+  }
+
   showCacheDir() {
     electron.remote.shell.showItemInFolder(
       electron.remote.app.getPath('userData')
@@ -39,5 +63,9 @@ export default class ExtraSettings extends Vue {
     ) {
       this.appService.relaunch({ clearCacheDir: true });
     }
+  }
+
+  isNiconicoLoggedIn(): boolean {
+    return this.userService.isNiconicoLoggedIn();
   }
 }

--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -1,0 +1,55 @@
+<template>
+<modal-layout
+  :title="$t('streaming.optimizationForNiconico.title')"
+  :show-controls="false"
+  :customControls="true">
+  <div slot="content">
+
+    {{ $t('streaming.optimizationForNiconico.description') }}
+    <ul>
+      <li>
+        {{ $t('settings.Output.Streaming.VBitrate.name') }}: {{ settings.currentVideoBitrate }}
+        <span v-if="settings.optimizedVideoBitrate"> -&gt; {{ settings.optimizedVideoBitrate }}</span>
+      </li>
+      <li>
+        {{ $t('settings.Output.Streaming.ABitrate.name') }}: {{ settings.currentAudioBitrate }}
+        <span v-if="settings.optimizedAudioBitrate"> -&gt; {{ settings.optimizedAudioBitrate }}</span>
+      </li>
+      <li>
+        {{ $t('settings.Output.name') }}: {{ qualityName(settings.currentQuality) }}
+        <span v-if="settings.optimizedQuality"> -&gt; {{ qualityName(settings.optimizedQuality) }}</span>
+      </li>
+      <li>
+        {{ $t('settings.Advanced.Video.ColorSpace.name') }}: {{ settings.currentColorSpace }}
+        <span v-if="settings.optimizedColorSpace"> -&gt; {{ settings.optimizedColorSpace }}</span>
+      </li>
+      <li>
+        {{ $t('streaming.FPS') }}: {{ settings.currentFps }}
+        <span v-if="settings.optimizedFps"> -&gt; {{ settings.optimizedFps }}</span>
+      </li>
+    </ul>
+    <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
+  </div>
+  <div slot="controls">
+    <button
+      class="button button--default"
+      @click="skip">
+      {{ $t('streaming.skipOptimization') }}
+    </button>
+    <button
+      class="button button--action"
+      @click="optimizeAndGoLive">
+      {{ $t('streaming.optimizeAndGoLive') }}
+    </button>
+  </div>
+</modal-layout>
+</template>
+
+<script lang="ts" src="./OptimizeForNiconico.vue.ts"></script>
+
+<style lang="less" scoped>
+.input-container {
+  margin-top: 12px;
+  flex-direction: column;
+}
+</style>

--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -1,0 +1,57 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import { Inject } from 'util/injector';
+import ModalLayout from '../ModalLayout.vue';
+import BoolInput from '../shared/forms/BoolInput.vue';
+import windowMixin from '../mixins/window';
+import { CustomizationService } from '../../services/customization';
+import { IFormInput } from '../../components/shared/forms/Input';
+import { StreamingService } from '../../services/streaming';
+import { WindowsService } from '../../services/windows';
+import { OptimizedSettings, SettingsService } from '../../services/settings';
+import { $t } from '../../services/i18n';
+
+@Component({
+  components: {
+    ModalLayout,
+    BoolInput
+  },
+  mixins: [windowMixin]
+})
+export default class OptimizeNiconico extends Vue {
+  @Inject() customizationService: CustomizationService;
+  @Inject() streamingService: StreamingService;
+  @Inject() windowsService: WindowsService;
+  @Inject() settingsService: SettingsService;
+
+  settings: OptimizedSettings = this.windowsService.getChildWindowQueryParams();
+
+  get doNotShowAgain(): IFormInput<boolean> {
+    return {
+      name: 'do_not_show_again',
+      description: $t('streaming.doNotShowAgainOptimizationDialog'),
+      value: false
+    };
+  }
+
+  qualityName(value: string): string {
+    const arg = `settings.Video.Untitled.Output.${value}`;
+    const name = $t(arg);
+    return name !== arg ? name : value;
+  }
+
+  setDoNotShowAgain(model: IFormInput<boolean>) {
+    this.customizationService.setShowOptimizationDialogForNiconico(!model.value);
+  }
+
+  optimizeAndGoLive() {
+    this.settingsService.optimizeForNiconico(this.settings);
+    this.streamingService.toggleStreaming();
+    this.windowsService.closeChildWindow();
+  }
+
+  skip() {
+    this.streamingService.toggleStreaming();
+    this.windowsService.closeChildWindow();
+  }
+}

--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -30,7 +30,7 @@ export default class OptimizeNiconico extends Vue {
     return {
       name: 'do_not_show_again',
       description: $t('streaming.doNotShowAgainOptimizationDialog'),
-      value: false
+      value: this.customizationService.showOptimizationDialogForNiconico === false
     };
   }
 
@@ -51,6 +51,9 @@ export default class OptimizeNiconico extends Vue {
   }
 
   skip() {
+    if (this.doNotShowAgain.value) {
+      this.customizationService.setOptimizeForNiconico(false);
+    }
     this.streamingService.toggleStreaming();
     this.windowsService.closeChildWindow();
   }

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -8,7 +8,8 @@ import NavItem from '../shared/NavItem.vue';
 import GenericFormGroups from '../shared/forms/GenericFormGroups.vue';
 import { WindowsService } from '../../services/windows';
 import { UserService } from '../../services/user';
-import { ISettingsServiceApi, ISettingsSubCategory } from '../../services/settings';
+import { CustomizationService } from '../../services/customization';
+import { SettingsService, ISettingsSubCategory } from '../../services/settings';
 import windowMixin from '../mixins/window';
 import ExtraSettings from '../ExtraSettings.vue';
 import ApiSettings from '../ApiSettings.vue';
@@ -35,9 +36,10 @@ import LanguageSettings from 'components/LanguageSettings.vue';
   mixins: [windowMixin]
 })
 export default class Settings extends Vue {
-  @Inject() settingsService: ISettingsServiceApi;
+  @Inject() settingsService: SettingsService;
   @Inject() windowsService: WindowsService;
   @Inject() userService: UserService;
+  @Inject() customizationService: CustomizationService;
 
   settingsData = this.settingsService.getSettingsFormData(this.categoryName);
   categoryNames = this.settingsService.getCategories();
@@ -82,6 +84,9 @@ export default class Settings extends Vue {
   }
 
   done() {
+    if (this.settingsService.isOutputModeAdvanced()) {
+      this.customizationService.setOptimizeForNiconico(false);
+    }
     this.windowsService.closeChildWindow();
   }
 

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -359,7 +359,8 @@
         "name": null,
         "1280x720": "nicolive High Definition (1280x720)",
         "800x450": "nicolive Standard Definition (800x450)",
-        "640x360": "nicolive Low Definition (640x360)",
+        "512x288": "nicolive Low Definition (512x288)",
+        "640x360": null,
         "1920x1080": null,
         "1536x864": null,
         "1440x810": null,
@@ -499,7 +500,9 @@
   "resolutionPlaceholder": "Select Option or Type New Value",
   "addFiles": "Add files",
   "addDirectory": "Add directory",
+  "optimizationForNiconicoLiveService": "Optimization for niconico live service",
   "cacheClearDescription": "If you are experiencing weird behavior, you can try deleting your cache directory.  This will result in you losing your scene configuration and settings, but can fix some stability issues.",
+  "cacheManagement": "Management of the cashe",
   "showCacheDirectory": "Show Cache Directory",
   "deleteCacheAndRestart": "Delete Cache and Restart",
   "confirmStreamTitleAndGameBeforeGoingLive": "Confirm stream title and game before going live",
@@ -513,5 +516,7 @@
   "default": "Default",
   "fontFamily": "Font Family",
   "fontStyle": "Font Style",
-  "fontSize": "Font Size"
+  "fontSize": "Font Size",
+  "optimizeForNiconico": "optimize settings for niconico live service",
+  "showOptimizationDialogForNiconico": "show confirmation dialog to check the optimization when starting streams"
 }

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -27,5 +27,17 @@
   "broadcastStatusFetchingError": {
     "default": "Failed to get information on streaming server.  Please check your internet connection.",
     "httpError": "Failed to get information on streaming server. (%{statusText})"
-  }
+  },
+  "bitrateFetchingError": {
+    "title": "Failed to get bitrate",
+    "message": "Failed to get bitrate on server. Please check your internet connection."
+  },
+  "optimizationForNiconico": {
+    "title": "Optimize simple settings",
+    "description": "Optimize simple settings to deliver Nicolive."
+  },
+  "FPS": "FPS",
+  "optimizeAndGoLive": "Optimize & Go Live",
+  "skipOptimization": "Skip Optimization",
+  "doNotShowAgainOptimizationDialog": "Do not show this dialog again"
 }

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -359,7 +359,8 @@
         "name": "配信映像の解像度",
         "1280x720": "HD配信用 (1280x720)",
         "800x450": "通常配信用 (800x450)",
-        "640x360": "低画質配信用 (640x360)",
+        "512x288": "低画質配信用 (512x288)",
+        "640x360": null,
         "1920x1080": null,
         "1536x864": null,
         "1440x810": null,
@@ -499,7 +500,9 @@
   "resolutionPlaceholder": "選択するか、値を入力してください",
   "addFiles": "ファイルを追加する",
   "addDirectory": "ディレクトリを追加する",
+  "optimizationForNiconicoLiveService": "ニコニコ生放送への最適化",
   "cacheClearDescription": "不具合が発生した場合、キャッシュディレクトリを削除すると改善する可能性があります。ただしシーン設定が初期化されますのでご注意ください。",
+  "cacheManagement": "キャッシュ管理",
   "showCacheDirectory": "キャッシュディレクトリを表示",
   "deleteCacheAndRestart": "キャッシュを削除して再起動",
   "confirmStreamTitleAndGameBeforeGoingLive": "ライブになる前にストリームのタイトルとゲームを確認して下さい。",
@@ -513,5 +516,7 @@
   "default": "標準",
   "fontFamily": "フォントファミリー",
   "fontStyle": "フォントスタイル",
-  "fontSize": "フォントサイズ"
+  "fontSize": "フォントサイズ",
+  "optimizeForNiconico": "配信設定をニコニコ生放送に最適化する",
+  "showOptimizationDialogForNiconico": "配信開始時に最適化の確認ダイアログを表示する"
 }

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -26,5 +26,17 @@
   "broadcastStatusFetchingError": {
     "default": "配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。",
     "httpError": "配信に必要な情報を取得できませんでした。（%{statusText}）"
-  }
+  },
+  "bitrateFetchingError": {
+    "title": "ビットレート取得失敗",
+    "message": "ビットレート情報を取得できませんでした。インターネットの接続状態を確認してください。"
+  },
+  "optimizationForNiconico": {
+    "title": "設定の最適化",
+    "description": "ニコニコ生放送に最適化した設定で配信します。"
+  },
+  "FPS": "フレームレート",
+  "optimizeAndGoLive": "最適化して配信を開始する",
+  "skipOptimization": "最適化しないで配信を開始する",
+  "doNotShowAgainOptimizationDialog": "今後、このダイアログを表示しない"
 }

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -4,6 +4,8 @@ import { TFormData } from '../../components/shared/forms/Input';
 export interface ICustomizationServiceState {
   performanceMode: boolean;
   studioControlsOpened: boolean;
+  optimizeForNiconico: boolean;
+  showOptimizationDialogForNiconico: boolean;
   experimental: any;
 }
 

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -22,6 +22,8 @@ export class CustomizationService
   static defaultState: ICustomizationServiceState = {
     performanceMode: false,
     studioControlsOpened: true,
+    optimizeForNiconico: true,
+    showOptimizationDialogForNiconico: true,
     experimental: {
       // put experimental features here
     }
@@ -45,6 +47,25 @@ export class CustomizationService
 
   toggleStudioControls() {
     this.setSettings({ studioControlsOpened: !this.state.studioControlsOpened });
+  }
+
+  get optimizeForNiconico() {
+    return this.state.optimizeForNiconico;
+  }
+
+  setOptimizeForNiconico(optimize: boolean) {
+    this.setSettings({
+      optimizeForNiconico: optimize,
+      showOptimizationDialogForNiconico: optimize
+    });
+  }
+
+  get showOptimizationDialogForNiconico() {
+    return this.state.showOptimizationDialogForNiconico;
+  }
+
+  setShowOptimizationDialogForNiconico(optimize: boolean) {
+    this.setSettings({ showOptimizationDialogForNiconico: optimize });
   }
 
   getSettingsFormData(): TFormData {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -267,6 +267,17 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
     return this.fetchStreamUrlAndKey().then(urlkey => urlkey.key);
   }
 
+  fetchBitrate(): Promise<number | undefined> {
+    return this.fetchRawChannelInfo().then(result => {
+      const status = result.status;
+      console.log('getpublishstatus status=' + status);
+      if (status === 'ok') {
+        return parseInt(result.items[0].rtmp[0].bitrate[0], 10);
+      }
+      return undefined;
+    });
+  }
+
   fetchChannelInfo(): Promise<IChannelInfo> {
     return this.fetchRawChannelInfo().then(json => {
       return {

--- a/app/services/settings/settings-api.ts
+++ b/app/services/settings/settings-api.ts
@@ -12,3 +12,16 @@ export interface ISettingsServiceApi {
   setSettings(categoryName: string, settingsData: ISettingsSubCategory[]): void;
   showSettings(categoryName?: string): void;
 }
+
+export interface OptimizedSettings {
+  optimizedVideoBitrate?: number;
+  optimizedAudioBitrate?: string;
+  optimizedQuality?: string;
+  optimizedColorSpace?: string;
+  optimizedFps?: string;
+  currentVideoBitrate?: number;
+  currentAudioBitrate?: string;
+  currentQuality?: string;
+  currentColorSpace?: string;
+  currentFps?: string;
+}

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -344,6 +344,10 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       return key;
     });
   }
+
+  isNiconicoLoggedIn() {
+    return this.isLoggedIn() && this.platform.type === 'niconico';
+  }
 }
 
 /**

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -19,6 +19,7 @@ import Troubleshooter from 'components/windows/Troubleshooter.vue';
 import Blank from 'components/windows/Blank.vue';
 import ManageSceneCollections from 'components/windows/ManageSceneCollections.vue';
 import Projector from 'components/windows/Projector.vue';
+import OptimizeForNiconico from 'components/windows/OptimizeForNiconico.vue';
 import { mutation, StatefulService } from 'services/stateful-service';
 import electron from 'electron';
 import Vue from 'vue';
@@ -83,7 +84,8 @@ export class WindowsService extends StatefulService<IWindowsState> {
     Notifications,
     Troubleshooter,
     ManageSceneCollections,
-    Projector
+    Projector,
+    OptimizeForNiconico
   };
 
   private windows: Dictionary<Electron.BrowserWindow> = {};

--- a/app/styles/classes.less
+++ b/app/styles/classes.less
@@ -45,7 +45,11 @@
 
 .section {
   padding: 16px 16px 0;
-  background: @bg-primary;
+  margin-bottom: 16px;
+  border-bottom: 2px solid @bg-secondary;
+  &:last-child {
+    border-bottom: none;
+  }
 
   .button {
     margin-bottom: 16px;

--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -21,8 +21,8 @@
 }
 
 .input-label {
-  width: 30%;
   padding-right: 15px;
+  margin-bottom: 8px;
 }
 
 .input-wrapper {


### PR DESCRIPTION
fixes #20 

**このpull requestが解決する内容**

自動設定するかどうかのフラグを設定に用意し、ニコニコにログイン状態でフラグが有効なときはニコ生配信開始時に設定を最適化する仕組みを実装しました。

* ダイアログ表示オプションが有効な場合は自動最適化前に確認ダイアログを表示
* 変更がある設定は変更前後の値を表示
* 設定に変更がない場合はそのまま配信

<img width="298" alt="optimize_for_niconico_settings" src="https://user-images.githubusercontent.com/911952/44191217-3b180980-a165-11e8-8816-86e4c71e5c6a.png">
<img width="187" alt="optimize_for_niconico" src="https://user-images.githubusercontent.com/911952/44191224-453a0800-a165-11e8-9e45-2cc6fd4351c7.png">

**動作確認手順**

* ニコニコにログインしていない場合はオプションが表示されないこと
* 最適化オプション有効 & ダイアログ表示有効でニコ生配信開始
  * ビデオビットレート、オーディオビットレート、解像度、カラースペース、フレームレートの値が表示されること
  * 最適化して配信した場合に設定が表示された値に書き換わっていること
  * 「ダイアログを表示しない」にチェックをつけた場合はダイアログ表示オプションが無効になっていること
  * 「ダイアログを表示しない」にチェックをつけて「最適化しないで配信」した場合は最適化オプションが無効になること
* 最適化オプション有効 & ダイアログ表示無効でニコ生配信開始
  * 設定が最適化された値に書き換わっていること
* 最適化オプション無効
  * ダイアログ表示オプションが表示されないこと
  * ニコ生配信開始後に設定がかわっていないこと
* 初期状態では最適化オプションが有効かつダイアログ表示オプションが有効
* `出力`タブの`出力モード`を`詳細`にして設定ダイアログを閉じると最適化オプションが無効になること
* `出力`タブの`出力モード`が`詳細`の状態で配信開始した場合に最適化オプションが無効になること