### PR TITLE
追加: パフォーマンス情報の定期取得を無効にする設定を追加

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -19,7 +19,7 @@
       <label>{{ $t('settings.cacheManagement')}}</label>
     </div>
     <p>{{ $t('settings.cacheClearDescription')}}</p>
-  
+
     <a class="button button--action" @click="showCacheDir">
       {{ $t('settings.showCacheDirectory')}}
     </a>
@@ -27,8 +27,7 @@
     <a class="button button--action" @click="deleteCacheDir">
       {{ $t('settings.deleteCacheAndRestart') }}
     </a>
- 
- 
+
     <div class="input-label">
       <label for="cacheId">{{ $t('settings.cacheId')}}</label>
     </div>
@@ -44,7 +43,12 @@
         </label>
         <button class="cacheid-copy" @click="copyToClipboard(cacheId);"><i class="icon-clipboard-copy"/>{{ $t('settings.cacheIdCopy')}}</button>
     </div>
+  </div>
 
+  <div class="section">
+    <BoolInput
+      :value="pollingPerformanceStatisticsModel"
+      @input="setPollingPerformanceStatistics" />
   </div>
 </div>
 </template>

--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -49,6 +49,7 @@
     <BoolInput
       :value="pollingPerformanceStatisticsModel"
       @input="setPollingPerformanceStatistics" />
+    <p>{{ $t('settings.pollingPerformanceStatisticsDescription') }}</p>
   </div>
 </div>
 </template>

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -67,6 +67,18 @@ export default class ExtraSettings extends Vue {
     this.customizationService.setShowOptimizationDialogForNiconico(model.value);
   }
 
+  get pollingPerformanceStatisticsModel(): IFormInput<boolean> {
+    return {
+      name: 'polling_performance_statistics',
+      description: $t('settings.pollingPerformanceStatistics'),
+      value: this.customizationService.pollingPerformanceStatistics
+    };
+  }
+
+  setPollingPerformanceStatistics(model: IFormInput<boolean>) {
+    this.customizationService.setPollingPerformanceStatistics(model.value);
+  }
+
   showCacheDir() {
     electron.remote.shell.showItemInFolder(
       electron.remote.app.getPath('userData')

--- a/app/components/PerformanceMetrics.vue.ts
+++ b/app/components/PerformanceMetrics.vue.ts
@@ -7,6 +7,7 @@ import { SettingsService } from '../services/settings';
 import { Inject } from '../util/injector';
 import { $t } from 'services/i18n';
 import { Component } from 'vue-property-decorator';
+import { CustomizationService } from 'services/customization';
 
 @Component({})
 export default class PerformanceMetrics extends Vue {
@@ -15,6 +16,7 @@ export default class PerformanceMetrics extends Vue {
   @Inject() userService: UserService;
   @Inject() streamInfoService: StreamInfoService;
   @Inject() settingsService: SettingsService;
+  @Inject() customizationService: CustomizationService;
 
   visitorTooltip = $t('common.numberOfVisitors');
   commentTooltip = $t('common.numberOfComments');
@@ -36,6 +38,7 @@ export default class PerformanceMetrics extends Vue {
   }
 
   get frameRate() {
+    if (!this.customizationService.pollingPerformanceStatistics) return '--';
     return this.performanceService.state.frameRate.toFixed(2);
   }
 
@@ -61,16 +64,19 @@ export default class PerformanceMetrics extends Vue {
   }
 
   get droppedFrames() {
+    if (!this.customizationService.pollingPerformanceStatistics) return '--';
     return this.performanceService.state.numberDroppedFrames;
   }
 
   get percentDropped() {
+    if (!this.customizationService.pollingPerformanceStatistics) return '--';
     return (this.performanceService.state.percentageDroppedFrames || 0).toFixed(
       1
     );
   }
 
   get bandwidth() {
+    if (!this.customizationService.pollingPerformanceStatistics) return '--';
     return this.performanceService.state.bandwidth.toFixed(0);
   }
 

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -564,5 +564,5 @@
   "keyframeInterval": "Keyframe Interval (in seconds)",
   "encoderPreset": "Encoder Preset",
   "pollingPerformanceStatistics": "Activate performance statistics(bitrate, FPS, dropped frames)",
-  "pollingPerformanceStatisticsDescription": "If the streaming is unstable, try to disable this option."
+  "pollingPerformanceStatisticsDescription": "If the streaming is unstable, try disabling this option."
 }

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -563,5 +563,6 @@
   "audioBitrate": "Audio Bitrate (kbps)",
   "keyframeInterval": "Keyframe Interval (in seconds)",
   "encoderPreset": "Encoder Preset",
-  "pollingPerformanceStatistics": "Activate performance statistics"
+  "pollingPerformanceStatistics": "Activate performance statistics(bitrate, FPS, dropped frames)",
+  "pollingPerformanceStatisticsDescription": "If the streaming is unstable, try to disable this option."
 }

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -563,5 +563,5 @@
   "audioBitrate": "Audio Bitrate (kbps)",
   "keyframeInterval": "Keyframe Interval (in seconds)",
   "encoderPreset": "Encoder Preset",
-  "pollingPerformanceStatistics": "activate performance statistics"
+  "pollingPerformanceStatistics": "Activate performance statistics"
 }

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -562,5 +562,6 @@
   "videoBitrate": "Video Bitrate (kbps)",
   "audioBitrate": "Audio Bitrate (kbps)",
   "keyframeInterval": "Keyframe Interval (in seconds)",
-  "encoderPreset": "Encoder Preset"
+  "encoderPreset": "Encoder Preset",
+  "pollingPerformanceStatistics": "activate performance statistics"
 }

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -563,5 +563,6 @@
   "audioBitrate": "音声ビットレート  (kbps)",
   "keyframeInterval": "キーフレーム間隔(秒)",
   "encoderPreset": "エンコーダープリセット",
-  "pollingPerformanceStatistics": "パフォーマンス統計情報を取得する"
+  "pollingPerformanceStatistics": "パフォーマンス統計情報（ビットレート・FPS・ドロップフレーム数）を取得する",
+  "pollingPerformanceStatisticsDescription": "配信が不安定な場合は無効にしてみてください。"
 }

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -562,5 +562,6 @@
   "videoBitrate": "映像ビットレート  (kbps)",
   "audioBitrate": "音声ビットレート  (kbps)",
   "keyframeInterval": "キーフレーム間隔(秒)",
-  "encoderPreset": "エンコーダープリセット"
+  "encoderPreset": "エンコーダープリセット",
+  "pollingPerformanceStatistics": "パフォーマンス統計情報を取得する"
 }

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -6,6 +6,7 @@ export interface ICustomizationServiceState {
   studioControlsOpened: boolean;
   optimizeForNiconico: boolean;
   showOptimizationDialogForNiconico: boolean;
+  pollingPerformanceStatistics: boolean;
   experimental: any;
 }
 

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -26,6 +26,7 @@ export class CustomizationService
     showOptimizationDialogForNiconico: true,
     experimental: {
       // put experimental features here
+      pollingPerformanceStatistics: true
     }
   };
 
@@ -66,6 +67,14 @@ export class CustomizationService
 
   setShowOptimizationDialogForNiconico(optimize: boolean) {
     this.setSettings({ showOptimizationDialogForNiconico: optimize });
+  }
+
+  get pollingPerformanceStatistics() {
+    return this.state.experimental.pollingPerformanceStatistics;
+  }
+
+  setPollingPerformanceStatistics(activate: boolean) {
+    this.setSettings({ experimental: { pollingPerformanceStatistics: activate } });
   }
 
   getSettingsFormData(): TFormData {

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -24,9 +24,9 @@ export class CustomizationService
     studioControlsOpened: true,
     optimizeForNiconico: true,
     showOptimizationDialogForNiconico: true,
+    pollingPerformanceStatistics: true,
     experimental: {
       // put experimental features here
-      pollingPerformanceStatistics: true
     }
   };
 
@@ -70,11 +70,11 @@ export class CustomizationService
   }
 
   get pollingPerformanceStatistics() {
-    return this.state.experimental.pollingPerformanceStatistics;
+    return this.state.pollingPerformanceStatistics;
   }
 
   setPollingPerformanceStatistics(activate: boolean) {
-    this.setSettings({ experimental: { pollingPerformanceStatistics: activate } });
+    this.setSettings({ pollingPerformanceStatistics: activate });
   }
 
   getSettingsFormData(): TFormData {

--- a/app/services/performance.ts
+++ b/app/services/performance.ts
@@ -2,8 +2,10 @@ import Vue from 'vue';
 import { Subject } from 'rxjs/Subject';
 
 import { StatefulService, mutation } from './stateful-service';
+import { CustomizationService } from 'services/customization';
 import { nodeObs } from './obs-api';
 import electron from 'electron';
+import { Inject } from 'util/injector';
 
 interface IPerformanceState {
   CPU: number;
@@ -17,6 +19,8 @@ interface IPerformanceState {
 
 // Keeps a store of up-to-date performance metrics
 export class PerformanceService extends StatefulService<IPerformanceState> {
+  @Inject()
+  customizationService: CustomizationService;
 
   static initialState: IPerformanceState = {
     CPU: 0,
@@ -30,7 +34,7 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
   private intervalId: number;
 
   @mutation()
-  SET_PERFORMANCE_STATS(stats: IPerformanceState) {
+  SET_PERFORMANCE_STATS(stats: Partial<IPerformanceState>) {
     Object.keys(stats).forEach(stat => {
       Vue.set(this.state, stat, stats[stat]);
     });
@@ -38,16 +42,7 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
 
   init() {
     this.intervalId = window.setInterval(() => {
-      const stats: IPerformanceState = nodeObs.OBS_API_getPerformanceStatistics();
-      if (stats.percentageDroppedFrames) {
-        this.droppedFramesDetected.next(stats.percentageDroppedFrames / 100);
-      }
-
-      stats.CPU = electron.remote.app.getAppMetrics().map(proc => {
-        return proc.cpu.percentCPUUsage;
-      }).reduce((sum, usage) => sum + usage);
-
-      this.SET_PERFORMANCE_STATS(stats);
+      this.updateStatistics();
     }, 2 * 1000);
   }
 
@@ -56,4 +51,25 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
     this.SET_PERFORMANCE_STATS(PerformanceService.initialState);
   }
 
+  private getStatistics(): Partial<IPerformanceState> {
+    if (this.customizationService.pollingPerformanceStatistics) {
+      return nodeObs.OBS_API_getPerformanceStatistics();
+    }
+
+    return {};
+  }
+
+  private updateStatistics(): void {
+    const stats = this.getStatistics();
+
+    if (stats.percentageDroppedFrames) {
+      this.droppedFramesDetected.next(stats.percentageDroppedFrames / 100);
+    }
+
+    stats.CPU = electron.remote.app.getAppMetrics().map(proc => {
+      return proc.cpu.percentCPUUsage;
+    }).reduce((sum, usage) => sum + usage);
+
+    this.SET_PERFORMANCE_STATS(stats);
+  }
 }

--- a/app/services/performance/index.ts
+++ b/app/services/performance/index.ts
@@ -1,0 +1,1 @@
+export *  from './performance';

--- a/app/services/performance/performance.test.ts
+++ b/app/services/performance/performance.test.ts
@@ -1,0 +1,130 @@
+import test from 'ava';
+import * as Proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import { merge } from 'lodash';
+
+const proxyquire = Proxyquire.noCallThru();
+
+function noop() {}
+
+function noopDecorator() {
+  return function() {};
+}
+
+function identity<T>(x: T): T {
+  return x;
+}
+
+function createInject(mockServices = {}) {
+  return function Inject(serviceName?: string) {
+    return function (target: Object, key: string) {
+      Object.defineProperty(target, key, {
+        get() {
+          const name = serviceName || key.charAt(0).toUpperCase() + key.slice(1);
+          const serviceInstance = mockServices[name];
+          if (!serviceInstance) throw new Error(`no mock defined for "${name}"`);
+          return serviceInstance;
+        }
+      });
+    };
+  };
+}
+
+function getStub({injectees = {}, stubs = {}}) {
+  return merge({
+    'services/stateful-service': {
+      mutation: noopDecorator,
+      '@noCallThru': false
+    },
+    'util/injector': {
+      Inject: createInject(injectees)
+    },
+    'services/obs-api': {},
+    'services/settings': {},
+    'services/customization': {},
+    'vue': {},
+    'electron': {}
+  }, stubs);
+}
+
+const createInjectees = ({
+  pollingPerformanceStatistics = true,
+} = {}) => ({
+  CustomizationService: {
+    pollingPerformanceStatistics
+  }
+});
+
+const createStubs = ({
+  OBS_API_getPerformanceStatistics = noop,
+} = {}) => ({
+  'services/obs-api': {
+    nodeObs: {
+      OBS_API_getPerformanceStatistics
+    }
+  }
+});
+
+function getModule(injectees = createInjectees(), stubs = createStubs()) {
+  return proxyquire('./performance', getStub({injectees, stubs}));
+}
+
+function setupStatefulService(state = {}) {
+  require('services/stateful-service')
+    .StatefulService
+    .setupVuexStore({ watch: identity, state });
+}
+
+test.beforeEach('setIntervalをstub化', t => {
+  const setInterval = sinon.stub();
+  (global as any).setInterval = setInterval;
+  t.context.setInterval = setInterval;
+});
+
+test.afterEach.always('setIntervalをrestore', t => {
+  delete (global as any).setInterval;
+});
+
+test('get instance', t => {
+  setupStatefulService()
+  const m = getModule();
+  t.truthy(m.PerformanceService.instance, 'インスタンスが取れる');
+});
+
+test('getStatisticsでpollingPerformanceStatisticsがtrueの場合', t => {
+  setupStatefulService();
+
+  const OBS_API_getPerformanceStatistics = sinon.stub().returns('obs result');
+  const pollingPerformanceStatistics = true;
+
+  const m = getModule(createInjectees({
+    pollingPerformanceStatistics
+  }), createStubs({
+    OBS_API_getPerformanceStatistics
+  }));
+
+  const { instance } = m.PerformanceService;
+  const result = instance.getStatistics();
+
+  t.true(OBS_API_getPerformanceStatistics.calledOnce, 'OBSのAPIを呼んでいる');
+  t.is('obs result', result, 'OBSのAPIを呼んだ結果が返ってくる');
+});
+
+test('getStatisticsでpollingPerformanceStatisticsがfalseの場合', t => {
+  setupStatefulService();
+
+  const OBS_API_getPerformanceStatistics = sinon.stub().returns('obs result');
+  const pollingPerformanceStatistics = false;
+
+  const m = getModule(createInjectees({
+    pollingPerformanceStatistics
+  }), createStubs({
+    OBS_API_getPerformanceStatistics
+  }));
+
+  const { instance } = m.PerformanceService;
+  const result = instance.getStatistics();
+
+  t.true(OBS_API_getPerformanceStatistics.notCalled, 'OBSのAPIを呼ばない');
+  t.deepEqual({}, result, '空のオブジェクトが返ってくる');
+});

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -1,9 +1,9 @@
 import Vue from 'vue';
 import { Subject } from 'rxjs/Subject';
 
-import { StatefulService, mutation } from './stateful-service';
+import { StatefulService, mutation } from 'services/stateful-service';
 import { CustomizationService } from 'services/customization';
-import { nodeObs } from './obs-api';
+import { nodeObs } from 'services/obs-api';
 import electron from 'electron';
 import { Inject } from 'util/injector';
 
@@ -41,9 +41,9 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
   }
 
   init() {
-    this.intervalId = window.setInterval(() => {
+    this.intervalId = setInterval(() => {
       this.updateStatistics();
-    }, 2 * 1000);
+    }, 2 * 1000) as any;
   }
 
   stop() {


### PR DESCRIPTION
**このpull requestが解決する内容**
パフォーマンス情報の定期取得を無効にする設定を追加します。
多くのエラーがこの取得を行うなかで発生しているようなので、回避する手段を提供します。
初期値は有効です。

|無効状態|有効状態|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/48775984-ef4fa000-ed11-11e8-840e-72f2591dbb16.png)|![image](https://user-images.githubusercontent.com/950573/48775936-d21ad180-ed11-11e8-86da-681283035c75.png)|

今のところ設定画面のここに設定項目を置いていますが、他にいい場所があれば……
![default](https://user-images.githubusercontent.com/950573/49014124-5feb3680-f1c2-11e8-95e3-a1c1f8bf4d52.PNG)

**動作確認手順**
- 設定画面から状態を変更してフッターの表示が変わることを確認する
- その状態が保存されることを確認する
