### PR TITLE
修正: 設定変更時に存在しないデバイスをソースから取り除く

### DIFF
--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -629,6 +629,10 @@ export class SettingsService extends StatefulService<ISettingsState>
       } else if (deviceForm.value !== null) {
 
         const device = audioDevices.find(device => device.id === deviceForm.value);
+        if (device === undefined) {
+          this.sourcesService.removeSource(source.sourceId);
+          return;
+        }
         const displayName = device.id === 'default' ? deviceForm.name : device.description;
 
         if (!source) {


### PR DESCRIPTION
**このpull requestが解決する内容**

「設定」 - 「音声」をひらいたときに認識していたデバイスが選択時に認識できなくなっていた場合にも選択できるので、選択したタイミングでエラーが発生します。
そこで選択時にデバイスが存在するかチェックし、存在しなければソースから取り除くようにします。

備考: 設定を保存しないので `無効` が選択されます

**動作確認手順**

- 「設定」 - 「音声」 - 「デスクトップ音声デバイス1」でPCから切断可能なデバイスを選択
    - 「マイク1」などでも確認できます
- ミキサーに選択したデバイスが表示されていることを確認
    - 表示されないようなら、いったん `無効` を選択してからデバイスを選択しなおすと表示されるようになります
-「デスクトップ音声デバイス1」で `標準` を選択
    - 設定ページは閉じない
- PCからデバイスを切断する
- 「デスクトップ音声デバイス1」で切断したデバイスを選択
- 「デスクトップ音声デバイス1」が `無効` になることを確認
- ミキサーからデバイス表示が消えていることを確認