### PR TITLE
番組情報から取得したbitrateを最適化に利用する

### DIFF
--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -3,7 +3,8 @@ import { NiconicoService } from './niconico';
 export type IStreamingSetting = {
   asking: boolean,
   url: string,
-  key: string
+  key: string,
+  bitrate: number | undefined
 }
 
 // All platform services should implement

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -234,15 +234,16 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
             height: 400
           }
         });
-        return { asking: true, url: '', key: '' }; // ダイアログでたから無視してね
+        return { asking: true, url: '', key: '', bitrate: undefined }; // ダイアログでたから無視してね
       }
       if (num < 1) {
-        return { asking: false, url: '', key: '' }; // 番組がない
+        return { asking: false, url: '', key: '', bitrate: undefined }; // 番組がない
       }
       const id = Object.keys(info)[0];
       const selected = info[id];
       const url = selected.url;
       const key = selected.key;
+      const bitrate = selected.bitrate;
       this.userService.updatePlatformChannelId(id);
 
       const settings = this.settingsService.getSettingsFormData('Stream');
@@ -264,7 +265,7 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
       });
       this.settingsService.setSettings('Stream', settings);
 
-      return { asking: false, url, key }; // 有効な番組が選択されているので stream keyを返す
+      return { asking: false, url, key, bitrate }; // 有効な番組が選択されているので stream keyを返す
     });
   }
 
@@ -328,17 +329,6 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
         }
       }
       return r;
-    });
-  }
-
-  fetchBitrate(): Promise<number | undefined> {
-    return this.fetchLiveProgramInfo(this.channelId).then(result => {
-      const status = result.status;
-      console.log('getpublishstatus status=' + status);
-      if (Object.keys(result).length === 1) {
-        return result[Object.keys(result)[0]].bitrate;
-      }
-      return undefined;
     });
   }
 

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -234,10 +234,10 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
             height: 400
           }
         });
-        return { asking: true, url: '', key: '', bitrate: undefined }; // ダイアログでたから無視してね
+        return NiconicoService.emptyStreamingSetting(true); // ダイアログでたから無視してね
       }
       if (num < 1) {
-        return { asking: false, url: '', key: '', bitrate: undefined }; // 番組がない
+        return NiconicoService.emptyStreamingSetting(false); // 番組がない
       }
       const id = Object.keys(info)[0];
       const selected = info[id];
@@ -265,8 +265,18 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
       });
       this.settingsService.setSettings('Stream', settings);
 
-      return { asking: false, url, key, bitrate }; // 有効な番組が選択されているので stream keyを返す
+      // 有効な番組が選択されているので stream keyを返す
+      return NiconicoService.createStreamingSetting(false, url, key, bitrate);
     });
+  }
+
+  private static emptyStreamingSetting(asking: boolean): IStreamingSetting {
+    return NiconicoService.createStreamingSetting(asking, '', '');
+  }
+
+  private static createStreamingSetting(asking: boolean, url: string, key: string, bitrate?: number)
+    : IStreamingSetting {
+    return { asking, url, key, bitrate };
   }
 
   // TODO ニコニコOAuthのtoken更新に使う


### PR DESCRIPTION
**このpull requestが解決する内容**

現行実装では Streaming 設定と 最適化処理のために2回 `getpublishstatus` を呼び出していた問題を解決します。

**動作確認手順**

- ニコニコにログインした状態でビットレートの最適化処理が行われること
- 配信可能な番組が複数ある場合は、選択した番組のビットレートで最適化されること