### PR TITLE
修正: 文言を「ディスプレイキャプチャ」から「画面キャプチャ」へ修正

### DIFF
--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -214,7 +214,7 @@
   },
   "monitor_capture": {
     "name": "Display Capture",
-    "description": "Capture your entire computer monitor.",
+    "description": "Capture your computer monitor.",
     "capture_cursor": {
       "name": "Capture Cursor"
     },

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -213,13 +213,13 @@
     "name": "Text (FreeType 2)"
   },
   "monitor_capture": {
-    "name": "Display Capture",
+    "name": "Monitor Capture",
     "description": "Capture your computer monitor.",
     "capture_cursor": {
       "name": "Capture Cursor"
     },
     "monitor": {
-      "name": "Display"
+      "name": "Monitor"
     }
   },
   "window_capture": {

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -213,7 +213,7 @@
     "name": "テキスト(FreeType 2)"
   },
   "monitor_capture": {
-    "name": "ディスプレイキャプチャ",
+    "name": "画面キャプチャ",
     "description": "PCの画面全体をキャプチャします。",
     "capture_cursor": {
       "name": "カーソルをキャプチャ"

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -214,7 +214,7 @@
   },
   "monitor_capture": {
     "name": "画面キャプチャ",
-    "description": "PCの画面をキャプチャします。",
+    "description": "ディスプレイの画面全体、もしくは一部の領域をキャプチャします。",
     "capture_cursor": {
       "name": "カーソルをキャプチャ"
     },

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -214,7 +214,7 @@
   },
   "monitor_capture": {
     "name": "画面キャプチャ",
-    "description": "PCの画面全体をキャプチャします。",
+    "description": "PCの画面をキャプチャします。",
     "capture_cursor": {
       "name": "カーソルをキャプチャ"
     },


### PR DESCRIPTION
**このpull requestが解決する内容**
ソース追加時に表示される文言の変更
![displaycapture1](https://user-images.githubusercontent.com/3591127/45250691-86dc5e00-b373-11e8-8e0d-1d850726ea28.PNG)
![displaycapture2](https://user-images.githubusercontent.com/3591127/45250236-e0d82600-b369-11e8-8fa9-4cbc66fed339.PNG)
![displaycapture3](https://user-images.githubusercontent.com/3591127/45250237-e0d82600-b369-11e8-9481-ce98ee2c9152.PNG)


**動作確認手順**
1.言語を日本語にしてN Airを起動
2.ソース追加文言、ソースの名称ダイアログ、ソースのプロパティ文言、ソース一覧の文言をそれぞれ確認する
