### PR TITLE
ソースのプロパティに表示されるlabelの横幅を調整

### DIFF
--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -21,12 +21,13 @@
 }
 
 .input-label {
+  width: 35%;
   padding-right: 15px;
   margin-bottom: 8px;
 }
 
 .input-wrapper {
-  width: 70%;
+  width: 65%;
 
   .checkbox {
     &:last-child {


### PR DESCRIPTION
**このpull requestが解決する内容**
https://github.com/n-air-app/n-air-app/issues/41
で報告を受けた対応です。

ソースのプロパティに表示されるラベルが別のPRで影響を受けて崩れた部分が修正されます
https://github.com/pocketberserker/n-air-app/commit/e9e2a047815a32e01211b61b65267bde308ab823#diff-682f144a6b1e3bb79599175f8ed4857b
![slide](https://user-images.githubusercontent.com/3591127/44516018-efce9f80-a6fe-11e8-9d34-16acb0b005d6.PNG)


**動作確認手順**
1.ソースを追加してからそのソースを選択し、歯車のアイコンからプロパティ画面を開いて崩れていないことを確認する。
2.ナビゲーションメニューから設定を開き、設定画面のラベルも崩れていないことを確認する
![setting](https://user-images.githubusercontent.com/3591127/44516037-fbba6180-a6fe-11e8-8624-3362c2011f38.PNG)
