### PR TITLE
変更: サブウィンドウを最小化不能にする

### DIFF
--- a/app/components/TitleBar.vue
+++ b/app/components/TitleBar.vue
@@ -5,7 +5,7 @@
     {{ title }}
   </div>
   <div class="titlebar-actions">
-    <i class="link icon-minimize titlebar-action" @click="minimize" />
+    <i v-if="isMinimizable" class="link icon-minimize titlebar-action" @click="minimize" />
     <i class="link icon-maximize titlebar-action" @click="maximize" />
     <i class="link icon-close titlebar-action" @click="close" />
   </div>

--- a/app/components/TitleBar.vue.ts
+++ b/app/components/TitleBar.vue.ts
@@ -20,6 +20,10 @@ export default class TitleBar extends Vue {
 
   @Prop() title: string;
 
+  get isMinimizable() {
+    return electron.remote.getCurrentWindow().isMinimizable();
+  }
+
   minimize() {
     electron.remote.getCurrentWindow().minimize();
   }

--- a/main.js
+++ b/main.js
@@ -208,6 +208,7 @@ function startApp() {
   // Pre-initialize the child window
   childWindow = new BrowserWindow({
     parent: mainWindow,
+    minimizable: false,
     show: false,
     frame: false
   });


### PR DESCRIPTION
**このpull requestが解決する内容**
#225 の変更によりサブウィンドウがモーダル化されましたが、サブウィンドウの最小化が考慮されていませんでした。
サブウィンドウを最小化すると、 `modal: true` 指定により操作できなくなったままのメインウィンドウが残り、混乱を招く恐れがあります。
（:memo: その場合は Alt+Tab やタスクバーからN Airを選択するか、画面上に小さく残ったサブウィンドウをダブルクリックすることで復帰できます）

**動作確認手順**
まずサブウィンドウを開き、次の項目を確認する
- サブウィンドウの右上に最小化ボタンが出ない、あったはずの場所を押しても最小化しない
- サブウィンドウのタイトルバーを右クリックして、最小化が無効になっている
- 最小化系ショートカットを押しても、サブウィンドウが最小化しない
    - ref. [Windows のキーボード ショートカット - Windows Help](https://support.microsoft.com/ja-jp/help/12445/windows-keyboard-shortcuts)
