### PR TITLE
updeterで指定しているcssを整理

### DIFF
--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -1,27 +1,28 @@
 <template>
-  <div class="UpdaterWindow">
-    <i18n :path="`${currentState}.message`">
-      <br place="br" />
-      <span place="version">{{ version }}</span>
-    </i18n>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
-    <div v-if="isDownloading && percentComplete !== null" class="UpdaterWindow-progressBarContainer">
-      <div
-        class="UpdaterWindow-progressBar"
-        :style="{ width: percentComplete + '%' }"/>
-      <div class="UpdaterWindow-progressPercent">
-        {{ percentComplete }}%
-      </div>
-    </div>
-    <div class="UpdaterWindow-issues" v-if="isInstalling || isError">
-      <i18n :path="`${currentState}.description`">
-        <br place="br" />
-        <a class="UpdaterWindow-link" @click="download" place="linkText">
-          {{ $t(`${currentState}.linkText`) }}
-        </a>
-      </i18n>
+<div class="UpdaterWindow">
+  <i18n :path="`${currentState}.message`" class="message" v-bind:class="{ error: isError }">
+    <br place="br" />
+    <span place="version">{{ version }}</span>
+  </i18n>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="!isError"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
+  <div v-if="isDownloading && percentComplete !== null" class="progressBarContainer">
+    <div
+      class="progressBar"
+      :style="{ width: percentComplete + '%' }"/>
+    <div class="progressPercent">
+      {{ percentComplete }}%
     </div>
   </div>
+  <div class="issues" v-if="isInstalling || isError">
+    <i18n :path="`${currentState}.description`">
+      <br place="br" />
+      <a class="link" @click="download" place="linkText">
+        {{ $t(`${currentState}.linkText`) }}
+      </a>
+    </i18n>
+  </div>
+</div>
 </template>
 
 <script>

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -1,27 +1,27 @@
 <template>
-<div class="UpdaterWindow">
-  <i18n :path="`${currentState}.message`">
-    <br place="br" />
-    <span place="version">{{ version }}</span>
-  </i18n>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
-  <div v-if="isDownloading && percentComplete !== null" class="UpdaterWindow-progressBarContainer">
-    <div
-      class="UpdaterWindow-progressBar"
-      :style="{ width: percentComplete + '%' }"/>
-    <div class="UpdaterWindow-progressPercent">
-      {{ percentComplete }}%
+  <div class="UpdaterWindow">
+    <i18n :path="`${currentState}.message`">
+      <br place="br" />
+      <span place="version">{{ version }}</span>
+    </i18n>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
+    <div v-if="isDownloading && percentComplete !== null" class="UpdaterWindow-progressBarContainer">
+      <div
+        class="UpdaterWindow-progressBar"
+        :style="{ width: percentComplete + '%' }"/>
+      <div class="UpdaterWindow-progressPercent">
+        {{ percentComplete }}%
+      </div>
+    </div>
+    <div class="UpdaterWindow-issues" v-if="isInstalling || isError">
+      <i18n :path="`${currentState}.description`">
+        <br place="br" />
+        <a class="UpdaterWindow-link" @click="download" place="linkText">
+          {{ $t(`${currentState}.linkText`) }}
+        </a>
+      </i18n>
     </div>
   </div>
-  <div class="UpdaterWindow-issues" v-if="isInstalling || isError">
-    <i18n :path="`${currentState}.description`">
-      <br place="br" />
-      <span class="UpdaterWindow-link" @click="download" place="linkText">
-        {{ $t(`${currentState}.linkText`) }}
-      </span>
-    </i18n>
-  </div>
-</div>
 </template>
 
 <script>
@@ -77,67 +77,3 @@ export default {
   }
 };
 </script>
-
-<style lang="less" scoped>
-.UpdaterWindow {
-  height: 100%;
-  padding: 24px;
-  background-color: #2F3340;
-  color: #9eeaf9;
-  font-size: 18px;
-  text-align: center;
-  -webkit-app-region: drag;
-  p {
-    white-space: pre-wrap;
-    color: #9eeaf9;
-  }
-}
-.UpdaterWindow-progressBarContainer {
-  position: relative;
-  margin-top: 36px;
-  background-color: #050e18;
-  border-radius: 3px;
-  overflow: hidden;
-}
-.UpdaterWindow-progressBar {
-  height: 24px;
-  background-color: #ff6952;
-}
-.UpdaterWindow-progressPercent {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  color: #fff;
-  text-align: center;
-  line-height: 24px;
-  font-size: 15px;
-}
-.UpdaterWindow-issues {
-  font-size: 12px;
-  font-weight: 300;
-  padding-top: 24px;
-  -webkit-app-region: no-drag;
-}
-.UpdaterWindow-link {
-  color: #70A0AF;
-  cursor: pointer;
-  &:hover {
-    color: #9eeaf9;
-  }
-}
-.icon-spin {
-  animation: icon-spin 2s infinite linear;
-  fill: #9eeaf9;
-  width: 22px;
-  vertical-align: middle;
-}
-@keyframes icon-spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(359deg);
-  }
-}
-</style>

--- a/updater/index.html
+++ b/updater/index.html
@@ -2,9 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../vendor/foundation.min.css" />
-    <link href="../vendor/roboto.css" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="../vendor/twitchalerts.css" />
+    <link rel="stylesheet" type="text/css" href="updater.css" />
     <script src="../bundles/updater.js"></script>
   </head>
   <body>

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -1,0 +1,78 @@
+@charset "utf-8";
+body {
+    padding: 0;
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Hiragino Kaku Gothic ProN", "Meiryo", "メイリオ", sans-serif;
+    font-weight: 400;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+body,
+html {
+    height: 100%;
+}
+.UpdaterWindow {
+    height: 100%;
+    padding: 24px;
+    margin: 0;
+    background-color: #2F3340;
+    color: #9eeaf9;
+    font-size: 18px;
+    text-align: center;
+    -webkit-app-region: drag;
+    box-sizing: border-box;
+}
+.UpdaterWindow p {
+    white-space: pre-wrap;
+    color: #9eeaf9;
+}
+.UpdaterWindow-progressBarContainer {
+    position: relative;
+    margin-top: 36px;
+    background-color: #050e18;
+    border-radius: 3px;
+    overflow: hidden;
+}
+.UpdaterWindow-progressBar {
+    height: 24px;
+    background-color: #ff6952;
+}
+.UpdaterWindow-progressPercent {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    color: #fff;
+    text-align: center;
+    line-height: 24px;
+    font-size: 15px;
+}
+.UpdaterWindow-issues {
+    font-size: 12px;
+    font-weight: 300;
+    padding-top: 24px;
+    -webkit-app-region: no-drag;
+}
+.UpdaterWindow-link {
+    color: #70A0AF;
+    text-decoration: underline;
+    cursor: pointer;
+}
+.UpdaterWindow-link:hover {
+    color: #9eeaf9;
+    text-decoration: none;
+}
+.icon-spin {
+    animation: icon-spin 2s infinite linear;
+    fill: #9eeaf9;
+    width: 22px;
+    vertical-align: middle;
+}
+@keyframes icon-spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(359deg);
+    }
+}

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -1,4 +1,6 @@
 @charset "utf-8";
+/*　updaterのみで参照するcssスタイル　*/
+
 body {
     padding: 0;
     margin: 0;
@@ -22,22 +24,25 @@ html {
     -webkit-app-region: drag;
     box-sizing: border-box;
 }
-.UpdaterWindow p {
-    white-space: pre-wrap;
+.message {
     color: #9eeaf9;
+    vertical-align: middle
 }
-.UpdaterWindow-progressBarContainer {
+.error {
+    color: #ff6952;
+}
+.progressBarContainer {
     position: relative;
     margin-top: 36px;
     background-color: #050e18;
     border-radius: 3px;
     overflow: hidden;
 }
-.UpdaterWindow-progressBar {
+.progressBar {
     height: 24px;
     background-color: #ff6952;
 }
-.UpdaterWindow-progressPercent {
+.progressPercent {
     position: absolute;
     top: 0;
     left: 0;
@@ -47,24 +52,29 @@ html {
     line-height: 24px;
     font-size: 15px;
 }
-.UpdaterWindow-issues {
+.issues {
     font-size: 12px;
     font-weight: 300;
     padding-top: 24px;
     -webkit-app-region: no-drag;
 }
-.UpdaterWindow-link {
+.link {
     color: #70A0AF;
     text-decoration: underline;
     cursor: pointer;
 }
-.UpdaterWindow-link:hover {
+.link:hover {
     color: #9eeaf9;
     text-decoration: none;
 }
 .icon-spin {
     animation: icon-spin 2s infinite linear;
     fill: #9eeaf9;
+    width: 22px;
+    vertical-align: middle;
+}
+.icon-warning {
+    fill: #ff6952;
     width: 22px;
     vertical-align: middle;
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
## アッデート時に表示されるtemplateに対してのcss整理。
- UpdaterWindow.vueに書かれていたstyleをupdater用のcssに分離。
- vendorのcssは軒並み削除してupdate時に読み込まれる容量を軽量化
- 最新インストラーのリンクテキストが溶け込んでいた部分にunderlineを追加
- 問題が発生しました場合の表示アイコンとテキストカラーを変更しました
それぞれの見た目は以下の表示になります。

### isChecking
![ischecking](https://user-images.githubusercontent.com/3591127/44382959-f2d85d00-a551-11e8-9caf-3e500be0f18b.PNG)

### isDownloading
![isdownloading](https://user-images.githubusercontent.com/3591127/44382966-f835a780-a551-11e8-9643-478c2d568762.PNG)

### isInstalling
![isinstalling](https://user-images.githubusercontent.com/3591127/44382970-fd92f200-a551-11e8-98a4-2f813233f438.PNG)

### isError
![iserror](https://user-images.githubusercontent.com/3591127/44382976-008de280-a552-11e8-9c76-abca9917950e.PNG)

**動作確認手順**
update画面を開き適切なスタイルが当たっているかを確認

* devビルドする場合
    * `NAIR_FORCE_AUTO_UPDATE=1 yarn start` でアップデータ経由起動する