### PR TITLE
変更: アップデートのダウンロード元を東京に変更し、ダウンロードの待ち時間を短縮

### DIFF
--- a/bin/mini-release.js
+++ b/bin/mini-release.js
@@ -77,7 +77,7 @@ async function uploadS3File(name, filePath) {
     const upload = new AWS.S3.ManagedUpload({
       params: {
         Bucket: process.env.RELEASE_S3_BUCKET_NAME,
-        Key: name,
+        Key: `windows/${name}`,
         Body: stream
       },
       queueSize: 1

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "detectUpdateChannel": false,
     "publish": {
       "provider": "generic",
+      "useMultipleRangeRequest": false,
       "channel": "latest",
       "url": "https://n-air-app.nicovideo.jp/download/windows"
     },

--- a/package.json
+++ b/package.json
@@ -48,12 +48,11 @@
       "LICENSE",
       "AGREEMENT.sjis"
     ],
+    "detectUpdateChannel": false,
     "publish": {
-      "provider": "github",
-      "owner": "n-air-app",
-      "repo": "n-air-app",
-      "host": "github.com",
-      "releaseType": "draft"
+      "provider": "generic",
+      "channel": "latest",
+      "url": "https://n-air-app.nicovideo.jp/download/windows"
     },
     "nsis": {
       "license": "AGREEMENT.sjis",


### PR DESCRIPTION
**このpull requestが解決する内容**
現在のN Airでは新バージョンのリリース時に配布元としてgithub releasesを使用していますが、github releasesが使用しているAWSのs3バケットはus-east-1(バージニア北部)リージョンに存在しており、ダウンロードが太平洋を越えて行われるため遅く、長時間待たされてしまう場合があるという問題がありました。

このPRによって、アップデートのダウンロード元をap-northeast-1(東京)リージョンに作成した自前のs3バケットへ移行し、アップデートのダウンロードにかかる時間を短縮します。