### PR TITLE
WIP！ブラウザーソースのサンプルURLの変更

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -134,7 +134,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
     if (type === 'browser_source') {
       if (settings.shutdown === void 0) settings.shutdown = true;
-      if (settings.url === void 0) settings.url = 'https://site.nicovideo.jp/nicolive/n-air-app/browser-source/';
+      if (settings.url === void 0) settings.url = 'https://n-air-app.nicovideo.jp/browser-source/';
     }
 
     if (type === 'text_gdiplus') {
@@ -431,4 +431,3 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     });
   }
 }
-


### PR DESCRIPTION
**このpull requestが解決する内容**
`site.` から `n-air-app.` のURL変更に伴うURLの変更
ソース追加時のブラウザーソースのsampleで表示されるURLの変更

#### 旧URL
http://site.nicovideo.jp/nicolive/n-air-app/browser-source/

#### 新URL
https://n-air-app.nicovideo.jp/browser-source/


**動作確認手順**
ソース追加でブラウザーソース追加を試し、URLを何も変更せずにdone。
プレビュー画面に表示されるブラウザー画面に以下のサンプルが表示出ていることを確認する
<img width="513" alt="2018-08-25 11 49 31" src="https://user-images.githubusercontent.com/3591127/44619452-8b0f7280-a8c1-11e8-9865-adf058249ed8.png">

