### PR TITLE
修正：childWindowのmodal指定を解除

### DIFF
--- a/main.js
+++ b/main.js
@@ -208,7 +208,6 @@ function startApp() {
   // Pre-initialize the child window
   childWindow = new BrowserWindow({
     parent: mainWindow,
-    modal: true,
     show: false,
     frame: false
   });


### PR DESCRIPTION
**このpull requestが解決する内容**
開発版を使って放送を行っていた際、音声系のフィルタをchildWindowで設定するときに、mainWindowの音声ミキサー部と同時に操作したい場面がありました。

parentを指定するだけでもmainWindowの裏には隠れないため、childWindowのmodal指定はいったん解除したいと思います。

related #225 

**動作確認手順**
