### PR TITLE
修正:最適化項目にビットレート制御(CBR)を追加 / 最適化ウィンドウの高さ自動計算

### DIFF
--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -28,6 +28,7 @@ export function getBestSettingsForNiconico(options: { bitrate: number }): Optimi
 
     return {
         outputMode: 'Advanced',
+        rateControl: 'CBR',
         videoBitrate: (options.bitrate - audioBitrate),
         audioBitrate: audioBitrate.toString(10),
         quality: quality,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -3,6 +3,7 @@ import { ISettingsSubCategory } from './settings-api';
 
 export enum OptimizationKey {
     outputMode = 'outputMode',
+    rateControl = 'rateControl',
     videoBitrate = 'videoBitrate',
     audioBitrate = 'audioBitrate',
     quality = 'quality',
@@ -20,11 +21,12 @@ export enum OptimizationKey {
 // OptimizationKey のキーと完全対応していること
 export type OptimizeSettings = {
     outputMode?: 'Simple' | 'Advanced'
+    rateControl?: 'CBR' | 'VBR' | 'ABR' | 'CRF'
     videoBitrate?: number
     audioBitrate?: string
     quality?: string
     colorSpace?: string
-    fpsType?: 'Common FPS Values'| 'Integer FPS Value'| 'Fractional FPS Value'
+    fpsType?: 'Common FPS Values' | 'Integer FPS Value' | 'Fractional FPS Value'
     fpsCommon?: string
     encoder?: 'obs_x264' | 'obs_qsv11'
     keyframeInterval?: number
@@ -61,20 +63,6 @@ const definitionParams: DefinitionParam[] = [
             value: 'Advanced',
             params: [
                 {
-                    key: OptimizationKey.videoBitrate,
-                    category: CategoryName.output,
-                    subCategory: 'Streaming',
-                    setting: 'bitrate',
-                    label: 'settings.videoBitrate',
-                },
-                {
-                    key: OptimizationKey.audioBitrate,
-                    category: CategoryName.output,
-                    subCategory: 'Audio - Track 1',
-                    setting: 'Track1Bitrate',
-                    label: 'settings.audioBitrate',
-                },
-                {
                     key: OptimizationKey.encoder,
                     category: CategoryName.output,
                     subCategory: 'Streaming',
@@ -83,6 +71,25 @@ const definitionParams: DefinitionParam[] = [
                     dependents: [{
                         value: 'obs_x264',
                         params: [
+                            {
+                                key: OptimizationKey.rateControl,
+                                category: CategoryName.output,
+                                subCategory: 'Streaming',
+                                setting: 'rate_control',
+                                lookupValueName: true,
+                                dependents: [{
+                                    value: 'CBR',
+                                    params: [
+                                        {
+                                            key: OptimizationKey.videoBitrate,
+                                            category: CategoryName.output,
+                                            subCategory: 'Streaming',
+                                            setting: 'bitrate',
+                                            label: 'settings.videoBitrate',
+                                        },
+                                    ]
+                                }]
+                            },
                             {
                                 key: OptimizationKey.encoderPreset,
                                 category: CategoryName.output,
@@ -120,6 +127,13 @@ const definitionParams: DefinitionParam[] = [
                     category: CategoryName.output,
                     subCategory: 'Streaming',
                     setting: 'TrackIndex',
+                },
+                {
+                    key: OptimizationKey.audioBitrate,
+                    category: CategoryName.output,
+                    subCategory: 'Audio - Track 1',
+                    setting: 'Track1Bitrate',
+                    label: 'settings.audioBitrate',
                 },
             ]
         }]

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -19,6 +19,7 @@ import { CustomizationService } from 'services/customization';
 import { StreamInfoService }from 'services/stream-info';
 import { UserService } from 'services/user';
 import { IStreamingSetting } from '../platforms';
+import { OptimizedSettings } from 'services/settings/optimizer';
 
 enum EOBSOutputType {
   Streaming = 'streaming',
@@ -216,6 +217,24 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     }
   }
 
+  // 最適化ウィンドウの高さを計算する
+  private calculateOptimizeWindowSize(settings: OptimizedSettings): number {
+    const windowHeader = 6 + 20 + 1;
+    const descriptionLabel = 22.4 + 12;
+    const doNotShowCheck = 28 + 12;
+    const contentOverhead = 16;
+    const modalControls = 8 + 36 + 8;
+    const categoryOverhead = 22.4 + 4 + 8 + 8 + 12;
+    const lineHeight = 20.8;
+
+    const overhead = windowHeader + descriptionLabel + doNotShowCheck + contentOverhead + modalControls;
+
+    const numCategories = settings.info.length;
+    const numLines = settings.info.reduce((sum, tuple) => sum + tuple[1].length, 0);
+    const height = overhead + numCategories * categoryOverhead + numLines * lineHeight;
+    return Math.floor(height); // floorしないと死ぬ
+  }
+
   private async optimizeForNiconico(streamingSetting: IStreamingSetting) {
     if (streamingSetting.bitrate === undefined) {
       return new Promise(resolve => {
@@ -240,7 +259,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           queryParams: settings,
           size: {
             width: 500,
-            height: 600
+            height: this.calculateOptimizeWindowSize(settings)
           }
         });
       } else {


### PR DESCRIPTION
**このpull requestが解決する内容**
#163 の問題3を解決するため、ビットレート制御も最適化対象項目に追加し、CBRを指定します。
![image](https://user-images.githubusercontent.com/864587/47155591-0de00700-d320-11e8-876d-b5a14dfd225b.png)

それと最適化ウィンドウの高さを自動計算するようにもしました。

**動作確認手順**
設定でストリーミングの `ビットレート制御` を `CBR` 以外に指定したり、ビットレートを変更した上で最適化をする。
(確認用のデバッグコミットは #162 の debugブランチのコミットをcherry-pickするなり...)