### PR TITLE
FIX updater.cssがバンドルされていなかった

### DIFF
--- a/updater/index.html
+++ b/updater/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="updater.css" />
     <script src="../bundles/updater.js"></script>
   </head>
   <body>

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -4,6 +4,7 @@ import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 import UpdaterWindow from './UpdaterWindow.vue';
 import electron from 'electron';
+import './updater.css';
 
 Vue.use(VueI18n);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,18 @@ module.exports = {
         exclude: /node_modules/,
       },
       {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 1
+            }
+          }
+        ]
+      },
+      {
         test: /\.less$/,
         use: [
           'style-loader',


### PR DESCRIPTION
**このpull requestが解決する内容**
#35 で発生した問題。updater.css ファイルにstyleを切り出したが単純にhtmlで読み込んでしまったため、リリースビルドしても組み込まれなかった。開発中はソースがあるためたまたま読み込まれていた

**動作確認手順**
`yarn compile:production && yarn package` してできたインストーラからインストールして起動、または
`yarn compile && NAIR_FORCE_AUTO_UPDATE=1 yarn start`
で起動して、Updaterが普通に表示されること。

