### PR TITLE
文言修正: 「配信開始時に」配信設定をニコニコ生放送に最適化する

### DIFF
--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -517,6 +517,6 @@
   "fontFamily": "フォントファミリー",
   "fontStyle": "フォントスタイル",
   "fontSize": "フォントサイズ",
-  "optimizeForNiconico": "配信設定をニコニコ生放送に最適化する",
+  "optimizeForNiconico": "配信開始時に配信設定をニコニコ生放送に最適化する",
   "showOptimizationDialogForNiconico": "配信開始時に最適化の確認ダイアログを表示する"
 }


### PR DESCRIPTION
describe the behavior precicely

**このpull requestが解決する内容**
設定の「配信設定をニコニコ生放送に最適化する」に「配信開始時に」という言葉を追加することで
配信中に変更しても次回配信開始まで反映されないという動作を正しく伝える

![image](https://user-images.githubusercontent.com/864587/44219075-17c97a80-a1b6-11e8-8167-2227ab7d9b6d.png)

**動作確認手順**
設定 - 一般を確認