### PR TITLE
リリーススクリプトから github release にuploadする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ electron.VC.db
 .vs/
 plugins/
 AGREEMENT.sjis
+patch-note.txt

--- a/bin/mini-release.js
+++ b/bin/mini-release.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const OctoKit = require('@octokit/rest');
 
 let sh;
 let moment;
@@ -38,8 +39,8 @@ function error(msg) {
     sh.echo(colors.red(`ERROR: ${msg}`));
 }
 
-function executeCmd(cmd) {
-    const result = sh.exec(cmd);
+function executeCmd(cmd, options) {
+    const result = sh.exec(cmd, options);
 
     if (result.code !== 0) {
         error(`Command Failed >>> ${cmd}`);
@@ -89,6 +90,55 @@ function generateNewVersion(previousTag, now = Date.now()) {
     return `${major}.${minor}.${date}-${ord}`;
 }
 
+function generateNotesTsContent(version, title, notes) {
+    const patchNote = `import { IPatchNotes } from '.';
+
+export const notes: IPatchNotes = {
+  version: '${version}',
+  title: '${title}',
+  notes: [
+${notes.trim().split('\n').map(s => `    '${s}'`).join(',\n')}
+  ]
+};
+`;
+    info(`patch-note: '${patchNote}'`);
+    return patchNote;
+}
+
+function splitToLines(lines) {
+    if (typeof lines === 'string') {
+        lines = lines.split(/\r?\n/g);
+    }
+    return lines;
+}
+
+function readPatchNoteFile(patchNoteFileName) {
+    try {
+        const lines = splitToLines(fs.readFileSync(patchNoteFileName, {encoding: 'utf8'}));
+        const version = lines.shift();
+        return {
+            version,
+            lines
+        };
+    } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+        return {
+            version: '',
+            lines: []
+        };
+    }
+}
+
+function writePatchNoteFile(patchNoteFileName, version, lines) {
+    lines = splitToLines(lines);
+    const body = [version, ...lines].join('\n');
+    fs.writeFileSync(patchNoteFileName, body);
+}
+
+function getTagCommitId(tag) {
+    return executeCmd(`git rev-parse -q --verify "refs/tags/${tag}" || cat /dev/null`, {silent: true}).stdout;
+}
+
 /**
  * This is the main function of the script
  */
@@ -98,27 +148,36 @@ async function runScript() {
     info(colors.magenta('|----------------------------------|'));
 
     const githubApiServer = 'https://api.github.com';
-    const githubWebServer = 'https://github.com';
-    const githubApi = `${githubApiServer}/api/v3`;
 
     const organization = 'n-air-app';
     const repository = 'n-air-app';
     const remote = 'origin';
 
     const targetBranch = 'n-air_development';
+    const draft = true;
+    const prerelease = true;
+
+    const generateNoteTs = true; // generate note.ts from git logs
+
+    const skipLocalModificationCheck = false; // for DEBUG
+    const skipBuild = false; // for DEBUG
 
     // Start by figuring out if this environment is configured properly
     // for releasing.
     checkEnv('CSC_LINK');
     checkEnv('CSC_KEY_PASSWORD');
     checkEnv('NAIR_LICENSE_API_KEY');
+    checkEnv('NAIR_GITHUB_TOKEN');
 
     info(`check whether remote ${remote} exists`);
     executeCmd(`git remote get-url ${remote}`)
 
-    info('make sure there is nothing to commit on local directory');
-    executeCmd('git status'); // there should be nothing to commit
-    executeCmd('git diff -s --exit-code'); // and nothing changed
+    if (skipLocalModificationCheck) {
+        info('make sure there is nothing to commit on local directory');
+
+        executeCmd('git status'); // there should be nothing to commit
+        executeCmd('git diff -s --exit-code'); // and nothing changed
+    }
 
     info('checking current branch...')
     const currentBranch = executeCmd('git rev-parse --abbrev-ref HEAD').stdout.trim()
@@ -134,56 +193,96 @@ async function runScript() {
     info('checking current tag...');
     const previousTag = executeCmd('git describe --tags --abbrev=0').stdout.trim();
 
-    let nothingChanged = sh.exec(`git diff -s --exit-code ${previousTag}`).code == 0;
+    const baseDir = executeCmd('git rev-parse --show-cdup', {silent: true}).stdout.trim();
 
-    let newVersion;
-    let rebuild = false;
-    if (nothingChanged) {
-        newVersion = previousTag.substr(1);
+    let defaultVersion = generateNewVersion(previousTag);
+    let notes = '';
 
-        if (!await confirm(`Are you sure you want to REBUILD as version v${newVersion} (nothing Changed)?`)) sh.exit(0);
-        rebuild = true;
+    info('checking patch-note.txt...');
+    const patchNoteFileName = `${baseDir}patch-note.txt`;
+    const patchNote = readPatchNoteFile(patchNoteFileName);
+    if (patchNote.version) {
+        if (patchNote.version === defaultVersion || !getTagCommitId(patchNote.version)) {
+            defaultVersion = patchNote.version;
+            notes = patchNote.lines.join('\n');
+            info(`${patchNoteFileName} loaded: ${defaultVersion}\n${notes}`);
+        } else {
+            info(`${patchNoteFileName} 's version ${patchNote.version} already exists.`);
+        }
     } else {
-        const defaultVersion = generateNewVersion(previousTag);
-
-        newVersion = (await inq.prompt({
-            type: 'input',
-            name: 'newVersion',
-            message: 'What should the new version number be?',
-            default: defaultVersion
-        })).newVersion;
-        if (!await confirm(`Are you sure you want to release as version v${newVersion}?`, false)) sh.exit(0);
-
-        // update package.json with newVersion and git tag
-        executeCmd(`yarn version --new-version=${newVersion}`);
+        info(`${patchNoteFileName} not found.`);
     }
 
-    if (!await confirm('skip cleaning node_modules?')) {
-        // clean
-        info('Removing old packages...');
-        sh.rm('-rf', 'node_modules');
+    const newVersion = (await inq.prompt({
+        type: 'input',
+        name: 'newVersion',
+        message: 'What should the new version number be?',
+        default: defaultVersion
+    })).newVersion;
+
+    const newTag = `v${newVersion}`;
+    if (getTagCommitId(newTag)) {
+        error(`tag ${newTag} already exists!`);
+        sh.exit(1);
     }
 
-    info('Installing yarn packages...');
-    executeCmd('yarn install');
+    if (!notes) {
+        notes = executeCmd(`git log --oneline --graph --decorate ${previousTag}.. --boundary`).stdout;
 
-    info('Compiling assets...');
-    executeCmd('yarn compile:production');
+        writePatchNoteFile(patchNoteFileName, newVersion, notes);
+        info(`generated ${patchNoteFileName}.`);
+        if (await confirm(`Do you want to edit ${patchNoteFileName}?`, true)) sh.exit(0);
+    } else if (newVersion !== defaultVersion) {
+        writePatchNoteFile(patchNoteFileName, newVersion, notes);
+        info(`updated version ${newVersion} to  ${patchNoteFileName}.`);
+    }
 
-    info('Making the package...');
-    executeCmd('yarn package');
+    if (draft) {
+        info('draft is true.');
+    }
+    if (prerelease) {
+        info(`prerelease is true.`);
+    }
+    if (!await confirm(`Are you sure you want to release as version ${newVersion}?`, false)) sh.exit(0);
+
+    if (!generateNoteTs) {
+        info('skipping to generate notes.ts...');
+    } else {
+        const noteFilename = `${baseDir}app/services/patch-notes/notes.ts`;
+        const patchNote = generateNotesTsContent(newVersion, newVersion, notes);
+
+        fs.writeFileSync(noteFilename, patchNote);
+        info(`generated patch-note file: ${noteFilename}.`)
+        executeCmd(`git commit -m "note.ts ${newVersion}" ${noteFilename}`);
+    }
+
+    // update package.json with newVersion and git tag
+    executeCmd(`yarn version --new-version=${newVersion}`);
+
+    if (skipBuild) {
+        info('SKIP build process since skipBuild is set...');
+    } else {
+        if (!await confirm('skip cleaning node_modules?')) {
+            // clean
+            info('Removing old packages...');
+            sh.rm('-rf', 'node_modules');
+        }
+
+        info('Installing yarn packages...');
+        executeCmd('yarn install');
+
+        info('Compiling assets...');
+        executeCmd('yarn compile:production');
+
+        info('Making the package...');
+        executeCmd('yarn package');
+    }
 
     info('Pushing to the repository...')
     executeCmd(`git push ${remote} ${targetBranch}`);
-    executeCmd(`git push ${remote} v${newVersion}`);
+    executeCmd(`git push ${remote} ${newTag}`);
 
-    info(`version: v${newVersion}`);
-
-    if (!rebuild) {
-        info(`log since ${previousTag}:`);
-        executeCmd(`git log --oneline --graph --decorate --ancestry-path ${previousTag}..`);
-        info('');
-    }
+    info(`version: ${newVersion}`);
 
     const distDir = path.resolve('.', 'dist');
     const latestYml = path.join(distDir, 'latest.yml');
@@ -199,18 +298,57 @@ async function runScript() {
 
     // TODO upload to the github directly via API...
 
-    info(`please upload latest.yml and ${binaryFile} to the release!`);
-    // open release page on github
-    if (rebuild) {
-        executeCmd(`start ${githubWebServer}/${organization}/${repository}/releases/edit/${previousTag}`);
-    } else {
-        executeCmd(`start ${githubWebServer}/${organization}/${repository}/releases/new`);
-    }
-    // open dist files directory
-    executeCmd('start dist');
+    const octokit = OctoKit({
+        baseUrl: githubApiServer
+    });
 
+    octokit.authenticate({
+        type: 'token',
+        token: process.env.NAIR_GITHUB_TOKEN_INTERNAL
+    });
+
+    info(`creating release ${newTag}...`);
+    const result = await octokit.repos.createRelease({
+        owner: organization,
+        repo: repository,
+        tag_name: newTag,
+        name: newTag,
+        body: notes,
+        draft,
+        prerelease
+    });
+
+    info(`uploading ${latestYml}...`);
+    const ymlResult = await octokit.repos.uploadAsset({
+        url: result.data.upload_url,
+        file: fs.createReadStream(latestYml),
+        name: path.basename(latestYml),
+        contentLength: fs.statSync(latestYml).size,
+        contentType: 'application/json',
+    });
+    info(`uploading ${binaryFile}...`);
+
+    await octokit.repos.uploadAsset({
+        url: result.data.upload_url,
+        name: binaryFile,
+        file: fs.createReadStream(binaryFilePath),
+        contentLength: fs.statSync(binaryFilePath).size,
+        contentType: 'application/octet-stream',
+    });
+
+    if (draft) {
+        // open release edit page on github
+        const editUrl = result.data.html_url.replace('/tag/', '/edit/');
+        executeCmd(`start ${editUrl}`);
+
+        info(`finally, release Version ${newVersion} on the browser!`);
+    } else {
+        // open release page on github
+        executeCmd(`start ${result.data.html_url}`);
+
+        info(`Version ${newVersion} is released!`);
+    }
     // done.
-    info(`Version ${newVersion} released successfully!`);
 }
 
 runScript().then(() => {

--- a/bin/package.json
+++ b/bin/package.json
@@ -4,7 +4,9 @@
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
   "version": "0.0.1",
-  "dependencies": {},
+  "dependencies": {
+    "@octokit/rest": "^15.9.5"
+  },
   "devDependencies": {
     "7zip-bin": "^2.2.7",
     "aws-sdk": "^2.157.0",

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -22,9 +22,28 @@
     "7zip-bin-mac" "^1.0.1"
     "7zip-bin-win" "^2.1.1"
 
+"@octokit/rest@^15.9.5":
+  version "15.9.5"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-15.9.5.tgz#e356d202bd0b517e381f705ad77d98ccb84e0c65"
+  dependencies:
+    before-after-hook "^1.1.0"
+    btoa-lite "^1.0.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.0"
+    lodash "^4.17.4"
+    node-fetch "^2.1.1"
+    url-template "^2.0.8"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+
+agent-base@4, agent-base@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv@^5.1.0:
   version "5.5.0"
@@ -123,6 +142,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+before-after-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
+
 "binary@>= 0.3.0 < 1":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
@@ -152,6 +175,10 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
 
 buffer@4.9.1:
   version "4.9.1"
@@ -300,6 +327,12 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+debug@3.1.0, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.1.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -323,6 +356,16 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -482,6 +525,13 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -489,6 +539,13 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+https-proxy-agent@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 iconv-lite@^0.4.17:
   version "0.4.19"
@@ -658,6 +715,10 @@ lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.4:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 "match-stream@>= 0.0.2 < 1":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/match-stream/-/match-stream-0.0.2.tgz#99eb050093b34dffade421b9ac0b410a9cfa17cf"
@@ -728,6 +789,10 @@ mute-stream@0.0.7:
 natives@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+
+node-fetch@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 
 nopt@~3.0.1:
   version "3.0.6"
@@ -1157,6 +1222,10 @@ unzip@^0.1.11:
 url-join@0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-0.0.1.tgz#1db48ad422d3402469a87f7d97bdebfe4fb1e3c8"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
 
 url@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
**このpull requestが解決する内容**
従来のリリーススクリプトはファイルを自分で release pageに drag and dropしていたが
自動で github release を作成し、ファイルをuploadするようにした。
また、patch-note.txt というファイルに更新情報を記述する必要があるため、前回リリースタグからのコミットグラフやPRの列をその初期値に生成するようにした。

**動作確認手順**
各種環境変数に署名鍵やトークンを設定し、 `yarn release` で実際にリリースする()