### PR TITLE
ディスプレイが150%時にシーンコレクションの文字列が切れる部分を解消

### DIFF
--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -95,6 +95,7 @@
 .studio-controls__label {
   color: @text-primary;
   margin-bottom: 0;
+  font-size: 12px;
   .semibold;
 }
 

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -36,10 +36,10 @@
   display: flex;
   text-align: left;
   align-items: center;
-  font-size: 13px;
+  font-size: 12px;
   .semibold;
   letter-spacing: .7px;
-  color: @text-primary;;
+  color: @text-primary;
 
   i {
     margin-left: 6px;


### PR DESCRIPTION
**このpull requestが解決する内容**
https://github.com/n-air-app/n-air-app/issues/17
に対する対応。
ディスプレイ倍率が100％だと問題ないが、150%に変更すると文字のサイズから上部が切れる問題に対応

### ディスプレイ表示倍率150％
![150](https://user-images.githubusercontent.com/3591127/44337062-5318c180-a4b4-11e8-9219-7408d3bafc6a.PNG)

### ディスプレイ表示倍率100％
![100](https://user-images.githubusercontent.com/3591127/44337035-41cfb500-a4b4-11e8-89c4-95fc1e646187.PNG)

**動作確認手順**
シーンコレクションで表示する文字列を「無題」等の漢字にしてディスプレイ倍率を変更して確認する。

