### PR TITLE
ニコニコ生放送最適化をショートカットキーから配信開始しても有効にする

### DIFF
--- a/app/components/StartStreamingButton.vue.ts
+++ b/app/components/StartStreamingButton.vue.ts
@@ -3,13 +3,8 @@ import { Component, Prop, Watch } from 'vue-property-decorator';
 import { StreamingService, EStreamingState } from 'services/streaming';
 import { Inject } from 'util/injector';
 import { NavigationService } from 'services/navigation';
-import { UserService } from 'services/user';
-import { CustomizationService } from 'services/customization';
 import { SettingsService } from 'services/settings';
-import { getPlatformService } from '../services/platforms';
-import { NiconicoService } from '../services/platforms/niconico';
 import { WindowsService } from '../services/windows';
-import electron from 'electron';
 import { $t } from 'services/i18n';
 const StartStreamingIcon = require('../../media/images/start-streaming-icon.svg');
 
@@ -20,8 +15,6 @@ const StartStreamingIcon = require('../../media/images/start-streaming-icon.svg'
 })
 export default class StartStreamingButton extends Vue {
   @Inject() streamingService: StreamingService;
-  @Inject() userService: UserService;
-  @Inject() customizationService: CustomizationService;
   @Inject() navigationService: NavigationService;
   @Inject() settingsService: SettingsService;
   @Inject() windowsService: WindowsService;
@@ -34,92 +27,7 @@ export default class StartStreamingButton extends Vue {
       return;
     }
 
-    console.log('Start Streaming button: platform=' + JSON.stringify(this.userService.platform));
-    if (this.userService.isNiconicoLoggedIn()) {
-      try {
-        const streamkey = await this.userService.updateStreamSettings();
-        if (streamkey === '') {
-          return new Promise(resolve => {
-            electron.remote.dialog.showMessageBox(
-              electron.remote.getCurrentWindow(),
-              {
-                title: $t('streaming.notBroadcasting'),
-                type: 'warning',
-                message: $t('streaming.notBroadcastingMessage'),
-                buttons: [$t('common.close')],
-                noLink: true,
-              },
-              done => resolve(done)
-            );
-          });
-        }
-        if (this.customizationService.optimizeForNiconico) {
-          const platform = getPlatformService(this.userService.platform.type);
-          if (platform instanceof NiconicoService) {
-            // FIXME: `this.userService.updateStreamSettings`とあわせて
-            //       2度 `getpublishstatus` を呼んでいるが
-            //       不整合回避のために1回だけにしたい
-            return this.optimizeForNiconico(platform);
-          }
-        }
-      } catch (e) {
-        const message = e instanceof Response
-          ? $t('streaming.broadcastStatusFetchingError.httpError', { statusText: e.statusText })
-          : $t('streaming.broadcastStatusFetchingError.default');
-
-        return new Promise(resolve => {
-          electron.remote.dialog.showMessageBox(
-            electron.remote.getCurrentWindow(),
-            {
-              type: 'warning',
-              message,
-              buttons: [$t('common.close')],
-              noLink: true,
-            },
-            done => resolve(done)
-          );
-        });
-      }
-    }
-
-    this.streamingService.toggleStreaming();
-  }
-
-  private async optimizeForNiconico(platform: NiconicoService) {
-    const bitrate = await platform.fetchBitrate();
-    if (bitrate === undefined) {
-      return new Promise(resolve => {
-        electron.remote.dialog.showMessageBox(
-          electron.remote.getCurrentWindow(),
-          {
-            title: $t('streaming.bitrateFetchingError.title'),
-            type: 'warning',
-            message: $t('streaming.bitrateFetchingError.message'),
-            buttons: [$t('common.close')],
-            noLink: true,
-          },
-          done => resolve(done)
-        );
-      });
-    }
-    const settings = this.settingsService.diffOptimizedSettings(bitrate);
-    if (settings) {
-      if (this.customizationService.showOptimizationDialogForNiconico) {
-        this.windowsService.showWindow({
-          componentName: 'OptimizeForNiconico',
-          queryParams: settings,
-          size: {
-            width: 500,
-            height: 400
-          }
-        });
-      } else {
-        this.settingsService.optimizeForNiconico(settings);
-        this.streamingService.toggleStreaming();
-      }
-    } else {
-      this.streamingService.toggleStreaming();
-    }
+    this.streamingService.toggleStreamingAsync();
   }
 
   get streamingStatus() {

--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -69,7 +69,7 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
     {
       name: 'TOGGLE_START_STREAMING',
       description: () => $t('hotkeys.startStreaming'),
-      down: () => getStreamingService().toggleStreaming(),
+      down: () => getStreamingService().toggleStreamingAsync(),
       isActive: () => {
         const streamingService = getStreamingService();
         return streamingService.isStreaming;
@@ -80,7 +80,7 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
       description: () => $t('hotkeys.stopStreaming'),
       down: () => {
         const streamingService = getStreamingService();
-        streamingService.toggleStreaming();
+        streamingService.toggleStreamingAsync();
       },
       isActive: () => {
         const streamingService = getStreamingService();


### PR DESCRIPTION
**このpull requestが解決する内容**
設定/ショートカットキーの「配信開始」のキーから起動したときに、ニコニコ生放送最適化処理が実行されていなかったのを修正しました。

**動作確認手順**
1. 設定/ショートカットキーの「配信開始」 にキー操作を登録する。
2. ニコニコ生放送で番組を作成する
3. 設定で、最適化で変更する内容が発生するように何かを変更する。
    * 例:詳細設定のYUVカラースペースを709以外にする
4. 1.で登録した配信開始キーを押すと、最適化ダイアログが現れること。(最適化せずに閉じて次に備える)
5. 画面上の配信開始ボタンクリックでも同じ動作をすること。