### PR TITLE
修正: アップデータの差分更新が動くようにする

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -63,7 +63,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
     main: {
       componentName: 'Main',
       scaleFactor: 1,
-      title: `N Air - Ver: ${remote.process.env.NAIR_VERSION}`
+      title: `${remote.process.env.NAIR_PRODUCT_NAME} - Ver: ${remote.process.env.NAIR_VERSION}`
     },
     child: {
       componentName: 'Blank',

--- a/main.js
+++ b/main.js
@@ -330,7 +330,7 @@ if (shouldQuit) {
 
 function copyFile(src, dest) {
   if (!fs.existsSync(src)) {
-    console.log(`copyFile: ${src} not found!`);
+    log(`copyFile: ${src} not found!`);
     return;
   }
 
@@ -339,7 +339,7 @@ function copyFile(src, dest) {
   if (fs.existsSync(dest)) {
     const cache = fs.statSync(dest);
     if (stat.size === cache.size && stat.mtime === cache.mtime) {
-      console.log('copyFile: the same file exists. skip.');
+      log('copyFile: the same file exists. skip.');
       return;
     }
   }
@@ -348,7 +348,7 @@ function copyFile(src, dest) {
     fs.copyFileSync(src, dest);
     fs.utimesSync(dest, stat.atime, stat.mtime);
   } catch (e) {
-    console.log(`copyFile Error: ${e.name}: ${e.message}`);
+    log(`copyFile Error: ${e.name}: ${e.message}`);
   }
 }
 
@@ -359,7 +359,7 @@ app.on('ready', () => {
     const nsisInstallerFileName = '__installer.exe';
     const installerPath = path.join(app.getPath('appData'), process.env.NAIR_PRODUCT_NAME, nsisInstallerFileName);
     const cachePath = path.join(app.getPath('userData'), nsisInstallerFileName);
-    console.log(`copying ${installerPath} to ${cachePath}...`);
+    log(`copying ${installerPath} to ${cachePath}...`);
     copyFile(installerPath, cachePath);
 
     (new Updater(startApp)).run();

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ if (pjson.name === 'n-air-app-ipc') {
   process.env.NAIR_IPC = true;
 }
 process.env.NAIR_VERSION = pjson.version;
+process.env.NAIR_PRODUCT_NAME = pjson.build.productName;
 
 if (!process.env.NAIR_LICENSE_API_KEY && pjson.getlicensenair_key) {
   process.env.NAIR_LICENSE_API_KEY = pjson.getlicensenair_key;
@@ -146,7 +147,7 @@ function startApp() {
     height: mainWindowState.height,
     show: false,
     frame: false,
-    title: 'N Air',
+    title: process.env.NAIR_PRODUCT_NAME,
     ...(mainWindowIsVisible ? {
       x: mainWindowState.x,
       y: mainWindowState.y


### PR DESCRIPTION
関連: #50, #75 
**このpull requestが解決する内容**
インストーラとアプリ設定の保存場所が違うため、 electron-updater の差分更新機能が働いていなかった。
既存キャッシュを消すのは辛いので、共存するかたちでアップデータ起動時に必要なファイルをコピーすることで解決する。
(インストール先に統合することも考えたが、キャッシュ削除機能でこれも消えてしまうことになるのでその対処が必要かな)
(あとアプリのタイトルバーのタイトルを package.json から取るようにした)

**動作確認手順(現在の公開版では条件が満たせない)**
0. 最新版が blockmapファイルつきで配布されている状態で
1. 最新より古い、blockmapファイルがあるバージョン()のフルインストーラのファイルを用意する
2. Windows のスタートメニューなどから `%appData%\N Air` と打ち込んで開き、ここにコピーし、 `__installer.exe` にリネームする(アンダースコアは2つ)
3. package.json の version もそのファイルのバージョンに書き換える
4. `yarn compile && NAIR_FORCE_AUTO_UPDATE=1 yarn start`
5. ダウンロードがすぐに終わって更新起動しようとすること。
このときコンソール上には以下のように出る
```
Checking for update
Found version 新バージョン名 (url: 新バージョンのファイル名)
Downloading update from 新バージョンのファイル名
No cached update info available
Download block maps (old: "古いバージョンのblockmapのURL", new: 新バージョンのblockmapのURL)
File has 340 changed blocks
Full: 94,956.94 KB, To download: 7,260.99 KB (8%)
Differential download: 新しいインストーラのURL
New version 新バージョン名 has been downloaded to アプリケーションデータのフォルダ\__update__\新バージョンのファイル名
```