### PR TITLE
修正: ニコニコ生放送最適化の設定書き込みを確実にするためにリトライ

### DIFF
--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -42,7 +42,7 @@ export default class OptimizeNiconico extends Vue {
   }
 
   optimizeAndGoLive() {
-    this.settingsService.optimizeForNiconico(this.settings.delta);
+    this.settingsService.optimizeForNiconico(this.settings.best);
     this.streamingService.toggleStreaming();
     this.windowsService.closeChildWindow();
   }

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -267,7 +267,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           }
         });
       } else {
-        this.settingsService.optimizeForNiconico(settings.delta);
+        this.settingsService.optimizeForNiconico(settings.best);
         this.toggleStreaming();
       }
     } else {


### PR DESCRIPTION
fixes #193 
**このpull requestが解決する内容**
ニコニコ生放送設定最適化を実行したはずなのに設定が正しくできていないとおぼしき現象報告があるため、現象確認のため、更新できていなければ書き込みを再度書き込むようにしてみる(合計3回まで)。
また、リトライの度に console.error として設定できなかった項目を書くことで、 Sentryに送信されるようにしてみる。
fixes #193 
**動作確認手順**
https://github.com/koizuka/n-air-app/tree/debug/optimizer ブランチのコミットを付けるとAPIを叩かずに配信開始ボタンで(最適化が走る。また、 optimizeForNiconico メソッドの中で opt.optimize(best); をコメントアウトすると書き込まないため、これによって失敗時の挙動が確認できる。