### PR TITLE
修正: SceneCollectionのmanifestファイル読み込み失敗を収集(エラー調査用)

### DIFF
--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -55,6 +55,14 @@ export class SceneCollectionsStateService extends StatefulService<
       }
     } catch (e) {
       console.warn('Error loading manifest file from disk');
+      // 存在しない場合はそのまま初期化してよいのでスルー
+
+      // 存在しない以外の理由で失敗する場合は上書きしてしまうので問題がある
+      if (e.code !== 'ENOENT') {
+        console.error('Error loading manifest file from disk : %o', e);
+
+        // TODO: 上書き確認をする https://github.com/n-air-app/n-air-app/pull/180
+      }
     }
 
     await this.flushManifestFile();


### PR DESCRIPTION
**このpull requestが解決する内容**
ref. #180 
マニフェストファイルの読み込み失敗をそもそも収集できていなかった。倒しきるために情報収集する

**動作確認手順**
`%AppData%\n-air-app\SceneCollections\manifest.json` をJSONとして破壊したりしてエラーログが出ること