### PR TITLE
upgrade raven-js (sentry.io) to latest(3.26.4)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7897,8 +7897,8 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
 
 raven-js@^3.20.1:
-  version "3.20.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.20.1.tgz#3170bdb35c05098ddb8548ee5be0687f9d763330"
+  version "3.26.4"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.4.tgz#32aae3a63a9314467a453c94c89a364ea43707be"
 
 rc@^1.0.1, rc@^1.1.6:
   version "1.2.1"


### PR DESCRIPTION
yarn.lock 更新のみなので `yarn install` で反映
影響ないか、内部リリースに入れて様子を見る