### PR TITLE
改善: 重複して埋め込まれるCSSを減らす

### DIFF
--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -39,7 +39,8 @@
 <script lang="ts" src="./EditableSceneCollection.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
 
 .editable-scene-collection {
   height: 35px;

--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -57,7 +57,7 @@
 <script lang="ts" src="./ExtraSettings.vue.ts"></script>
 
 <style lang="less">
-@import "../styles/index";
+@import "../styles/_colors";
 
 .optional-item {
   margin-left: 24px;

--- a/app/components/Login.vue
+++ b/app/components/Login.vue
@@ -23,7 +23,9 @@
 <script lang="ts" src="./Login.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
+
 .login__status {
   display: flex;
   align-items: center;
@@ -33,7 +35,7 @@
   margin-right: 8px;
   display: flex;
   align-items: center;
-  
+
   .user__thumbnail {
     display: flex;
     align-items: center;

--- a/app/components/MixerItem.vue
+++ b/app/components/MixerItem.vue
@@ -53,7 +53,7 @@
 <script lang="ts" src="./MixerItem.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .mixer-item {
   position: relative;

--- a/app/components/MixerVolmeter.vue
+++ b/app/components/MixerVolmeter.vue
@@ -8,7 +8,7 @@
 <script lang="ts" src="./MixerVolmeter.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .volmeter {
   position: absolute;

--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -34,7 +34,7 @@
 <script lang="ts" src="./ModalLayout.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .modal-layout {
   height: 100%;

--- a/app/components/NotificationsArea.vue
+++ b/app/components/NotificationsArea.vue
@@ -41,7 +41,7 @@
 <script lang="ts" src="./NotificationsArea.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .notifications-area {
   overflow: hidden;

--- a/app/components/PerformanceMetrics.vue
+++ b/app/components/PerformanceMetrics.vue
@@ -54,7 +54,7 @@
 <script lang="ts" src="./PerformanceMetrics.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .performance-metrics {
   flex-wrap: wrap;
@@ -71,7 +71,7 @@
 .performance-metric-wrapper {
   padding-right: 12px;
   color: @text-secondary;
-  white-space: nowrap; 
+  white-space: nowrap;
 }
 
 .performance-metric {

--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -63,7 +63,7 @@
 <script lang="ts" src="./SceneSelector.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .scene-collections-wrapper {
   position: relative;

--- a/app/components/Selector.vue
+++ b/app/components/Selector.vue
@@ -26,7 +26,8 @@
 <script lang="ts" src="./Selector.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
 
 .sortable-ghost {
   opacity: .7;

--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -88,7 +88,8 @@
 <script lang="ts" src="./SourceSelector.vue.ts"></script>
 
 <style lang="less" >
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
 @import "~sl-vue-tree/dist/sl-vue-tree-dark.css";
 
 .source-selector-action {

--- a/app/components/StreamingStatus.vue
+++ b/app/components/StreamingStatus.vue
@@ -10,7 +10,8 @@
 <script lang="ts" src="./StreamingStatus.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
 
 .streaming-status-text {
   margin: 0 2px 0 4px;

--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -14,7 +14,7 @@
 <script lang="ts" src="./StudioControls.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .studio-controls {
   position: relative;
@@ -76,7 +76,8 @@
 </style>
 
 <style lang="less">
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
 
 .studio-controls-panel {
   display: flex;

--- a/app/components/StudioEditor.vue
+++ b/app/components/StudioEditor.vue
@@ -20,7 +20,7 @@
 <script lang="ts" src="./StudioEditor.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .studio-editor-display-container {
   position: relative;

--- a/app/components/StudioFooter.vue
+++ b/app/components/StudioFooter.vue
@@ -25,7 +25,8 @@
 <script lang="ts" src="./StudioFooter.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
+@import "../styles/mixins";
 
 .footer {
   display: flex;
@@ -55,7 +56,7 @@
 .error-wrapper {
   position: absolute;
   z-index: 2;
-  
+
 }
 
 .platform-error {

--- a/app/components/StudioModeControls.vue
+++ b/app/components/StudioModeControls.vue
@@ -19,7 +19,7 @@
 <script lang="ts" src="./StudioModeControls.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .studio-mode-controls {
   height: 60px;

--- a/app/components/TitleBar.vue
+++ b/app/components/TitleBar.vue
@@ -15,7 +15,7 @@
 <script lang="ts" src="./TitleBar.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .titlebar {
   display: flex;

--- a/app/components/TopNav.vue
+++ b/app/components/TopNav.vue
@@ -32,7 +32,7 @@
     </div>
   </div>
 
-  <div class="top-nav-profile">    
+  <div class="top-nav-profile">
     <div class="top-nav-item" v-if="isDevMode">
       <a
         @click="openDevTools"
@@ -50,7 +50,7 @@
 <script lang="ts" src="./TopNav.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import "../styles/_colors";
 
 .top-nav {
   display: flex;

--- a/app/components/pages/Onboarding.vue
+++ b/app/components/pages/Onboarding.vue
@@ -7,7 +7,8 @@
 <script lang="ts" src="./Onboarding.vue.ts"></script>
 
 <style lang="less">
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .onboarding {
   display: flex;

--- a/app/components/pages/PatchNotes.vue
+++ b/app/components/pages/PatchNotes.vue
@@ -32,7 +32,7 @@
 <script lang="ts" src="./PatchNotes.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .patch-notes-page {
   flex-direction: column;

--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -24,7 +24,7 @@
 <script lang="ts" src="./Studio.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .studio-page {
   display: flex;

--- a/app/components/pages/onboarding_steps/SceneCollectionsImport.vue
+++ b/app/components/pages/onboarding_steps/SceneCollectionsImport.vue
@@ -20,7 +20,7 @@
 <script lang="ts" src="./SceneCollectionsImport.vue.ts"></script>
 
 <style lang="less" scoped>
-@import '../../../styles/index';
+@import "../../../styles/_colors";
 
 .scene-collections-list {
   margin: 0;

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -15,7 +15,8 @@
 <script lang="ts" src="./DropdownMenu.vue.ts"></script>
 
 <style lang="less">
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .dropdown-menu {
   width: 124%;

--- a/app/components/shared/HelpTip.vue
+++ b/app/components/shared/HelpTip.vue
@@ -14,7 +14,9 @@
 <script lang="ts" src="./HelpTip.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
+
 .help-tip {
   position: absolute;
   background: @text-primary;

--- a/app/components/shared/NavItem.vue
+++ b/app/components/shared/NavItem.vue
@@ -12,7 +12,8 @@
 <script lang="ts" src="./NavItem.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .nav-item {
   cursor: pointer;

--- a/app/components/shared/NavMenu.vue
+++ b/app/components/shared/NavMenu.vue
@@ -7,7 +7,7 @@
 <script lang="ts" src="./NavMenu.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .nav-menu {
   margin: 0;

--- a/app/components/shared/Slider.vue
+++ b/app/components/shared/Slider.vue
@@ -29,7 +29,8 @@
 <script lang="ts" src="./Slider.vue.ts"></script>
 
 <style lang="less">
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .slider-container {
   width: 100%;

--- a/app/components/shared/forms/ColorInput.vue
+++ b/app/components/shared/forms/ColorInput.vue
@@ -32,7 +32,8 @@
 <script lang="ts" src="./ColorInput.vue.ts"></script>
 
 <style lang="less">
-@import "../../../styles/index";
+@import "../../../styles/_colors";
+@import "../../../styles/mixins";
 .colorpicker {
   position: relative;
   width: 220px;

--- a/app/components/shared/forms/EditableListInput.vue
+++ b/app/components/shared/forms/EditableListInput.vue
@@ -33,7 +33,7 @@
 <script lang="ts" src="./EditableListInput.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../../styles/index";
+@import "../../../styles/_colors";
 
 .editable-list__list {
   background: @bg-secondary;

--- a/app/components/shared/forms/IntInput.vue
+++ b/app/components/shared/forms/IntInput.vue
@@ -29,7 +29,8 @@
 <script lang="ts" src="./IntInput.vue.ts"></script>
 
 <style lang="less">
-@import "../../../styles/index";
+@import "../../../styles/_colors";
+@import "../../../styles/mixins";
 
 .int-input {
   position: relative;

--- a/app/components/shared/forms/SliderInput.vue
+++ b/app/components/shared/forms/SliderInput.vue
@@ -25,7 +25,7 @@
 <script lang="ts" src="./SliderInput.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../../styles/index";
+@import "../../../styles/_colors";
 
 .slider-container {
   height: 45px;

--- a/app/components/shared/forms/SystemFontSelector.vue
+++ b/app/components/shared/forms/SystemFontSelector.vue
@@ -58,7 +58,7 @@
 <script lang="ts" src="./SystemFontSelector.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../../styles/index";
+@import "../../../styles/_colors";
 
 .multiselect--font {
   margin-bottom: 0px;

--- a/app/components/windows/AddSource.vue
+++ b/app/components/windows/AddSource.vue
@@ -64,7 +64,7 @@
 <script lang="ts" src="./AddSource.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .NameSource-label {
   margin-bottom: 8px;

--- a/app/components/windows/AddSourceInfo.vue
+++ b/app/components/windows/AddSourceInfo.vue
@@ -19,7 +19,8 @@
 <script lang="ts" src="./AddSourceInfo.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .source-info--no-selection {
   ol {

--- a/app/components/windows/AdvancedAudio.vue
+++ b/app/components/windows/AdvancedAudio.vue
@@ -36,7 +36,7 @@
 <script lang="ts" src="./AdvancedAudio.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 table {
   min-width: 1060px;
@@ -49,14 +49,14 @@ table {
 .downmix {
   width: 120px;
 }
-.syncOffset {}     
+.syncOffset {}
 .audioMonitor {}
 .track {}
 
 .device,
 .volume,
 .downmix,
-.syncOffset,     
+.syncOffset,
 .audioMonitor,
 .track {
   color: @text-secondary;

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -22,7 +22,7 @@
 <script lang="ts" src="./Main.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .main {
   display: flex;

--- a/app/components/windows/ManageSceneCollections.vue
+++ b/app/components/windows/ManageSceneCollections.vue
@@ -25,12 +25,13 @@
 <script lang="ts" src="./ManageSceneCollections.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .manage-scene-collections__header {
   margin-bottom: 20px;
-  .flex;
-  .flex--space-between;
+  display: flex;
+  justify-content: space-between;
   align-items: center;
 }
 

--- a/app/components/windows/NicoliveProgramSelector.vue
+++ b/app/components/windows/NicoliveProgramSelector.vue
@@ -41,7 +41,7 @@
 <script lang="ts" src="./NicoliveProgramSelector.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 .caption {
   letter-spacing: .1em;
   font-size: 18px;

--- a/app/components/windows/Notifications.vue
+++ b/app/components/windows/Notifications.vue
@@ -39,7 +39,8 @@
 <script lang="ts" src="./Notifications.vue.ts"></script>
 
 <style lang="less" scoped>
-  @import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .notification {
   color: @text-primary;

--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -37,7 +37,8 @@
 <script lang="ts" src="./OptimizeForNiconico.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
 .input-container {
   flex-direction: column;

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -51,7 +51,7 @@
 <script lang="ts" src="./Settings.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .settings {
   display: flex;
@@ -74,7 +74,7 @@
 </style>
 
 <style lang="less">
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 /*
 配信中に設定ダイアログへ表示するメッセージのstyle

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -180,7 +180,7 @@
 <script lang="ts" src="./SourcesShowcase.vue.ts"></script>
 
 <style lang="less">
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .source-info {
   padding: 0 20px;
@@ -209,7 +209,9 @@
 </style>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
+@import "../../styles/mixins";
+
 .modal-layout-controls {
   border-top: 1px solid @bg-secondary;
 }

--- a/app/components/windows/Troubleshooter.vue
+++ b/app/components/windows/Troubleshooter.vue
@@ -103,7 +103,7 @@
 <script lang="ts" src="./Troubleshooter.vue.ts"></script>
 
 <style lang="less" scoped>
-  @import "../../styles/index";
+  @import "../../styles/_colors";
 
   .icon-warning {
     color: @red;


### PR DESCRIPTION
**このpull requestが解決する内容**
埋め込まれるCSSのサイズがおよそ1/10になる。

コンポーネントでscopedなstyle要素を書くとき、mixinや色変数を使いたい場合に、グローバルな定義を全てimportしていた。結果、グローバルな定義にscoped対応の属性セレクタが付与されて、実質的に重複した内容のstyle要素が大量にhead要素に挿入されていた。

このPRの変更により、必要なファイル（色変数とmixin）だけをimportするようになり、重複して挿入されるスタイルの量を削減する。

依然として、引数を持たないmixinは重複して挿入される。この問題はlessの構文に起因すると考えられ、scssやpostcssへの移行が対抗策となる見込み。
<ins>https://github.com/n-air-app/n-air-app/pull/236#issuecomment-465467789 構文側にアップデートがありそれでも対応は可能</ins>

rel. #167 

**動作確認手順**
ビルドが通る（lessのシンボルの解決ができている）
見た目が大きくおかしくない（適用順序に乱れがない）

**効果の確認**
起動直後のメイン画面でDevToolを開いて次の情報を収集し、結果を比較する。
1. head要素内style要素の数
2. head要素内全style要素の内容の文字数
3. 重複読み込み数（特徴的な内容をマーカーにした）

before
```
> [...document.head.querySelectorAll('style')].length
24
> [...document.head.querySelectorAll('style')].map(el => el.textContent.length).reduce((a, b) => a + b)
1003221
> [...document.head.querySelectorAll('style')].filter(el => el.textContent.trim().startsWith('@charset "UTF-8"')).length
19
```

after
```
> [...document.head.querySelectorAll('style')].length
24
> [...document.head.querySelectorAll('style')].map(el => el.textContent.length).reduce((a, b) => a + b)
115015
> [...document.head.querySelectorAll('style')].filter(el => el.textContent.trim().startsWith('@charset "UTF-8"')).length
1
```

以上より挿入されるCSSのサイズはおよそ1/10となる。これは空白文字類を含むことに注意する。

**依然として重複している箇所**

次のように確認できる：

```
> [...document.head.querySelectorAll('style')].filter(el => el.textContent.trim().startsWith('.aspect-ratio--16-9')).length
8
```

引数を持たないmixinが先頭に来ており、引数を持つmixinが除去されていることは、上記ワンライナーの途中で得られるstyle要素の内容を改めれば確認できる。
https://github.com/n-air-app/n-air-app/blob/e725bcd50a5d0c549ca4c4dfff2d7a4c98b3db08/app/styles/mixins.less#L31