### PR TITLE
修正: 再生数やコメント数がAPIで取れないときに0 に丸め込む

### DIFF
--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -371,13 +371,25 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
   @requiresToken()
   fetchViewerCount(): Promise<number> {
     return this.fetchPlayerStatus()
-      .then(o => o['stream'][0]['watch_count'][0]);
+      .then(o => {
+        try {
+          return o['stream'][0]['watch_count'][0]
+        } catch {
+          return 0;
+        }
+      });
   }
 
   @requiresToken()
   fetchCommentCount(): Promise<number> {
     return this.fetchPlayerStatus()
-      .then(o => o['stream'][0]['comment_count'][0]);
+      .then(o => {
+        try {
+          return o['stream'][0]['comment_count'][0];
+        } catch {
+          return 0;
+        }
+      });
   }
 
   getChatUrl(mode: string): Promise<string> {


### PR DESCRIPTION
sentryに沢山来ていた

**このpull requestが解決する内容**
ニコニコ生放送で、N Airが放送中と認識しているが getplayerstatus APIが failを返している場合に内部エラーが発生していたのを 0に丸める
