### PR TITLE
ログイン状態で起動するとStream設定が取得できずエラーになる問題を修正

### DIFF
--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -137,11 +137,13 @@ export class SettingsService extends StatefulService<ISettingsState>
     // ensure 'custom streaming server'
     {
       const settings = settingsFormData['Stream'];
-      const setting = this.findSetting(settings, 'Untitled', 'streamType');
-      if (setting) {
-        if (setting.value !== 'rtmp_custom') {
-          setting.value = 'rtmp_custom';
-          this.setSettings('Stream', settings);
+      if (settings) {
+        const setting = this.findSetting(settings, 'Untitled', 'streamType');
+        if (setting) {
+          if (setting.value !== 'rtmp_custom') {
+            setting.value = 'rtmp_custom';
+            this.setSettings('Stream', settings);
+          }
         }
       }
     }


### PR DESCRIPTION
**このpull requestが解決する内容**

ログインしている状態では "Stream"（日本語だと"配信"）設定が存在しないのですが、 #31 の変更で設定存在チェックが抜けていたため、存在しないデータにアクセスしようとしてエラーが発生していました。
チェックを追加することで、この問題を解決します。

**動作確認手順**

1. キャッシュ削除して起動
1. ログイン
1. 一度アプリを終了し、再度起動
1. プレビュー画面が表示されることを確認
    * developer toolsでエラー表示がないこともあわせて確認
1. ログアウト
1. #32 の動作確認手順を実行