### PR TITLE
WIP: renderer側の初期化中エラーを表示・記録する

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -154,6 +154,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
+  }).catch(e => {
+    console.error(e);
+    remote.dialog.showErrorBox(
+      'N Air - Error',
+      '初期化中にエラーが発生しました。\n' +
+      'An error occured in initialize sequence.\n' +
+      e.message);
   });
 
   // Used for replacing the contents of this window with

--- a/app/util/quit.ts
+++ b/app/util/quit.ts
@@ -1,0 +1,15 @@
+
+import { ipcRenderer, remote } from 'electron';
+
+export function relaunch({ clearCacheDir }: { clearCacheDir?: boolean } = {}) {
+  const originalArgs: string[] = remote.process.argv.slice(1);
+  // キャッシュクリアしたいときだけつくようにする
+  const args = clearCacheDir
+    ? originalArgs.concat('--clearCacheDir')
+    : originalArgs.filter(x => x !== '--clearCacheDir');
+  ipcRenderer.send('restartApp', args);
+}
+
+export function quit() {
+  ipcRenderer.send('quitApp');
+}

--- a/main.js
+++ b/main.js
@@ -250,7 +250,10 @@ function startApp() {
 
   ipcMain.on('services-ready', () => {
     callService('AppService', 'setArgv', process.argv);
-    childWindow.loadURL(`${global.indexUrl}?windowId=child`);
+
+    if (childWindow && !childWindow.isDestroyed()) {
+      childWindow.loadURL(`${global.indexUrl}?windowId=child`);
+    }
   });
 
   ipcMain.on('window-childWindowIsReadyToShow', () => {

--- a/main.js
+++ b/main.js
@@ -578,12 +578,13 @@ ipcMain.on('getUniqueId', event => {
   event.returnValue = uuid();
 });
 
-ipcMain.on('restartApp', () => {
-  // prevent unexpected cache clear
-  const args = process.argv.slice(1).filter(x => x !== '--clearCacheDir');
-
-  app.relaunch( {args} );
+ipcMain.on('restartApp', (e, args) => {
+  app.relaunch(args ? { args } : undefined);
   // Closing the main window starts the shut down sequence
+  mainWindow.close();
+});
+
+ipcMain.on('quitApp', () => {
   mainWindow.close();
 });
 


### PR DESCRIPTION
**このpull requestが解決する内容**
mainプロセス側ではuncaughtExceptionを拾っているが、renderer側では同等のイベントがなく、非同期に発生したエラーを拾えない。
同期処理中のエラーでも、利用者へのフィードバックがなく、何も表示されないまま終了している可能性がある。
renderer側の初期化中に発生するエラーをcatchし、ダイアログを出すことで異常を通知する。ついでにログを送る。

利用が続行できる可能性を否定できないので、アプリケーションは終了しない選択肢を用意する。

- [ ] 英語文言
- [ ] ヘルプへの誘導（そもそもするかしないか含めて）

**動作確認手順**
適当にthrowを仕込む（異常系なので困る）