### PR TITLE
修正: デザイン:モーダル部分のスペーシングをシンプルにする

### DIFF
--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -84,19 +84,6 @@
   }
 }
 
-.modal--side-nav {
-  display: flex;
-  align-content: stretch;
-  align-items: stretch;
-  height: 100%;
-}
-
-.modal-container--side-nav {
-  flex-grow: 1;
-  margin: -20px -20px -20px 0;
-  overflow: auto;
-}
-
 .icon-spin {
   animation: icon-spin 2s infinite linear;
 }

--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -6,9 +6,7 @@
     :style="fixedStyle">
     <slot name="fixed"/>
   </div>
-  <div
-    class="modal-layout-content"
-    :style="contentStyle">
+  <div class="modal-layout-content" :class="{ bareContent }">
     <slot name="content" v-if="!loading"/>
     <i class="icon-spinner icon-spin modal-layout-spinner" v-else/>
   </div>
@@ -57,6 +55,12 @@
 .modal-layout-content {
   flex-grow: 1;
   height: 100%;
+  padding: 16px;
+  overflow: auto;
+
+  &.bareContent {
+    padding: 0;
+  }
 }
 
 .modal-layout-spinner {

--- a/app/components/ModalLayout.vue.ts
+++ b/app/components/ModalLayout.vue.ts
@@ -38,9 +38,6 @@ export default class ModalLayout extends Vue {
   // this will just close the window.
   @Prop() cancelHandler: Function;
 
-  // Additional CSS styles for the content section
-  @Prop() contentStyles: Dictionary<string>;
-
   // The height of the fixed section
   @Prop() fixedSectionHeight: number;
 
@@ -51,20 +48,15 @@ export default class ModalLayout extends Vue {
   @Prop({ default: false })
   customControls: boolean;
 
+  /** Contentにpaddingを持たせない場合 */
+  @Prop({ default: false })
+  bareContent: boolean;
 
   created() {
-    const contentStyle = {
-      padding: '16px',
-      overflow: 'auto'
-    };
-
-    Object.assign(contentStyle, this.contentStyles);
-
     const fixedStyle = {
       height: (this.fixedSectionHeight || 0).toString() + 'px'
     };
 
-    this.contentStyle = contentStyle;
     this.fixedStyle = fixedStyle;
 
     electron.remote.getCurrentWindow().setTitle(this.title);

--- a/app/components/shared/NavMenu.vue
+++ b/app/components/shared/NavMenu.vue
@@ -10,11 +10,10 @@
 @import "../../styles/index";
 
 .nav-menu {
-  margin: 0 0 -16px -20px;
+  margin: 0;
   flex: 0 0 220px;
   display: flex;
   flex-direction: column;
-  margin-top: -16px;
   padding-top: 16px;
 }
 

--- a/app/components/windows/Projector.vue
+++ b/app/components/windows/Projector.vue
@@ -8,8 +8,8 @@
   </div>
   <modal-layout
     v-else
+    bare-content
     :title="title"
-    :content-styles="{ padding: 0 }"
     :showControls="false">
     <div slot="content" class="projector-windowed">
       <div class="projector-buttons">

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -1,5 +1,6 @@
 <template>
 <modal-layout
+  bare-content
   :title="$t('common.settings')"
   :show-cancel="false"
   :done-handler="done">
@@ -47,18 +48,27 @@
   align-content: stretch;
   align-items: stretch;
   height: 100%;
+  overflow: hidden;
+}
+
+.side-menu {
+  overflow-y: auto;
 }
 
 .settings-container {
   flex-grow: 1;
-  margin: -20px -20px -20px 0;
-  overflow: auto;
+  margin: 0;
+  overflow-y: auto;
 }
 </style>
 
 <style lang="less">
 @import "../../styles/index";
-/*配信中に設定ダイアログへ表示するメッセージのstyle*/
+
+/*
+配信中に設定ダイアログへ表示するメッセージのstyle
+子コンポーネントのclassを直接参照しているのでscopedにできない
+*/
 .notice-section {
   padding-top: 16px;
 

--- a/app/components/windows/SourceFilters.vue
+++ b/app/components/windows/SourceFilters.vue
@@ -8,7 +8,7 @@
   >
     <display slot="fixed" :sourceId="sourceId" />
 
-    <div slot="content" class="modal--side-nav" data-test="SourceFilters">
+    <div slot="content" class="container" data-test="SourceFilters">
       <NavMenu v-model="selectedFilterName" class="side-menu">
         <div class="controls">
           <i
@@ -44,7 +44,7 @@
 
       </NavMenu>
 
-      <div class="modal-container--side-nav">
+      <div class="content">
         <div v-if="selectedFilterName">
           <GenericForm v-model="properties" @input="save"></GenericForm>
         </div>
@@ -58,14 +58,23 @@
 
 <script lang="ts" src="./SourceFilters.vue.ts"></script>
 
-<style scoped>
+<style lang="less" scoped>
 @import "~sl-vue-tree/dist/sl-vue-tree-dark.css";
 
-.modal-container--side-nav {
+.content {
+  flex-grow: 1;
+  overflow: auto;
   padding: 16px;
 }
 
-.modal--side-nav >>> .sl-vue-tree-toggle {
+.container {
+  display: flex;
+  align-content: stretch;
+  align-items: stretch;
+  height: 100%;
+}
+
+.side-menu > .sl-vue-tree-toggle {
   display: none;
 }
 

--- a/app/components/windows/SourceFilters.vue
+++ b/app/components/windows/SourceFilters.vue
@@ -4,6 +4,7 @@
     :show-cancel="false"
     :done-handler="done"
     :fixedSectionHeight="250"
+    bare-content
   >
     <display slot="fixed" :sourceId="sourceId" />
 

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -228,9 +228,8 @@
 }
 
 .source-group {
-  border-right: 1px solid @border;
-  margin: -20px 0px -20px 0px;
-  padding: 20px 20px 20px 0;
+  margin: 0;
+  padding: 4px;
   flex: 0 0 100%;
 }
 

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -1,7 +1,7 @@
 <template>
 <modal-layout
+  bare-content
   :show-controls="false"
-  :content-styles="{ padding: 0 }"
   :title="$t('sources.addSourceTitle')">
 
   <div slot="content"


### PR DESCRIPTION
**このpull requestが解決する内容**
ModalLayoutのスペーシングをリファクタリングします。
設定画面のスクロールバーが著しくドラッグ操作しづらい問題の解消を狙ったものです。 ref. #103

- スクロールバー自体が細すぎて、ウィンドウのリサイズ操作と干渉してしまう
    - [x] 別Issue化 #121 
- 設定画面の大項目タブ部分と大項目内のスクロールを独立させます。
    - スクロールバーが重なって表示されていて操作が極めて難しかったのを一部解消します。
- ModalLayoutがpaddingを持たなくなるプロパティを新設します。
    - 親のpaddingの数値に合わせて子が負値のmarginを指定していて、暗黙に強い依存がありました

**動作確認手順**
- 設定画面およびソースフィルタ画面のデザインが大きく崩れていないこと
- ~設定画面でスクロールバーが出ているときにマウス操作でスクロールできること~

## スクリーンショット
| - | before | after |
----|----|---- 
| 設定画面 | ![settings-org](https://user-images.githubusercontent.com/950573/46299076-8a15e300-c5db-11e8-83a9-9bd490e07692.PNG) | ![settings-pr](https://user-images.githubusercontent.com/950573/46299077-8a15e300-c5db-11e8-9b91-ce6ac5e50327.PNG) |
| ソース追加画面 | ![sourcesshowcase-org](https://user-images.githubusercontent.com/950573/46299185-c77a7080-c5db-11e8-82ee-ea9988e87f20.PNG) | ![sourcesshowcase-pr](https://user-images.githubusercontent.com/950573/46299197-ccd7bb00-c5db-11e8-99ea-9d4bb1969766.PNG) |


