### PR TITLE
修正: getplayerstatusのHTTPエラーおよびネットワークエラーを間引く(エラー調査用)

### DIFF
--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -20,6 +20,8 @@ function parseXml(xml: String): Promise<object> {
   return new Promise((resolve, reject) => {
     parseString(xml, (err, result) => {
       if (err) {
+        // sentryに送る
+        console.error(err, xml);
         reject(err);
       } else {
         resolve(result);

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -372,11 +372,7 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
   fetchViewerCount(): Promise<number> {
     return this.fetchPlayerStatus()
       .then(o => {
-        try {
-          return o['stream'][0]['watch_count'][0]
-        } catch {
-          return 0;
-        }
+        return o['stream'][0]['watch_count'][0]
       });
   }
 
@@ -384,11 +380,7 @@ export class NiconicoService extends StatefulService<INiconicoServiceState> impl
   fetchCommentCount(): Promise<number> {
     return this.fetchPlayerStatus()
       .then(o => {
-        try {
-          return o['stream'][0]['comment_count'][0];
-        } catch {
-          return 0;
-        }
+        return o['stream'][0]['comment_count'][0];
       });
   }
 

--- a/app/services/stream-info.ts
+++ b/app/services/stream-info.ts
@@ -13,6 +13,7 @@ interface IStreamInfoServiceState {
 }
 
 const PLATFORM_STATUS_UPDATE_INTERVAL = 60 * 1000;
+const SENTRY_REPORTING_RATIO = 0.10;
 
 /**
  * The stream info service is responsible for keeping
@@ -40,11 +41,21 @@ export class StreamInfoService extends StatefulService<IStreamInfoServiceState> 
 
         platform.fetchViewerCount().then(viewers => {
           this.SET_VIEWER_COUNT(viewers);
+        }, e => {
+          // Sentryに送信する量を間引く
+          if (Math.random() < SENTRY_REPORTING_RATIO) {
+            console.error(e);
+          }
         });
 
         if (platform instanceof NiconicoService) {
           platform.fetchCommentCount().then(comments => {
             this.SET_COMMENT_COUNT(comments);
+          }, e => {
+            // Sentryに送信する量を間引く
+            if (Math.random() < SENTRY_REPORTING_RATIO) {
+              console.error(e);
+            }
           });
         }
       }


### PR DESCRIPTION
**このpull requestが解決する内容**
気付くべきエラーが発生した場合には気づけるように、かつ邪魔な情報は見なくて済むように、間引きます
resolve https://github.com/n-air-app/n-air-app/issues/107 
related to https://github.com/n-air-app/n-air-app/issues/109

**動作確認手順**
- fetchPlayerStatusが失敗するように変更してログイン状態での配信を確認し、エラーが1割に間引かれること
