### PR TITLE
頂点にあるリサイズボックスでもクロップ可能にする

### DIFF
--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -25,7 +25,7 @@ interface IResizeRegion {
 
 interface IResizeOptions {
   lockRatio: boolean; // preserve the aspect ratio (default: true)
-  lockedAnchor: AnchorPoint; // 操作中のアンカーの真逆位置のアンカー
+  anchor: AnchorPoint; // anchor: an AnchorPoint enum to resize around
   verticalEdge?: AnchorPoint; // 鉛直方向に動く辺に対応する方角
   horizontalEdge?: AnchorPoint; // 水平方向に動く辺に対応する方角
 }
@@ -201,14 +201,14 @@ export default class StudioEditor extends Vue {
       const name = this.resizeRegion.name;
 
       const optionsMap = Object.freeze({
-        nw: { lockedAnchor: AnchorPoint.SouthEast, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.West },
-        sw: { lockedAnchor: AnchorPoint.NorthEast, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.West },
-        ne: { lockedAnchor: AnchorPoint.SouthWest, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.East },
-        se: { lockedAnchor: AnchorPoint.NorthWest, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.East },
-        n: { lockedAnchor: AnchorPoint.South, verticalEdge: AnchorPoint.North },
-        s: { lockedAnchor: AnchorPoint.North, verticalEdge: AnchorPoint.South },
-        e: { lockedAnchor: AnchorPoint.West, horizontalEdge: AnchorPoint.East },
-        w: { lockedAnchor: AnchorPoint.East, horizontalEdge: AnchorPoint.West },
+        nw: { anchor: AnchorPoint.SouthEast, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.West },
+        sw: { anchor: AnchorPoint.NorthEast, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.West },
+        ne: { anchor: AnchorPoint.SouthWest, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.East },
+        se: { anchor: AnchorPoint.NorthWest, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.East },
+        n: { anchor: AnchorPoint.South, verticalEdge: AnchorPoint.North },
+        s: { anchor: AnchorPoint.North, verticalEdge: AnchorPoint.South },
+        e: { anchor: AnchorPoint.West, horizontalEdge: AnchorPoint.East },
+        w: { anchor: AnchorPoint.East, horizontalEdge: AnchorPoint.West },
       });
 
       const options = {
@@ -260,7 +260,7 @@ export default class StudioEditor extends Vue {
     const rect = new ScalableRectangle(source.getRectangle());
 
     rect.normalized(() => {
-      rect.withAnchor(options.lockedAnchor, () => {
+      rect.withAnchor(options.anchor, () => {
         if (options.horizontalEdge === AnchorPoint.West) {
           const croppableWidth = rect.width - rect.crop.right - 2;
           const distance = (croppableWidth * rect.scaleX) - (rect.x - x);
@@ -307,7 +307,7 @@ export default class StudioEditor extends Vue {
     const rect = new ScalableRectangle(source.getRectangle());
 
     rect.normalized(() => {
-      rect.withAnchor(opts.lockedAnchor, () => {
+      rect.withAnchor(opts.anchor, () => {
         const distanceX = Math.abs(x - rect.x);
         const distanceY = Math.abs(y - rect.y);
 

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -261,20 +261,21 @@ export default class StudioEditor extends Vue {
 
     rect.normalized(() => {
       rect.withAnchor(options.lockedAnchor, () => {
-        // There's probably a more generic way to do this math
-        if (options.lockedAnchor === AnchorPoint.East) {
+        if (options.horizontalEdge === AnchorPoint.West) {
           const croppableWidth = rect.width - rect.crop.right - 2;
           const distance = (croppableWidth * rect.scaleX) - (rect.x - x);
           rect.crop.left = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.lockedAnchor === AnchorPoint.West) {
+        } else if (options.horizontalEdge === AnchorPoint.East) {
           const croppableWidth = rect.width - rect.crop.left - 2;
           const distance = (croppableWidth * rect.scaleX) + (rect.x - x);
           rect.crop.right = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.lockedAnchor === AnchorPoint.South) {
+        }
+
+        if (options.verticalEdge === AnchorPoint.North) {
           const croppableHeight = rect.height - rect.crop.bottom - 2;
           const distance = (croppableHeight * rect.scaleY) - (rect.y - y);
           rect.crop.top = _.clamp(distance / rect.scaleY, 0, croppableHeight);
-        } else if (options.lockedAnchor === AnchorPoint.North) {
+        } else if (options.verticalEdge === AnchorPoint.South) {
           const croppableHeight = rect.height - rect.crop.top - 2;
           const distance = (croppableHeight * rect.scaleY) + (rect.y - y);
           rect.crop.bottom = _.clamp(distance / rect.scaleY, 0, croppableHeight);

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -27,7 +27,7 @@ interface IResizeOptions {
   lockRatio: boolean; // preserve the aspect ratio (default: true)
   lockX: boolean; // prevent changes to the X scale (default: false)
   lockY: boolean; // lockY: prevent changes to the Y scale (default: false)
-  anchor: AnchorPoint; // anchor: an AnchorPoint enum to resize around
+  lockedAnchor: AnchorPoint; // anchor: an AnchorPoint enum to resize around
 }
 
 @Component({
@@ -202,14 +202,14 @@ export default class StudioEditor extends Vue {
 
       // We choose an anchor point opposite the resize region
       const optionsMap = {
-        nw: { anchor: AnchorPoint.SouthEast },
-        sw: { anchor: AnchorPoint.NorthEast },
-        ne: { anchor: AnchorPoint.SouthWest },
-        se: { anchor: AnchorPoint.NorthWest },
-        n: { anchor: AnchorPoint.South, lockX: true },
-        s: { anchor: AnchorPoint.North, lockX: true },
-        e: { anchor: AnchorPoint.West, lockY: true },
-        w: { anchor: AnchorPoint.East, lockY: true }
+        nw: { lockedAnchor: AnchorPoint.SouthEast },
+        sw: { lockedAnchor: AnchorPoint.NorthEast },
+        ne: { lockedAnchor: AnchorPoint.SouthWest },
+        se: { lockedAnchor: AnchorPoint.NorthWest },
+        n: { lockedAnchor: AnchorPoint.South, lockX: true },
+        s: { lockedAnchor: AnchorPoint.North, lockX: true },
+        e: { lockedAnchor: AnchorPoint.West, lockY: true },
+        w: { lockedAnchor: AnchorPoint.East, lockY: true }
       };
 
       const options = {
@@ -261,21 +261,21 @@ export default class StudioEditor extends Vue {
     const rect = new ScalableRectangle(source.getRectangle());
 
     rect.normalized(() => {
-      rect.withAnchor(options.anchor, () => {
+      rect.withAnchor(options.lockedAnchor, () => {
         // There's probably a more generic way to do this math
-        if (options.anchor === AnchorPoint.East) {
+        if (options.lockedAnchor === AnchorPoint.East) {
           const croppableWidth = rect.width - rect.crop.right - 2;
           const distance = (croppableWidth * rect.scaleX) - (rect.x - x);
           rect.crop.left = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.anchor === AnchorPoint.West) {
+        } else if (options.lockedAnchor === AnchorPoint.West) {
           const croppableWidth = rect.width - rect.crop.left - 2;
           const distance = (croppableWidth * rect.scaleX) + (rect.x - x);
           rect.crop.right = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.anchor === AnchorPoint.South) {
+        } else if (options.lockedAnchor === AnchorPoint.South) {
           const croppableHeight = rect.height - rect.crop.bottom - 2;
           const distance = (croppableHeight * rect.scaleY) - (rect.y - y);
           rect.crop.top = _.clamp(distance / rect.scaleY, 0, croppableHeight);
-        } else if (options.anchor === AnchorPoint.North) {
+        } else if (options.lockedAnchor === AnchorPoint.North) {
           const croppableHeight = rect.height - rect.crop.top - 2;
           const distance = (croppableHeight * rect.scaleY) + (rect.y - y);
           rect.crop.bottom = _.clamp(distance / rect.scaleY, 0, croppableHeight);
@@ -307,7 +307,7 @@ export default class StudioEditor extends Vue {
     const rect = new ScalableRectangle(source.getRectangle());
 
     rect.normalized(() => {
-      rect.withAnchor(opts.anchor, () => {
+      rect.withAnchor(opts.lockedAnchor, () => {
         const distanceX = Math.abs(x - rect.x);
         const distanceY = Math.abs(y - rect.y);
 

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -25,7 +25,7 @@ interface IResizeRegion {
 
 interface IResizeOptions {
   lockRatio: boolean; // preserve the aspect ratio (default: true)
-  anchor: AnchorPoint; // anchor: an AnchorPoint enum to resize around
+  anchor: AnchorPoint; // リサイズの中心となるResizeBoxの方角
   verticalEdge?: AnchorPoint; // 鉛直方向に動く辺に対応する方角
   horizontalEdge?: AnchorPoint; // 水平方向に動く辺に対応する方角
 }

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -6,7 +6,7 @@ import { Inject } from 'util/injector';
 import { ScenesService, SceneItem, Scene, TSceneNode } from 'services/scenes';
 import { VideoService } from 'services/video';
 import { EditMenu } from 'util/menus/EditMenu';
-import { ScalableRectangle, AnchorPoint } from 'util/ScalableRectangle';
+import { ScalableRectangle, ResizeBoxPoint } from 'util/ScalableRectangle';
 import { WindowsService } from 'services/windows';
 import { SelectionService } from 'services/selection/selection';
 import Display from 'components/shared/Display.vue';
@@ -25,9 +25,9 @@ interface IResizeRegion {
 
 interface IResizeOptions {
   lockRatio: boolean; // preserve the aspect ratio (default: true)
-  anchor: AnchorPoint; // リサイズの中心となるResizeBoxの方角
-  verticalEdge?: AnchorPoint; // 鉛直方向に動く辺に対応する方角
-  horizontalEdge?: AnchorPoint; // 水平方向に動く辺に対応する方角
+  anchor: ResizeBoxPoint; // リサイズの中心となるResizeBoxの方角
+  verticalEdge?: ResizeBoxPoint; // 鉛直方向に動く辺に対応する方角
+  horizontalEdge?: ResizeBoxPoint; // 水平方向に動く辺に対応する方角
 }
 
 @Component({
@@ -201,14 +201,42 @@ export default class StudioEditor extends Vue {
       const name = this.resizeRegion.name;
 
       const optionsMap = Object.freeze({
-        nw: { anchor: AnchorPoint.SouthEast, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.West },
-        sw: { anchor: AnchorPoint.NorthEast, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.West },
-        ne: { anchor: AnchorPoint.SouthWest, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.East },
-        se: { anchor: AnchorPoint.NorthWest, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.East },
-        n: { anchor: AnchorPoint.South, verticalEdge: AnchorPoint.North },
-        s: { anchor: AnchorPoint.North, verticalEdge: AnchorPoint.South },
-        e: { anchor: AnchorPoint.West, horizontalEdge: AnchorPoint.East },
-        w: { anchor: AnchorPoint.East, horizontalEdge: AnchorPoint.West },
+        nw: {
+          anchor: ResizeBoxPoint.SouthEast,
+          verticalEdge: ResizeBoxPoint.North,
+          horizontalEdge: ResizeBoxPoint.West,
+        },
+        sw: {
+          anchor: ResizeBoxPoint.NorthEast,
+          verticalEdge: ResizeBoxPoint.South,
+          horizontalEdge: ResizeBoxPoint.West,
+        },
+        ne: {
+          anchor: ResizeBoxPoint.SouthWest,
+          verticalEdge: ResizeBoxPoint.North,
+          horizontalEdge: ResizeBoxPoint.East,
+        },
+        se: {
+          anchor: ResizeBoxPoint.NorthWest,
+          verticalEdge: ResizeBoxPoint.South,
+          horizontalEdge: ResizeBoxPoint.East,
+        },
+        n: {
+          anchor: ResizeBoxPoint.South,
+          verticalEdge: ResizeBoxPoint.North,
+        },
+        s: {
+          anchor: ResizeBoxPoint.North,
+          verticalEdge: ResizeBoxPoint.South,
+        },
+        e: {
+          anchor: ResizeBoxPoint.West,
+          horizontalEdge: ResizeBoxPoint.East,
+        },
+        w: {
+          anchor: ResizeBoxPoint.East,
+          horizontalEdge: ResizeBoxPoint.West,
+        },
       });
 
       const options = {
@@ -261,21 +289,21 @@ export default class StudioEditor extends Vue {
 
     rect.normalized(() => {
       rect.withAnchor(options.anchor, () => {
-        if (options.horizontalEdge === AnchorPoint.West) {
+        if (options.horizontalEdge === ResizeBoxPoint.West) {
           const croppableWidth = rect.width - rect.crop.right - 2;
           const distance = (croppableWidth * rect.scaleX) - (rect.x - x);
           rect.crop.left = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.horizontalEdge === AnchorPoint.East) {
+        } else if (options.horizontalEdge === ResizeBoxPoint.East) {
           const croppableWidth = rect.width - rect.crop.left - 2;
           const distance = (croppableWidth * rect.scaleX) + (rect.x - x);
           rect.crop.right = _.clamp(distance / rect.scaleX, 0, croppableWidth);
         }
 
-        if (options.verticalEdge === AnchorPoint.North) {
+        if (options.verticalEdge === ResizeBoxPoint.North) {
           const croppableHeight = rect.height - rect.crop.bottom - 2;
           const distance = (croppableHeight * rect.scaleY) - (rect.y - y);
           rect.crop.top = _.clamp(distance / rect.scaleY, 0, croppableHeight);
-        } else if (options.verticalEdge === AnchorPoint.South) {
+        } else if (options.verticalEdge === ResizeBoxPoint.South) {
           const croppableHeight = rect.height - rect.crop.top - 2;
           const distance = (croppableHeight * rect.scaleY) + (rect.y - y);
           rect.crop.bottom = _.clamp(distance / rect.scaleY, 0, croppableHeight);
@@ -325,8 +353,8 @@ export default class StudioEditor extends Vue {
         }
 
         // Aspect ratio preservation overrides lockX and lockY
-        if (AnchorPoint[opts.horizontalEdge] || opts.lockRatio) rect.scaleX = newScaleX;
-        if (AnchorPoint[opts.verticalEdge] || opts.lockRatio) rect.scaleY = newScaleY;
+        if (ResizeBoxPoint[opts.horizontalEdge] || opts.lockRatio) rect.scaleX = newScaleX;
+        if (ResizeBoxPoint[opts.verticalEdge] || opts.lockRatio) rect.scaleY = newScaleY;
       });
     });
 

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -25,7 +25,7 @@ interface IResizeRegion {
 
 interface IResizeOptions {
   lockRatio: boolean; // preserve the aspect ratio (default: true)
-  anchor: ResizeBoxPoint; // リサイズの中心となるResizeBoxの方角
+  anchor: ResizeBoxPoint; // リサイズの基準として固定するResizeBoxの方角、操作中のResizeBoxからソースの中心に対して反対側
   verticalEdge?: ResizeBoxPoint; // 鉛直方向に動く辺に対応する方角
   horizontalEdge?: ResizeBoxPoint; // 水平方向に動く辺に対応する方角
 }

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -25,9 +25,9 @@ interface IResizeRegion {
 
 interface IResizeOptions {
   lockRatio: boolean; // preserve the aspect ratio (default: true)
-  lockX: boolean; // prevent changes to the X scale (default: false)
-  lockY: boolean; // lockY: prevent changes to the Y scale (default: false)
-  lockedAnchor: AnchorPoint; // anchor: an AnchorPoint enum to resize around
+  lockedAnchor: AnchorPoint; // 操作中のアンカーの真逆位置のアンカー
+  verticalEdge?: AnchorPoint; // 鉛直方向に動く辺に対応する方角
+  horizontalEdge?: AnchorPoint; // 水平方向に動く辺に対応する方角
 }
 
 @Component({
@@ -200,17 +200,16 @@ export default class StudioEditor extends Vue {
     if (this.resizeRegion) {
       const name = this.resizeRegion.name;
 
-      // We choose an anchor point opposite the resize region
-      const optionsMap = {
-        nw: { lockedAnchor: AnchorPoint.SouthEast },
-        sw: { lockedAnchor: AnchorPoint.NorthEast },
-        ne: { lockedAnchor: AnchorPoint.SouthWest },
-        se: { lockedAnchor: AnchorPoint.NorthWest },
-        n: { lockedAnchor: AnchorPoint.South, lockX: true },
-        s: { lockedAnchor: AnchorPoint.North, lockX: true },
-        e: { lockedAnchor: AnchorPoint.West, lockY: true },
-        w: { lockedAnchor: AnchorPoint.East, lockY: true }
-      };
+      const optionsMap = Object.freeze({
+        nw: { lockedAnchor: AnchorPoint.SouthEast, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.West },
+        sw: { lockedAnchor: AnchorPoint.NorthEast, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.West },
+        ne: { lockedAnchor: AnchorPoint.SouthWest, verticalEdge: AnchorPoint.North, horizontalEdge: AnchorPoint.East },
+        se: { lockedAnchor: AnchorPoint.NorthWest, verticalEdge: AnchorPoint.South, horizontalEdge: AnchorPoint.East },
+        n: { lockedAnchor: AnchorPoint.South, verticalEdge: AnchorPoint.North },
+        s: { lockedAnchor: AnchorPoint.North, verticalEdge: AnchorPoint.South },
+        e: { lockedAnchor: AnchorPoint.West, horizontalEdge: AnchorPoint.East },
+        w: { lockedAnchor: AnchorPoint.East, horizontalEdge: AnchorPoint.West },
+      });
 
       const options = {
         ...optionsMap[name],
@@ -325,8 +324,8 @@ export default class StudioEditor extends Vue {
         }
 
         // Aspect ratio preservation overrides lockX and lockY
-        if (!opts.lockX || opts.lockRatio) rect.scaleX = newScaleX;
-        if (!opts.lockY || opts.lockRatio) rect.scaleY = newScaleY;
+        if (AnchorPoint[opts.horizontalEdge] || opts.lockRatio) rect.scaleX = newScaleX;
+        if (AnchorPoint[opts.verticalEdge] || opts.lockRatio) rect.scaleY = newScaleY;
       });
     });
 

--- a/app/util/ScalableRectangle.ts
+++ b/app/util/ScalableRectangle.ts
@@ -4,7 +4,7 @@ import { get, set, invert } from 'lodash';
 // with rectangles that can be scaled, including
 // negative scales.
 
-export enum AnchorPoint {
+export enum ResizeBoxPoint {
   North,
   NorthEast,
   East,
@@ -24,15 +24,15 @@ export enum CenteringAxis {
 
 // Positions on a positive unit grid
 const AnchorPositions = {
-  [AnchorPoint.North]: { x: 0.5, y: 0 },
-  [AnchorPoint.NorthEast]: { x: 1, y: 0 },
-  [AnchorPoint.East]: { x: 1, y: 0.5 },
-  [AnchorPoint.SouthEast]: { x: 1, y: 1 },
-  [AnchorPoint.South]: { x: 0.5, y: 1 },
-  [AnchorPoint.SouthWest]: { x: 0, y: 1 },
-  [AnchorPoint.West]: { x: 0, y: 0.5 },
-  [AnchorPoint.NorthWest]: { x: 0, y: 0 },
-  [AnchorPoint.Center]: { x: 0.5, y: 0.5 }
+  [ResizeBoxPoint.North]: { x: 0.5, y: 0 },
+  [ResizeBoxPoint.NorthEast]: { x: 1, y: 0 },
+  [ResizeBoxPoint.East]: { x: 1, y: 0.5 },
+  [ResizeBoxPoint.SouthEast]: { x: 1, y: 1 },
+  [ResizeBoxPoint.South]: { x: 0.5, y: 1 },
+  [ResizeBoxPoint.SouthWest]: { x: 0, y: 1 },
+  [ResizeBoxPoint.West]: { x: 0, y: 0.5 },
+  [ResizeBoxPoint.NorthWest]: { x: 0, y: 0 },
+  [ResizeBoxPoint.Center]: { x: 0.5, y: 0.5 }
 };
 
 
@@ -47,7 +47,7 @@ export class ScalableRectangle implements IScalableRectangle {
   crop: ICrop;
   rotation: number;
 
-  private anchor: AnchorPoint;
+  private anchor: ResizeBoxPoint;
 
 
   constructor(options: IScalableRectangle) {
@@ -68,7 +68,7 @@ export class ScalableRectangle implements IScalableRectangle {
 
     this.rotation = options.rotation || 0;
 
-    this.anchor = AnchorPoint.NorthWest;
+    this.anchor = ResizeBoxPoint.NorthWest;
   }
 
 
@@ -102,7 +102,7 @@ export class ScalableRectangle implements IScalableRectangle {
   }
 
 
-  setAnchor(anchor: AnchorPoint) {
+  setAnchor(anchor: ResizeBoxPoint) {
     // We need to calculate the distance to the new anchor point
     const currentPosition = AnchorPositions[this.anchor];
     const newPosition = AnchorPositions[anchor];
@@ -128,7 +128,7 @@ export class ScalableRectangle implements IScalableRectangle {
 
     // This is where the anchor point would actually be if this
     // were a zero rotated object
-    let anchor = AnchorPoint.NorthWest;
+    let anchor = ResizeBoxPoint.NorthWest;
 
     if (this.rotation === 90) {
       mapFields['width'] = 'height';
@@ -139,13 +139,13 @@ export class ScalableRectangle implements IScalableRectangle {
       mapFields['crop.right'] = 'crop.top';
       mapFields['crop.bottom'] = 'crop.right';
       mapFields['crop.left'] = 'crop.bottom';
-      anchor = AnchorPoint.NorthEast;
+      anchor = ResizeBoxPoint.NorthEast;
     } else if (this.rotation === 180) {
       mapFields['crop.top'] = 'crop.bottom';
       mapFields['crop.right'] = 'crop.left';
       mapFields['crop.bottom'] = 'crop.top';
       mapFields['crop.left'] = 'crop.right';
-      anchor = AnchorPoint.SouthEast;
+      anchor = ResizeBoxPoint.SouthEast;
     } else if (this.rotation === 270) {
       mapFields['width'] = 'height';
       mapFields['height'] = 'width';
@@ -155,7 +155,7 @@ export class ScalableRectangle implements IScalableRectangle {
       mapFields['crop.right'] = 'crop.bottom';
       mapFields['crop.bottom'] = 'crop.left';
       mapFields['crop.left'] = 'crop.top';
-      anchor = AnchorPoint.SouthWest;
+      anchor = ResizeBoxPoint.SouthWest;
     }
 
     this.mapFields(mapFields);
@@ -164,7 +164,7 @@ export class ScalableRectangle implements IScalableRectangle {
 
     // Return the anchor to the NW, since the editor code assumes
     // that all rectangles are anchored from the NW
-    this.setAnchor(AnchorPoint.NorthWest);
+    this.setAnchor(ResizeBoxPoint.NorthWest);
 
     const rotation = this.rotation;
     this.rotation = 0;
@@ -195,7 +195,7 @@ export class ScalableRectangle implements IScalableRectangle {
    * Executes the function with a specific anchor point, after
    * which it is returned to its original anchor point.
    */
-  withAnchor(anchor: AnchorPoint, fun: Function) {
+  withAnchor(anchor: ResizeBoxPoint, fun: Function) {
     const oldAnchor = this.anchor;
     this.setAnchor(anchor);
 
@@ -304,8 +304,8 @@ export class ScalableRectangle implements IScalableRectangle {
     // Normalize both rectangles for this operation
     this.normalized(() => rect.normalized(() => {
       // Anchor both rectangles in the axis center
-      this.withAnchor(AnchorPoint.Center, () => {
-        rect.withAnchor(AnchorPoint.Center, () => {
+      this.withAnchor(ResizeBoxPoint.Center, () => {
+        rect.withAnchor(ResizeBoxPoint.Center, () => {
           switch (axis) {
             case CenteringAxis.X:
               this.x = rect.x;


### PR DESCRIPTION
**このpull requestが解決する内容**
エディタ上のソースは、Altキーを押しながらリサイズボックスをドラッグするとクロップできる。
この操作は辺にあるリサイズボックス限定で、頂点にあるリサイズボックスでは動作しない。
頂点のリサイズボックスでもクロップするよう変更する。

![crop](https://user-images.githubusercontent.com/950573/44597289-0f9eba00-a80a-11e8-8271-a7ce6df422cd.gif)

**動作確認手順**
## 追加した機能
1. エディタ上に表示される任意のソースを追加し、選択状態にする。
2. Altキーを押しながら頂点にあるリサイズボックスをドラッグし、クロップできる。

## 影響が予想される既存機能
1. エディタ上に表示される任意のソースを追加し、選択状態にする。
2. 辺および頂点にあるリサイズボックスをドラッグし、アスペクト比を維持してリサイズできる。
3. Altキーを押しながら辺にあるリサイズボックスをドラッグし、クロップできる。
4. Shiftキーを押しながら辺および頂点にあるリサイズボックスをドラッグし、アスペクト比を無視してリサイズできる。