### PR TITLE
変更: プレビューエリアの背景色を変更

### DIFF
--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -59,6 +59,7 @@
   padding: 16px;
   overflow: auto;
   background-color: @bg-tertiary;
+  border-top: 1px solid @bg-tertiary;
 
   &.bareContent {
     padding: 0;

--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -58,7 +58,7 @@
   height: 100%;
   padding: 16px;
   overflow: auto;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
 
   &.bareContent {
     padding: 0;

--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -21,6 +21,8 @@
   height: 0;
   width: 100%;
   padding: 16px 8px 0 8px;
+  border-top: 1px solid @padding-color;
+
   svg {
     width: 140px;
     height: 10px;
@@ -46,7 +48,8 @@
   position: absolute;
   background-color: @bg-primary;
   border: 1px solid @bg-secondary;
-  border: none 1px 1px 1px;
+  border-width: 0 1px 1px 1px;
+
   width: 180px;
   height: 16px;
   margin: -16px auto 0 auto;

--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -21,7 +21,7 @@
   height: 0;
   width: 100%;
   padding: 16px 8px 0 8px;
-  border-top: 1px solid @padding-color;
+  border-top: 1px solid @bg-tertiary;
 
   svg {
     width: 140px;
@@ -103,7 +103,7 @@
 }
 
 .studio-controls-selector {
-  background: @padding-color;
+  background: @bg-tertiary;
   .radius;
   flex-grow: 1;
   overflow-y: auto;

--- a/app/components/StudioEditor.vue
+++ b/app/components/StudioEditor.vue
@@ -25,7 +25,7 @@
 .studio-editor-display-container {
   position: relative;
   flex-grow: 1;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
 }
 
 .studio-editor-display {

--- a/app/components/StudioModeControls.vue
+++ b/app/components/StudioModeControls.vue
@@ -26,7 +26,7 @@
   display: flex;
   align-items: center;
   color: @text-primary;
-  background-color: @padding-color;
+  background-color: @bg-secondary;
 
   &.stacked {
     flex-direction: column;

--- a/app/components/TopNav.vue
+++ b/app/components/TopNav.vue
@@ -62,7 +62,7 @@
   position: relative;
   flex: 0 0 38px;
   min-width: 100%;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
   i {
     font-size: 14px;
     margin-right: 4px;

--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -64,7 +64,7 @@
 .no-preview {
   position: relative;
   flex-grow: 1;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/components/shared/NavItem.vue
+++ b/app/components/shared/NavItem.vue
@@ -27,7 +27,7 @@
   &.active {
     opacity: 1;
     color: @text-primary;
-    background: @padding-color;
+    background: @bg-tertiary;
     .semibold;
 
     i {
@@ -36,7 +36,7 @@
   }
 
   &:not(.active):hover {
-    background: @padding-color;
+    background: @bg-tertiary;
   }
 
   &.disabled {

--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -59,7 +59,7 @@
 }
 .optimize-setting-list {
   list-style: none;
-  background: @padding-color;
+  background: @bg-tertiary;
   .radius;
   margin: 0;
   padding: 8px;

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -69,7 +69,7 @@
   flex-grow: 1;
   margin: 0;
   overflow-y: auto;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
 }
 </style>
 

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -184,7 +184,7 @@
 
 .source-info {
   padding: 0 20px;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -64,7 +64,7 @@ export class Display {
     });
 
     // 映像部分以外の色
-    nodeObs.OBS_content_setPaddingColor(name, 5, 14, 24);
+    nodeObs.OBS_content_setPaddingColor(name, 31, 34, 45);
 
     // ソースの枠線の色
     nodeObs.OBS_content_setOutlineColor(name, 255, 105, 82);

--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -18,4 +18,4 @@
 
 @bg-primary: #2F3340;
 @bg-secondary: #1F222D;
-@padding-color: #050e18;
+@bg-tertiary: #050e18;

--- a/app/styles/classes.less
+++ b/app/styles/classes.less
@@ -46,7 +46,7 @@
 .section {
   padding: 16px;
   border-bottom: 1px solid @bg-primary;
-  background-color: @padding-color;
+  background-color: @bg-tertiary;
   &:last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
**このpull requestが解決する内容**

https://github.com/n-air-app/n-air-app/issues/118 のPRです。
エリアの背景色を変更し、プレビュー画面の境界をわかりやすくしました。

<img width="641" alt="20" src="https://user-images.githubusercontent.com/43235200/49782150-b165fa80-fd58-11e8-93c9-a01be4072b1a.PNG">
