### PR TITLE
修正: ディスプレイキャプチャの領域指定機能の文言修正

### DIFF
--- a/app/i18n/ja-JP/sources.json
+++ b/app/i18n/ja-JP/sources.json
@@ -55,7 +55,7 @@
   "createSourceProjector": "ソースプロジェクターを作成する",
   "useGoogleFont": "Googleのフォントを使う",
   "unhideAll": "すべて表示する",
-  "interactiveCrop": "画面上でクロップする",
+  "interactiveCrop": "領域を指定してキャプチャする（実験的機能）",
   "selectCroppingArea": "キャプチャする領域をドラッグして指定してください",
   "pressEscapeToCancel": "Escキーでキャンセルします"
 }


### PR DESCRIPTION
実験的な機能であることを明記し、文言をわかりやすくする：
「画面上でクロップする」→「領域を指定してキャプチャする（実験的機能）」

**このpull requestが解決する内容**

**動作確認手順**
