### PR TITLE
高度な音声設定の音声遅延を0未満にしようとするとエラーになる問題を修正

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -331,7 +331,7 @@ export class AudioSource implements IAudioSourceApi {
         name: 'syncOffset',
         description: $t('audio.syncOffsetInMs'),
         showDescription: false,
-        type: 'OBS_PROPERTY_INT',
+        type: 'OBS_PROPERTY_UINT',
         visible: true,
         enabled: true,
       },


### PR DESCRIPTION
**このpull requestが解決する内容**

"高度な音声設定" で "Desktop Audio" の "音声遅延" の値を0未満にしようとするとdeveloper tools上でエラーが確認できます。

```
Error in event handler for "input": "IPC request failed: check the errors in the main window"

Expected a time object
```

音声遅延はミリ秒単位なので、0未満を入力できないように修正します。

**動作確認手順**

- "高度な音声設定" を開く
- "Desktop Audio" の "音声遅延" が0の状態で、さらに値を下げようとする（実際には下がらない）
- developer toolでエラーが発生していないことを確認