### PR TITLE
配信中、設定ダイアログの最上部に一部設定が変更できない旨のメッセージを表示する

### DIFF
--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -17,6 +17,9 @@
       </NavItem>
     </NavMenu>
     <div class="settings-container">
+      <div class="section" v-if="isStreaming">
+        <p class="notice">{{ $t('settings.noticeWhileStreaming')}}</p>
+      </div>
       <extra-settings v-if="categoryName === 'General'" />
       <language-settings v-if="categoryName === 'General'" />
       <hotkeys v-if="categoryName === 'Hotkeys'" />

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -10,6 +10,7 @@ import { WindowsService } from '../../services/windows';
 import { UserService } from '../../services/user';
 import { CustomizationService } from '../../services/customization';
 import { SettingsService, ISettingsSubCategory } from '../../services/settings';
+import { StreamingService } from '../../services/streaming';
 import windowMixin from '../mixins/window';
 import ExtraSettings from '../ExtraSettings.vue';
 import ApiSettings from '../ApiSettings.vue';
@@ -40,6 +41,7 @@ export default class Settings extends Vue {
   @Inject() windowsService: WindowsService;
   @Inject() userService: UserService;
   @Inject() customizationService: CustomizationService;
+  @Inject() streamingService: StreamingService;
 
   settingsData = this.settingsService.getSettingsFormData(this.categoryName);
   categoryNames = this.settingsService.getCategories();
@@ -68,6 +70,10 @@ export default class Settings extends Vue {
     if (this.userSubscription) {
       this.userSubscription.unsubscribe();
     }
+  }
+
+  get isStreaming() {
+    return this.streamingService.isStreaming;
   }
 
   get categoryName() {

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -503,6 +503,7 @@
   "optimizationForNiconicoLiveService": "Optimization for niconico live service",
   "cacheClearDescription": "If you are experiencing weird behavior, you can try deleting your cache directory.  This will result in you losing your scene configuration and settings, but can fix some stability issues.",
   "cacheManagement": "Management of the cashe",
+  "noticeWhileStreaming": "Some settings cannot be changed while streaming.",
   "showCacheDirectory": "Show Cache Directory",
   "deleteCacheAndRestart": "Delete Cache and Restart",
   "confirmStreamTitleAndGameBeforeGoingLive": "Confirm stream title and game before going live",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -503,6 +503,7 @@
   "optimizationForNiconicoLiveService": "ニコニコ生放送への最適化",
   "cacheClearDescription": "不具合が発生した場合、キャッシュディレクトリを削除すると改善する可能性があります。ただしシーン設定が初期化されますのでご注意ください。",
   "cacheManagement": "キャッシュ管理",
+  "noticeWhileStreaming": "現在配信中のため、一部の設定は変更できません。",
   "showCacheDirectory": "キャッシュディレクトリを表示",
   "deleteCacheAndRestart": "キャッシュを削除して再起動",
   "confirmStreamTitleAndGameBeforeGoingLive": "ライブになる前にストリームのタイトルとゲームを確認して下さい。",

--- a/vendor/twitchalertsCustom.css
+++ b/vendor/twitchalertsCustom.css
@@ -27,3 +27,10 @@ vendor分離前暫定対応
 .checkbox input:checked~label:before {
     background-color: rgba(252,80,53,.2);
 }
+
+/*配信中に設定ダイアログへ表示するメッセージのstyle*/
+.settings .settings-container .section .notice {
+    font-size: 1rem;
+    font-weight: bold;
+    color: #ff6952;
+}


### PR DESCRIPTION
**このpull requestが解決する内容**
n-airでは配信中に映像エンコードの設定を変更することができませんが、現状は設定ダイアログ内で単に値の変更を禁止しているだけのため、利用者が変更できない理由を知ることが出来ない問題があります。

本PRでは配信を行っている間、設定ダイアログの最上部に「配信中のため一部設定が変更できない」旨を表示します。

英語文言とデザインに関しては検討が必要かと思います。

![image](https://user-images.githubusercontent.com/24884114/44283689-2f7a2f00-a29a-11e8-8bc8-354972a14b9d.png)


**動作確認手順**

1. ニコ生で枠を取る
1. 配信開始ボタンを押す
1. 設定ダイアログを開く

または、 https://github.com/takayamaki/n-air-app/blob/70aeabd57bb949ae546760f88f78bdc86d4c10d1/app/components/windows/Settings.vue#L20 を`v-if="true"`にする