### PR TITLE
Download pageのURLサブドメイン変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/0vvxc20s1re3094d?svg=true)](https://ci.appveyor.com/project/n-air-app/n-air-app)
 
 N AirはStreamlabs OBSをベースにした、生放送に便利な機能が豊富に組み込まれた高画質配信ソフトです。NLE（Niconico Live Encoder）よりも、さらに便利になって生まれ変わりました。
-![N Air](https://site.nicovideo.jp/nicolive/n-air-app/image/screenshot.png)
+![N Air](https://n-air-app.nicovideo.jp/image/screenshot.png)
 
 ## 動作条件
 * DirectX 10.1 互換のGPU
@@ -13,7 +13,7 @@ N AirはStreamlabs OBSをベースにした、生放送に便利な機能が豊�
 * インターネット接続環境が必要です。
 
 ## インストール
-<http://site.nicovideo.jp/nicolive/n-air-app/>
+<https://n-air-app.nicovideo.jp/>
 
 ## ビルド方法
 ### Node.js

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -134,7 +134,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
     if (type === 'browser_source') {
       if (settings.shutdown === void 0) settings.shutdown = true;
-      if (settings.url === void 0) settings.url = 'https://site.nicovideo.jp/nicolive/n-air-app/browser-source/';
+      if (settings.url === void 0) settings.url = 'https://n-air-app.nicovideo.jp/browser-source/';
     }
 
     if (type === 'text_gdiplus') {


### PR DESCRIPTION
**このpull requestが解決する内容**
Download pageのURLサブドメイン変更に伴う以下の3つの作業

1.DownloadページURL変更
  - 旧：http://site.nicovideo.jp/nicolive/n-air-app/
  - 新：https://n-air-app.nicovideo.jp/
2.スクリーンショットURLの変更
  - 旧：https://site.nicovideo.jp/nicolive/n-air-app/image/screenshot.png
  - 新：https://n-air-app.nicovideo.jp/image/screenshot.png
3.ソース追加時のブラウザーソースのsampleで表示されるURLの変更
  - 旧：https://site.nicovideo.jp/nicolive/n-air-app/browser-source/
  - 新：https://n-air-app.nicovideo.jp/browser-source/

**動作確認手順**
#### 1と2
README.mdを表示し、画像とリンクが新しいアドレスになっていることを確認する
ソース追加でブラウザーソース追加を試し、URLを何も変更せずにdone。

#### 3
プレビュー画面に表示されるブラウザー画面に以下のサンプルが表示出ていることを確認する.
<img width="513" alt="44619452-8b0f7280-a8c1-11e8-9865-adf058249ed8" src="https://user-images.githubusercontent.com/3591127/44640156-ff99fc80-a9fa-11e8-8454-9d15e32e34de.png">
