### PR TITLE
変更: 設定/配信設定に警告を表示しつつ、ログイン中で表示(編集は無効)

### DIFF
--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -24,7 +24,9 @@
       </aside>
       <aside class="notice-section" v-if="categoryName === 'Stream'">
         <p class="notice-message">
-          <i class="icon-warning"/>{{ $t('settings.noticeForStreaming')}}
+          <i class="icon-warning"/><i18n path="settings.noticeForStreaming">
+            <br place="br" />
+          </i18n>
         </p>
       </aside>
 

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -22,6 +22,12 @@
           <i class="icon-warning"/>{{ $t('settings.noticeWhileStreaming')}}
         </p>
       </aside>
+      <aside class="notice-section" v-if="categoryName === 'Stream'">
+        <p class="notice-message">
+          <i class="icon-warning"/>{{ $t('settings.noticeForStreaming')}}
+        </p>
+      </aside>
+
       <extra-settings v-if="categoryName === 'General'" />
       <language-settings v-if="categoryName === 'General'" />
       <hotkeys v-if="categoryName === 'Hotkeys'" />

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -506,6 +506,7 @@
   "cacheIdCopy": "Copy",
   "cacheManagement": "Management of the cache",
   "noticeWhileStreaming": "Some settings cannot be changed while streaming.",
+  "noticeForStreaming": "These settings are filled automatically while logged in to niconico.",
   "showCacheDirectory": "Show Cache Directory",
   "deleteCacheAndRestart": "Delete Cache and Restart",
   "confirmStreamTitleAndGameBeforeGoingLive": "Confirm stream title and game before going live",

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -506,7 +506,7 @@
   "cacheIdCopy": "Copy",
   "cacheManagement": "Management of the cache",
   "noticeWhileStreaming": "Some settings cannot be changed while streaming.",
-  "noticeForStreaming": "These settings are filled automatically while logged in to niconico.",
+  "noticeForStreaming": "These settings are filled automatically{br}while you are logged in to niconico.",
   "showCacheDirectory": "Show Cache Directory",
   "deleteCacheAndRestart": "Delete Cache and Restart",
   "confirmStreamTitleAndGameBeforeGoingLive": "Confirm stream title and game before going live",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -506,6 +506,7 @@
   "cacheIdCopy": "コピーする",
   "cacheManagement": "キャッシュ管理",
   "noticeWhileStreaming": "現在配信中のため、一部の設定は変更できません。",
+  "noticeForStreaming": "niconicoログイン中は、これらの項目はニコニコ生放送用に自動設定されます。",
   "showCacheDirectory": "キャッシュディレクトリを表示",
   "deleteCacheAndRestart": "キャッシュを削除して再起動",
   "confirmStreamTitleAndGameBeforeGoingLive": "ライブになる前にストリームのタイトルとゲームを確認して下さい。",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -506,7 +506,7 @@
   "cacheIdCopy": "コピーする",
   "cacheManagement": "キャッシュ管理",
   "noticeWhileStreaming": "現在配信中のため、一部の設定は変更できません。",
-  "noticeForStreaming": "niconicoログイン中は、これらの項目はニコニコ生放送用に自動設定されます。",
+  "noticeForStreaming": "niconicoにログインしている場合、{br}これらの項目はニコニコ生放送用に自動で設定されます。",
   "showCacheDirectory": "キャッシュディレクトリを表示",
   "deleteCacheAndRestart": "キャッシュを削除して再起動",
   "confirmStreamTitleAndGameBeforeGoingLive": "ライブになる前にストリームのタイトルとゲームを確認して下さい。",


### PR DESCRIPTION
fixes #105 

WIP
* [x] 日本語文言確認
* [x] 英語文言確認

**このpull requestが解決する内容**
* ニコニコログイン中は配信サーバーとストリームキー設定が不要であるということが分かりにくい問題を解決する。
* そのために:
    * ニコニコログイン中であっても、設定の配信タブを消さなくした。
    * 配信タブ上部に、ニコニコログイン中は自動設定される旨を表示する。
    * 配信タブはニコニコログイン中はどの項目も変更できなくする。

日本語
![image](https://user-images.githubusercontent.com/864587/46650532-d82c7700-cbd7-11e8-806f-21d45bebd512.png)

英語
![image](https://user-images.githubusercontent.com/864587/46650770-c3041800-cbd8-11e8-98e0-a0579697d644.png)

**動作確認手順**
* ログイン時と未ログイン時で、設定の配信タブを確認する。
* 上部に、ニコニコログイン中は自動設定される旨の警告ががあること。
* ログイン中は各項目が編集できないこと。
* 設定ウィンドウを出したままログイン・ログアウトしても読み直されること。