### PR TITLE
修正: リリーススクリプトで GitHubにアップロード時の切断エラーをリトライする

### DIFF
--- a/bin/mini-release.js
+++ b/bin/mini-release.js
@@ -474,13 +474,15 @@ async function runScript() {
         const MAX_RETRY = 3;
         for (let retry = 0; retry < MAX_RETRY; ++retry) {
             try {
-                return await octokit.repos.uploadAsset({
+                const result = await octokit.repos.uploadAsset({
                     url,
                     name,
                     file: fs.createReadStream(pathname),
                     contentLength: fs.statSync(pathname).size,
                     contentType
                 });
+                info('done.');
+                return result;
             } catch (e) {
                 if ('code' in e && 'status' in e) {
                     error(`${e.name}: '${e.message}', code = ${e.code}, status = ${e.status}`);


### PR DESCRIPTION
**このpull requestが解決する内容**
`yarn release` 時に GitHub へのupload途中で切断されると従来は手でリカバーしないといけなかったが、リトライして続行するようにする。(github.comでは全然遭遇しないが、ドワンゴ社内サーバーがよくこける...)
ついでに `enableUploadTo*` フラグを定義して動作確認しやすくする。

**動作確認手順**
社内GitHubではエラーが発生するまで無理矢理アップロード続けるように書き換えて検証したので
レビューはソース目視(reformatコミットなどは分けてあるので主に真ん中のコミット)で...