### PR TITLE
修正: 設定のキャッシュクリア・表示ボタンの位置を修正

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -19,11 +19,20 @@
       <label>{{ $t('settings.cacheManagement')}}</label>
     </div>
     <p>{{ $t('settings.cacheClearDescription')}}</p>
+  
+    <a class="button button--action" @click="showCacheDir">
+      {{ $t('settings.showCacheDirectory')}}
+    </a>
+
+    <a class="button button--action" @click="deleteCacheDir">
+      {{ $t('settings.deleteCacheAndRestart') }}
+    </a>
+ 
+ 
     <div class="input-label">
       <label for="cacheId">{{ $t('settings.cacheId')}}</label>
     </div>
     <p>{{ $t('settings.cacheIdDescription')}}</p>
-
 
     <div class="cacheid-view">
         <label>
@@ -36,14 +45,6 @@
         <button class="cacheid-copy" @click="copyToClipboard(cacheId);"><i class="icon-clipboard-copy"/>{{ $t('settings.cacheIdCopy')}}</button>
     </div>
 
-    <a class="button button--action" @click="showCacheDir">
-      {{ $t('settings.showCacheDirectory')}}
-    </a>
-
-    <a class="button button--action" @click="deleteCacheDir">
-      {{ $t('settings.deleteCacheAndRestart') }}
-    </a>
-    
   </div>
 </div>
 </template>


### PR DESCRIPTION
**このpull requestが解決する内容**
設定画面のキャッシュクリアとフォルダ表示ボタンがIDコピーの下にきていて、表示位置がおかしい状態を修正。
![20181001image](https://user-images.githubusercontent.com/3591127/46271422-82c4ea00-c587-11e8-93c6-2a4f63e32afd.png)

※割愛しますがen-USも同様


**動作確認手順**
1.設定画面を開き、キャッシュクリアとキャッシュフォルダの位置が正しいことを確認。
2.念の為、キャッシュクリア、表示が正しく動くことと、ID表示・コピーが動くことを確認する。
