### PR TITLE
配信中の設定ダイアログに表示するメッセージの補足styleを作成

### DIFF
--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -17,9 +17,11 @@
       </NavItem>
     </NavMenu>
     <div class="settings-container">
-      <div class="section" v-if="isStreaming">
-        <p class="notice">{{ $t('settings.noticeWhileStreaming')}}</p>
-      </div>
+      <aside class="notice-section" v-if="isStreaming">
+        <p class="notice-message">
+          <i class="icon-warning"/>{{ $t('settings.noticeWhileStreaming')}}
+        </p>
+      </aside>
       <extra-settings v-if="categoryName === 'General'" />
       <language-settings v-if="categoryName === 'General'" />
       <hotkeys v-if="categoryName === 'Hotkeys'" />
@@ -55,6 +57,24 @@
 </style>
 
 <style lang="less">
+@import "../../styles/index";
+/*配信中に設定ダイアログへ表示するメッセージのstyle*/
+.notice-section {
+  padding-top: 16px;
+
+  .notice-message {
+    color: @accent;
+    font-size: 18px;
+    font-weight: bold;
+    text-align: center;
+    padding-top: 12px;
+  }
+
+  .icon-warning {
+    margin-right: 4px;
+  }
+}
+
 .settings-container {
   .input-container {
     flex-direction: column;

--- a/vendor/twitchalertsCustom.css
+++ b/vendor/twitchalertsCustom.css
@@ -27,10 +27,3 @@ vendor分離前暫定対応
 .checkbox input:checked~label:before {
     background-color: rgba(252,80,53,.2);
 }
-
-/*配信中に設定ダイアログへ表示するメッセージのstyle*/
-.settings .settings-container .section .notice {
-    font-size: 1rem;
-    font-weight: bold;
-    color: #ff6952;
-}


### PR DESCRIPTION
**このpull requestが解決する内容**
@takayamaki さんの対応PR#30 に対するstyle追加になります。
配信中に表示される設定ダイアログ上部にでる注意書きメッセージに対して注意書きアイコンと文字サイズ、余白を整理しました。
#### ja-jp
![ja-jp](https://user-images.githubusercontent.com/3591127/44309591-24431280-a404-11e8-9367-a8160a4903e3.PNG)

#### en-us
![en-us](https://user-images.githubusercontent.com/3591127/44309588-1b524100-a404-11e8-915b-86e4db071595.PNG)

**動作確認手順**

1. ニコ生で枠を取る
1. 配信開始ボタンを押す
1. 設定ダイアログを開く

または、 https://github.com/takayamaki/n-air-app/blob/70aeabd57bb949ae546760f88f78bdc86d4c10d1/app/components/windows/Settings.vue#L20 を`v-if="true"`にする