### PR TITLE
ニコニコ未ログイン時、配信設定のURLとストリームキーを起動時に消さないように修正

### DIFF
--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -135,19 +135,16 @@ export class SettingsService extends StatefulService<ISettingsState>
     this.SET_SETTINGS(SettingsService.convertFormDataToState(settingsFormData));
 
     // ensure 'custom streaming server'
-    this.setSettings('Stream', [
-      {
-        nameSubCategory: 'Untitled',
-        parameters: [
-          {
-            name: 'streamType',
-            type: 'OBS_PROPERTY_LIST',
-            description: 'Stream Type',
-            value: 'rtmp_custom',
-          }
-        ]
+    {
+      const settings = settingsFormData['Stream'];
+      const setting = this.findSetting(settings, 'Untitled', 'streamType');
+      if (setting) {
+        if (setting.value !== 'rtmp_custom') {
+          setting.value = 'rtmp_custom';
+          this.setSettings('Stream', settings);
+        }
       }
-    ]);
+    }
   }
 
   showSettings(categoryName?: string) {


### PR DESCRIPTION
fixes #31
**このpull requestが解決する内容**
ログインしていないときに現れる `設定`/`配信`内の`URL`と`ストリームキー` を、起動時に誤って消去していたのを修正

**動作確認手順**
![image](https://user-images.githubusercontent.com/864587/44297440-6c7f0980-a30c-11e8-886b-de925eac66aa.png)

1. `設定`/`配信`の `URL`, `ストリームキー`に何か書き込む
2. 一度アプリを終了し、再度起動する
3. 上で書き込んだ値が残っていればok
