### PR TITLE
platformがundefinedのときにエラーになる問題を修正

### DIFF
--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -333,7 +333,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }
 
   isNiconicoLoggedIn() {
-    return this.isLoggedIn() && this.platform.type === 'niconico';
+    return this.isLoggedIn() && this.platform && this.platform.type === 'niconico';
   }
 }
 


### PR DESCRIPTION
https://github.com/n-air-app/n-air-app/commit/e9e2a047815a32e01211b61b65267bde308ab823 この変更の際に `UserService.isNiconicoLoggedIn` 内で `platform` の `undefined` チェックをいれ忘れていてエラーが発生しているようなので、チェックコードを追加しました。