### PR TITLE
改善: mainWindowの画面内判定を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,9 +138,9 @@ function startApp() {
 
   const mainWindowIsVisible = electron.screen.getAllDisplays().some(display => (
     display.workArea.x < mainWindowState.x + mainWindowState.width &&
-    display.workArea.x + display.workArea.width > mainWindowState.x &&
+    mainWindowState.x < display.workArea.x + display.workArea.width &&
     display.workArea.y < mainWindowState.y &&
-    display.workArea.y < mainWindowState.y + mainWindowState.height
+    mainWindowState.y < display.workArea.y + display.workArea.height
   ));
 
   mainWindow = new BrowserWindow({


### PR DESCRIPTION
**このpull requestが解決する内容**
一部のパターンでmainWindowが画面外領域に出ることを判定できなかった問題を修正します。
たとえばマルチディスプレイかつディスプレイの付け外しを行う環境で、画面外の座標が保存されてしまい、そのまま操作できなくなる場合がありました。
https://github.com/n-air-app/n-air-app/pull/94#pullrequestreview-158413179 に関係していると見えて、完全には解消していない可能性が否定できませんが、効果ありと見て変更します。

**動作確認手順**
1. 何らかの方法で画面外にN AirのmainWindowを移動する。
    - タイトルバーを右クリックして「移動」を選び、矢印キーで画面外へもっていく
        - マルチディスプレイ環境でディスプレイ間に段差を作るとそこから追い出せる
2. N Airを終了する。
3. N Airを起動する。
4. mainWindowがプライマリディスプレイに戻ってくる。
