### PR TITLE
【WIP】新しいソースを追加した際に自動でキャンバスに収まる最大サイズまで拡縮するように変更

### DIFF
--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -53,7 +53,8 @@ export default class AddSource extends Vue {
       alert($t('sources.circularReferenceMessage'));
       return;
     }
-    this.scenesService.activeScene.addSource(this.selectedSourceId);
+    const addedItem = this.scenesService.activeScene.addSource(this.selectedSourceId);
+    addedItem.fitToScreen();
     this.close();
   }
 
@@ -80,7 +81,7 @@ export default class AddSource extends Vue {
       this.scenesService.activeScene.addSource(source.sourceId);
 
       this.close();
-      if (source.hasProps()) this.sourcesService.showSourceProperties(source.sourceId);
+      if (source.hasProps()) this.sourcesService.showSourceProperties(source.sourceId, true);
     }
   }
 

--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -9,6 +9,7 @@ import ModalLayout from 'components/ModalLayout.vue';
 import Selector from 'components/Selector.vue';
 import Display from 'components/shared/Display.vue';
 import { $t } from 'services/i18n';
+import autoFitToScreen from '../../util/autoFitToScreen'
 
 @Component({
   components: { ModalLayout, Selector, Display },
@@ -54,7 +55,7 @@ export default class AddSource extends Vue {
       return;
     }
     const addedItem = this.scenesService.activeScene.addSource(this.selectedSourceId);
-    addedItem.fitToScreen();
+    if (autoFitToScreen.isRequired(addedItem.getSource())) addedItem.fitToScreen();
     this.close();
   }
 

--- a/app/components/windows/NameSource.vue.ts
+++ b/app/components/windows/NameSource.vue.ts
@@ -70,7 +70,7 @@ export default class NameSource extends Vue {
         sourceId = source.sourceId;
       }
 
-      this.sourcesService.showSourceProperties(sourceId);
+      this.sourcesService.showSourceProperties(sourceId, true);
     }
   }
 

--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -12,6 +12,7 @@ import ModalLayout from 'components/ModalLayout.vue';
 import Display from 'components/shared/Display.vue';
 import GenericForm from 'components/shared/forms/GenericForm.vue';
 import { $t } from 'services/i18n';
+import autoFitToScreen from '../../util/autoFitToScreen'
 
 @Component({
   components: {
@@ -71,30 +72,13 @@ export default class SourceProperties extends Vue {
   }
 
   initialFitToScreen() {
-    if (this.isRequireFitToScreen()){
+    if (this.initial && autoFitToScreen.isRequired(this.source)){
       const activeSceneItems = this.scenesService.activeScene.getItems();
       activeSceneItems.forEach(element => {
         if (element.sourceId === this.sourceId) {
           element.fitToScreen();
         }
       });
-    }
-  }
-
-  isRequireFitToScreen() {
-    if (this.initial) {
-      switch(this.source.type) {
-        case 'text_ft2_source':
-        case 'text_gdiplus':
-        case 'color_source':
-        case 'wasapi_input_capture':
-        case 'wasapi_output_capture':
-          return false
-        default:
-          return true
-      }
-    }else{
-      return false 
     }
   }
 

--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -6,6 +6,7 @@ import { TFormData } from 'components/shared/forms/Input';
 import { WindowsService } from 'services/windows';
 import windowMixin from 'components/mixins/window';
 import { ISourcesServiceApi } from 'services/sources';
+import { IScenesServiceApi } from '../../services/scenes';
 
 import ModalLayout from 'components/ModalLayout.vue';
 import Display from 'components/shared/Display.vue';
@@ -25,10 +26,14 @@ export default class SourceProperties extends Vue {
   @Inject()
   sourcesService: ISourcesServiceApi;
 
+  @Inject() 
+  scenesService: IScenesServiceApi;
+
   @Inject()
   windowsService: WindowsService;
 
   sourceId = this.windowsService.getChildWindowQueryParams().sourceId;
+  initial = this.windowsService.getChildWindowQueryParams().initial;
   source = this.sourcesService.getSource(this.sourceId);
   properties: TFormData = [];
   initialProperties: TFormData = [];
@@ -61,7 +66,36 @@ export default class SourceProperties extends Vue {
   }
 
   done() {
+    this.initialFitToScreen();
     this.closeWindow();
+  }
+
+  initialFitToScreen() {
+    if (this.isRequireFitToScreen()){
+      const activeSceneItems = this.scenesService.activeScene.getItems();
+      activeSceneItems.forEach(element => {
+        if (element.sourceId === this.sourceId) {
+          element.fitToScreen();
+        }
+      });
+    }
+  }
+
+  isRequireFitToScreen() {
+    if (this.initial) {
+      switch(this.source.type) {
+        case 'text_ft2_source':
+        case 'text_gdiplus':
+        case 'color_source':
+        case 'wasapi_input_capture':
+        case 'wasapi_output_capture':
+          return false
+        default:
+          return true
+      }
+    }else{
+      return false 
+    }
   }
 
   cancel() {
@@ -71,6 +105,7 @@ export default class SourceProperties extends Vue {
         this.initialProperties
       );
     }
+    this.initialFitToScreen();
     this.closeWindow();
   }
 

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -65,7 +65,7 @@ export interface ISourcesServiceApi {
    */
   addFile(path: string): ISourceApi;
   suggestName(name: string): string;
-  showSourceProperties(sourceId: string): void;
+  showSourceProperties(sourceId: string, initial?: boolean): void;
   showShowcase(): void;
   showAddSource(sourceType: TSourceType): void;
   showNameSource(sourceType: TSourceType): void;

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -377,11 +377,11 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
 
-  showSourceProperties(sourceId: string) {
+  showSourceProperties(sourceId: string, initial: boolean = false) {
     this.windowsService.closeChildWindow();
     this.windowsService.showWindow({
       componentName: 'SourceProperties',
-      queryParams: { sourceId },
+      queryParams: { sourceId, initial },
       size: {
         width: 600,
         height: 600

--- a/app/util/AutoFitToScreen.ts
+++ b/app/util/AutoFitToScreen.ts
@@ -1,0 +1,16 @@
+import { ISourceApi } from 'services/sources';
+
+export default {
+  isRequired(source: ISourceApi) : boolean {
+    switch(source.type) {
+      case 'text_ft2_source':
+      case 'text_gdiplus':
+      case 'color_source':
+      case 'wasapi_input_capture':
+      case 'wasapi_output_capture':
+        return false
+      default:
+        return true
+    }
+  }
+}


### PR DESCRIPTION
**このpull requestが解決する内容**
新しいソースを追加した際に自動でキャンバスに収まる最大サイズまで拡縮します。

- テキストソース、カラーソース、音声入力キャプチャ、音声出力キャプチャでは発動しません
  - テキストソースはfitToScreenするとフォントサイズは変わらないまま画像処理で拡大されるので解像度不足でボケてしまうため
  - カラーソースはソースのプロパティに縦横サイズが存在するため
  - 音声入力/出力キャプチャはfitToScreenする意味がないため
- 追加直後かつキャンセルボタンが押下されたときに発動させるかどうか迷いましたが、とりあえずさせる方向にしました

![2018-12-05 11-51-48](https://user-images.githubusercontent.com/24884114/49487319-2e8afe80-f885-11e8-884e-babcf9c714ef.gif)

related #210
**動作確認手順**
