### PR TITLE
修正: サイドチェーンのトリガー一覧にソースの名前を表示する

### DIFF
--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -1,7 +1,8 @@
 import { Service } from './service';
 import {
   TFormData, getPropertiesFormData, setPropertiesFormData, IListOption,
-  TObsValue
+  TObsValue,
+  IListInput
 } from '../components/shared/forms/Input';
 import { Inject } from '../util/injector';
 import { SourcesService } from './sources';
@@ -195,7 +196,21 @@ export class SourceFiltersService extends Service {
 
   getPropertiesFormData(sourceId: string, filterName: string): TFormData {
     if (!filterName) return [];
-    return getPropertiesFormData(this.getObsFilter(sourceId, filterName));
+    const formData = getPropertiesFormData(this.getObsFilter(sourceId, filterName));
+
+    // Show SLOBS frontend display names for the sidechain source options
+    formData.forEach(input => {
+      if (input.name === 'sidechain_source') {
+        (input as IListInput<string>).options.forEach(option => {
+          if (option.value === 'none') return;
+
+          const source = this.sourcesService.getSourceById(option.value);
+          if (source) option.description = source.name;
+        });
+      }
+    });
+
+    return formData;
   }
 
 

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -198,7 +198,7 @@ export class SourceFiltersService extends Service {
     if (!filterName) return [];
     const formData = getPropertiesFormData(this.getObsFilter(sourceId, filterName));
 
-    // Show SLOBS frontend display names for the sidechain source options
+    // サイドチェーンのトリガーにする音声ソースがIDしかもらえないので、名前に変換する
     formData.forEach(input => {
       if (input.name === 'sidechain_source') {
         (input as IListInput<string>).options.forEach(option => {


### PR DESCRIPTION
**このpull requestが解決する内容**
cherry-pick of https://github.com/stream-labs/streamlabs-obs/pull/628

**動作確認手順**
動画ソースあたりの音声のあるソースを追加し、サイドチェーンフィルターを刺す。
「サイドチェーン／ダッキングソース」のリストを展開して、IDの文字列ではなくミキサーに出ているような名前が出てくること