### PR TITLE
追加: アップデートが必須でない場合、スキップ可能にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",
     "rimraf": "^2.6.1",
+    "semver": "^5.5.1",
     "socket.io-client": "2.0.3",
     "uuid": "^3.3.2",
     "vue-svg-loader": "^0.5.0"
@@ -111,6 +112,7 @@
     "@types/node": "^8.0.0",
     "@types/proxyquire": "^1.3.28",
     "@types/request": "^2.47.0",
+    "@types/semver": "^5.5.0",
     "@types/sinon": "^5.0.1",
     "@types/socket.io-client": "^1.4.31",
     "@types/urijs": "^1.15.37",

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -57,14 +57,14 @@ class Updater {
     return false;
   }
 
-  textToHtml(text) {
-    return text.split('\n').map(s => `${s}</br>`).join('\n');
+  textToLines(text) {
+    return text.split('\n')
   }
 
   bindListeners() {
     autoUpdater.on('update-available', info => {
       this.updateState.asking = true;
-      this.updateState.releaseNotes = this.textToHtml(info.releaseNotes);
+      this.updateState.releaseNotes = this.textToLines(info.releaseNotes);
       this.updateState.releaseDate = info.releaseDate;
       this.updateState.fileSize = info.files[0].size;
       this.updateState.version = info.version;
@@ -151,6 +151,10 @@ isUnskippable: ${this.updateState.isUnskippable}`);
       }
       if (!this.finished) app.quit();
     });
+
+    if (process.env.NODE_ENV !== 'production') {
+      browserWindow.webContents.openDevTools({ mode: 'undocked' });
+    }
 
     browserWindow.loadURL('file://' + __dirname + '/index.html');
 

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -57,10 +57,14 @@ class Updater {
     return false;
   }
 
+  textToHtml(text) {
+    return text.split('\n').map(s => `${s}</br>`).join('\n');
+  }
+
   bindListeners() {
     autoUpdater.on('update-available', info => {
       this.updateState.asking = true;
-      this.updateState.releaseNotes = info.releaseNotes;
+      this.updateState.releaseNotes = this.textToHtml(info.releaseNotes);
       this.updateState.releaseDate = info.releaseDate;
       this.updateState.fileSize = info.files[0].size;
       this.updateState.version = info.version;
@@ -123,8 +127,9 @@ isUnskippable: ${this.updateState.isUnskippable}`);
 
   initWindow() {
     const browserWindow = new BrowserWindow({
-      width: 600,
-      height: 350,
+      width: 596,
+      height: 369,
+      useContentSize: true,
       title: `${process.env.NAIR_PRODUCT_NAME} - Ver: ${process.env.NAIR_VERSION}`,
       frame: true,
       closable: true,

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -3,6 +3,7 @@
 
 const { autoUpdater } = require('electron-updater');
 const { app, BrowserWindow, ipcMain } = require('electron');
+const semver = require('semver');
 
 class Updater {
   // startApp is a callback that will start the app.  Ideally this
@@ -41,6 +42,21 @@ class Updater {
 
   // PRIVATE
 
+  isUnskippableUpdate(currentVersion, newVersion) {
+    const currentVer = semver.parse(currentVersion);
+    const newVer = semver.parse(newVersion);
+    if (!currentVer || !newVer) {
+      return true;
+    }
+    if (currentVer.major != newVer.major) {
+      return true;
+    }
+    if (currentVer.minor != newVer.minor) {
+      return true;
+    }
+    return false;
+  }
+
   bindListeners() {
     autoUpdater.on('update-available', info => {
       this.updateState.asking = true;
@@ -49,6 +65,10 @@ class Updater {
       this.updateState.fileSize = info.files[0].size;
       this.updateState.version = info.version;
       this.updateState.percent = 0;
+      this.updateState.isUnskippable = this.isUnskippableUpdate(process.env.NAIR_VERSION, info.version);
+      console.log(`oldVersion: ${process.env.NAIR_VERSION}
+newVersion: ${info.version}
+isUnskippable: ${this.updateState.isUnskippable}`);
       this.cancellationToken = info.cancellationToken;
       this.pushState();
     });

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -105,6 +105,7 @@ class Updater {
     const browserWindow = new BrowserWindow({
       width: 600,
       height: 350,
+      title: `${process.env.NAIR_PRODUCT_NAME} - Ver: ${process.env.NAIR_VERSION}`,
       frame: true,
       closable: true,
       resizable: false,

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -103,8 +103,8 @@ class Updater {
 
   initWindow() {
     const browserWindow = new BrowserWindow({
-      width: 400,
-      height: 250,
+      width: 600,
+      height: 350,
       frame: true,
       closable: true,
       resizable: false,

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -61,7 +61,8 @@ export default {
       version: null,
       percentComplete: null,
       releaseNotes: null,
-      releaseDate: null
+      releaseDate: null,
+      isUnskippable: null
     };
   },
   computed: {
@@ -93,7 +94,7 @@ export default {
       this.currentState = 'checking';
       this.version = null,
       this.percentComplete = null;
-      if (data.isUnkippable) {
+      if (data.isUnskippable) {
         this.isUnskippable = data.isUnskippable;
       }
       if (data.version) {

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -4,14 +4,38 @@
     <br place="br" />
     <span place="version">{{ version }}</span>
   </i18n>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="!isError"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="showSpin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
+  <div v-if="isAsking" class="modal-layout-controls">
+    <button
+      class="button button--default"
+      @click="proceedDownload"
+      data-test="Download">
+      {{ $t('asking.download') }}
+    </button>
+    <button
+      class="button"
+      @click="cancel"
+      data-test="Cancel">
+      {{ $t('asking.skip') }}
+    </button>
+    <div v-html="releaseNotes"/>
+  </div>
   <div v-if="isDownloading && percentComplete !== null" class="progressBarContainer">
     <div
       class="progressBar"
       :style="{ width: percentComplete + '%' }"/>
     <div class="progressPercent">
       {{ percentComplete }}%
+    </div>
+
+    <div class="modal-layout-controls">
+      <button
+        class="button"
+        @click="cancel"
+        data-test="Cancel">
+        {{ $t('cancel') }}
+      </button>
     </div>
   </div>
   <div class="issues" v-if="isInstalling || isError">
@@ -32,12 +56,22 @@ export default {
     return {
       currentState: 'checking',
       version: null,
-      percentComplete: null
+      percentComplete: null,
+      releaseNotes: null,
+      releaseDate: null
     };
   },
   computed: {
+    showSpin() {
+      return this.currentState === 'checking' ||
+        this.currentState === 'downloading' ||
+        this.currentState === 'installing';
+    },
     isChecking() {
       return this.currentState === 'checking';
+    },
+    isAsking() {
+      return this.currentState === 'asking';
     },
     isDownloading() {
       return this.currentState === 'downloading';
@@ -57,9 +91,14 @@ export default {
       if (data.version) {
         this.currentState = 'downloading';
         this.version = data.version;
+        this.releaseNotes = data.releaseNotes;
+        this.releaseDate = data.releaseDate;
       }
       if (data.percent) {
         this.percentComplete = Math.floor(data.percent);
+      }
+      if (data.asking) {
+        this.currentState = 'asking';
       }
       if (data.installing) {
         this.currentState = 'installing';
@@ -71,6 +110,13 @@ export default {
     ipcRenderer.send('autoUpdate-getState');
   },
   methods: {
+    proceedDownload() {
+      ipcRenderer.send('autoUpdate-startDownload');
+    },
+    cancel() {
+      this.currentState = '';
+      ipcRenderer.send('autoUpdate-cancelDownload');
+    },
     download() {
       remote.shell.openExternal('https://site.nicovideo.jp/nicolive/n-air-app/');
       remote.app.quit();

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -5,7 +5,7 @@
   </i18n>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="showSpin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
-  <div v-if="isAsking" class="modal-layout-controls">
+  <div v-if="isAsking" class="asking">
     <p class="caption">{{ $t('asking.changeLog') }}</p>
     <div class="patch-notes-wrap">
       <p v-html="releaseNotes" class="patch-notes"/>
@@ -23,32 +23,28 @@
       {{ $t('asking.download') }}
     </button>
   </div>
-  <div v-if="isDownloading && percentComplete !== null" class="progressBarContainer">
-    <div
-      class="progressBar"
-      :style="{ width: percentComplete + '%' }"/>
-    <div class="progressPercent">
-      {{ percentComplete }}%
-    </div>
-
-    <div class="modal-layout-controls">
+  <div v-if="isDownloading && percentComplete !== null" class="downloading">
+    <div class="progressBarContainer">
+      <div
+        class="progressBar"
+        :style="{ width: percentComplete + '%' }"/>
+        <div class="progressPercent">{{ percentComplete }}%</div>
+      </div>
       <button
-        class="button"
+        class="button--dark"
         @click="cancel"
         data-test="Cancel">
         {{ $t('cancel') }}
       </button>
+    <div class="issues" v-if="isInstalling || isError">
+      <i18n :path="`${currentState}.description`">
+        <a class="link" @click="download" place="linkText">
+          {{ $t(`${currentState}.linkText`) }}
+        </a>
+      </i18n>
+    </div>
     </div>
   </div>
-  <div class="issues" v-if="isInstalling || isError">
-    <i18n :path="`${currentState}.description`">
-      <br place="br"/>
-      <a class="link" @click="download" place="linkText">
-        {{ $t(`${currentState}.linkText`) }}
-      </a>
-    </i18n>
-  </div>
-</div>
 </template>
 
 <script>
@@ -120,7 +116,7 @@ export default {
       ipcRenderer.send('autoUpdate-cancelDownload');
     },
     download() {
-      remote.shell.openExternal('https://site.nicovideo.jp/nicolive/n-air-app/');
+      remote.shell.openExternal('https://n-air-app.nicovideo.jp/');
       remote.app.quit();
     }
   }

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -13,7 +13,9 @@
     </p>
     <p class="caption">{{ $t('asking.changeLog') }}</p>
     <div class="patch-notes-wrap">
-      <p v-html="releaseNotes" class="patch-notes"/>
+      <div class="patch-notes">
+        <p v-for="(line,index) in releaseNotes" v-bind:key="index" v-text="line" />
+      </div>
     </div>
     <button v-if="!isUnskippable"
       class="button--dark"

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -1,25 +1,27 @@
 <template>
 <div class="UpdaterWindow">
   <i18n :path="`${currentState}.message`" class="message" v-bind:class="{ error: isError }">
-    <br place="br" />
     <span place="version">{{ version }}</span>
   </i18n>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="showSpin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
   <div v-if="isAsking" class="modal-layout-controls">
+    <p class="caption">{{ $t('asking.changeLog') }}</p>
+    <div class="patch-notes-wrap">
+      <p v-html="releaseNotes" class="patch-notes"/>
+    </div>
     <button
-      class="button button--default"
-      @click="proceedDownload"
-      data-test="Download">
-      {{ $t('asking.download') }}
-    </button>
-    <button
-      class="button"
+      class="button--dark"
       @click="cancel"
       data-test="Cancel">
       {{ $t('asking.skip') }}
     </button>
-    <div v-html="releaseNotes"/>
+    <button
+      class="button--action"
+      @click="proceedDownload"
+      data-test="Download">
+      {{ $t('asking.download') }}
+    </button>
   </div>
   <div v-if="isDownloading && percentComplete !== null" class="progressBarContainer">
     <div
@@ -40,7 +42,7 @@
   </div>
   <div class="issues" v-if="isInstalling || isError">
     <i18n :path="`${currentState}.description`">
-      <br place="br" />
+      <br place="br"/>
       <a class="link" @click="download" place="linkText">
         {{ $t(`${currentState}.linkText`) }}
       </a>

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -10,7 +10,9 @@
     <div class="patch-notes-wrap">
       <p v-html="releaseNotes" class="patch-notes"/>
     </div>
-    <button
+    <p v-if="isUnskippable">必須アップデートです</p>
+    <p v-if="!isUnskippable">スキップ可能なアップデートです</p>
+    <button v-if="!isUnskippable"
       class="button--dark"
       @click="cancel"
       data-test="Cancel">
@@ -30,7 +32,7 @@
         :style="{ width: percentComplete + '%' }"/>
         <div class="progressPercent">{{ percentComplete }}%</div>
       </div>
-      <button
+      <button v-if="!isUnskippable"
         class="button--dark"
         @click="cancel"
         data-test="Cancel">
@@ -82,10 +84,15 @@ export default {
     }
   },
   mounted() {
+    this.isUnskippable = null;
+
     ipcRenderer.on('autoUpdate-pushState', (event, data) => {
       this.currentState = 'checking';
       this.version = null,
       this.percentComplete = null;
+      if (data.isUnkippable) {
+        this.isUnskippable = data.isUnskippable;
+      }
       if (data.version) {
         this.currentState = 'downloading';
         this.version = data.version;

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -6,12 +6,15 @@
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="showSpin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
   <div v-if="isAsking" class="asking">
+    <p class="caption">
+      <span>{{ $t('asking.changeLog') }}</span>
+      <span class="supplement mandatory" v-if="isUnskippable">{{ $t('asking.mandatoryUpdate') }}</span>
+      <span class="supplement" v-if="!isUnskippable">{{ $t('asking.skippableUpdate') }}</span>
+    </p>
     <p class="caption">{{ $t('asking.changeLog') }}</p>
     <div class="patch-notes-wrap">
       <p v-html="releaseNotes" class="patch-notes"/>
     </div>
-    <p v-if="isUnskippable">必須アップデートです</p>
-    <p v-if="!isUnskippable">スキップ可能なアップデートです</p>
     <button v-if="!isUnskippable"
       class="button--dark"
       @click="cancel"

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -21,6 +21,7 @@ const i18n = new VueI18n({
       },
       asking: {
         message: 'There is an update. download?',
+        changeLog: `Change log`,
         download: 'Download',
         skip: 'skip'
       },
@@ -45,6 +46,7 @@ const i18n = new VueI18n({
       },
       asking: {
         message: 'アップデート {version} があります。{br}更新しますか?',
+        changeLog: `更新履歴`,
         download: 'ダウンロードして更新',
         skip: '更新せずに N Air を起動'
       },

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -21,7 +21,7 @@ const i18n = new VueI18n({
       },
       asking: {
         message: 'There is an update. download?',
-        changeLog: `Change log`,
+        changeLog: `Update contents`,
         download: 'Download',
         skip: 'skip'
       },
@@ -46,7 +46,7 @@ const i18n = new VueI18n({
       },
       asking: {
         message: 'アップデート {version} があります。{br}更新しますか?',
-        changeLog: `更新履歴`,
+        changeLog: `更新内容`,
         download: 'ダウンロードして更新',
         skip: '更新せずに N Air を起動'
       },

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -19,6 +19,11 @@ const i18n = new VueI18n({
       checking: {
         message: 'Checking for updates'
       },
+      asking: {
+        message: 'There is an update. download?',
+        download: 'Download',
+        skip: 'skip'
+      },
       downloading: {
         message: 'Downloading version {version}'
       },
@@ -31,11 +36,17 @@ const i18n = new VueI18n({
         message: 'Something went wrong',
         description: 'There was an error updating. Please {linkText}',
         linkText: 'download a fresh installer.'
-      }
+      },
+      cancel: 'Cancel'
     },
     'ja': {
       checking: {
         message: 'アップデート情報を確認しています'
+      },
+      asking: {
+        message: 'アップデート {version} があります。{br}更新しますか?',
+        download: 'ダウンロードして更新',
+        skip: '更新せずに N Air を起動'
       },
       downloading: {
         message: 'バージョン{version}を{br}ダウンロードしています'
@@ -49,7 +60,8 @@ const i18n = new VueI18n({
         message: '問題が発生しました',
         description: 'アップデートに失敗しました。{br}{linkText}',
         linkText: '最新のインストーラーをダウンロードしてください。'
-      }
+      },
+      cancel: 'キャンセル'
     }
   },
   silentTranslationWarn: true

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -22,6 +22,8 @@ const i18n = new VueI18n({
       asking: {
         message: 'There is an update. download?',
         changeLog: `Update contents`,
+        mandatoryUpdate: `Mandatory Update`,
+        skippableUpdate: `Skippable updates`,
         download: 'Download',
         skip: 'skip'
       },
@@ -47,6 +49,8 @@ const i18n = new VueI18n({
       asking: {
         message: 'アップデート {version} があります。{br}更新しますか?',
         changeLog: `更新内容`,
+        mandatoryUpdate: `必須アップデートです`,
+        skippableUpdate: `スキップ可能なアップデートです`,
         download: 'ダウンロードして更新',
         skip: '更新せずに N Air を起動'
       },

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -41,11 +41,25 @@ html {
 }
 
 .caption {
+    display: flex;
+    justify-content: space-between;
     font-size: 16px;
     text-align: left;
     padding: 0;
     margin: 0;
     margin-top: 24px;
+}
+
+.caption .supplement {
+    font-size: 12px;
+    color: #9eeaf9;
+    border: solid 1px #9eeaf9;
+    border-radius: 2px;
+    padding: 2px 4px;
+}
+ .caption .mandatory {
+    color: #ff6952;
+    border: solid 1px #ff6952;
 }
 
 .patch-notes-wrap {

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -13,6 +13,7 @@ body,
 html {
     height: 100%;
 }
+
 .UpdaterWindow {
     height: 100%;
     padding: 24px;
@@ -31,12 +32,65 @@ html {
 .error {
     color: #ff6952;
 }
+
+.asking {
+    width: 546px;
+    padding: 0;
+    text-align: right;
+    z-index: 10;
+}
+
+.caption {
+    font-size: 16px;
+    text-align: left;
+    padding: 0;
+    margin: 0;
+    margin-top: 24px;
+}
+
+.patch-notes-wrap {
+    width: 546px;
+    overflow: hidden;
+    margin-bottom: 16px;
+}
+.patch-notes {
+    font-size: 14px;
+    color: #70A0AF;
+    text-align: left;
+    line-height: 1.7em;
+    width: 564px;
+    height: 160px;
+    padding: 0;
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    box-sizing: border-box;
+}
+.patch-notes a {
+    color: #70A0AF;
+    pointer-events: none;
+    text-decoration: none;
+}
+
+.downloading {
+    margin: 0;
+    position: absolute;
+    width: 546px;
+    left: 50%;
+    top: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+    text-align: right;
+}
+
 .progressBarContainer {
     position: relative;
-    margin-top: 36px;
+    width: 546px;
+    margin-bottom: 16px;
     background-color: #050e18;
-    border-radius: 3px;
+    border-radius: 2px;
     overflow: hidden;
+    text-align: center;
 }
 .progressBar {
     height: 24px;
@@ -55,6 +109,7 @@ html {
 .issues {
     font-size: 12px;
     font-weight: 300;
+    text-align: center;
     padding-top: 24px;
     -webkit-app-region: no-drag;
 }
@@ -87,85 +142,34 @@ html {
     }
 }
 
-.modal-layout-controls {
-  box-shadow: 0 -5px 10px 2px #2F3340;
-  padding: 8px 16px;
-  text-align: right;
-  flex-shrink: 0;
-  z-index: 10;
-}
-
-.caption {
-  font-size: 16px;
-  color: #9eeaf9;
-  text-align: left;
-  padding: 0;
-  margin: 0;
-  margin-top: 24px;
-}
-
-.patch-notes-wrap {
-  width: 514px;
-  overflow: hidden;
-  margin-bottom: 16px;
-}
-.patch-notes {
-  font-size: 14px;
-  color: #70A0AF;
-  text-align: left;
-  line-height: 1.8em;
-  width: 532px;
-  max-height: 160px;
-  padding: 0;
-  margin: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  box-sizing: border-box;
-}
-.patch-notes a {
-  color: #9eeaf9;
-  text-decoration: underline;
-}
-.patch-notes a:hover {
-  text-decoration: none;
+button {
+    display: inline-block;
+    color: #fff;
+    font-size: 12px;
+    padding: 4px 8px;
+    border-radius: 3px;
+    text-align: center;
+    vertical-align: middle;
+    -webkit-user-select: none;
+    white-space: nowrap;
+    margin: 0;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    transition: all .3s ease;
 }
 
 .button--action {
-  display: inline-block;
-  color: #fff;
-  background-color: #ff6952;
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 3px;
-  text-align: center;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  white-space: nowrap;
-  margin: 0;
-  border: none;
-  cursor: pointer;
-  transition: all .3s ease;
+    background-color: #ff6952;
+    margin-left: 16px;
 }
 .button--action:hover {
-  background-color:rgba(#ff6952,.1);
+    background-color:rgba(#fc5035,.25);
 }
 
 .button--dark {
-  display: inline-block;
-  color: #fff;
-  background-color: #37474f;
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 3px;
-  text-align: center;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  white-space: nowrap;
-  margin: 0;
-  border: none;
-  cursor: pointer;
-  transition: all .3s ease;
+    background-color: #050F14;
 }
 .button--dark:hover {
-  background-color:rgba(#37474f,.1);
+    background-color:rgba(#2b383f,.25);
 }

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -19,14 +19,14 @@ html {
     margin: 0;
     background-color: #2F3340;
     color: #9eeaf9;
-    font-size: 18px;
+    font-size: 16px;
     text-align: center;
     -webkit-app-region: no-drag;
     box-sizing: border-box;
 }
 .message {
     color: #9eeaf9;
-    vertical-align: middle
+    vertical-align: middle;
 }
 .error {
     color: #ff6952;
@@ -88,13 +88,84 @@ html {
 }
 
 .modal-layout-controls {
-  /* background-color: @bg-primary; */
   box-shadow: 0 -5px 10px 2px #2F3340;
   padding: 8px 16px;
   text-align: right;
   flex-shrink: 0;
   z-index: 10;
 }
-.modal-layout-controls.button {
-  margin-left: 8px;
+
+.caption {
+  font-size: 16px;
+  color: #9eeaf9;
+  text-align: left;
+  padding: 0;
+  margin: 0;
+  margin-top: 24px;
+}
+
+.patch-notes-wrap {
+  width: 514px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+.patch-notes {
+  font-size: 14px;
+  color: #70A0AF;
+  text-align: left;
+  line-height: 1.8em;
+  width: 532px;
+  max-height: 160px;
+  padding: 0;
+  margin: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+.patch-notes a {
+  color: #9eeaf9;
+  text-decoration: underline;
+}
+.patch-notes a:hover {
+  text-decoration: none;
+}
+
+.button--action {
+  display: inline-block;
+  color: #fff;
+  background-color: #ff6952;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 3px;
+  text-align: center;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  white-space: nowrap;
+  margin: 0;
+  border: none;
+  cursor: pointer;
+  transition: all .3s ease;
+}
+.button--action:hover {
+  background-color:rgba(#ff6952,.1);
+}
+
+.button--dark {
+  display: inline-block;
+  color: #fff;
+  background-color: #37474f;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 3px;
+  text-align: center;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  white-space: nowrap;
+  margin: 0;
+  border: none;
+  cursor: pointer;
+  transition: all .3s ease;
+}
+.button--dark:hover {
+  background-color:rgba(#37474f,.1);
 }

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -7,6 +7,7 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Hiragino Kaku Gothic ProN", "Meiryo", "メイリオ", sans-serif;
     font-weight: 400;
     line-height: 1.5;
+    background-color: #2F3340;
     -webkit-font-smoothing: antialiased;
 }
 body,

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -79,6 +79,10 @@ html {
     overflow-y: auto;
     box-sizing: border-box;
 }
+.patch-notes p {
+    -webkit-margin-before: 0;
+    -webkit-margin-after: 0;
+}
 .patch-notes a {
     color: #70A0AF;
     pointer-events: none;

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -21,7 +21,7 @@ html {
     color: #9eeaf9;
     font-size: 18px;
     text-align: center;
-    -webkit-app-region: drag;
+    -webkit-app-region: no-drag;
     box-sizing: border-box;
 }
 .message {
@@ -85,4 +85,16 @@ html {
     100% {
         transform: rotate(359deg);
     }
+}
+
+.modal-layout-controls {
+  /* background-color: @bg-primary; */
+  box-shadow: 0 -5px 10px 2px #2F3340;
+  padding: 8px 16px;
+  text-align: right;
+  flex-shrink: 0;
+  z-index: 10;
+}
+.modal-layout-controls.button {
+  margin-left: 8px;
 }

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -15,7 +15,6 @@ html {
 }
 
 .UpdaterWindow {
-    height: 100%;
     padding: 24px;
     margin: 0;
     background-color: #2F3340;

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,6 +259,10 @@
     "@types/node" "*"
     "@types/tough-cookie" "*"
 
+"@types/semver@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+
 "@types/shelljs@0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.0.tgz#229c157c6bc1e67d6b990e6c5e18dbd2ff58cff0"
@@ -8587,7 +8591,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 


### PR DESCRIPTION
#50 関連

## TODO ##
* 現状のコードは以下の理由でWIP (まだマージ禁止)です。
    * [x] 必須アップデートのデザインをあてる
    * [x] debugコミットでupdate自体をつぶしたバージョンで、update完了してアプリ継続すると何かのタイマーイベントが残っているらしく、エラーが出る -> debug版限定なのでスルーする

## 動作 ##
* 現在のバージョンと最新のバージョンを比較し、 semver の majorまたはminorが異なるときは必須アップデート扱いになる
* アップデートがあるときにバージョンとリリースノートを表示し、(必須アップデートでなければ)更新するか確認する
    * 更新しないときはそのまま既存アプリ起動
* ダウンロード中もキャンセル可能(必須アップデートでなければ)
    * キャンセルすると既存アプリが起動する
* ウィンドウフレームをつけ、閉じるボタンがある
    * 押すと既存アプリを起動せずに終了する

## ローカル実行方法 ##
https://github.com/koizuka/n-air-app/tree/debug/skip-updater (このブランチから出ている) を取ってきて、これを
`yarn compile && yarn start`

![image](https://user-images.githubusercontent.com/864587/44988370-6b650200-afc5-11e8-9ee1-a70d51cc3bfe.png)
