### PR TITLE
修正: サブモニタをキャプチャしている場合のクロップの動作を改善

### DIFF
--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -47,12 +47,16 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
   startCropping(sceneId: string, sceneItemId: string, sourceId: string) {
     if (this.isCropping) return;
 
-    this.START_CROPPING(sceneId, sceneItemId, sourceId);
-
     const source = this.sourcesService.getSource(sourceId);
     const targetDisplayId = source.getSettings().monitor;
     const displays = electron.remote.screen.getAllDisplays();
     const display = displays[targetDisplayId];
+    if (!display) {
+      console.error('クロップ対象のソースが指定するモニタが存在しません');
+      return;
+    }
+
+    this.START_CROPPING(sceneId, sceneItemId, sourceId);
 
     const windowId = this.windowsService.createOneOffWindow({
       componentName: 'CroppingOverlay',
@@ -95,12 +99,16 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
     const sceneItem = new SceneItem(this.state.sceneId, this.state.sceneItemId, this.state.sourceId);
     const rect = new ScalableRectangle(sceneItem.getRectangle());
 
-    const { width: displayWidth, height: displayHeight } = display.bounds;
-
     const source = sceneItem.getSource();
     const targetDisplayId = source.getSettings().monitor;
     const displays = electron.remote.screen.getAllDisplays();
     const display = displays[targetDisplayId];
+    if (!display) {
+      console.error('クロップ対象のソースが指定するモニタが存在しません');
+      return;
+    }
+
+    const { width: displayWidth, height: displayHeight } = display.bounds;
     const factor = display.scaleFactor;
 
     rect.normalized(() => {

--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -51,7 +51,11 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
   }
 
   startCropping(sceneId: string, sceneItemId: string, sourceId: string) {
-    if (this.isCropping) return;
+    if (this.isCropping) {
+      // 後勝ち
+      this.endCropping();
+      return;
+    }
 
     const source = this.sourcesService.getSource(sourceId);
     const targetDisplayId = source.getSettings().monitor;

--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -23,7 +23,6 @@ interface Area {
 export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptureCroppingServiceState> {
   @Inject() windowsService: WindowsService;
   @Inject() sourcesService: ISourcesServiceApi;
-  timer: number;
 
   private _currentWindow: BrowserWindow | null;
   set currentWindow(windowObj: BrowserWindow | null) {
@@ -85,7 +84,6 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
     this.currentWindow = null;
     if (!this.isCropping) return;
 
-    clearTimeout(this.timer);
     this.END_CROPPING();
     this.CLEAR_WINDOW_ID();
   }

--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -24,7 +24,14 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
   @Inject() windowsService: WindowsService;
   @Inject() sourcesService: ISourcesServiceApi;
   timer: number;
-  currentWindow: BrowserWindow | null;
+
+  private _currentWindow: BrowserWindow | null;
+  set currentWindow(windowObj: BrowserWindow | null) {
+    if (this._currentWindow && !this._currentWindow.isDestroyed()) {
+      this._currentWindow.close();
+    }
+    this._currentWindow = windowObj;
+  }
 
   static initialState = {
     sceneId: null,
@@ -71,16 +78,11 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
     const windowObj = this.windowsService.getWindow(windowId);
     windowObj.on('close', () => this.endCropping());
 
-    if (this.currentWindow && !this.currentWindow.isDestroyed()) {
-      this.currentWindow.close();
-    }
     this.currentWindow = windowObj;
   }
 
   private endCropping() {
-    if (this.currentWindow && !this.currentWindow.isDestroyed()) {
-      this.currentWindow.close();
-    }
+    this.currentWindow = null;
     if (!this.isCropping) return;
 
     clearTimeout(this.timer);

--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -87,14 +87,20 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
   crop(targetArea: Area) {
     if (!this.isCropping) return;
 
+    // 面積がゼロになるとOBS側に触れない像が残るので無視
+    if (targetArea.width === 0 || targetArea.height === 0) {
+      return;
+    }
+
     const sceneItem = new SceneItem(this.state.sceneId, this.state.sceneItemId, this.state.sourceId);
     const rect = new ScalableRectangle(sceneItem.getRectangle());
+
+    const { width: displayWidth, height: displayHeight } = display.bounds;
 
     const source = sceneItem.getSource();
     const targetDisplayId = source.getSettings().monitor;
     const displays = electron.remote.screen.getAllDisplays();
     const display = displays[targetDisplayId];
-    const { width: displayWidth, height: displayHeight } = display.bounds;
     const factor = display.scaleFactor;
 
     rect.normalized(() => {

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -164,10 +164,6 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
     const newWindow = this.windows[windowId] = new BrowserWindow({
       frame: false,
-      x: (options.size && options.size.x) || undefined,
-      y: (options.size && options.size.y) || undefined,
-      width: (options.size && options.size.width) || 400,
-      height: (options.size && options.size.height) || 400,
       title: options.title || 'New Window',
       transparent: options.transparent,
       resizable: options.resizable,
@@ -185,6 +181,15 @@ export class WindowsService extends StatefulService<IWindowsState> {
     }
 
     const indexUrl = remote.getGlobal('indexUrl');
+
+    const width = options.size && typeof options.size.width === 'number' ? options.size.width : 400;
+    const height = options.size && typeof options.size.height === 'number' ? options.size.height : 400;
+    newWindow.setSize(width, height);
+
+    if (options.size && typeof options.size.x === 'number' && typeof options.size.y === 'number') {
+      newWindow.setPosition(options.size.x, options.size.y);
+    }
+
     newWindow.loadURL(`${indexUrl}?windowId=${windowId}`);
 
     return windowId;

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -182,6 +182,8 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
     const indexUrl = remote.getGlobal('indexUrl');
 
+    // サイズ指定をコンストラクタで行うと、メインモニタより大きなウィンドウを作れない
+    // enableLargerThanScreenを指定しても効かなかったので後から明示的に与える
     const width = options.size && typeof options.size.width === 'number' ? options.size.width : 400;
     const height = options.size && typeof options.size.height === 'number' ? options.size.height : 400;
     newWindow.setSize(width, height);

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -188,6 +188,10 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
     if (options.size && typeof options.size.x === 'number' && typeof options.size.y === 'number') {
       newWindow.setPosition(options.size.x, options.size.y);
+
+      // サブモニタの座標がそれぞれ負のときに異常な値になる問題があり
+      // 非同期にもう一回座標を与えてやるといい感じに画面内に収めてくれる
+      setTimeout(() => newWindow.setPosition(options.size.x, options.size.y), 200);
     }
 
     newWindow.loadURL(`${indexUrl}?windowId=${windowId}`);


### PR DESCRIPTION
improvement of #58
ref. #78 

- [x] 既存動作の確認
- [x] 詳細な動作検証

**このpull requestが解決する内容**
サブモニタをキャプチャしている場合に、キャプチャ用オーバレイウィンドウの位置がおかしい問題を修正します。
複雑な問題へのハック的なワークアラウンドを含みます。

**動作確認手順**
- メインモニタのクロップ操作に問題がないこと
- サブモニタのクロップ操作に問題がないこと
    - メイン・サブ間の相対位置がいかなる状態でも動くか
        - サブモニタの左上座標が軸を問わず負の値を取る場合に異常な値が取れる問題があり、 bc762fc のワークアラウンドで対処しているが、十分カバーできているか
    - メイン・サブ間の論理解像度の大小関係を変えても動くか
    - メイン・サブそれぞれのスケーリング倍率がいかなる値でも動くか
 
開発中は画面2枚で検証していたので、3枚以上の動作は未確認