### PR TITLE
改善: childWindowが画面内に出現することを保証する

### DIFF
--- a/main.js
+++ b/main.js
@@ -395,9 +395,16 @@ ipcMain.on('window-showChildWindow', (event, windowOptions) => {
       childWindow.setMinimumSize(width, height);
 
       if (windowOptions.center) {
-        const overflowsVertically = Math.max(0, mainWindowBounds.y + height - targetWorkArea.y - targetWorkArea.height);
-        const childX = (mainWindowBounds.x + (mainWindowBounds.width / 2)) - (width / 2);
-        const childY = mainWindowBounds.y - overflowsVertically;
+        const baseChildY = mainWindowBounds.y;
+        const overflowsBottom = Math.max(0, baseChildY + height - targetWorkArea.y - targetWorkArea.height);
+        const overflowsTop = Math.max(0, targetWorkArea.y - baseChildY);
+
+        const baseChildX = (mainWindowBounds.x + (mainWindowBounds.width / 2)) - (width / 2);
+        const overflowsRight = Math.max(0, baseChildX + width - targetWorkArea.x - targetWorkArea.width);
+        const overflowsLeft = Math.max(0, targetWorkArea.x - baseChildX);
+
+        const childX = baseChildX + overflowsLeft - overflowsRight;
+        const childY = baseChildY + overflowsTop - overflowsBottom;
 
         childWindow.setBounds({
           x: Math.floor(childX),


### PR DESCRIPTION
**このpull requestが解決する内容**
resolves #228 
childWindowを表示しようとするとき、その出現位置が画面外にはみ出す場合に、画面内に完全に収まるよう位置を修正します。

**動作確認手順**
https://github.com/n-air-app/n-air-app/pull/225#issuecomment-459245501