### PR TITLE
修正: ソースアイテムを削除したらそのプロジェクターウィンドウも閉じる

### DIFF
--- a/app/components/windows/Projector.vue.ts
+++ b/app/components/windows/Projector.vue.ts
@@ -8,6 +8,7 @@ import { ISourcesServiceApi } from 'services/sources';
 import electron from 'electron';
 import Util from 'services/utils';
 import { $t } from 'services/i18n';
+import { Subscription } from 'rxjs/subscription';
 
 @Component({
   components: {
@@ -21,6 +22,20 @@ export default class Projector extends Vue {
 
   fullscreen = false;
   oldBounds: electron.Rectangle;
+
+  sourcesSubscription: Subscription;
+
+  mounted() {
+    this.sourcesSubscription = this.sourcesService.sourceRemoved.subscribe(source => {
+      if (source.sourceId === this.sourceId) {
+        electron.remote.getCurrentWindow().close();
+      }
+    });
+  }
+
+  destroyed() {
+    this.sourcesSubscription.unsubscribe();
+  }
 
   get sourceId() {
     const windowId = Util.getCurrentUrlParams().windowId;


### PR DESCRIPTION
fixes #62 

cherry-pick https://github.com/stream-labs/streamlabs-obs/pull/549

**このpull requestが解決する内容**
ソースアイテムのプロジェクターウィンドウを開いた状態でソースアイテムを削除すると、プロジェクターウィンドウが取り残されてクラッシュの原因となっていた問題を、自動的にプロジェクターウィンドウも閉じることで修正する。

**動作確認手順**
1. ソースアイテムを作成し、コンテキストメニューからプロジェクターウィンドウを開く。
2. そのソースアイテムを削除すると、プロジェクターウィンドウも閉じること。