### PR TITLE
修正: キャッシュ消去時に削除対象から __installer.exe を除外する

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,10 +34,6 @@ const windowStateKeeper = require('electron-window-state');
 
 app.disableHardwareAcceleration();
 
-if (process.argv.includes('--clearCacheDir')) {
-  rimraf.sync(app.getPath('userData'));
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Main Program
 ////////////////////////////////////////////////////////////////////////////////
@@ -46,6 +42,13 @@ function log(...args) {
   if (!process.env.NAIR_DISABLE_MAIN_LOGGING) {
     console.log(...args);
   }
+}
+
+if (process.argv.includes('--clearCacheDir')) {
+  // __installer.exe は electron-updater 差分アップデートの比較元になるので消してはいけない
+  const rmPath = path.join(app.getPath('appData'), 'n-air-app', '!(__installer.exe)');
+  log('clear cache directory!: ', rmPath);
+  rimraf.sync(rmPath);
 }
 
 // Windows


### PR DESCRIPTION
関連: #75 

**このpull requestが解決する内容**
設定のキャッシュ消去をしたときに差分アップデータの基準ファイルまで消していたのを、削除から除外するようにする

**動作確認手順**
1. スタートメニューから `%appData%\n-air-app` で開いたフォルダに __installer.exe があること(無ければ一度インストーラ版アプリを実行すると作成される)
2. `yarn compile && yarn start --clearCacheDir` する
3. (1.) で開いたフォルダに __insaller.exe が残っていること