### PR TITLE
画像スライドのプロパティから「スライドモード」の設定を隠す

### DIFF
--- a/app/services/sources/properties-managers/default-manager.ts
+++ b/app/services/sources/properties-managers/default-manager.ts
@@ -34,6 +34,10 @@ export class DefaultManager extends PropertiesManager {
   init() {
     if (!this.settings.mediaBackup) this.settings.mediaBackup = {};
     this.downloadGoogleFont();
+
+    if (this.obsSource.id === 'slideshow') {
+      this.blacklist = ['slide_mode'];
+    }
   }
 
   setPropertiesFormData(properties: input.TFormData) {


### PR DESCRIPTION
**このpull requestが解決する内容**

現状のN Airにはスライドショーを制御するためのショートカットキーを設定する項目がなく、表示されていても利用できないため、画像スライドのプロパティから「スライドモード」の設定を隠します。

![image](https://user-images.githubusercontent.com/418982/44446849-51204100-a621-11e8-8aa3-4117d1e9af93.png)

**動作確認手順**

1. ソースに「画像スライド」を追加する
2. 画像スライドのプロパティを開く
3. プロパティ内に「スライドモード」が存在しないことを確認する