### PR TITLE
アイテムのリサイズ時にディスプレイ倍率が1以外の環境でずれる問題を修正

### DIFF
--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -188,10 +188,10 @@ export default class StudioEditor extends Vue {
   }
 
   handleMouseMove(event: MouseEvent) {
-    const mousePosX = event.offsetX - this.renderedOffsetX;
-    const mousePosY = event.offsetY - this.renderedOffsetY;
-
     const factor = this.windowsService.state.main.scaleFactor;
+    const mousePosX = event.offsetX - this.renderedOffsetX / factor;
+    const mousePosY = event.offsetY - this.renderedOffsetY / factor;
+
     const converted = this.convertScalarToBaseSpace(
       mousePosX * factor,
       mousePosY * factor


### PR DESCRIPTION
**このpull requestが解決する内容**
Windowsの画面倍率が1.0以外の環境で、
ウィンドウの縦横比が画面編集域の縦横比と異なるときに、
縦横どちらかの隙間ができている側の軸上で
配置したソースアイテムのリサイズハンドルを掴んでリサイズすると
ドラッグ開始した瞬間に隙間ができている軸上で、隙間に比例した距離ずれる問題を修正する。
なお、このバグはStreamlabs-OBSでも発生する。

**動作確認手順**
拡大率が1.0以外のディスプレイ環境で
N Airのウィンドウを縦長または横長にリサイズしてから
ソースを縦横どちらのハンドルからリサイズしてもマウスカーソルにぴったりくっついてくること
