### PR TITLE
配信中は最適化設定を変更できないようにする

### DIFF
--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -29,7 +29,8 @@ export default class ExtraSettings extends Vue {
     return {
       name: 'optimize_for_niconico',
       description: $t('settings.optimizeForNiconico'),
-      value: this.customizationService.state.optimizeForNiconico
+      value: this.customizationService.state.optimizeForNiconico,
+      enabled: this.streamingService.isStreaming === false
     };
   }
 
@@ -41,7 +42,8 @@ export default class ExtraSettings extends Vue {
     return {
       name: 'show_optimization_dialog_for_niconico',
       description: $t('settings.showOptimizationDialogForNiconico'),
-      value: this.customizationService.state.showOptimizationDialogForNiconico
+      value: this.customizationService.state.showOptimizationDialogForNiconico,
+      enabled: this.streamingService.isStreaming === false
     };
   }
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" href="vendor/foundation.min.css" />
     <link href="vendor/roboto.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="vendor/twitchalerts.css" />
+    <link rel="stylesheet" type="text/css" href="vendor/twitchalertsCustom.css" />
     <script src="bundles/renderer.js"></script>
   </head>
   <body>

--- a/vendor/twitchalertsCustom.css
+++ b/vendor/twitchalertsCustom.css
@@ -1,0 +1,29 @@
+@charset "UTF-8";
+/*
+vendor分離前暫定対応
+ニコニコ生放送最適化設定用style
+*/
+
+/*checkbox disabled styleの変更*/
+.section .input-container.disabled .input-wrapper .checkbox label:before {
+    background-color: #91979A;
+    border: #91979A;
+    cursor: default;
+}
+.section .input-container.disabled .input-wrapper .checkbox label:after {
+    background-color: #91979A;
+    border: #91979A;
+    color: #2F3340;
+    cursor: default;
+}
+.section .input-container.disabled .input-wrapper .checkbox label > span {
+    color: #91979A;
+}
+
+/*checkbox styleの変更*/
+.checkbox label:before {
+    border: 2px solid #91979A;
+}
+.checkbox input:checked~label:before {
+    background-color: rgba(252,80,53,.2);
+}


### PR DESCRIPTION
**このpull requestが解決する内容**

"ニコ生に最適化する処理"に関する設定は配信中に変更しても放送に影響を与えることはありません。
しかし、配信中に設定を操作できてしまうと誤解を招くのではないかという指摘があったため、配信中は最適化に関する設定を変更できないようにします。

**動作確認手順**

配信中に最適化とダイアログ表示のチェックボックスをクリックし、チェックが変更されないことを確認する。