### PR TITLE
修正: ログイン中に配信を開始して番組がないと返ってきたら1回リトライ

### DIFF
--- a/app/components/StartStreamingButton.vue
+++ b/app/components/StartStreamingButton.vue
@@ -1,7 +1,7 @@
 <template>
 <button
   class="button button--go-live"
-  :class="{ 'button--soft-warning': getIsRedButton() }"
+  :class="{ 'button--soft-warning': isStreaming }"
   :disabled="isDisabled"
   @click="toggleStreaming"
   data-test="StartStreamingButton"

--- a/app/components/StartStreamingButton.vue.ts
+++ b/app/components/StartStreamingButton.vue.ts
@@ -21,7 +21,7 @@ export default class StartStreamingButton extends Vue {
 
   @Prop() disabled: boolean;
 
-  async toggleStreaming() {
+  toggleStreaming() {
     if (this.streamingService.isStreaming) {
       this.streamingService.toggleStreaming();
       return;
@@ -34,7 +34,15 @@ export default class StartStreamingButton extends Vue {
     return this.streamingService.state.streamingStatus;
   }
 
+  get programFetching() {
+    return this.streamingService.state.programFetching;
+  }
+
   getStreamButtonLabel() {
+    if (this.programFetching) {
+      return $t('streaming.programFetching');
+    }
+
     if (this.streamingStatus === EStreamingState.Live) {
       return $t('streaming.endStream');
     }
@@ -62,16 +70,12 @@ export default class StartStreamingButton extends Vue {
     return $t('streaming.goLive');
   }
 
-  getIsRedButton() {
-    return this.streamingStatus !== EStreamingState.Offline;
-  }
-
   get isStreaming() {
     return this.streamingService.isStreaming;
   }
 
   get isDisabled() {
-    return this.disabled ||
+    return this.disabled || this.programFetching ||
       ((this.streamingStatus === EStreamingState.Starting) && (this.streamingService.delaySecondsRemaining === 0)) ||
       ((this.streamingStatus === EStreamingState.Ending) && (this.streamingService.delaySecondsRemaining === 0));
   }

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -12,6 +12,7 @@
   "optimizedProfileForAverageCpUs": "Optimized profile for average CPUs",
   "optimizedProfileForWeakCpUs": "Optimized profile for weak CPUs",
   "recording": "REC",
+  "programFetching": "FETCHING",
   "endStream": "END STREAM",
   "starting": "STARTING",
   "startingWithDelay": "STARTING %{delaySeconds}s",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -12,6 +12,7 @@
   "optimizedProfileForAverageCpUs": "平均的なCPUに最適化されたプロファイル",
   "optimizedProfileForWeakCpUs": "低性能なCPUに最適化されたプロファイル",
   "recording": "REC",
+  "programFetching": "番組取得中",
   "endStream": "配信終了",
   "starting": "配信開始中",
   "startingWithDelay": "配信開始中 %{delaySeconds}秒",

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -1,0 +1,138 @@
+import test from 'ava';
+import * as Proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+
+const proxyquire = Proxyquire.noCallThru();
+
+function noopDecorator() {
+  return function() {};
+}
+
+function createInject(mockServices: any) {
+  return function Inject(serviceName?: string) {
+    return function (target: Object, key: string) {
+      Object.defineProperty(target, key, {
+        get() {
+          const name = serviceName || key.charAt(0).toUpperCase() + key.slice(1);
+          const serviceInstance = mockServices[name];
+          if (!serviceInstance) throw new Error(`no mock defined for "${name}"`);
+          return serviceInstance;
+        }
+      });
+    };
+  };
+}
+
+function identity<T>(x: T): T {
+  return x;
+}
+
+const getStub = (injectTable = {}) => ({
+  './../stateful-service': {
+    mutation: noopDecorator,
+    '@noCallThru': false
+  },
+  '../../util/injector': {
+    Inject: createInject({
+      StreamingService: {
+        streamingStatusChange: {
+          subscribe() {}
+        }
+      },
+      ...injectTable
+    })
+  },
+  '../streaming': {
+    StreamingService: {}
+  },
+  '../user': {
+    UserService: {}
+  },
+  '../settings': {
+    SettingsService: {}
+  },
+  'services/windows': {
+    WindowsService: {}
+  },
+});
+
+test('get instance', t => {
+  require('../stateful-service')
+    .StatefulService
+    .setupVuexStore({ watch: identity });
+
+  const m = proxyquire('./niconico', getStub());
+  t.truthy(m.NiconicoService.instance);
+});
+
+test('setupStreamSettingsで番組がない場合', async t => {
+  require('../stateful-service')
+    .StatefulService
+    .setupVuexStore({ watch: identity });
+
+  const m = proxyquire('./niconico', getStub());
+  const { instance } = m.NiconicoService;
+  const spy = sinon.spy(() => Promise.resolve({}));
+  instance.fetchLiveProgramInfo = spy;
+
+  const result = await instance.setupStreamSettings()
+  t.falsy(result.url, '空の配信設定を得る');
+  t.false(result.asking, 'ポップアップは出さない');
+  t.true(spy.calledTwice, 'リトライするので2回呼ぶ')
+});
+
+test('setupStreamSettingsで番組がひとつある場合', async t => {
+  require('../stateful-service')
+    .StatefulService
+    .setupVuexStore({ watch: identity });
+
+  const updatePlatformChannelIdStub = sinon.stub();
+  const getSettingsFormDataStub = sinon.stub();
+  const setSettingsStub = sinon.stub();
+
+  getSettingsFormDataStub.returns([
+    {
+      nameSubCategory: 'Untitled',
+      parameters: [
+        { name: 'service', value: '' },
+        { name: 'server', value: '' },
+        { name: 'key', value: '' }
+      ]
+    }
+  ]);
+
+  const injectMap = {
+    UserService: {
+      updatePlatformChannelId: updatePlatformChannelIdStub
+    },
+    SettingsService: {
+      getSettingsFormData: getSettingsFormDataStub,
+      setSettings: setSettingsStub
+    }
+  };
+
+  const m = proxyquire('./niconico', getStub(injectMap));
+
+  const { instance } = m.NiconicoService;
+
+  const fetchLiveProgramInfoStub = sinon.stub();
+  instance.fetchLiveProgramInfo = fetchLiveProgramInfoStub;
+  fetchLiveProgramInfoStub.returns(Promise.resolve({
+    channelId: {
+      url: 'url1',
+      key: 'key1',
+      bitrate: 'bitrate1',
+    }
+  }));
+
+  const result = await instance.setupStreamSettings();
+  t.is(result.url, 'url1', '配信設定を受け取れる');
+  t.true(updatePlatformChannelIdStub.calledOnceWith('channelId'), 'チャンネルIDをUsersServiceに通知する');
+  t.true(setSettingsStub.args[0][0] === 'Stream', '配信設定を更新する');
+
+  const wroteSettings = setSettingsStub.args[0][1];
+  const params = wroteSettings[0].parameters;
+  t.is(params.find((x: any) => x.name === 'service').value, 'niconico ニコニコ生放送');
+  t.is(params.find((x: any) => x.name === 'server').value, 'url1');
+  t.is(params.find((x: any) => x.name === 'key').value, 'key1');
+});

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -5,10 +5,6 @@ import { sleep } from 'util/sleep';
 
 const proxyquire = Proxyquire.noCallThru();
 
-function noopDecorator() {
-  return function() {};
-}
-
 function createInject(mockServices: any) {
   return function Inject(serviceName?: string) {
     return function (target: Object, key: string) {
@@ -24,15 +20,7 @@ function createInject(mockServices: any) {
   };
 }
 
-function identity<T>(x: T): T {
-  return x;
-}
-
 const getStub = (injectTable = {}) => ({
-  './../stateful-service': {
-    mutation: noopDecorator,
-    '@noCallThru': false
-  },
   '../../util/injector': {
     Inject: createInject({
       StreamingService: {
@@ -46,50 +34,31 @@ const getStub = (injectTable = {}) => ({
   '../../util/sleep': {
     sleep: () => sleep(0),
   },
-  '../streaming': {
-    StreamingService: {}
-  },
-  '../user': {
-    UserService: {}
-  },
-  '../settings': {
-    SettingsService: {}
-  },
-  'services/windows': {
-    WindowsService: {}
-  },
+  '../streaming': {},
+  '../user': {},
+  '../settings': {},
+  'services/windows': {},
 });
 
 test('get instance', t => {
-  require('../stateful-service')
-    .StatefulService
-    .setupVuexStore({ watch: identity });
-
   const m = proxyquire('./niconico', getStub());
   t.truthy(m.NiconicoService.instance);
 });
 
 test('setupStreamSettingsで番組がない場合', async t => {
-  require('../stateful-service')
-    .StatefulService
-    .setupVuexStore({ watch: identity });
-
   const m = proxyquire('./niconico', getStub());
   const { instance } = m.NiconicoService;
-  const spy = sinon.spy(() => Promise.resolve({}));
-  instance.fetchLiveProgramInfo = spy;
+  const fetchLiveProgramInfoStub = sinon.stub();
+  fetchLiveProgramInfoStub.returns(Promise.resolve({}));
+  instance.fetchLiveProgramInfo = fetchLiveProgramInfoStub;
 
   const result = await instance.setupStreamSettings()
   t.falsy(result.url, '空の配信設定を得る');
   t.false(result.asking, 'ポップアップは出さない');
-  t.true(spy.calledTwice, 'リトライするので2回呼ぶ')
+  t.true(fetchLiveProgramInfoStub.calledTwice, 'リトライするので2回呼ぶ')
 });
 
 test('setupStreamSettingsで番組がひとつある場合', async t => {
-  require('../stateful-service')
-    .StatefulService
-    .setupVuexStore({ watch: identity });
-
   const updatePlatformChannelIdStub = sinon.stub();
   const getSettingsFormDataStub = sinon.stub();
   const setSettingsStub = sinon.stub();
@@ -142,10 +111,6 @@ test('setupStreamSettingsで番組がひとつある場合', async t => {
 });
 
 test('setupStreamSettingsで番組取得にリトライで成功する場合', async t => {
-  require('../stateful-service')
-    .StatefulService
-    .setupVuexStore({ watch: identity });
-
   const updatePlatformChannelIdStub = sinon.stub();
   const getSettingsFormDataStub = sinon.stub();
   const setSettingsStub = sinon.stub();
@@ -199,10 +164,6 @@ test('setupStreamSettingsで番組取得にリトライで成功する場合', a
 });
 
 test('setupStreamSettingsで番組が複数ある場合', async t => {
-  require('../stateful-service')
-    .StatefulService
-    .setupVuexStore({ watch: identity });
-
   const updatePlatformChannelIdStub = sinon.stub();
   const getSettingsFormDataStub = sinon.stub();
   const setSettingsStub = sinon.stub();

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import * as Proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
+import { sleep } from 'util/sleep';
 
 const proxyquire = Proxyquire.noCallThru();
 
@@ -41,6 +42,9 @@ const getStub = (injectTable = {}) => ({
       },
       ...injectTable
     })
+  },
+  '../../util/sleep': {
+    sleep: () => sleep(0),
   },
   '../streaming': {
     StreamingService: {}

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -140,3 +140,122 @@ test('setupStreamSettingsで番組がひとつある場合', async t => {
   t.is(params.find((x: any) => x.name === 'server').value, 'url1');
   t.is(params.find((x: any) => x.name === 'key').value, 'key1');
 });
+
+test('setupStreamSettingsで番組取得にリトライで成功する場合', async t => {
+  require('../stateful-service')
+    .StatefulService
+    .setupVuexStore({ watch: identity });
+
+  const updatePlatformChannelIdStub = sinon.stub();
+  const getSettingsFormDataStub = sinon.stub();
+  const setSettingsStub = sinon.stub();
+
+  getSettingsFormDataStub.returns([
+    {
+      nameSubCategory: 'Untitled',
+      parameters: [
+        { name: 'service', value: '' },
+        { name: 'server', value: '' },
+        { name: 'key', value: '' }
+      ]
+    }
+  ]);
+
+  const injectMap = {
+    UserService: {
+      updatePlatformChannelId: updatePlatformChannelIdStub
+    },
+    SettingsService: {
+      getSettingsFormData: getSettingsFormDataStub,
+      setSettings: setSettingsStub
+    }
+  };
+
+  const m = proxyquire('./niconico', getStub(injectMap));
+
+  const { instance } = m.NiconicoService;
+
+  const fetchLiveProgramInfoStub = sinon.stub();
+  instance.fetchLiveProgramInfo = fetchLiveProgramInfoStub;
+  fetchLiveProgramInfoStub.onCall(0).returns(Promise.resolve({}));
+  fetchLiveProgramInfoStub.returns(Promise.resolve({
+    channelId: {
+      url: 'url1',
+      key: 'key1',
+      bitrate: 'bitrate1',
+    }
+  }));
+
+  const result = await instance.setupStreamSettings();
+  t.is(result.url, 'url1', '配信設定を受け取れる');
+  t.true(updatePlatformChannelIdStub.calledOnceWith('channelId'), 'チャンネルIDをUsersServiceに通知する');
+  t.true(setSettingsStub.args[0][0] === 'Stream', '配信設定を更新する');
+
+  const wroteSettings = setSettingsStub.args[0][1];
+  const params = wroteSettings[0].parameters;
+  t.is(params.find((x: any) => x.name === 'service').value, 'niconico ニコニコ生放送');
+  t.is(params.find((x: any) => x.name === 'server').value, 'url1');
+  t.is(params.find((x: any) => x.name === 'key').value, 'key1');
+});
+
+test('setupStreamSettingsで番組が複数ある場合', async t => {
+  require('../stateful-service')
+    .StatefulService
+    .setupVuexStore({ watch: identity });
+
+  const updatePlatformChannelIdStub = sinon.stub();
+  const getSettingsFormDataStub = sinon.stub();
+  const setSettingsStub = sinon.stub();
+  const showWindowStub = sinon.stub();
+
+  getSettingsFormDataStub.returns([
+    {
+      nameSubCategory: 'Untitled',
+      parameters: [
+        { name: 'service', value: '' },
+        { name: 'server', value: '' },
+        { name: 'key', value: '' }
+      ]
+    }
+  ]);
+
+  const injectMap = {
+    UserService: {
+      updatePlatformChannelId: updatePlatformChannelIdStub
+    },
+    SettingsService: {
+      getSettingsFormData: getSettingsFormDataStub,
+      setSettings: setSettingsStub
+    },
+    WindowsService: {
+      showWindow: showWindowStub
+    }
+  };
+
+  const m = proxyquire('./niconico', getStub(injectMap));
+
+  const { instance } = m.NiconicoService;
+
+  const fetchLiveProgramInfoStub = sinon.stub();
+  instance.fetchLiveProgramInfo = fetchLiveProgramInfoStub;
+  const info = {
+    channelId1: {
+      url: 'url1',
+      key: 'key1',
+      bitrate: 'bitrate1',
+    },
+    channelId2: {
+      url: 'url2',
+      key: 'key2',
+      bitrate: 'bitrate2',
+    }
+  };
+  fetchLiveProgramInfoStub.returns(Promise.resolve(info));
+
+  const result = await instance.setupStreamSettings();
+  t.deepEqual(showWindowStub.args[0][0].queryParams, info, 'ポップアップに番組設定を渡す');
+  t.falsy(result.url, '空の配信設定を受け取る');
+  t.true(result.asking, 'ポップアップを出す');
+  t.true(updatePlatformChannelIdStub.notCalled, 'チャンネルIDは通知しない');
+  t.true(setSettingsStub.notCalled, '配信設定は更新しない');
+});

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -3,6 +3,7 @@ import { IPlatformService, IStreamingSetting } from '.';
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
+import { sleep } from 'util/sleep';
 import { handleErrors, requiresToken, authorizedHeaders } from '../../util/requests';
 import { UserService } from '../user';
 import { Builder, parseString } from 'xml2js';
@@ -226,7 +227,7 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
       return result;
     } catch (e) {
       // APIのレスポンスに番組状態が反映されるのが遅れる場合があるので、少し待ってリトライ
-      await new Promise(done => setTimeout(done, 3000));
+      await sleep(3000);
     }
 
     try {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -1,4 +1,4 @@
-import { StatefulService, mutation } from './../stateful-service';
+import { Service } from './../service';
 import { IPlatformService, IStreamingSetting } from '.';
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
@@ -10,8 +10,6 @@ import { Builder, parseString } from 'xml2js';
 import { StreamingService, EStreamingState } from '../streaming';
 import { WindowsService } from 'services/windows';
 
-interface INiconicoServiceState {
-}
 export type INiconicoProgramSelection = {
   info: LiveProgramInfo
   selectedId: string
@@ -118,7 +116,7 @@ class GetPublishStatusResult {
   }
 }
 
-export class NiconicoService extends StatefulService<INiconicoServiceState> implements IPlatformService {
+export class NiconicoService extends Service implements IPlatformService {
 
   @Inject() hostsService: HostsService;
   @Inject() settingsService: SettingsService;
@@ -129,9 +127,6 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
   authWindowOptions: Electron.BrowserWindowConstructorOptions = {
     width: 800,
     height: 800,
-  };
-
-  static initialState: INiconicoServiceState = {
   };
 
   getUserKey(): Promise<string> {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -230,7 +230,8 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
     }
 
     try {
-      return this._setupStreamSettings(programId);
+      const result = await this._setupStreamSettings(programId);
+      return result;
     } catch (e) {
       // リトライは1回だけ
       return NiconicoService.emptyStreamingSetting(false);

--- a/app/services/streaming/streaming-api.ts
+++ b/app/services/streaming/streaming-api.ts
@@ -16,6 +16,7 @@ export enum ERecordingState {
 }
 
 export interface IStreamingServiceState {
+  programFetching: boolean;
   streamingStatus: EStreamingState;
   streamingStatusTime: string;
   recordingStatus: ERecordingState;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -60,6 +60,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   powerSaveId: number;
 
   static initialState = {
+    programFetching: false,
     streamingStatus: EStreamingState.Offline,
     streamingStatusTime: new Date().toISOString(),
     recordingStatus: ERecordingState.Offline,
@@ -110,6 +111,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     console.log('Start Streaming button: platform=' + JSON.stringify(this.userService.platform));
     if (this.userService.isNiconicoLoggedIn()) {
       try {
+        this.SET_PROGRAM_FETCHING(true);
         const setting = await this.userService.updateStreamSettings(programId);
         if (setting.asking) {
           return;
@@ -150,6 +152,8 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
             done => resolve(done)
           );
         });
+      } finally {
+        this.SET_PROGRAM_FETCHING(false);
       }
     }
     this.toggleStreaming();
@@ -406,6 +410,11 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
 
       alert(errorText);
     }
+  }
+
+  @mutation()
+  private SET_PROGRAM_FETCHING(status: boolean) {
+    this.state.programFetching = status;
   }
 
   @mutation()

--- a/app/util/sleep.ts
+++ b/app/util/sleep.ts
@@ -1,3 +1,3 @@
-export function sleep (timeout: number) {
+export function sleep (timeout: number): Promise<void> {
   return new Promise(done => setTimeout(done, timeout));
 }

--- a/app/util/sleep.ts
+++ b/app/util/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep (timeout: number) {
+  return new Promise(done => setTimeout(done, timeout));
+}


### PR DESCRIPTION
**このpull requestが解決する内容**
resolve #102 

- [x] 3秒待っているが十分遅延を吸収するか確認
  - ユニットテストで動作は確認した（実地で改善してなかったらまた対処を考える）
- [x] 演出改善
  - 操作してからの待ち時間がリトライ分伸びるので、配信開始ボタンの操作が受理されていることを演出すべき

**動作確認手順**
- 番組を作って配信開始ボタンを押したら、そのまま配信を始められること。
- APIへの反映遅延がある場合は、初回のリクエストで失敗して、リトライすること。
  - リトライである程度成功する範囲に待ち時間を定めたい
- ログインして番組を作らずに配信開始ボタンを押したら、1回だけリトライして失敗すること