### PR TITLE
追加: ゲームキャプチャソースに案内文追加

### DIFF
--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -96,6 +96,9 @@
       sourceType="game_capture"
       key="11">
       <GameCaptureIcon slot="media" />
+      <p slot="attention-text" class="attention">
+         {{$t('sources.gameCaptureMessage') }}
+      </p>
     </add-source-info>
 
     <add-source-info

--- a/app/i18n/en-US/sources.json
+++ b/app/i18n/en-US/sources.json
@@ -3,6 +3,7 @@
   "addSourceButton": "Add Source",
 
   "windowCaptureMessage": "If you can not capture please turn off hardware acceleration from Google Chrome settings.",
+  "gameCaptureMessage": "Some games may not properly be captured. Try window capture in such case.",
 
   "sourcesWelcomeMessage": "Welcome to sources!",
   "addSourceProcess1": "Browse through our sources",

--- a/app/i18n/ja-JP/sources.json
+++ b/app/i18n/ja-JP/sources.json
@@ -3,6 +3,7 @@
   "addSourceButton": "ソースの追加",
 
   "windowCaptureMessage": "※Google Chromeの場合、設定のハードウェアアクセラレーションが有効だとキャプチャできないことがあります。",
+  "gameCaptureMessage": "※PCゲームの種類によってはキャプチャできない場合があります。その際はウィンドウキャプチャをお試しください。",
 
   "sourcesWelcomeMessage": "ここではシーンに追加するソースを選択できます。",
   "addSourceProcess1": "追加したいソースを下記の中から選んでください。",


### PR DESCRIPTION
**このpull requestが解決する内容**
ゲームキャプチャソースでキャプチャできないゲームがあるので、ウィンドウソースも試すよう案内文追加

日本語
![image](https://user-images.githubusercontent.com/864587/45071111-ae32f100-b10f-11e8-9c9f-33dea352179a.png)

英語
![image](https://user-images.githubusercontent.com/864587/45071394-f4d51b00-b110-11e8-9c0b-64cb67045245.png)

**動作確認手順**
ソース追加でゲームキャプチャを選択