### PR TITLE
修正: シーンエディタ上で右クリックしたときに対象が未選択だった場合、対象単体が選択されるように変更

### DIFF
--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -151,10 +151,6 @@ export default class StudioEditor extends Vue {
           }
         } else if (event.button === 0) {
           overNode.select();
-        } else if (event.button === 2) {
-          if (!overNode.isSelected()) {
-            overNode.select();
-          }
         }
       } else if (event.button === 0) {
         this.selectionService.reset();
@@ -164,7 +160,9 @@ export default class StudioEditor extends Vue {
       if ((event.button === 2)) {
         let menu: EditMenu;
         if (overSource) {
-          this.selectionService.add(overSource.sceneItemId);
+          if (!overSource.isSelected()) {
+            overSource.select();
+          }
           menu = new EditMenu({
             selectedSceneId: this.scene.id,
             showSceneItemMenu: true,

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -151,6 +151,10 @@ export default class StudioEditor extends Vue {
           }
         } else if (event.button === 0) {
           overNode.select();
+        } else if (event.button === 2) {
+          if (!overNode.isSelected()) {
+            overNode.select();
+          }
         }
       } else if (event.button === 0) {
         this.selectionService.reset();


### PR DESCRIPTION
fixes #59

**このpull requestが解決する内容**
シーンエディター上のアイテムを右クリックしてコンテキストメニューを出すときの選択挙動を改善する。
* 従来挙動: 右クリックしたときに現在の選択状態に加えて右クリックしたアイテムが選択される
* このPRの挙動: クリックしたアイテムが選択されていないときは、他の選択は解除し、そのアイテムだけが選択された状態になる

これにより、右クリックしたアイテムの固有のコンテキストメニューを確実に開くことができる。
複数選択になってしまうと、複数選択グループを扱うコンテキストメニューになってしまう。

**動作確認手順**
1. シーンにソースを複数配置する
2. 何か選択した状態で、選択されていないアイテムを右クリックすると、既存の選択は解除され、右クリックしたアイテムだけが選択状態になってコンテキストメニューが開く。
3. 一つまたは複数選択した状態で、選択したアイテムを右クリックすると、選択状態は変わらずコンテキストメニューが開く。(従来挙動)
4. アイテムが無いところを右クリックすると、選択状態は変わらずコンテキストメニューが開く。(従来挙動)
5. シーンでソース複数をフォルダに入れておく
6. そのフォルダの所属アイテムを(未選択状態から)右クリックすると、そのアイテムだけが選択されてコンテキストメニューが開く。