### PR TITLE
インフォ導線のスタイル実装

### DIFF
--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -40,7 +40,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 0 2px;
+  padding: 0 2px 2px;
   color: @text-primary;
   background-color: @bg-primary;
 }

--- a/app/components/TopNav.vue
+++ b/app/components/TopNav.vue
@@ -30,13 +30,13 @@
         <i class="icon-help" /><span>{{ $t('common.help') }}</span>
       </a>
     </div>
-    <div class="top-nav-item" v-if="isDevMode">
+    <div class="top-nav-item information-button" v-if="isDevMode">
       <a
         @click="openInformations"
         class="link">
-        <!-- TODO: アイコンを入れる -->
-        <span v-if="hasUnseenInformation">info(hasUnseen)</span>
-        <span v-else>info</span>
+        <i class="icon-notification" />
+        <span class="unseen-label" v-if="hasUnseenInformation">お知らせ</span>
+        <span v-else>お知らせ</span>
       </a>
     </div>
   </div>
@@ -119,6 +119,23 @@
 .user__name {
   &:hover {
     color: @white;
+  }
+}
+
+.unseen-label {
+  position: relative;
+
+  &:after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: -12px;
+    bottom: 2px;
+    width: 9px;
+    height: 9px;
+    background-color: @accent-hover;
+    border-radius: 100%;
+    border: 1px solid @bg-tertiary;
   }
 }
 

--- a/app/components/TopNav.vue
+++ b/app/components/TopNav.vue
@@ -34,9 +34,8 @@
       <a
         @click="openInformations"
         class="link">
-        <i class="icon-notification" />
-        <span class="unseen-label" v-if="hasUnseenInformation">お知らせ</span>
-        <span v-else>お知らせ</span>
+        <i class="icon-notification" :class="{'isUnseen': hasUnseenInformation}" />
+        <span>お知らせ</span>
       </a>
     </div>
   </div>
@@ -122,21 +121,23 @@
   }
 }
 
-.unseen-label {
+.icon-notification {
   position: relative;
 
-  &:after {
-    content: '';
-    display: block;
-    position: absolute;
-    left: -12px;
-    bottom: 2px;
-    width: 9px;
-    height: 9px;
-    background-color: @accent-hover;
-    border-radius: 100%;
-    border: 1px solid @bg-tertiary;
-  }
+   &.isUnseen {
+     &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      right: -2px;
+      bottom: -1px;
+      width: 9px;
+      height: 9px;
+      background-color: @accent-hover;
+      border-radius: 100%;
+      border: 1px solid @bg-tertiary;
+    }
+   }
 }
 
 </style>

--- a/app/components/windows/Informations.vue
+++ b/app/components/windows/Informations.vue
@@ -32,7 +32,7 @@
 <script lang="ts" src="./Informations.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import "../../styles/_colors";
 
 .informations {
   display: flex;
@@ -46,9 +46,7 @@
 }
 
 .information-list-item {
-  &:not(:last-child) {
-    border-bottom: 1px solid @border;
-  }
+  border-bottom: 1px solid @border;
 }
 
 .information-link {

--- a/app/components/windows/Informations.vue
+++ b/app/components/windows/Informations.vue
@@ -53,8 +53,8 @@
 
 .information-link {
   display: flex;
-  padding: 16px 40px 16px 16px;
   align-items: center;
+  padding: 16px 40px 16px 16px;
   text-decoration: none;
   position: relative;
 
@@ -117,8 +117,8 @@
 }
 
 .icon-warning {
-  font-size: 70px;
   color: @bg-primary;
+  font-size: 70px;
   margin-bottom: 16px;
 }
 

--- a/app/components/windows/Informations.vue
+++ b/app/components/windows/Informations.vue
@@ -1,29 +1,28 @@
 <template>
 <modal-layout title="お知らせ" :showControls="false">
 
-  <div slot="content" data-test="Informations">
-    <ul v-if="!fetching && !hasError">
-      <li v-for="(information, index) in informations" :key="index">
-        <span><template v-if="shouldShowNewLabel(information.date)">New!!</template></span>
-        <time>{{format(information.date)}}</time>
-        <a :href="information.url" @click="handleAnchorClick($event)">{{information.title}}</a>
+  <div class="informations" slot="content" data-test="Informations">
+    <ul class="information-list" v-if="!fetching && !hasError">
+      <li class="information-list-item" v-for="(information, index) in informations" :key="index">
+        <a class="information-link" :href="information.url" @click="handleAnchorClick($event)">
+          <span class="information-label-new"><template v-if="shouldShowNewLabel(information.date)">NEW</template></span>
+          <time class="information-date">{{format(information.date)}}</time>
+          <p class="information-title">{{information.title}}</p>
+        </a>
       </li>
     </ul>
     <div v-else-if="fetching">
       <p>fetching...</p>
     </div>
-    <div v-else-if="hasError">
-      <i>
-        <!-- TODO: アイコン -->
-        error
-      </i>
-      <h2>ニコニコインフォ一覧の取得に失敗しました</h2>
-      <p>
+    <div class="information-error" v-else-if="hasError">
+      <i class="icon-warning"></i>
+      <h2 class="error-title">ニコニコインフォ一覧の取得に失敗しました</h2>
+      <p class="error-text">
         オフラインになっている可能性があります。
         <br />
         ネットワークが正しく接続されているかを確認してください。
       </p>
-      <p>※N Airに関するニコニコインフォ一覧をWebブラウザで表示する場合は<a href="http://blog.nicovideo.jp/niconews/category/se_n-air/" @click="handleAnchorClick($event)">こちら</a></p>
+      <p class="error-attention">※N Airに関するニコニコインフォ一覧をWebブラウザで表示する場合は<a href="http://blog.nicovideo.jp/niconews/category/se_n-air/" @click="handleAnchorClick($event)">こちら</a></p>
     </div>
   </div>
 
@@ -35,6 +34,110 @@
 <style lang="less" scoped>
 @import "../../styles/index";
 
+.informations {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 
+.information-list {
+  margin: -16px;
+  list-style: none;
+}
+
+.information-list-item {
+  &:not(:last-child) {
+    border-bottom: 1px solid @border;
+  }
+}
+
+.information-link {
+  display: flex;
+  padding: 16px 40px 16px 16px;
+  align-items: center;
+  text-decoration: none;
+  position: relative;
+
+  &:after {
+    border-style: solid;
+    border-color: @text-secondary;
+    border-width: 1px 1px 0 0;
+    content: "";
+    display: block;
+    width: 8px;
+    height: 8px;
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: rotate(45deg) translateY(-50%);
+  }
+
+  &:hover {
+    background-color: @bg-secondary;
+
+    &:after {
+      border-color: @text-primary;
+    }
+  }
+}
+
+.information-label-new {
+  color: @white;
+  background-color: @accent-hover;
+  font-size: 10px;
+  font-weight: bold;
+  text-align: center;
+  line-height: 16px;
+  flex-basis: 32px;
+  flex-shrink: 0;
+}
+
+.information-date {
+  color: @grey;
+  margin-left: 16px;
+  white-space: nowrap;
+}
+
+.information-title {
+  color: @white;
+  margin: 0;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  margin-left: 16px;
+}
+
+.information-error {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-warning {
+  font-size: 70px;
+  color: @bg-primary;
+  margin-bottom: 16px;
+}
+
+.error-title {
+  color: @white;
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+
+.error-text {
+  color: @grey;
+  text-align: center;
+}
+
+.error-attention {
+  color: @grey;
+  font-size: 12px;
+  margin-bottom: 0;
+}
 
 </style>

--- a/app/components/windows/Informations.vue.ts
+++ b/app/components/windows/Informations.vue.ts
@@ -7,6 +7,7 @@ import { $t } from 'services/i18n';
 import { InformationsService } from 'services/informations';
 import ModalLayout from 'components/ModalLayout.vue';
 import { shell } from 'electron';
+import moment from 'moment';
 
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
 
@@ -36,8 +37,7 @@ export default class Informations extends Vue {
   }
 
   format(unixtime: number) {
-    const date = new Date(unixtime);
-    return `${date.getFullYear()}-${('0'+(date.getMonth()+1)).slice(-2)}-${('0'+date.getDate()).slice(-2)}`;
+    return moment(unixtime).format('YYYY-MM-DD');
   }
 
   shouldShowNewLabel(unixtime: number) {

--- a/app/components/windows/Informations.vue.ts
+++ b/app/components/windows/Informations.vue.ts
@@ -46,7 +46,7 @@ export default class Informations extends Vue {
 
   handleAnchorClick(event: MouseEvent) {
     event.preventDefault();
-    const url = (event.target as HTMLAnchorElement).href;
+    const url = (event.currentTarget as HTMLAnchorElement).href;
     try {
       const parsed = new URL(url);
       if (parsed.protocol.match(/https?/)) {

--- a/app/components/windows/Informations.vue.ts
+++ b/app/components/windows/Informations.vue.ts
@@ -37,7 +37,7 @@ export default class Informations extends Vue {
 
   format(unixtime: number) {
     const date = new Date(unixtime);
-    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+    return `${date.getFullYear()}-${('0'+(date.getMonth()+1)).slice(-2)}-${('0'+date.getDate()).slice(-2)}`;
   }
 
   shouldShowNewLabel(unixtime: number) {


### PR DESCRIPTION
インフォ導線にデザインをあてました。

<img width="673" alt="default" src="https://user-images.githubusercontent.com/43235200/53321799-cc3e1900-391c-11e9-9207-037ca907737c.PNG">

#### エラー時
<img width="459" alt="info_error" src="https://user-images.githubusercontent.com/43235200/53386126-4ecde380-39c4-11e9-90b2-e25b1e1ab43a.PNG">

#### アイコン（未読あり）
<img width="71" alt="default" src="https://user-images.githubusercontent.com/43235200/53386262-db78a180-39c4-11e9-8cba-2b2a2967527b.PNG">

