### PR TITLE
修正: カスタムURLスキーム "n-air-app" を登録して起動出来るようにする

### DIFF
--- a/app/services/protocol-links.ts
+++ b/app/services/protocol-links.ts
@@ -30,7 +30,7 @@ export class ProtocolLinksService extends Service {
   start(argv: string[]) {
     // Check if this instance was started with a protocol link
     argv.forEach(arg => {
-      if (arg.match(/^nair:\/\//)) this.handleLink(arg);
+      if (arg.match(/^n-air-app:\/\//)) this.handleLink(arg);
     });
 
     // Other instances started with a protocol link will receive this message

--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -35,12 +35,6 @@ const config = {
     rfc3161TimeStampServer: 'http://timestamp.digicert.com/?alg=sha1',
     timeStampServer: 'http://timestamp.digicert.com',
   },
-  protocols: [
-    {
-      name: 'N Air',
-      schemes: ['n-air-app'],
-    },
-  ],
   extraMetadata: {
     env: 'production',
   },

--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -11,19 +11,15 @@ const config = {
     'updater/Updater.js',
     'index.html',
     'main.js',
-    'obs-api'
+    'obs-api',
   ],
-  extraFiles: [
-    'scene-presets',
-    'LICENSE',
-    'AGREEMENT.sjis'
-  ],
+  extraFiles: ['scene-presets', 'LICENSE', 'AGREEMENT.sjis'],
   detectUpdateChannel: false,
   publish: {
     provider: 'generic',
     useMultipleRangeRequest: false,
     channel: 'latest',
-    url: 'https://n-air-app.nicovideo.jp/download/windows'
+    url: 'https://n-air-app.nicovideo.jp/download/windows',
   },
   nsis: {
     license: 'AGREEMENT.sjis',
@@ -32,18 +28,22 @@ const config = {
     allowToChangeInstallationDirectory: true,
     // eslint-disable-next-line no-template-curly-in-string
     artifactName: 'n-air-app-setup.${version}.${ext}',
-    include: 'installer.nsh'
+    include: 'installer.nsh',
   },
   win: {
-    publisherName: [
-      'DWANGO Co.,Ltd.'
-    ],
+    publisherName: ['DWANGO Co.,Ltd.'],
     rfc3161TimeStampServer: 'http://timestamp.digicert.com/?alg=sha1',
-    timeStampServer: 'http://timestamp.digicert.com'
+    timeStampServer: 'http://timestamp.digicert.com',
   },
+  protocols: [
+    {
+      name: 'N Air',
+      schemes: ['n-air-app'],
+    },
+  ],
   extraMetadata: {
-    env: 'production'
-  }
+    env: 'production',
+  },
 };
 
 if (process.env.NAIR_LICENSE_API_KEY) {

--- a/installer.nsh
+++ b/installer.nsh
@@ -1,5 +1,26 @@
+
+!macro registerProtocol Protocol
+  DetailPrint "Register ${Protocol} URI Handler"
+	DeleteRegKey HKCU "Software\Classes\${Protocol}"
+	WriteRegStr HKCU "Software\Classes\${Protocol}" "" "URL:${Protocol}"
+	WriteRegStr HKCU "Software\Classes\${Protocol}" "URL Protocol" ""
+	WriteRegStr HKCU "Software\Classes\${Protocol}\shell" "" ""
+	WriteRegStr HKCU "Software\Classes\${Protocol}\shell\Open" "" ""
+	WriteRegStr HKCU "Software\Classes\${Protocol}\shell\Open\command" "" '"$appExe" "%1"'
+!macroend
+
+!macro unregisterProtocol Protocol
+	DeleteRegKey HKCU "Software\Classes\${Protocol}"
+!macroend
+
 !macro customInstall
   FileOpen $0 "$INSTDIR\installername" w
   FileWrite $0 $EXEFILE
   FileClose $0
+
+  !insertMacro registerProtocol "n-air-app"
+!macroend
+
+!macro customUninstall
+  !insertMacro unregisterProtocol "n-air-app"
 !macroend

--- a/main.js
+++ b/main.js
@@ -352,12 +352,12 @@ if (!gotTheLock) {
   const haDisableFile = path.join(app.getPath('userData'), 'HADisable');
   if (fs.existsSync(haDisableFile)) app.disableHardwareAcceleration();
 
-  app.setAsDefaultProtocolClient('nair');
+  app.setAsDefaultProtocolClient('n-air-app');
 
   app.on('second-instance', (event, argv, cwd) => {
     // Check for protocol links in the argv of the other process
     argv.forEach(arg => {
-      if (arg.match(/^nair:\/\//)) {
+      if (arg.match(/^n-air-app:\/\//)) {
         mainWindow.send('protocolLink', arg);
       }
     });


### PR DESCRIPTION
* [x] スキーム名変更
* [x] installer.nsh にレジストリ追加処理を追加する
    * 参考: https://github.com/electron/electron/blob/64ba8feb9379d9c16ab1473d0abe48ddcd728c45/shell/browser/browser_win.cc#L489

**このpull requestが解決する内容**
`n-air-app://` のリンクからアプリを起動出来るようにする。これによりニコ生配信ページから直接起動したい。

**動作確認手順**
1. 事前にレジストリの `HKEY_CLASSES_ROOT\n-air-app` が(regeditなどで)存在しない状態にする。
2. `yarn package:internal-stable` などでインストーラをビルドし、`dist/` にあるインストーラを起動する。
1. インストーラがカスタムURLスキームを設定したことを確認する
    1. インストーラでインストールするときにアプリを起動するチェックを外して完了させ、アプリを起動せずとも上記レジストリが登録されていること。 
    2. ブラウザで n-air-app://test などを開くと N Air を起動する確認がでること。
1. アプリが起動時にカスタムURLを設定したことを確認する
    1. インストーラでインストールして一回起動した後、ブラウザから `n-air-app://` を開くとN Air が起動すること。
    2. 上記レジストリを削除して再度アプリを起動すると上記レジストリが登録されていること。
1.アンインストール
    1. アンインストールをすると、上記レジストリが削除されること。

**関連issue**
#514 