### PR TITLE
ニコニコ最適化と出力モードの関係を整理(最適化対象にする)

### DIFF
--- a/app/components/StartStreamingButton.vue.ts
+++ b/app/components/StartStreamingButton.vue.ts
@@ -54,16 +54,12 @@ export default class StartStreamingButton extends Vue {
           });
         }
         if (this.customizationService.optimizeForNiconico) {
-          if (this.settingsService.isOutputModeAdvanced()) {
-            this.customizationService.setOptimizeForNiconico(false);
-          } else {
-            const platform = getPlatformService(this.userService.platform.type);
-            if (platform instanceof NiconicoService) {
-              // FIXME: `this.userService.updateStreamSettings`とあわせて
-              //       2度 `getpublishstatus` を呼んでいるが
-              //       不整合回避のために1回だけにしたい
-              return this.optimizeForNiconico(platform);
-            }
+          const platform = getPlatformService(this.userService.platform.type);
+          if (platform instanceof NiconicoService) {
+            // FIXME: `this.userService.updateStreamSettings`とあわせて
+            //       2度 `getpublishstatus` を呼んでいるが
+            //       不整合回避のために1回だけにしたい
+            return this.optimizeForNiconico(platform);
           }
         }
       } catch (e) {
@@ -71,7 +67,7 @@ export default class StartStreamingButton extends Vue {
           ? $t('streaming.broadcastStatusFetchingError.httpError', { statusText: e.statusText })
           : $t('streaming.broadcastStatusFetchingError.default');
 
-          return new Promise(resolve => {
+        return new Promise(resolve => {
           electron.remote.dialog.showMessageBox(
             electron.remote.getCurrentWindow(),
             {
@@ -113,8 +109,8 @@ export default class StartStreamingButton extends Vue {
           componentName: 'OptimizeForNiconico',
           queryParams: settings,
           size: {
-          width: 500,
-          height: 400
+            width: 500,
+            height: 400
           }
         });
       } else {

--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -27,6 +27,10 @@
         {{ $t('streaming.FPS') }}: {{ settings.currentFps }}
         <span v-if="settings.optimizedFps"> -&gt; {{ settings.optimizedFps }}</span>
       </li>
+      <li>
+        {{ $t('settings.Output.Untitled.Mode.name') }}: {{ outputModeName(settings.currentOutputMode) }}
+        <span v-if="settings.optimizedOutputMode"> -&gt; {{ outputModeName(settings.optimizedOutputMode) }}</span>
+      </li>
     </ul>
     <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
   </div>

--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -40,6 +40,12 @@ export default class OptimizeNiconico extends Vue {
     return name !== arg ? name : value;
   }
 
+  outputModeName(value: string): string {
+    const arg = `settings.Output.Untitled.Mode.${value}`;
+    const name = $t(arg);
+    return name !== arg ? name : value;
+  }
+
   setDoNotShowAgain(model: IFormInput<boolean>) {
     this.customizationService.setShowOptimizationDialogForNiconico(!model.value);
   }

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -84,9 +84,6 @@ export default class Settings extends Vue {
   }
 
   done() {
-    if (this.settingsService.isOutputModeAdvanced()) {
-      this.customizationService.setOptimizeForNiconico(false);
-    }
     this.windowsService.closeChildWindow();
   }
 

--- a/app/services/settings/settings-api.ts
+++ b/app/services/settings/settings-api.ts
@@ -19,9 +19,11 @@ export interface OptimizedSettings {
   optimizedQuality?: string;
   optimizedColorSpace?: string;
   optimizedFps?: string;
+  optimizedOutputMode?: string;
   currentVideoBitrate?: number;
   currentAudioBitrate?: string;
   currentQuality?: string;
   currentColorSpace?: string;
   currentFps?: string;
+  currentOutputMode?: string;
 }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -361,10 +361,6 @@ export class SettingsService extends StatefulService<ISettingsState>
     };
   }
 
-  isOutputModeAdvanced(): boolean {
-    return this.findSettingValue(this.getSettingsFormData('Output'), 'Untitled', 'Mode') === 'Advanced';
-  }
-
   diffOptimizedSettings(bitrate: number): OptimizedSettings {
     let audioBitrate: number;
     let quality: string;
@@ -387,6 +383,7 @@ export class SettingsService extends StatefulService<ISettingsState>
     const videoBitrate = bitrate - audioBitrate;
     const colorSpace = '709';
     const fps = '30';
+    const outputMode = 'Simple';
     const output = this.getSettingsFormData('Output');
     const video = this.getSettingsFormData('Video');
     const advanced = this.getSettingsFormData('Advanced');
@@ -395,7 +392,8 @@ export class SettingsService extends StatefulService<ISettingsState>
       currentAudioBitrate: this.findSettingValue(output, 'Streaming', 'ABitrate'),
       currentQuality: this.findSettingValue(video, 'Untitled', 'Output'),
       currentColorSpace: this.findSettingValue(advanced, 'Video', 'ColorSpace'),
-      currentFps: this.findSettingValue(video, 'Untitled', 'FPSCommon')
+      currentFps: this.findSettingValue(video, 'Untitled', 'FPSCommon'),
+      currentOutputMode: this.findSettingValue(output, 'Untitled', 'Mode')
     };
     const length = Object.keys(settings).length;
     if (videoBitrate !== settings.currentVideoBitrate) {
@@ -414,6 +412,9 @@ export class SettingsService extends StatefulService<ISettingsState>
     }
     if (fps !== settings.currentFps) {
       settings.optimizedFps = fps;
+    }
+    if (outputMode !== settings.currentOutputMode) {
+      settings.optimizedOutputMode = outputMode;
     }
     return Object.keys(settings).length > length ? settings : undefined;
   }
@@ -442,6 +443,12 @@ export class SettingsService extends StatefulService<ISettingsState>
       const aBitrateSetting = this.findSetting(output, 'Streaming', 'ABitrate');
       if (aBitrateSetting) {
         aBitrateSetting.value = settings.optimizedAudioBitrate;
+      }
+    }
+    if ('optimizedOutputMode' in settings) {
+      const anOutputMode = this.findSetting(output, 'Untitled', 'Mode');
+      if (anOutputMode) {
+        anOutputMode.value = settings.optimizedOutputMode;
       }
     }
     this.setSettings('Output', output);


### PR DESCRIPTION
**このpull requestが解決する内容**
現状の最適化は「出力モード」の「詳細」(Advanced)と衝突するため特別処理をしているが、
最適化対象にすることで一貫性が得られる。
![image](https://user-images.githubusercontent.com/864587/44247584-3e240000-a220-11e8-8cde-b455450c880a.png)

**動作確認手順**
`設定` - `出力モード` を `詳細` に変更し、ニコニコ生放送最適化とダイアログはともにonとした状態で
ニコニコ生放送で放送開始をすると、上記ダイアログがでて、最適化をすると `出力モード` が `基本` に変更されること。
また、その他の値も基本のときの値が正しく読み取られていること。
配信開始するとすべてその値に変化していること。