### PR TITLE
追加: ニコ生番組作成機能の実装

### DIFF
--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="(Ctrl+Enterで固定表示)" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" >
+    <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)">送信</button>
+  </div>
+</template>
+
+<script lang="ts" src="./CommentForm.vue.ts"></script>

--- a/app/components/nicolive-area/CommentForm.vue.ts
+++ b/app/components/nicolive-area/CommentForm.vue.ts
@@ -1,0 +1,29 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import { Inject } from 'util/injector';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+
+@Component({})
+export default class CommentForm extends Vue {
+  @Inject()
+  nicoliveProgramService: NicoliveProgramService;
+
+  isCommentSending: boolean = false;
+  operatorCommentValue: string = '';
+
+  async sendOperatorComment(event: KeyboardEvent) {
+    const text = this.operatorCommentValue;
+    const isPermanent = event.ctrlKey;
+
+    try {
+      this.isCommentSending = true;
+      await this.nicoliveProgramService.sendOperatorComment(text, isPermanent);
+      this.operatorCommentValue = '';
+    } catch (err) {
+      // TODO
+      console.warn(err);
+    } finally {
+      this.isCommentSending = false;
+    }
+  }
+}

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="nicolive-area">
+    NicoliveArea
+  </div>
+</template>
+
+<script lang="ts" src="./NicoliveArea.vue.ts"></script>

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -7,7 +7,8 @@
     <template v-else>
       <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
       <div><button @click="editProgram" :disabled="isEditing">番組編集</button></div>
-      <div v-if="programStatus === 'test'"><button @click="startProgram" :disabled="isStarting">番組開始</button></div>
+      <div v-if="programStatus === 'reserved'">番組開始まであと {{ format(-programCurrentTime) }}</div>
+      <div v-else-if="programStatus === 'test'"><button @click="startProgram" :disabled="isStarting">番組開始</button></div>
       <div v-else-if="programStatus === 'onAir'"><button @click="endProgram" :disabled="isEnding">番組終了</button></div>
       <div v-else><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
       <div><button @click="toggleAutoExtension">自動延長を{{ autoExtensionEnabled ? 'OFF' : 'ON' }}にする</button></div>

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -1,6 +1,38 @@
 <template>
   <div class="nicolive-area">
-    NicoliveArea
+    <template v-if="!hasProgram">
+      <div><button @click="createProgram">番組作成</button></div>
+      <div><button @click="fetchProgram">番組取得</button></div>
+    </template>
+    <template v-else>
+      <div v-if="programStatus === 'end'"><button @click="fetchProgram">番組取得</button></div>
+      <div v-else><button @click="refreshProgram">番組情報更新</button></div>
+      <div><button @click="editProgram">番組編集</button></div>
+      <div v-if="programStatus === 'test'"><button @click="startProgram">番組開始</button></div>
+      <div v-else-if="programStatus === 'onAir'"><button @click="endProgram">番組終了</button></div>
+      <div v-else><button @click="createProgram">番組作成</button></div>
+      <div><button @click="toggleAutoExtension">自動延長を{{ autoExtensionEnabled ? 'OFF' : 'ON' }}にする</button></div>
+      <div><button @click="extendProgram">延長する</button></div>
+      <div>
+        <h1>{{programTitle}}</h1>
+        <div>status: {{ programStatus }}</div>
+        <img :src="communitySymbol" /><p>{{communityName}}</p>
+        <ul>
+          <li>視聴者数: {{ viewers }}</li>
+          <li>コメント数: {{ comments }}</li>
+          <li>ニコニ広告pt: {{ adPoint }}</li>
+          <li>ギフトpt: {{ giftPoint }}</li>
+        </ul>
+      </div>
+      <div>
+        <h1>番組詳細</h1>
+        <div>{{ programDescription }}</div>
+      </div>
+      <div>
+        <input type="text" placeholder="(Ctrl+Enterで固定表示)" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" >
+        <button type="submit" @click="sendOperatorComment($event)">送信</button>
+      </div>
+    </template>
   </div>
 </template>
 

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="nicolive-area">
     <template v-if="!hasProgram">
-      <div><button @click="createProgram">番組作成</button></div>
-      <div><button @click="fetchProgram">番組取得</button></div>
+      <div><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
+      <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
     </template>
     <template v-else>
-      <div v-if="programStatus === 'end'"><button @click="fetchProgram">番組取得</button></div>
-      <div v-else><button @click="refreshProgram">番組情報更新</button></div>
-      <div><button @click="editProgram">番組編集</button></div>
-      <div v-if="programStatus === 'test'"><button @click="startProgram">番組開始</button></div>
-      <div v-else-if="programStatus === 'onAir'"><button @click="endProgram">番組終了</button></div>
-      <div v-else><button @click="createProgram">番組作成</button></div>
+      <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
+      <div><button @click="editProgram" :disabled="isEditing">番組編集</button></div>
+      <div v-if="programStatus === 'test'"><button @click="startProgram" :disabled="isStarting">番組開始</button></div>
+      <div v-else-if="programStatus === 'onAir'"><button @click="endProgram" :disabled="isEnding">番組終了</button></div>
+      <div v-else><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
       <div><button @click="toggleAutoExtension">自動延長を{{ autoExtensionEnabled ? 'OFF' : 'ON' }}にする</button></div>
       <div>
-        <button @click="extendProgram" :disabled="isExtending || !isProgramExtendable">
-          <template v-if="isExtending">延長中です……</template>
+        <button @click="extendProgram" :disabled="autoExtensionEnabled || isExtending || !isProgramExtendable">
+          <template v-if="autoExtensionEnabled">自動延長が有効です</template>
+          <template v-else-if="isExtending">延長中です……</template>
           <template v-else-if="isProgramExtendable">延長する</template>
           <template v-else>延長できません</template>
         </button>
@@ -36,8 +36,8 @@
         <div>{{ programDescription }}</div>
       </div>
       <div>
-        <input type="text" placeholder="(Ctrl+Enterで固定表示)" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" >
-        <button type="submit" @click="sendOperatorComment($event)">送信</button>
+        <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="(Ctrl+Enterで固定表示)" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" >
+        <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)">送信</button>
       </div>
     </template>
   </div>

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -12,7 +12,13 @@
       <div v-else-if="programStatus === 'onAir'"><button @click="endProgram">番組終了</button></div>
       <div v-else><button @click="createProgram">番組作成</button></div>
       <div><button @click="toggleAutoExtension">自動延長を{{ autoExtensionEnabled ? 'OFF' : 'ON' }}にする</button></div>
-      <div><button @click="extendProgram">延長する</button></div>
+      <div>
+        <button @click="extendProgram" :disabled="isExtending || !isProgramExtendable">
+          <template v-if="isExtending">延長中です……</template>
+          <template v-else-if="isProgramExtendable">延長する</template>
+          <template v-else>延長できません</template>
+        </button>
+      </div>
       <div>
         <h1>{{programTitle}}</h1>
         <div>status: {{ programStatus }}</div>

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -1,45 +1,15 @@
 <template>
   <div class="nicolive-area">
-    <template v-if="!hasProgram">
-      <div><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
-      <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
+    <top-nav />
+    <template v-if="hasProgram">
+      <program-info />
+      <tool-bar />
+      <program-description />
+      <comment-form />
     </template>
     <template v-else>
+      <div><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
       <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
-      <div><button @click="editProgram" :disabled="isEditing">番組編集</button></div>
-      <div v-if="programStatus === 'reserved'">番組開始まであと {{ format(-programCurrentTime) }}</div>
-      <div v-else-if="programStatus === 'test'"><button @click="startProgram" :disabled="isStarting">番組開始</button></div>
-      <div v-else-if="programStatus === 'onAir'"><button @click="endProgram" :disabled="isEnding">番組終了</button></div>
-      <div v-else><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
-      <div><button @click="toggleAutoExtension">自動延長を{{ autoExtensionEnabled ? 'OFF' : 'ON' }}にする</button></div>
-      <div>
-        <button @click="extendProgram" :disabled="autoExtensionEnabled || isExtending || !isProgramExtendable">
-          <template v-if="autoExtensionEnabled">自動延長が有効です</template>
-          <template v-else-if="isExtending">延長中です……</template>
-          <template v-else-if="isProgramExtendable">延長する</template>
-          <template v-else>延長できません</template>
-        </button>
-      </div>
-      <div>
-        <h1>{{programTitle}}</h1>
-        <div>status: {{ programStatus }}</div>
-        <img :src="communitySymbol" /><p>{{communityName}}</p>
-        <ul>
-          <li>視聴者数: {{ viewers }}</li>
-          <li>コメント数: {{ comments }}</li>
-          <li>ニコニ広告pt: {{ adPoint }}</li>
-          <li>ギフトpt: {{ giftPoint }}</li>
-          <li>{{ format(programCurrentTime) }} / {{ format(programTotalTime) }}</li>
-        </ul>
-      </div>
-      <div>
-        <h1>番組詳細</h1>
-        <div>{{ programDescription }}</div>
-      </div>
-      <div>
-        <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="(Ctrl+Enterで固定表示)" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" >
-        <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)">送信</button>
-      </div>
     </template>
   </div>
 </template>

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -22,6 +22,7 @@
           <li>コメント数: {{ comments }}</li>
           <li>ニコニ広告pt: {{ adPoint }}</li>
           <li>ギフトpt: {{ giftPoint }}</li>
+          <li>{{ format(programCurrentTime) }} / {{ format(programTotalTime) }}</li>
         </ul>
       </div>
       <div>

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -13,10 +13,10 @@ export default class NicolivePanelRoot extends Vue {
   nicoliveProgramService: NicoliveProgramService;
 
   isCreating: boolean = false;
-  async createProgram() {
+  async createProgram(): Promise<void> {
     try {
       this.isCreating = true;
-      return await this.nicoliveProgramService.createProgram();
+      await this.nicoliveProgramService.createProgram();
     } catch (e) {
       // TODO
       console.warn(e);
@@ -26,10 +26,10 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   isFetching: boolean = false;
-  async fetchProgram() {
+  async fetchProgram(): Promise<void> {
     try {
       this.isFetching = true;
-      return await this.nicoliveProgramService.fetchProgram();
+      await this.nicoliveProgramService.fetchProgram();
     } catch (e) {
       console.warn(e);
       // TODO: 翻訳
@@ -52,10 +52,10 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   isEditing: boolean = false;
-  async editProgram() {
+  async editProgram(): Promise<void> {
     try {
       this.isEditing = true;
-      return await this.nicoliveProgramService.editProgram();
+      await this.nicoliveProgramService.editProgram();
     } catch (e) {
       // TODO
       console.warn(e);
@@ -65,10 +65,10 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   isStarting: boolean = false;
-  async startProgram() {
+  async startProgram(): Promise<void> {
     try {
       this.isStarting = true;
-      return await this.nicoliveProgramService.startProgram();
+      await this.nicoliveProgramService.startProgram();
     } catch (e) {
       // TODO
       console.warn(e);
@@ -78,7 +78,7 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   isEnding: boolean = false;
-  async endProgram() {
+  async endProgram(): Promise<void> {
     try {
       this.isEnding = true;
       const isOk = await new Promise(resolve => {
@@ -96,7 +96,7 @@ export default class NicolivePanelRoot extends Vue {
       });
 
       if (isOk) {
-        return await this.nicoliveProgramService.endProgram();
+        await this.nicoliveProgramService.endProgram();
       }
     } catch (e) {
       // TODO
@@ -107,10 +107,10 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   isExtending: boolean = false;
-  async extendProgram() {
+  async extendProgram(): Promise<void> {
     try {
       this.isExtending = true;
-      return await this.nicoliveProgramService.extendProgram();
+      await this.nicoliveProgramService.extendProgram();
     } catch (e) {
       // TODO
       console.warn(e);
@@ -119,13 +119,13 @@ export default class NicolivePanelRoot extends Vue {
     }
   }
 
-  toggleAutoExtension() {
+  toggleAutoExtension(): void {
     this.nicoliveProgramService.toggleAutoExtension();
   }
 
   isCommentSending: boolean = false;
   operatorCommentValue: string = '';
-  async sendOperatorComment(event: KeyboardEvent) {
+  async sendOperatorComment(event: KeyboardEvent): Promise<void> {
     const text = this.operatorCommentValue;
     const isPermanent = event.ctrlKey;
 
@@ -197,16 +197,16 @@ export default class NicolivePanelRoot extends Vue {
     return this.nicoliveProgramService.state.giftPoint;
   }
 
-  get isProgramExtendable() {
+  get isProgramExtendable(): boolean {
     return this.nicoliveProgramService.isProgramExtendable && this.programEndTime - this.currentTime > 60;
   }
 
-  get autoExtensionEnabled() {
+  get autoExtensionEnabled(): boolean {
     return this.nicoliveProgramService.state.autoExtensionEnabled;
   }
 
   currentTime: number = 0;
-  updateCurrrentTime() {
+  updateCurrrentTime(): void {
     this.currentTime = Math.floor(Date.now() / 1000);
   }
 
@@ -231,7 +231,7 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   @Watch('programStatus')
-  onStatusChange(newValue: string, oldValue: string) {
+  onStatusChange(newValue: string, oldValue: string): void {
     if (newValue === 'end') {
       clearInterval(this.timeTimer);
     } else if (oldValue === 'end') {
@@ -240,7 +240,7 @@ export default class NicolivePanelRoot extends Vue {
     }
   }
 
-  startTimer() {
+  startTimer(): void {
     this.timeTimer = (setInterval(() => this.updateCurrrentTime(), 1000) as any) as number;
   }
 

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -2,6 +2,8 @@ import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { remote } from 'electron';
+import { $t } from 'services/i18n';
 
 @Component({
   components: {},
@@ -29,8 +31,21 @@ export default class NicolivePanelRoot extends Vue {
       this.isFetching = true;
       return await this.nicoliveProgramService.fetchProgram();
     } catch (e) {
-      // TODO
       console.warn(e);
+      // TODO: 翻訳
+      // TODO: エラー理由を見て出し分ける
+      await new Promise(resolve => {
+        remote.dialog.showMessageBox(
+          remote.getCurrentWindow(),
+          {
+            type: 'warning',
+            message: 'ニコニコ生放送にて番組が作成されていません。\n［番組作成］ボタンより、番組を作成してください。',
+            buttons: [$t('common.ok')],
+            noLink: true,
+          },
+          done => resolve(done)
+        );
+      });
     } finally {
       this.isFetching = false;
     }
@@ -78,7 +93,23 @@ export default class NicolivePanelRoot extends Vue {
   async endProgram() {
     try {
       this.isEnding = true;
-      return await this.nicoliveProgramService.endProgram();
+      const isOk = await new Promise(resolve => {
+        // TODO: 翻訳
+        remote.dialog.showMessageBox(
+          remote.getCurrentWindow(),
+          {
+            type: 'warning',
+            message: '番組を終了しますか？',
+            buttons: ['終了する', $t('common.cancel')],
+            noLink: true,
+          },
+          idx => resolve(idx === 0)
+        );
+      });
+
+      if (isOk) {
+        return await this.nicoliveProgramService.endProgram();
+      }
     } catch (e) {
       // TODO
       console.warn(e);

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -1,9 +1,192 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
+import { NicoliveClient } from 'services/nicolive-program/NicoliveClient';
+
+interface State {
+  programID: string;
+  status: string;
+  title: string;
+  description: string;
+  communityID: string;
+  communityName: string;
+  communitySymbol: string;
+}
 
 @Component({
-  components: { }
+  components: {},
 })
 export default class NicolivePanelRoot extends Vue {
-  hasProgram: boolean = false;
+  state: State = null;
+
+  viewers: number = 0;
+  comments: number = 0;
+  adPoint: number = 0;
+  giftPoint: number = 0;
+  statsTimer: number = 0;
+
+  get hasProgram(): boolean {
+    return Boolean(this.state);
+  }
+
+  get programTitle() {
+    return this.state.title;
+  }
+  get programDescription() {
+    return this.state.description;
+  }
+  get programStatus() {
+    return this.state.status;
+  }
+  get communityName() {
+    return this.state.communityName;
+  }
+  get communitySymbol() {
+    return this.state.communitySymbol;
+  }
+
+  private setState(nextState: State) {
+    this.refreshStatisticsPolling(this.state, nextState);
+    this.state = nextState;
+  }
+
+  client: NicoliveClient = new NicoliveClient();
+  autoExtensionEnabled = false;
+  async createProgram() {
+    const result = await this.client.createProgram();
+    if (result === 'CREATED') {
+      await this.fetchProgram();
+    }
+  }
+  async fetchProgram() {
+    const schedulesResponse = await this.client.fetchProgramSchedules();
+    if (schedulesResponse.ok === false) {
+      console.error(schedulesResponse.value.meta.errorCode);
+      return;
+    }
+    // TODO: select suitable program
+    const programSchedule = schedulesResponse.value[0];
+
+    if (!programSchedule) {
+      if (this.state) {
+        this.setState({ ...this.state, status: 'end' });
+      }
+      return;
+    }
+    const { nicoliveProgramId, socialGroupId } = programSchedule;
+
+    const [programResponse, communityResponse] = await Promise.all([
+      this.client.fetchProgram(nicoliveProgramId),
+      this.client.fetchCommunity(socialGroupId),
+    ]);
+    if (programResponse.ok === false) {
+      console.error(programResponse.value.meta.errorCode);
+      return;
+    }
+    if (communityResponse.ok === false) {
+      console.error(communityResponse.value.meta.errorCode);
+      return;
+    }
+
+    const community = communityResponse.value;
+    const program = programResponse.value;
+
+    this.setState({
+      programID: nicoliveProgramId,
+      status: program.status,
+      title: program.title,
+      description: program.description,
+      communityID: socialGroupId,
+      communityName: community.name,
+      communitySymbol: community.thumbnailUrl.small,
+    });
+  }
+  async refreshProgram() {
+    const programResponse = await this.client.fetchProgram(this.state.programID);
+    if (programResponse.ok === false) {
+      this.setState({ ...this.state, status: 'end' });
+      console.error(programResponse.value.meta.errorCode);
+      return;
+    }
+
+    const program = programResponse.value;
+
+    this.setState({
+      ...this.state,
+      status: program.status,
+      title: program.title,
+      description: program.description,
+    });
+  }
+  async editProgram() {
+    const result = await this.client.editProgram(this.state.programID);
+    if (result === 'EDITED') {
+      await this.refreshProgram();
+    }
+  }
+  async startProgram() {
+    const result = await this.client.startProgram(this.state.programID);
+    if (result.ok) {
+      this.setState({ ...this.state, status: 'onAir' });
+    }
+  }
+  async endProgram() {
+    const result = await this.client.endProgram(this.state.programID);
+    if (result.ok) {
+      this.setState({ ...this.state, status: 'end' });
+    }
+  }
+  toggleAutoExtension() {
+    this.autoExtensionEnabled = !this.autoExtensionEnabled;
+  }
+  extendProgram() {
+    this.client.extendProgram(this.state.programID);
+  }
+
+  private refreshStatisticsPolling(prevState: State, nextState: State) {
+    const onInitialize = !prevState;
+    const hasNextProgram = Boolean(nextState.programID);
+    const programUpdated = onInitialize || prevState.programID !== nextState.programID;
+    const nextStatusIsOnAir = nextState.status === 'onAir';
+    const statusUpdated = onInitialize || prevState.status !== nextState.status;
+
+    if (hasNextProgram && nextStatusIsOnAir && (programUpdated || statusUpdated)) {
+      console.log('(re)start polling');
+      clearInterval(this.statsTimer);
+      this.updateStatistics(nextState.programID); // run and forget
+      this.statsTimer = setInterval((id: string) => this.updateStatistics(id), 60000, nextState.programID);
+    } else if (!nextStatusIsOnAir) {
+      console.log('stop polling');
+      clearInterval(this.statsTimer);
+    }
+  }
+
+  updateStatistics(programID: string) {
+    this.client
+      .fetchStatistics(programID)
+      .then(res => {
+        if (res.ok) {
+          this.viewers = res.value.watchCount;
+          this.comments = res.value.commentCount;
+        }
+      })
+      .catch(() => null);
+    this.client
+      .fetchNicoadStatistics(programID)
+      .then(res => {
+        if (res.ok) {
+          this.adPoint = res.value.totalAdPoint;
+          this.giftPoint = res.value.totalGiftPoint;
+        }
+      })
+      .catch(() => null);
+  }
+
+  operatorCommentValue: string = '';
+  sendOperatorComment(event: KeyboardEvent) {
+    const text = this.operatorCommentValue;
+    const isPermanent = event.ctrlKey;
+    this.client.sendOperatorComment(this.state.programID, { text, isPermanent }).then(() => {
+      this.operatorCommentValue = '';
+    });
+  }
 }

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -244,8 +244,12 @@ export default class NicolivePanelRoot extends Vue {
 
   @Watch('programStatus')
   onStatusChange(newValue: string, oldValue: string) {
-    if (newValue === 'end') clearInterval(this.timeTimer);
-    else if (oldValue === 'end') this.startTimer();
+    if (newValue === 'end') {
+      clearInterval(this.timeTimer);
+    } else if (oldValue === 'end') {
+      clearInterval(this.timeTimer);
+      this.startTimer();
+    }
   }
 
   startTimer() {

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -1,0 +1,9 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+
+@Component({
+  components: { }
+})
+export default class NicolivePanelRoot extends Vue {
+  hasProgram: boolean = false;
+}

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -210,7 +210,7 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   get isProgramExtendable() {
-    return this.nicoliveProgramService.state.extendable;
+    return this.nicoliveProgramService.isProgramExtendable;
   }
 
   get autoExtensionEnabled() {

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -210,7 +210,7 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   get isProgramExtendable() {
-    return this.nicoliveProgramService.isProgramExtendable;
+    return this.nicoliveProgramService.isProgramExtendable && this.programEndTime - this.currentTime > 60;
   }
 
   get autoExtensionEnabled() {

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 
@@ -184,5 +184,45 @@ export default class NicolivePanelRoot extends Vue {
 
   get autoExtentionEnabled() {
     return this.nicoliveProgramService.state.autoExtentionEnabled;
+  }
+
+  currentTime: number = 0;
+  updateCurrrentTime() {
+    this.currentTime = Math.floor(Date.now() / 1000);
+  }
+
+  get programCurrentTime(): number {
+    return this.currentTime - this.programStartTime;
+  }
+
+  get programTotalTime(): number {
+    return this.programEndTime - this.programStartTime;
+  }
+
+  format(timeInSeconds: number): string {
+    const absTime = Math.abs(timeInSeconds);
+    const s = absTime % 60;
+    const m = Math.floor(absTime / 60) % 60;
+    const h = Math.floor(absTime / 3600);
+    const sign = Math.sign(timeInSeconds) > 0 ? '' : '-';
+    const ss = s.toString(10).padStart(2, '0');
+    const mm = m.toString(10).padStart(2, '0');
+    const hh = h.toString(10).padStart(2, '0');
+    return `${sign}${hh}:${mm}:${ss}`;
+  }
+
+  @Watch('programStatus')
+  onStatusChange(newValue: string, oldValue: string) {
+    if (newValue === 'end') clearInterval(this.timeTimer);
+    else if (oldValue === 'end') this.startTimer();
+  }
+
+  startTimer() {
+    this.timeTimer = (setInterval(() => this.updateCurrrentTime(), 1000) as any) as number;
+  }
+
+  timeTimer: number = 0;
+  mounted() {
+    this.startTimer();
   }
 }

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -213,8 +213,8 @@ export default class NicolivePanelRoot extends Vue {
     return this.nicoliveProgramService.state.extendable;
   }
 
-  get autoExtentionEnabled() {
-    return this.nicoliveProgramService.state.autoExtentionEnabled;
+  get autoExtensionEnabled() {
+    return this.nicoliveProgramService.state.autoExtensionEnabled;
   }
 
   currentTime: number = 0;

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -51,18 +51,6 @@ export default class NicolivePanelRoot extends Vue {
     }
   }
 
-  async refreshProgram() {
-    try {
-      this.isFetching = true;
-      return await this.nicoliveProgramService.fetchProgram();
-    } catch (e) {
-      // TODO
-      console.warn(e);
-    } finally {
-      this.isFetching = false;
-    }
-  }
-
   isEditing: boolean = false;
   async editProgram() {
     try {

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -1,192 +1,188 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
-import { NicoliveClient } from 'services/nicolive-program/NicoliveClient';
-
-interface State {
-  programID: string;
-  status: string;
-  title: string;
-  description: string;
-  communityID: string;
-  communityName: string;
-  communitySymbol: string;
-}
+import { Inject } from 'util/injector';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 
 @Component({
   components: {},
 })
 export default class NicolivePanelRoot extends Vue {
-  state: State = null;
+  @Inject()
+  nicoliveProgramService: NicoliveProgramService;
 
-  viewers: number = 0;
-  comments: number = 0;
-  adPoint: number = 0;
-  giftPoint: number = 0;
-  statsTimer: number = 0;
-
-  get hasProgram(): boolean {
-    return Boolean(this.state);
-  }
-
-  get programTitle() {
-    return this.state.title;
-  }
-  get programDescription() {
-    return this.state.description;
-  }
-  get programStatus() {
-    return this.state.status;
-  }
-  get communityName() {
-    return this.state.communityName;
-  }
-  get communitySymbol() {
-    return this.state.communitySymbol;
-  }
-
-  private setState(nextState: State) {
-    this.refreshStatisticsPolling(this.state, nextState);
-    this.state = nextState;
-  }
-
-  client: NicoliveClient = new NicoliveClient();
-  autoExtensionEnabled = false;
+  isCreating: boolean = false;
   async createProgram() {
-    const result = await this.client.createProgram();
-    if (result === 'CREATED') {
-      await this.fetchProgram();
+    try {
+      this.isCreating = true;
+      return await this.nicoliveProgramService.createProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isCreating = false;
     }
   }
+
+  isFetching: boolean = false;
   async fetchProgram() {
-    const schedulesResponse = await this.client.fetchProgramSchedules();
-    if (schedulesResponse.ok === false) {
-      console.error(schedulesResponse.value.meta.errorCode);
-      return;
+    try {
+      this.isFetching = true;
+      return await this.nicoliveProgramService.fetchProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isFetching = false;
     }
-    // TODO: select suitable program
-    const programSchedule = schedulesResponse.value[0];
-
-    if (!programSchedule) {
-      if (this.state) {
-        this.setState({ ...this.state, status: 'end' });
-      }
-      return;
-    }
-    const { nicoliveProgramId, socialGroupId } = programSchedule;
-
-    const [programResponse, communityResponse] = await Promise.all([
-      this.client.fetchProgram(nicoliveProgramId),
-      this.client.fetchCommunity(socialGroupId),
-    ]);
-    if (programResponse.ok === false) {
-      console.error(programResponse.value.meta.errorCode);
-      return;
-    }
-    if (communityResponse.ok === false) {
-      console.error(communityResponse.value.meta.errorCode);
-      return;
-    }
-
-    const community = communityResponse.value;
-    const program = programResponse.value;
-
-    this.setState({
-      programID: nicoliveProgramId,
-      status: program.status,
-      title: program.title,
-      description: program.description,
-      communityID: socialGroupId,
-      communityName: community.name,
-      communitySymbol: community.thumbnailUrl.small,
-    });
   }
+
   async refreshProgram() {
-    const programResponse = await this.client.fetchProgram(this.state.programID);
-    if (programResponse.ok === false) {
-      this.setState({ ...this.state, status: 'end' });
-      console.error(programResponse.value.meta.errorCode);
-      return;
+    try {
+      this.isFetching = true;
+      return await this.nicoliveProgramService.fetchProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isFetching = false;
     }
-
-    const program = programResponse.value;
-
-    this.setState({
-      ...this.state,
-      status: program.status,
-      title: program.title,
-      description: program.description,
-    });
   }
+
+  isEditing: boolean = false;
   async editProgram() {
-    const result = await this.client.editProgram(this.state.programID);
-    if (result === 'EDITED') {
-      await this.refreshProgram();
+    try {
+      this.isEditing = true;
+      return await this.nicoliveProgramService.editProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isEditing = false;
     }
   }
+
+  isStarting: boolean = false;
   async startProgram() {
-    const result = await this.client.startProgram(this.state.programID);
-    if (result.ok) {
-      this.setState({ ...this.state, status: 'onAir' });
+    try {
+      this.isStarting = true;
+      return await this.nicoliveProgramService.startProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isStarting = false;
     }
   }
+
+  isEnding: boolean = false;
   async endProgram() {
-    const result = await this.client.endProgram(this.state.programID);
-    if (result.ok) {
-      this.setState({ ...this.state, status: 'end' });
+    try {
+      this.isEnding = true;
+      return await this.nicoliveProgramService.endProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isEnding = false;
     }
   }
+
+  isExtending: boolean = false;
+  async extendProgram() {
+    try {
+      this.isExtending = true;
+      return await this.nicoliveProgramService.extendProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isExtending = false;
+    }
+  }
+
   toggleAutoExtension() {
-    this.autoExtensionEnabled = !this.autoExtensionEnabled;
-  }
-  extendProgram() {
-    this.client.extendProgram(this.state.programID);
+    this.nicoliveProgramService.toggleAutoExtension();
   }
 
-  private refreshStatisticsPolling(prevState: State, nextState: State) {
-    const onInitialize = !prevState;
-    const hasNextProgram = Boolean(nextState.programID);
-    const programUpdated = onInitialize || prevState.programID !== nextState.programID;
-    const nextStatusIsOnAir = nextState.status === 'onAir';
-    const statusUpdated = onInitialize || prevState.status !== nextState.status;
-
-    if (hasNextProgram && nextStatusIsOnAir && (programUpdated || statusUpdated)) {
-      console.log('(re)start polling');
-      clearInterval(this.statsTimer);
-      this.updateStatistics(nextState.programID); // run and forget
-      this.statsTimer = setInterval((id: string) => this.updateStatistics(id), 60000, nextState.programID);
-    } else if (!nextStatusIsOnAir) {
-      console.log('stop polling');
-      clearInterval(this.statsTimer);
-    }
-  }
-
-  updateStatistics(programID: string) {
-    this.client
-      .fetchStatistics(programID)
-      .then(res => {
-        if (res.ok) {
-          this.viewers = res.value.watchCount;
-          this.comments = res.value.commentCount;
-        }
-      })
-      .catch(() => null);
-    this.client
-      .fetchNicoadStatistics(programID)
-      .then(res => {
-        if (res.ok) {
-          this.adPoint = res.value.totalAdPoint;
-          this.giftPoint = res.value.totalGiftPoint;
-        }
-      })
-      .catch(() => null);
-  }
-
+  isCommentSending: boolean = false;
   operatorCommentValue: string = '';
-  sendOperatorComment(event: KeyboardEvent) {
+  async sendOperatorComment(event: KeyboardEvent) {
     const text = this.operatorCommentValue;
     const isPermanent = event.ctrlKey;
-    this.client.sendOperatorComment(this.state.programID, { text, isPermanent }).then(() => {
+
+    try {
+      this.isCommentSending = true;
+      await this.nicoliveProgramService.sendOperatorComment(text, isPermanent);
       this.operatorCommentValue = '';
-    });
+    } catch (err) {
+      // TODO
+      console.warn(err);
+    } finally {
+      this.isCommentSending = false;
+    }
+  }
+
+  get hasProgram(): boolean {
+    return this.nicoliveProgramService.hasProgram;
+  }
+
+  get programID(): string {
+    return this.nicoliveProgramService.state.programID;
+  }
+
+  get programStatus(): string {
+    return this.nicoliveProgramService.state.status;
+  }
+
+  get programTitle(): string {
+    return this.nicoliveProgramService.state.title;
+  }
+
+  get programDescription(): string {
+    return this.nicoliveProgramService.state.description;
+  }
+
+  get programEndTime(): number {
+    return this.nicoliveProgramService.state.endTime;
+  }
+
+  get programStartTime(): number {
+    return this.nicoliveProgramService.state.startTime;
+  }
+
+  get communityID(): string {
+    return this.nicoliveProgramService.state.communityID;
+  }
+
+  get communityName(): string {
+    return this.nicoliveProgramService.state.communityName;
+  }
+
+  get communitySymbol(): string {
+    return this.nicoliveProgramService.state.communitySymbol;
+  }
+
+  get viewers(): number {
+    return this.nicoliveProgramService.state.viewers;
+  }
+
+  get comments(): number {
+    return this.nicoliveProgramService.state.comments;
+  }
+
+  get adPoint(): number {
+    return this.nicoliveProgramService.state.adPoint;
+  }
+
+  get giftPoint(): number {
+    return this.nicoliveProgramService.state.giftPoint;
+  }
+
+  get isProgramExtendable() {
+    return this.nicoliveProgramService.state.extendable;
+  }
+
+  get autoExtentionEnabled() {
+    return this.nicoliveProgramService.state.autoExtentionEnabled;
   }
 }

--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>番組詳細</h1>
+    <!-- TODO: 自動リンク等 -->
+    <div v-html="programDescription"></div>
+  </div>
+</template>
+
+<script lang="ts" src="./ProgramDescription.vue.ts"></script>
+

--- a/app/components/nicolive-area/ProgramDescription.vue.ts
+++ b/app/components/nicolive-area/ProgramDescription.vue.ts
@@ -1,0 +1,14 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import { Inject } from 'util/injector';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+
+@Component({})
+export default class ProgramDescription extends Vue {
+  @Inject()
+  nicoliveProgramService: NicoliveProgramService;
+
+  get programDescription(): string {
+    return this.nicoliveProgramService.state.description;
+  }
+}

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <img :src="communitySymbol" />
+    <h1>{{programTitle}}</h1>
+    <h2>{{communityName}}</h2>
+    <div>
+      <span>視聴者数: {{ viewers }}</span>
+      <span>コメント数: {{ comments }}</span>
+      <span>ニコニ広告pt: {{ adPoint }}</span>
+      <span>ギフトpt: {{ giftPoint }}</span>
+    </div>
+    <div>status: {{ programStatus }}</div>
+    <div v-if="programStatus === 'onAir'"><button @click="endProgram" :disabled="isEnding">番組終了</button></div>
+    <div v-else-if="programStatus === 'end'"><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
+    <div v-else><button @click="startProgram" :disabled="isStarting || programStatus === 'reserved'">番組開始</button></div>
+  </div>
+</template>
+
+<script lang="ts" src="./ProgramInfo.vue.ts"></script>

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -1,0 +1,165 @@
+import Vue from 'vue';
+import { Component, Watch } from 'vue-property-decorator';
+import { Inject } from 'util/injector';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { remote } from 'electron';
+import { $t } from 'services/i18n';
+
+@Component({})
+export default class ProgramInfo extends Vue {
+  @Inject()
+  nicoliveProgramService: NicoliveProgramService;
+
+  isCreating: boolean = false;
+  async createProgram() {
+    try {
+      this.isCreating = true;
+      return await this.nicoliveProgramService.createProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isCreating = false;
+    }
+  }
+
+  isFetching: boolean = false;
+  async fetchProgram() {
+    try {
+      this.isFetching = true;
+      return await this.nicoliveProgramService.fetchProgram();
+    } catch (e) {
+      console.warn(e);
+      // TODO: 翻訳
+      // TODO: エラー理由を見て出し分ける
+      await new Promise(resolve => {
+        remote.dialog.showMessageBox(
+          remote.getCurrentWindow(),
+          {
+            type: 'warning',
+            message: 'ニコニコ生放送にて番組が作成されていません。\n［番組作成］ボタンより、番組を作成してください。',
+            buttons: [$t('common.ok')],
+            noLink: true,
+          },
+          done => resolve(done)
+        );
+      });
+    } finally {
+      this.isFetching = false;
+    }
+  }
+
+  isStarting: boolean = false;
+  async startProgram() {
+    try {
+      this.isStarting = true;
+      return await this.nicoliveProgramService.startProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isStarting = false;
+    }
+  }
+
+  isEnding: boolean = false;
+  async endProgram() {
+    try {
+      this.isEnding = true;
+      const isOk = await new Promise(resolve => {
+        // TODO: 翻訳
+        remote.dialog.showMessageBox(
+          remote.getCurrentWindow(),
+          {
+            type: 'warning',
+            message: '番組を終了しますか？',
+            buttons: ['終了する', $t('common.cancel')],
+            noLink: true,
+          },
+          idx => resolve(idx === 0)
+        );
+      });
+
+      if (isOk) {
+        return await this.nicoliveProgramService.endProgram();
+      }
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isEnding = false;
+    }
+  }
+
+  get programStatus(): string {
+    return this.nicoliveProgramService.state.status;
+  }
+
+  get programTitle(): string {
+    return this.nicoliveProgramService.state.title;
+  }
+
+  get communityID(): string {
+    return this.nicoliveProgramService.state.communityID;
+  }
+
+  get communityName(): string {
+    return this.nicoliveProgramService.state.communityName;
+  }
+
+  get communitySymbol(): string {
+    return this.nicoliveProgramService.state.communitySymbol;
+  }
+
+  get viewers(): number {
+    return this.nicoliveProgramService.state.viewers;
+  }
+
+  get comments(): number {
+    return this.nicoliveProgramService.state.comments;
+  }
+
+  get adPoint(): number {
+    return this.nicoliveProgramService.state.adPoint;
+  }
+
+  get giftPoint(): number {
+    return this.nicoliveProgramService.state.giftPoint;
+  }
+
+  get programEndTime(): number {
+    return this.nicoliveProgramService.state.endTime;
+  }
+
+  get programStartTime(): number {
+    return this.nicoliveProgramService.state.startTime;
+  }
+
+  currentTime: number = 0;
+  updateCurrrentTime() {
+    this.currentTime = Math.floor(Date.now() / 1000);
+  }
+
+  get programCurrentTime(): number {
+    return this.currentTime - this.programStartTime;
+  }
+
+  @Watch('programStatus')
+  onStatusChange(newValue: string, oldValue: string) {
+    if (newValue === 'end') {
+      clearInterval(this.timeTimer);
+    } else if (oldValue === 'end') {
+      clearInterval(this.timeTimer);
+      this.startTimer();
+    }
+  }
+
+  startTimer() {
+    this.timeTimer = (setInterval(() => this.updateCurrrentTime(), 1000) as any) as number;
+  }
+
+  timeTimer: number = 0;
+  mounted() {
+    this.startTimer();
+  }
+}

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <span class="status-indicator" :class="{ 'is-live': programStatus === 'onAir' }">LIVE</span>
+    <span><time>{{ format(programCurrentTime) }}</time> / <time>{{ format(programTotalTime) }}</time></span>
+    <button @click="extendProgram" :disabled="autoExtensionEnabled || isExtending || !isProgramExtendable">
+      30分延長
+    </button>
+    <span>自動延長 <input type="checkbox" :checked="autoExtensionEnabled" @click="toggleAutoExtension" /></span>
+  </div>
+</template>
+
+<script lang="ts" src="./ToolBar.vue.ts"></script>

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -1,0 +1,83 @@
+import Vue from 'vue';
+import { Component, Watch } from 'vue-property-decorator';
+import { Inject } from 'util/injector';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+
+@Component({})
+export default class ToolBar extends Vue {
+  @Inject()
+  nicoliveProgramService: NicoliveProgramService;
+
+  format(timeInSeconds: number): string {
+    return NicoliveProgramService.format(timeInSeconds);
+  }
+
+  isExtending: boolean = false;
+  async extendProgram() {
+    try {
+      this.isExtending = true;
+      return await this.nicoliveProgramService.extendProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isExtending = false;
+    }
+  }
+
+  toggleAutoExtension() {
+    this.nicoliveProgramService.toggleAutoExtension();
+  }
+
+  get programStatus(): string {
+    return this.nicoliveProgramService.state.status;
+  }
+
+  get programEndTime(): number {
+    return this.nicoliveProgramService.state.endTime;
+  }
+
+  get programStartTime(): number {
+    return this.nicoliveProgramService.state.startTime;
+  }
+
+  get isProgramExtendable() {
+    return this.nicoliveProgramService.isProgramExtendable && this.programEndTime - this.currentTime > 60;
+  }
+
+  get autoExtensionEnabled() {
+    return this.nicoliveProgramService.state.autoExtensionEnabled;
+  }
+
+  currentTime: number = 0;
+  updateCurrrentTime() {
+    this.currentTime = Math.floor(Date.now() / 1000);
+  }
+
+  get programCurrentTime(): number {
+    return this.currentTime - this.programStartTime;
+  }
+
+  get programTotalTime(): number {
+    return this.programEndTime - this.programStartTime;
+  }
+
+  @Watch('programStatus')
+  onStatusChange(newValue: string, oldValue: string) {
+    if (newValue === 'end') {
+      clearInterval(this.timeTimer);
+    } else if (oldValue === 'end') {
+      clearInterval(this.timeTimer);
+      this.startTimer();
+    }
+  }
+
+  startTimer() {
+    this.timeTimer = (setInterval(() => this.updateCurrrentTime(), 1000) as any) as number;
+  }
+
+  timeTimer: number = 0;
+  mounted() {
+    this.startTimer();
+  }
+}

--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <div v-if="hasProgram">
+      <button @click="fetchProgram" :disabled="isFetching">番組取得</button>
+      <button @click="editProgram" :disabled="isEditing">番組編集</button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" src="./TopNav.vue.ts"></script>

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -5,43 +5,20 @@ import { NicoliveProgramService } from 'services/nicolive-program/nicolive-progr
 import { remote } from 'electron';
 import { $t } from 'services/i18n';
 
-import CommentForm from './CommentForm.vue';
-import ProgramDescription from './ProgramDescription.vue';
-import ProgramInfo from './ProgramInfo.vue';
-import ToolBar from './ToolBar.vue';
-import TopNav from './TopNav.vue';
-
-@Component({
-  components: {
-    TopNav,
-    ProgramInfo,
-    ProgramDescription,
-    ToolBar,
-    CommentForm,
-  },
-})
-export default class NicolivePanelRoot extends Vue {
+@Component({})
+export default class TopNav extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
-  isCreating: boolean = false;
-  async createProgram(): Promise<void> {
-    try {
-      this.isCreating = true;
-      await this.nicoliveProgramService.createProgram();
-    } catch (e) {
-      // TODO
-      console.warn(e);
-    } finally {
-      this.isCreating = false;
-    }
+  get hasProgram(): boolean {
+    return this.nicoliveProgramService.hasProgram;
   }
 
   isFetching: boolean = false;
-  async fetchProgram(): Promise<void> {
+  async fetchProgram() {
     try {
       this.isFetching = true;
-      await this.nicoliveProgramService.fetchProgram();
+      return await this.nicoliveProgramService.fetchProgram();
     } catch (e) {
       console.warn(e);
       // TODO: 翻訳
@@ -63,7 +40,16 @@ export default class NicolivePanelRoot extends Vue {
     }
   }
 
-  get hasProgram(): boolean {
-    return this.nicoliveProgramService.hasProgram;
+  isEditing: boolean = false;
+  async editProgram() {
+    try {
+      this.isEditing = true;
+      return await this.nicoliveProgramService.editProgram();
+    } catch (e) {
+      // TODO
+      console.warn(e);
+    } finally {
+      this.isEditing = false;
+    }
   }
 }

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -15,6 +15,9 @@
         :params="params"/>
       <studio-footer v-if="(page !== 'Onboarding')" :locked="applicationLoading" />
     </div>
+    <div class="nicolive-area" v-if="showNicoliveArea">
+      <nicolive-area />
+    </div>
   </div>
 </div>
 </template>

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -18,6 +18,7 @@ import StudioFooter from '../StudioFooter.vue';
 import CustomLoader from '../CustomLoader.vue';
 import PatchNotes from '../pages/PatchNotes.vue';
 import Questionaire from '../pages/Questionaire.vue';
+import NicoliveArea from '../nicolive-area/NicoliveArea.vue';
 
 @Component({
   mixins: [windowMixin],
@@ -29,7 +30,8 @@ import Questionaire from '../pages/Questionaire.vue';
     StudioFooter,
     CustomLoader,
     PatchNotes,
-    Questionaire
+    Questionaire,
+    NicoliveArea,
   }
 })
 export default class Main extends Vue {
@@ -63,6 +65,10 @@ export default class Main extends Vue {
 
   get isOnboarding() {
     return this.navigationService.state.currentPage === 'Onboarding';
+  }
+
+  get showNicoliveArea() {
+    return this.page === 'Studio' && this.isLoggedIn;
   }
 
   /**

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -61,6 +61,7 @@ import { I18nService } from 'services/i18n';
 import { OutageNotificationsService } from 'services/outage-notifications';
 import { QuestionaireService } from 'services/questionaire';
 import { MonitorCaptureCroppingService } from 'services/sources/monitor-capture-cropping';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 
 const { ipcRenderer } = electron;
 
@@ -125,6 +126,7 @@ export class ServicesManager extends Service {
     OutageNotificationsService,
     QuestionaireService,
     MonitorCaptureCroppingService,
+    NicoliveProgramService,
   };
 
   private instances: Dictionary<Service> = {};

--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -3,7 +3,7 @@ const { NicoliveClient } = require('./NicoliveClient');
 
 afterEach(() => {
   fetchMock.reset();
-})
+});
 
 test('constructor', () => {
   const client = new NicoliveClient();
@@ -27,9 +27,9 @@ const dummyBody = {
 const dummyErrorBody = {
   meta: {
     status: 404,
-    errorCode: 'NOT_FOUND'
-  }
-}
+    errorCode: 'NOT_FOUND',
+  },
+};
 
 test('wrapResultはレスポンスのdataを取り出す', async () => {
   fetchMock.get(dummyURL, dummyBody);
@@ -47,20 +47,26 @@ test('wrapResultは結果が200でないときレスポンス全体を返す', a
   expect(fetchMock.done()).toBe(true);
 });
 
-test('wrapResultはJSONが壊れていたらrejectする', async () => {
+test('wrapResultはbodyがJSONでなければ元のbodyを込めたオブジェクトをthrowする', async () => {
   fetchMock.get(dummyURL, 'invalid json');
   const res = await fetch(dummyURL);
 
-  await expect(NicoliveClient.wrapResult(res)).rejects.toThrow('invalid json response body');
+  await expect(NicoliveClient.wrapResult(res)).rejects.toMatchInlineSnapshot(`
+Object {
+  "body": "invalid json",
+  "status": 200,
+  "statusText": "OK",
+}
+`);
   expect(fetchMock.done()).toBe(true);
 });
 
 interface Suite {
-  name: string,
-  method: string,
-  base: string,
-  path: string,
-  args?: any[],
+  name: string;
+  method: string;
+  base: string;
+  path: string;
+  args?: any[];
 }
 const suites: Suite[] = [
   {
@@ -141,11 +147,11 @@ const dummyCommunities = {
     communities: [
       {
         id: communityID,
-      }
+      },
     ],
     errors: [] as any,
-  }
-}
+  },
+};
 
 test('fetchCommunityはコミュをひとつだけ返す', async () => {
   const client = new NicoliveClient();
@@ -154,6 +160,22 @@ test('fetchCommunityはコミュをひとつだけ返す', async () => {
   const result = await client.fetchCommunity(communityID);
 
   expect(result).toEqual({ ok: true, value: dummyCommunities.data.communities[0] });
+  expect(fetchMock.done()).toBe(true);
+});
+
+test('fetchCommunityはbodyがJSONでなければbodyを込めたオブジェクトをthrowする', async () => {
+  const client = new NicoliveClient();
+
+  fetchMock.get(`${NicoliveClient.publicBaseURL}/v1/communities.json?communityIds=${communityID}`, 'invalid json');
+  const result = client.fetchCommunity(communityID);
+
+  await expect(result).rejects.toMatchInlineSnapshot(`
+Object {
+  "body": "invalid json",
+  "status": 200,
+  "statusText": "OK",
+}
+`);
   expect(fetchMock.done()).toBe(true);
 });
 
@@ -166,8 +188,8 @@ function setupMock() {
     webContents = {
       on: (_event: string, callback: (ev: any, url: string) => any) => {
         this.webContentsCallbacks.push(callback);
-      }
-    }
+      },
+    };
     on(event: string, callback: (evt: any) => any) {
       this.callbacks.push(callback);
     }
@@ -191,7 +213,7 @@ function setupMock() {
   }
 
   let wrapper: {
-    browserWindow: BrowserWindow
+    browserWindow: BrowserWindow;
   } = {
     browserWindow: null,
   };
@@ -200,7 +222,7 @@ function setupMock() {
       BrowserWindow,
     },
     ipcRenderer: {
-      send() {}
+      send() {},
     },
   }));
 

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -83,7 +83,20 @@ export class NicoliveClient {
   }
 
   static async wrapResult<ResultType>(res: Response): Promise<WrappedResult<ResultType>> {
-    const obj = await res.json();
+    const body = await res.text();
+    let obj: any = null;
+    try {
+      obj = JSON.parse(body);
+    } catch(e) {
+      // bodyがJSONになってない異常失敗
+      throw {
+        status: res.status,
+        statusText: res.statusText,
+        body,
+      };
+    }
+
+    // 正常成功
     if (res.ok) {
       return {
         ok: true,
@@ -91,6 +104,7 @@ export class NicoliveClient {
       };
     }
 
+    // 正常失敗
     return {
       ok: false,
       value: obj as CommonErrorResponse,
@@ -209,7 +223,19 @@ export class NicoliveClient {
       },
     });
 
-    const obj = await res.json();
+    const body = await res.text()
+    let obj: any = null;
+    try {
+      obj = JSON.parse(body);
+    } catch (e) {
+      // bodyがJSONになってない異常失敗
+      throw {
+        status: res.status,
+        statusText: res.statusText,
+        body,
+      };
+    }
+
     if (res.ok) {
       const data = obj.data as Communities['data'];
       const communities = data.communities || [];
@@ -217,6 +243,7 @@ export class NicoliveClient {
 
       const community = communities.find(c => c.id === communityId);
       if (community) {
+        // 正常成功
         return {
           ok: true,
           value: community,
@@ -225,6 +252,7 @@ export class NicoliveClient {
 
       const error = errors.find(e => e.id === communityId);
       if (error) {
+        // 正常失敗
         return {
           ok: false,
           value: errors[0] as CommonErrorResponse,
@@ -232,6 +260,7 @@ export class NicoliveClient {
       }
     }
 
+    // 正常失敗
     return {
       ok: false,
       value: obj as CommonErrorResponse,

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -1,241 +1,185 @@
-export type ProgramSchedules =
-  | {
-      data: {
-        /** 番組ID */
-        nicoliveProgramId: string;
-        /** テスト開始時刻 */
-        testBeginAt: number;
-        /** 放送開始時刻 */
-        onAirBeginAt: number;
-        /** 放送終了予定時刻 */
-        onAirEndAt: number;
-        /** 配信コミュニティ・チャンネルID */
-        socialGroupId: string;
-        /** 配信状態 */
-        status: 'reserved' | 'test' | 'onAir' | 'end';
-      }[];
-      meta: {
-        status: 200;
-        errorCode: 'OK';
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-      };
-      data?: { message: string };
-    };
+export interface CommonErrorResponse {
+  meta: {
+    status: number;
+    errorCode?: string;
+    errorMessage?: string;
+  };
+  data?: { message: string };
+}
 
-export type ProgramInfo =
-  | {
-      meta: {
-        status: 200;
-        errorCode: 'OK';
-      };
-      data: {
-        /** 番組の状態 */
-        status: 'test' | 'onAir' | 'end';
-        /** 番組の配信者に関係する情報 */
-        socialGroup:
-          | {
-              providerType: 'community';
-              /** コミュニティ名 */
-              name: string;
-              /** コミュニティID */
-              id: string;
-            }
-          | {
-              providerType: 'channel';
-              /** チャンネル名 */
-              name: string;
-              /** チャンネルID */
-              id: string;
-              /** 配信会社名 */
-              ownerName: string;
-              /** コミュレベル */
-              communityLevel: number;
-            };
-        /** コメントのルーム */
-        rooms: {
-          /** 部屋ID */
-          id: number;
-          /** 部屋名 */
+export interface ProgramSchedules {
+  meta: {
+    status: 200;
+    errorCode: 'OK';
+  };
+  data: {
+    /** 番組ID */
+    nicoliveProgramId: string;
+    /** テスト開始時刻 */
+    testBeginAt: number;
+    /** 放送開始時刻 */
+    onAirBeginAt: number;
+    /** 放送終了予定時刻 */
+    onAirEndAt: number;
+    /** 配信コミュニティ・チャンネルID */
+    socialGroupId: string;
+    /** 配信状態 */
+    status: 'reserved' | 'test' | 'onAir' | 'end';
+  }[];
+}
+
+export interface ProgramInfo {
+  meta: {
+    status: 200;
+    errorCode: 'OK';
+  };
+  data: {
+    /** 番組の状態 */
+    status: 'test' | 'onAir' | 'end';
+    /** 番組の配信者に関係する情報 */
+    socialGroup:
+      | {
+          providerType: 'community';
+          /** コミュニティ名 */
           name: string;
-          /** コメントサーバーの接続先(WebSocket) */
-          webSocketUri: string;
-          /** コメントサーバーの接続先(XmlSocket) */
-          xmlSocketUri: string;
-          /** スレッドID */
-          threadId: string;
-        }[];
-        /** 番組タイトル */
-        title: string;
-        /** 番組情報 */
-        description: string;
-        /** メンバー限定放送であるか */
-        isMemberOnly: boolean;
-        /** vpos基準時刻 */
-        vposBaseTime: number;
-        /** 開演時間 */
-        beginAt: number;
-        /** 終了時間 */
-        endAt: number;
-        /** 番組のカテゴリ・追加カテゴリ一覧 */
-        categories: string[];
-        /** ニコニ広告許可設定 */
-        isAdsEnabled: boolean;
-        /** 配信者情報 */
-        broadcaster: {
-          /** 配信者/チャンネルのID */
-          id: number;
-          /** 配信者/配信会社名 */
-          name: string;
-        }[];
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-      };
-      data?: { message: string };
-    };
-
-export type Segment =
-  | {
-      meta: {
-        status: 200;
-        errorCode: 'OK';
-      };
-      data: {
-        end_time: number;
-        start_time: number;
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-        errorMessage: string;
-      };
-      data?: { message: string };
-    };
-
-export type Extension =
-  | {
-      meta: {
-        status: 200;
-        errorCode: 'OK';
-      };
-      data: {
-        end_time: number;
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-        errorMessage: string;
-      };
-      data?: { message: string };
-    };
-
-export type OperatorComment =
-  | {
-      meta: {
-        status: 200;
-        errorCode: 'OK';
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-        errorMessage: string;
-      };
-      data?: { message: string };
-    };
-
-export type Statistics =
-  | {
-      meta: {
-        status: 200;
-        errorCode: 'OK';
-      };
-      data: {
-        watchCount: number;
-        commentCount: number;
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-      };
-      data?: { message: string };
-    };
-
-export type NicoadStatistics =
-  | {
-      meta: {
-        status: 200;
-      };
-      data: {
-        totalAdPoint: number;
-        totalGiftPoint: number;
-        conductors: {
-          text: string;
-          url: string;
-        }[];
-      };
-    }
-  | {
-      meta: {
-        status: number;
-        errorCode: string;
-        errorMessage: string;
-      };
-    };
-
-export type Communities =
-  | {
-      meta: {
-        status: 200;
-      };
-      data: {
-        communities: {
-          // 使用しそうなものだけ雑に抜粋
+          /** コミュニティID */
           id: string;
+        }
+      | {
+          providerType: 'channel';
+          /** チャンネル名 */
           name: string;
-          description: 'string';
-          status: 'open' | 'closed';
-          thumbnailUrl: {
-            normal: string;
-            small: string;
-          };
-          thumbnails: {
-            '1024x1024': string;
-            '512x512': string;
-            '256x256': string;
-            '128x128': string;
-            '64x64': string;
-          };
-        }[];
-        errors: {
-          id: string
-          meta: {
-            status: number;
-            errorCode: string;
-            errorMessage: string;
-          }
-        }[];
-      };
-    }
-  | {
+          /** チャンネルID */
+          id: string;
+          /** 配信会社名 */
+          ownerName: string;
+          /** コミュレベル */
+          communityLevel: number;
+        };
+    /** コメントのルーム */
+    rooms: {
+      /** 部屋ID */
+      id: number;
+      /** 部屋名 */
+      name: string;
+      /** コメントサーバーの接続先(WebSocket) */
+      webSocketUri: string;
+      /** コメントサーバーの接続先(XmlSocket) */
+      xmlSocketUri: string;
+      /** スレッドID */
+      threadId: string;
+    }[];
+    /** 番組タイトル */
+    title: string;
+    /** 番組情報 */
+    description: string;
+    /** メンバー限定放送であるか */
+    isMemberOnly: boolean;
+    /** vpos基準時刻 */
+    vposBaseTime: number;
+    /** 開演時間 */
+    beginAt: number;
+    /** 終了時間 */
+    endAt: number;
+    /** 番組のカテゴリ・追加カテゴリ一覧 */
+    categories: string[];
+    /** ニコニ広告許可設定 */
+    isAdsEnabled: boolean;
+    /** 配信者情報 */
+    broadcaster: {
+      /** 配信者/チャンネルのID */
+      id: number;
+      /** 配信者/配信会社名 */
+      name: string;
+    }[];
+  };
+}
+
+export interface Segment {
+  meta: {
+    status: 200;
+    errorCode: 'OK';
+  };
+  data: {
+    end_time: number;
+    start_time: number;
+  };
+}
+
+export interface Extension {
+  meta: {
+    status: 200;
+    errorCode: 'OK';
+  };
+  data: {
+    end_time: number;
+  };
+}
+
+export interface OperatorComment {
+  meta: {
+    status: 200;
+    errorCode: 'OK';
+  };
+}
+
+export interface Statistics {
+  meta: {
+    status: 200;
+    errorCode: 'OK';
+  };
+  data: {
+    watchCount: number;
+    commentCount: number;
+  };
+}
+
+export interface NicoadStatistics {
+  meta: {
+    status: 200;
+  };
+  data: {
+    totalAdPoint: number;
+    totalGiftPoint: number;
+    conductors: {
+      text: string;
+      url: string;
+    }[];
+  };
+}
+
+export interface Community {
+  // 使用しそうなものだけ雑に抜粋
+  id: string;
+  name: string;
+  description: 'string';
+  status: 'open' | 'closed';
+  thumbnailUrl: {
+    normal: string;
+    small: string;
+  };
+  thumbnails: {
+    '1024x1024': string;
+    '512x512': string;
+    '256x256': string;
+    '128x128': string;
+    '64x64': string;
+  };
+}
+
+export interface Communities {
+  meta: {
+    status: 200;
+  };
+  data: {
+    communities: Community[];
+    errors: {
+      id: string;
       meta: {
         status: number;
         errorCode: string;
         errorMessage: string;
       };
-    };
+    }[];
+  };
+}

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -7,25 +7,23 @@ const initialState = {
 };
 
 const schedules = {
-  ch: { nicoliveProgramId: 'lv1', socialGroupId: 'ch1', status: 'onAir', testBeginAt: 50, beginAt: 100, endAt: 150 },
-  onAir: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'onAir', testBeginAt: 50, beginAt: 100, endAt: 150 },
-  test: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'test', testBeginAt: 50, beginAt: 100, endAt: 150 },
-  end: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'end', testBeginAt: 50, beginAt: 100, endAt: 150 },
+  ch: { nicoliveProgramId: 'lv1', socialGroupId: 'ch1', status: 'onAir', onAirBeginAt: 100, onAirEndAt: 150 },
+  onAir: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'onAir', onAirBeginAt: 100, onAirEndAt: 150 },
+  test: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'test', onAirBeginAt: 100, onAirEndAt: 150 },
+  end: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'end', onAirBeginAt: 100, onAirEndAt: 150 },
   reserved1: {
     nicoliveProgramId: 'lv1',
     socialGroupId: 'co1',
     status: 'reserved',
-    testBeginAt: 100,
-    beginAt: 150,
-    endAt: 200,
+    onAirBeginAt: 150,
+    onAirEndAt: 200,
   },
   reserved2: {
     nicoliveProgramId: 'lv1',
     socialGroupId: 'co1',
     status: 'reserved',
-    testBeginAt: 200,
-    beginAt: 250,
-    endAt: 300,
+    onAirBeginAt: 250,
+    onAirEndAt: 300,
   },
 };
 
@@ -34,8 +32,8 @@ const programs = {
     status: schedules.onAir.status,
     title: '番組タイトル',
     description: '番組詳細情報',
-    beginAt: schedules.onAir.beginAt,
-    endAt: schedules.onAir.endAt,
+    beginAt: schedules.onAir.onAirBeginAt,
+    endAt: schedules.onAir.onAirEndAt,
   },
 };
 
@@ -179,7 +177,6 @@ Array [
     "programID": "lv1",
     "startTime": 100,
     "status": "onAir",
-    "testStartTime": 50,
     "title": "番組タイトル",
   },
 ]

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -1,0 +1,630 @@
+import { createSetupFunction } from 'util/test-setup';
+import { NicoliveProgramService } from './nicolive-program';
+
+const initialState = {
+  ...NicoliveProgramService.initialState,
+  programID: 'lv1',
+};
+
+const schedules = {
+  ch: { nicoliveProgramId: 'lv1', socialGroupId: 'ch1', status: 'onAir', testBeginAt: 50, beginAt: 100, endAt: 150 },
+  onAir: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'onAir', testBeginAt: 50, beginAt: 100, endAt: 150 },
+  test: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'test', testBeginAt: 50, beginAt: 100, endAt: 150 },
+  end: { nicoliveProgramId: 'lv1', socialGroupId: 'co1', status: 'end', testBeginAt: 50, beginAt: 100, endAt: 150 },
+  reserved1: {
+    nicoliveProgramId: 'lv1',
+    socialGroupId: 'co1',
+    status: 'reserved',
+    testBeginAt: 100,
+    beginAt: 150,
+    endAt: 200,
+  },
+  reserved2: {
+    nicoliveProgramId: 'lv1',
+    socialGroupId: 'co1',
+    status: 'reserved',
+    testBeginAt: 200,
+    beginAt: 250,
+    endAt: 300,
+  },
+};
+
+const programs = {
+  onAir: {
+    status: schedules.onAir.status,
+    title: '番組タイトル',
+    description: '番組詳細情報',
+    beginAt: schedules.onAir.beginAt,
+    endAt: schedules.onAir.endAt,
+  },
+};
+
+const setup = createSetupFunction({
+  state: {
+    NicoliveProgramService: initialState,
+  },
+});
+
+beforeEach(() => {
+  jest.doMock('services/stateful-service');
+  jest.doMock('util/injector');
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('get instance', () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  expect(NicoliveProgramService.instance).toBeInstanceOf(NicoliveProgramService);
+});
+
+test('isProgramExtendable', () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const { isProgramExtendable } = NicoliveProgramService;
+
+  expect(isProgramExtendable({ status: 'reserved', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(false);
+  expect(isProgramExtendable({ status: 'test', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(false);
+  expect(isProgramExtendable({ status: 'onAir', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(true);
+  expect(isProgramExtendable({ status: 'end', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(false);
+  expect(isProgramExtendable({ status: 'onAir', startTime: 0, endTime: 6 * 60 * 60 })).toBe(false);
+});
+
+test('findSuitableProgram', () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const { findSuitableProgram } = NicoliveProgramService;
+
+  const { ch, reserved1, reserved2, test, onAir, end } = schedules;
+
+  expect(findSuitableProgram([])).toBeNull();
+  expect(findSuitableProgram([ch])).toBeNull();
+  expect(findSuitableProgram([end])).toBeNull();
+  expect(findSuitableProgram([ch, test])).toBe(test);
+  expect(findSuitableProgram([ch, onAir])).toBe(onAir);
+  expect(findSuitableProgram([ch, reserved1])).toBe(reserved1);
+  expect(findSuitableProgram([ch, reserved1, test])).toBe(test);
+  expect(findSuitableProgram([ch, reserved1, onAir])).toBe(onAir);
+  expect(findSuitableProgram([reserved1, reserved2])).toBe(reserved1);
+  expect(findSuitableProgram([reserved2, reserved1])).toBe(reserved1);
+  expect(findSuitableProgram([reserved2])).toBe(reserved2);
+});
+
+test.each([['CREATED', 1], ['RESERVED', 0], ['OTHER', 0]])(
+  'createProgram with %s',
+  async (result, fetchProgramCalled) => {
+    setup();
+    const { NicoliveProgramService } = require('./nicolive-program');
+    const instance = NicoliveProgramService.instance as NicoliveProgramService;
+
+    instance.client.createProgram = jest.fn().mockResolvedValue(result);
+    instance.fetchProgram = jest.fn();
+
+    await expect(instance.createProgram()).resolves.toBe(result);
+    expect(instance.client.createProgram).toHaveBeenCalledTimes(1);
+    expect(instance.fetchProgram).toHaveBeenCalledTimes(fetchProgramCalled);
+  }
+);
+
+test.each([['EDITED', 1], ['OTHER', 0]])('editProgram with %s', async (result, refreshProgramCalled) => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.editProgram = jest.fn().mockResolvedValue(result);
+  instance.refreshProgram = jest.fn();
+
+  await expect(instance.editProgram()).resolves.toBe(result);
+  expect(instance.client.editProgram).toHaveBeenCalledTimes(1);
+  expect(instance.refreshProgram).toHaveBeenCalledTimes(refreshProgramCalled);
+});
+
+test('fetchProgramで結果が空ならエラー', async () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const instance = NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.fetchProgramSchedules = jest.fn().mockResolvedValue({ ok: true, value: [] });
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.fetchProgram()).rejects.toThrow('no suitable schedule');
+  expect(instance.client.fetchProgramSchedules).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "status": "end",
+  },
+]
+`);
+});
+
+test('fetchProgram:成功', async () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const instance = NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.fetchProgramSchedules = jest.fn().mockResolvedValue({ ok: true, value: [schedules.onAir] });
+  instance.client.fetchProgram = jest.fn().mockResolvedValue({
+    ok: true,
+    value: {
+      status: schedules.onAir.status,
+      title: '番組タイトル',
+      description: '番組詳細情報',
+      beginAt: 100,
+      endAt: 150,
+    },
+  });
+  instance.client.fetchCommunity = jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: { name: 'comunity.name', thumbnailUrl: { small: 'symbol url' } } });
+
+  // TODO: StatefulServiceのモックをVue非依存にする
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.fetchProgram()).resolves.toBeUndefined();
+  expect(instance.client.fetchProgramSchedules).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchCommunity).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "communityID": "co1",
+    "communityName": "comunity.name",
+    "communitySymbol": "symbol url",
+    "description": "番組詳細情報",
+    "endTime": 150,
+    "programID": "lv1",
+    "startTime": 100,
+    "status": "onAir",
+    "testStartTime": 50,
+    "title": "番組タイトル",
+  },
+]
+`);
+});
+
+test('fetchProgramで番組があったが取りに行ったらエラー', async () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const instance = NicoliveProgramService.instance as NicoliveProgramService;
+  const value = { meta: { status: 404 } };
+
+  instance.client.fetchProgramSchedules = jest.fn().mockResolvedValue({ ok: true, value: [schedules.onAir] });
+  instance.client.fetchProgram = jest.fn().mockResolvedValue({
+    ok: false,
+    value,
+  });
+  instance.client.fetchCommunity = jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: { name: 'comunity.name', thumbnailUrl: { small: 'symbol url' } } });
+
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.fetchProgram()).rejects.toEqual(value);
+  expect(instance.client.fetchProgramSchedules).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchCommunity).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState).not.toHaveBeenCalled();
+});
+
+test('fetchProgramで番組があったがコミュ情報がエラー', async () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const instance = NicoliveProgramService.instance as NicoliveProgramService;
+  const value = { meta: { status: 404 } };
+
+  instance.client.fetchProgramSchedules = jest.fn().mockResolvedValue({ ok: true, value: [schedules.onAir] });
+  instance.client.fetchProgram = jest.fn().mockResolvedValue({
+    ok: true,
+    value: {
+      status: schedules.onAir.status,
+      title: '番組タイトル',
+      description: '番組詳細情報',
+      beginAt: 100,
+      endAt: 150,
+    },
+  });
+  instance.client.fetchCommunity = jest.fn().mockResolvedValue({ ok: false, value });
+
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.fetchProgram()).rejects.toEqual(value);
+  expect(instance.client.fetchProgramSchedules).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchCommunity).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState).not.toHaveBeenCalled();
+});
+
+test('refreshProgram:成功', async () => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.fetchProgram = jest.fn().mockResolvedValue({ ok: true, value: programs.onAir });
+
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.refreshProgram()).resolves.toBeUndefined();
+  expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchProgram).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "description": "番組詳細情報",
+    "endTime": 150,
+    "startTime": 100,
+    "status": "onAir",
+    "title": "番組タイトル",
+  },
+]
+`);
+});
+
+test('refreshProgram:失敗', async () => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+  const value = { meta: { status: 500 } };
+
+  instance.client.fetchProgram = jest.fn().mockResolvedValue({ ok: false, value });
+
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.refreshProgram()).rejects.toEqual(value);
+  expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchProgram).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).not.toHaveBeenCalled();
+});
+
+test('endProgram:成功', async () => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.endProgram = jest.fn().mockResolvedValue({ ok: true, value: { end_time: 125 } });
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.endProgram()).resolves.toBeUndefined();
+  expect(instance.client.endProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.endProgram).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "endTime": 125,
+    "status": "end",
+  },
+]
+`);
+});
+
+test('endProgram:失敗', async () => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+  const value = { meta: { status: 500 } };
+  instance.client.endProgram = jest.fn().mockResolvedValue({ ok: false, value });
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.endProgram()).rejects.toEqual(value);
+  expect(instance.client.endProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.endProgram).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).not.toHaveBeenCalled();
+});
+
+test('extendProgram:成功', async () => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.extendProgram = jest.fn().mockResolvedValue({ ok: true, value: { end_time: 125 } });
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.extendProgram()).resolves.toBeUndefined();
+  expect(instance.client.extendProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.extendProgram).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).toHaveBeenCalledTimes(1);
+  expect((instance as any).setState.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "endTime": 125,
+  },
+]
+`);
+});
+
+test('extendProgram:失敗', async () => {
+  setup();
+  const m = require('./nicolive-program');
+  const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+  const value = { meta: { status: 500 } };
+  instance.client.extendProgram = jest.fn().mockResolvedValue({ ok: false, value });
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.extendProgram()).rejects.toEqual(value);
+  expect(instance.client.extendProgram).toHaveBeenCalledTimes(1);
+  expect(instance.client.extendProgram).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).not.toHaveBeenCalled();
+});
+
+describe('refreshStatisticsPolling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const suites: {
+    name: string;
+    prev: any;
+    next: any;
+    result: 'REFRESH' | 'STOP' | 'NOOP';
+  }[] = [
+    {
+      name: '初期状態から予約状態の番組を開くとタイマーは止まったまま',
+      prev: initialState,
+      next: { status: 'reserved', programID: 'lv1' },
+      result: 'NOOP',
+    },
+    {
+      name: '初期状態からテスト状態の番組を開くとタイマーは止まったまま',
+      prev: initialState,
+      next: { status: 'test', programID: 'lv1' },
+      result: 'NOOP',
+    },
+    {
+      name: '初期状態から放送中状態の番組を開くとタイマーを更新する',
+      prev: initialState,
+      next: { status: 'onAir', programID: 'lv1' },
+      result: 'REFRESH',
+    },
+    {
+      name: '初期状態から終了状態の番組を開くとタイマーは止まったまま',
+      prev: initialState,
+      next: { status: 'end', programID: 'lv1' },
+      result: 'NOOP',
+    },
+    {
+      name: 'テスト状態から放送中状態になったらタイマーを更新する',
+      prev: { status: 'test', programID: 'lv1' },
+      next: { status: 'onAir', programID: 'lv1' },
+      result: 'REFRESH',
+    },
+    {
+      name: 'テスト状態から終了状態になったらタイマーを止める',
+      prev: { status: 'onAir', programID: 'lv1' },
+      next: { status: 'end', programID: 'lv1' },
+      result: 'STOP',
+    },
+    {
+      name: '放送中状態から別番組の放送中状態になったらタイマーを更新する',
+      prev: { status: 'onAir', programID: 'lv1' },
+      next: { status: 'onAir', programID: 'lv2' },
+      result: 'REFRESH',
+    },
+  ];
+
+  for (const suite of suites) {
+    test(suite.name, () => {
+      jest.spyOn(window, 'setInterval').mockImplementation(jest.fn());
+      jest.spyOn(window, 'clearInterval').mockImplementation(jest.fn());
+
+      setup();
+      const { NicoliveProgramService } = require('./nicolive-program');
+      const instance = NicoliveProgramService.instance as NicoliveProgramService;
+
+      instance.updateStatistics = jest.fn();
+
+      instance.refreshStatisticsPolling(suite.prev, suite.next);
+      switch (suite.result) {
+        case 'REFRESH':
+          expect(window.clearInterval).toHaveBeenCalledTimes(1);
+          expect(window.clearInterval).toHaveBeenCalledWith(0);
+          expect(window.setInterval).toHaveBeenCalledTimes(1);
+          expect(window.setInterval).toHaveBeenCalledWith(expect.anything(), 60 * 1000, suite.next.programID);
+          break;
+        case 'STOP':
+          expect(window.clearInterval).toHaveBeenCalledTimes(1);
+          expect(window.clearInterval).toHaveBeenCalledWith(0);
+          expect(window.setInterval).not.toHaveBeenCalled();
+          break;
+        case 'NOOP':
+          break;
+      }
+    });
+  }
+});
+
+test('updateStatistics', async () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const instance = NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.fetchStatistics = jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: { watchCount: 123, commentCount: 456 } });
+  instance.client.fetchNicoadStatistics = jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: { totalAdPoint: 175, totalGiftPoint: 345 } });
+
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.updateStatistics('lv1')).resolves.toBeInstanceOf(Array);
+  expect(instance.client.fetchStatistics).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchStatistics).toHaveBeenCalledWith('lv1');
+  expect(instance.client.fetchNicoadStatistics).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchNicoadStatistics).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).toHaveBeenCalledTimes(2);
+  expect((instance as any).setState.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    Object {
+      "comments": 456,
+      "viewers": 123,
+    },
+  ],
+  Array [
+    Object {
+      "adPoint": 175,
+      "giftPoint": 345,
+    },
+  ],
+]
+`);
+});
+
+test('updateStatistics:APIがエラーでも無視', async () => {
+  setup();
+  const { NicoliveProgramService } = require('./nicolive-program');
+  const instance = NicoliveProgramService.instance as NicoliveProgramService;
+
+  instance.client.fetchStatistics = jest.fn().mockResolvedValue({ ok: false, value: { meta: { status: 500 } } });
+  instance.client.fetchNicoadStatistics = jest.fn().mockResolvedValue({ ok: false, value: { meta: { status: 500 } } });
+
+  (instance as any).setState = jest.fn();
+
+  await expect(instance.updateStatistics('lv1')).resolves.toBeInstanceOf(Array);
+  expect(instance.client.fetchStatistics).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchStatistics).toHaveBeenCalledWith('lv1');
+  expect(instance.client.fetchNicoadStatistics).toHaveBeenCalledTimes(1);
+  expect(instance.client.fetchNicoadStatistics).toHaveBeenCalledWith('lv1');
+  expect((instance as any).setState).not.toHaveBeenCalled();
+});
+
+describe('refreshProgramStatusTimer', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const suites: {
+    name: string;
+    prev: any;
+    next: any;
+    result: 'REFRESH' | 'STOP' | 'NOOP';
+  }[] = [
+    {
+      name: '初期状態から予約状態の番組を開くとタイマーを更新する',
+      prev: initialState,
+      next: { status: 'reserved', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'REFRESH',
+    },
+    {
+      name: '初期状態からテスト状態の番組を開くとタイマーを更新する',
+      prev: initialState,
+      next: { status: 'test', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'REFRESH',
+    },
+    {
+      name: '初期状態から放送中状態の番組を開くとタイマーを更新する',
+      prev: initialState,
+      next: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'REFRESH',
+    },
+    {
+      name: '初期状態から終了状態の番組を開くとタイマーは止まったまま',
+      prev: initialState,
+      next: { status: 'end', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'NOOP',
+    },
+    {
+      name: '終了状態から予約状態になったらタイマーを更新する',
+      prev: { status: 'end', programID: 'lv0', testStartTime: 10, startTime: 20, endTime: 30 },
+      next: { status: 'reserved', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'REFRESH',
+    },
+    {
+      name: '予約状態からテスト状態になったらタイマーを更新する',
+      prev: { status: 'reserved', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'test', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'REFRESH',
+    },
+    {
+      name: 'テスト状態から放送中状態になったらタイマーを更新する',
+      prev: { status: 'test', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'REFRESH',
+    },
+    {
+      name: 'テスト状態から終了状態になったらタイマーを止める',
+      prev: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'end', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'STOP',
+    },
+    {
+      name: '放送中に終了時間が変わったらタイマーを更新する',
+      prev: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 350 },
+      result: 'REFRESH',
+    },
+    {
+      name: '何も変わらなければ何もしない',
+      prev: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      result: 'NOOP',
+    },
+    // 以下、N Air外部で状態を操作した場合に壊れないことを保証したい
+    {
+      name: '予約状態から別番組の予約状態になったらタイマーを更新する',
+      prev: { status: 'reserved', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'reserved', programID: 'lv2', testStartTime: 400, startTime: 500, endTime: 600 },
+      result: 'REFRESH',
+    },
+    {
+      name: 'テスト状態から別番組のテスト状態になったらタイマーを更新する',
+      prev: { status: 'test', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'test', programID: 'lv2', testStartTime: 400, startTime: 500, endTime: 600 },
+      result: 'REFRESH',
+    },
+    {
+      name: '放送中状態から別番組の放送中状態になったらタイマーを更新する',
+      prev: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'onAir', programID: 'lv2', testStartTime: 400, startTime: 500, endTime: 600 },
+      result: 'REFRESH',
+    },
+    {
+      name: '終了状態から別番組の終了状態になってもタイマーは止まったまま',
+      prev: { status: 'end', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'end', programID: 'lv2', testStartTime: 400, startTime: 500, endTime: 600 },
+      result: 'NOOP',
+    },
+  ];
+
+  for (const suite of suites) {
+    test(suite.name, () => {
+      setup();
+      const m = require('./nicolive-program');
+      const instance = m.NicoliveProgramService.instance as NicoliveProgramService;
+
+      jest.spyOn(window, 'setTimeout').mockImplementation(jest.fn());
+      jest.spyOn(window, 'clearTimeout').mockImplementation(jest.fn());
+      jest.spyOn(Date, 'now').mockImplementation(jest.fn().mockReturnValue(50));
+
+      instance.updateStatistics = jest.fn();
+
+      instance.refreshProgramStatusTimer(suite.prev, suite.next);
+      switch (suite.result) {
+        case 'REFRESH':
+          expect(window.clearTimeout).toHaveBeenCalledTimes(1);
+          expect(window.clearTimeout).toHaveBeenCalledWith(0);
+          expect(window.setTimeout).toHaveBeenCalledTimes(1);
+          expect(window.setTimeout).toHaveBeenCalledWith(expect.anything(), expect.anything());
+          break;
+        case 'STOP':
+          expect(window.clearTimeout).toHaveBeenCalledTimes(1);
+          expect(window.clearTimeout).toHaveBeenCalledWith(0);
+          expect(window.setTimeout).not.toHaveBeenCalled();
+          break;
+        case 'NOOP':
+          break;
+      }
+    });
+  }
+});
+
+// TODO: 自動延長系は永続化してから
+test.todo('toggleAutoExtension');
+test.todo('refreshAutoExtensionTimer');

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -389,6 +389,12 @@ describe('refreshStatisticsPolling', () => {
       result: 'NOOP',
     },
     {
+      name: '予約状態から放送中状態になったらタイマーを更新する',
+      prev: { status: 'reserved', programID: 'lv1' },
+      next: { status: 'onAir', programID: 'lv1' },
+      result: 'REFRESH',
+    },
+    {
       name: 'テスト状態から放送中状態になったらタイマーを更新する',
       prev: { status: 'test', programID: 'lv1' },
       next: { status: 'onAir', programID: 'lv1' },
@@ -401,10 +407,28 @@ describe('refreshStatisticsPolling', () => {
       result: 'STOP',
     },
     {
+      name: '放送中状態から別番組の予約状態になったらタイマーを止める',
+      prev: { status: 'onAir', programID: 'lv1' },
+      next: { status: 'reserved', programID: 'lv2' },
+      result: 'STOP',
+    },
+    {
+      name: '放送中状態から別番組の放送中状態になったらタイマーを止める',
+      prev: { status: 'onAir', programID: 'lv1' },
+      next: { status: 'test', programID: 'lv2' },
+      result: 'STOP',
+    },
+    {
       name: '放送中状態から別番組の放送中状態になったらタイマーを更新する',
       prev: { status: 'onAir', programID: 'lv1' },
       next: { status: 'onAir', programID: 'lv2' },
       result: 'REFRESH',
+    },
+    {
+      name: '放送中状態から別番組の終了状態になったらタイマーを止める',
+      prev: { status: 'onAir', programID: 'lv1' },
+      next: { status: 'end', programID: 'lv2' },
+      result: 'STOP',
     },
   ];
 
@@ -537,9 +561,9 @@ describe('refreshProgramStatusTimer', () => {
       result: 'REFRESH',
     },
     {
-      name: '予約状態からテスト状態になったらタイマーを更新する',
+      name: '予約状態から放送中状態になったらタイマーを更新する',
       prev: { status: 'reserved', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
-      next: { status: 'test', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
+      next: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
       result: 'REFRESH',
     },
     {

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -84,7 +84,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   static isProgramExtendable(state: INicoliveProgramState): boolean {
-    return state && state.status === 'onAir' && state.endTime - state.startTime < 6 * 60 * 60;
+    return state.status === 'onAir' && state.endTime - state.startTime < 6 * 60 * 60;
   }
 
   get hasProgram(): boolean {
@@ -113,9 +113,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     const programSchedule = NicoliveProgramService.findSuitableProgram(schedulesResponse.value);
 
     if (!programSchedule) {
-      if (this.state) {
-        this.setState({ status: 'end' });
-      }
+      this.setState({ status: 'end' });
       throw new Error('no suitable schedule');
     }
     const { nicoliveProgramId, socialGroupId } = programSchedule;
@@ -208,10 +206,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
   private statsTimer: number = 0;
   refreshStatisticsPolling(prevState: INicoliveProgramState, nextState: INicoliveProgramState): void {
-    const programUpdated = !prevState || prevState.programID !== nextState.programID;
+    const programUpdated = prevState.programID !== nextState.programID;
 
-    const prev = prevState && prevState.status === 'onAir';
-    const next = nextState && nextState.status === 'onAir';
+    const prev = prevState.status === 'onAir';
+    const next = nextState.status === 'onAir';
 
     if ((!prev && next) || (next && programUpdated)) {
       clearInterval(this.statsTimer);
@@ -263,16 +261,16 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   };
   private refreshProgramTimer = 0;
   refreshProgramStatusTimer(prevState: INicoliveProgramState, nextState: INicoliveProgramState): void {
-    const programUpdated = !prevState || prevState.programID !== nextState.programID;
-    const statusUpdated = !prevState || prevState.status !== nextState.status;
+    const programUpdated = prevState.programID !== nextState.programID;
+    const statusUpdated = prevState.status !== nextState.status;
 
     /** 放送状態が変化しなかった前提で、放送状態が次に変化するであろう時刻 */
     const prevTargetTime: number = prevState[NicoliveProgramService.REFRESH_TARGET_TIME_TABLE[nextState.status]];
     const nextTargetTime: number = nextState[NicoliveProgramService.REFRESH_TARGET_TIME_TABLE[nextState.status]];
     const targetTimeUpdated = !statusUpdated && prevTargetTime !== nextTargetTime;
 
-    const prev = prevState && prevState.status !== 'end';
-    const next = nextState && nextState.status !== 'end';
+    const prev = prevState.status !== 'end';
+    const next = nextState.status !== 'end';
 
     if (next && (!prev || programUpdated || statusUpdated || targetTimeUpdated)) {
       const now = Date.now();
@@ -290,10 +288,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   private autoExtensionTimer = 0;
   refreshAutoExtensionTimer(prevState: INicoliveProgramState, nextState: INicoliveProgramState): void {
     const now = Date.now();
-    const endTimeUpdated = !prevState || prevState.endTime !== nextState.endTime;
+    const endTimeUpdated = prevState.endTime !== nextState.endTime;
 
     /** 更新前の状態でタイマーが動作しているべきか */
-    const prev = prevState && prevState.autoExtensionEnabled && NicoliveProgramService.isProgramExtendable(prevState);
+    const prev = prevState.autoExtensionEnabled && NicoliveProgramService.isProgramExtendable(prevState);
     /** 更新後の状態でタイマーが動作しているべきか */
     const next = nextState.autoExtensionEnabled && NicoliveProgramService.isProgramExtendable(nextState);
 

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -1,0 +1,233 @@
+import { StatefulService, mutation } from 'services/stateful-service';
+import { NicoliveClient, CreateResult, EditResult, isOk } from './NicoliveClient';
+
+interface INicoliveProgramState {
+  programID: string;
+  status: string;
+  title: string;
+  description: string;
+  endTime: number;
+  startTime: number;
+  communityID: string;
+  communityName: string;
+  communitySymbol: string;
+  viewers: number;
+  comments: number;
+  adPoint: number;
+  giftPoint: number;
+  extendable: boolean;
+  /** TODO: 永続化 */
+  autoExtentionEnabled: boolean;
+}
+
+export class NicoliveProgramService extends StatefulService<INicoliveProgramState> {
+  static initialState: INicoliveProgramState = {
+    programID: '',
+    status: '',
+    title: '',
+    description: '',
+    endTime: 0,
+    startTime: 0,
+    communityID: '',
+    communityName: '',
+    communitySymbol: '',
+    viewers: 0,
+    comments: 0,
+    adPoint: 0,
+    giftPoint: 0,
+    extendable: true,
+    autoExtentionEnabled: false,
+  };
+
+  client: NicoliveClient = new NicoliveClient();
+
+  get hasProgram(): boolean {
+    return Boolean(this.state.programID);
+  }
+
+  private setState(partialState: Partial<INicoliveProgramState>) {
+    const nextState = { ...this.state, ...partialState };
+    this.refreshStatisticsPolling(this.state, nextState);
+    this.SET_STATE(nextState);
+  }
+
+  @mutation()
+  private SET_STATE(nextState: INicoliveProgramState): void {
+    this.state = nextState;
+  }
+
+  async createProgram(): Promise<CreateResult> {
+    const result = await this.client.createProgram();
+    if (result === 'CREATED') {
+      await this.fetchProgram();
+    }
+    return result;
+  }
+
+  async fetchProgram(): Promise<void> {
+    const schedulesResponse = await this.client.fetchProgramSchedules();
+    if (!isOk(schedulesResponse)) {
+      console.warn(schedulesResponse.value.meta.errorCode);
+      throw schedulesResponse.value;
+    }
+
+    // TODO: select suitable program
+    const programSchedule = schedulesResponse.value[0];
+
+    if (!programSchedule) {
+      if (this.state) {
+        this.setState({ status: 'end' });
+      }
+      throw new Error('no suitable schedule');
+    }
+    const { nicoliveProgramId, socialGroupId } = programSchedule;
+
+    const [programResponse, communityResponse] = await Promise.all([
+      this.client.fetchProgram(nicoliveProgramId),
+      this.client.fetchCommunity(socialGroupId),
+    ]);
+    if (!isOk(programResponse)) {
+      console.warn(programResponse.value.meta.errorCode);
+      throw programResponse.value;
+    }
+    if (!isOk(communityResponse)) {
+      console.warn(communityResponse.value.meta.errorCode);
+      throw communityResponse.value;
+    }
+
+    const community = communityResponse.value;
+    const program = programResponse.value;
+
+    this.setState({
+      programID: nicoliveProgramId,
+      status: program.status,
+      title: program.title,
+      description: program.description,
+      startTime: program.beginAt,
+      endTime: program.endAt,
+      communityID: socialGroupId,
+      communityName: community.name,
+      communitySymbol: community.thumbnailUrl.small,
+      extendable: true,
+    });
+  }
+
+  async refreshProgram(): Promise<void> {
+    const programResponse = await this.client.fetchProgram(this.state.programID);
+    if (!isOk(programResponse)) {
+      console.warn(programResponse.value.meta.errorCode);
+      throw programResponse.value;
+    }
+
+    const program = programResponse.value;
+
+    this.setState({
+      status: program.status,
+      title: program.title,
+      description: program.description,
+      startTime: program.beginAt,
+      endTime: program.endAt,
+    });
+  }
+
+  async editProgram(): Promise<EditResult> {
+    const result = await this.client.editProgram(this.state.programID);
+    if (result === 'EDITED') {
+      await this.refreshProgram();
+    }
+    return result;
+  }
+
+  async startProgram(): Promise<void> {
+    const result = await this.client.startProgram(this.state.programID);
+    if (isOk(result)) {
+      const endTime = result.value.end_time;
+      const startTime = result.value.start_time;
+      this.setState({ status: 'onAir', endTime, startTime });
+      return;
+    }
+
+    throw result.value;
+  }
+
+  async endProgram(): Promise<void> {
+    const result = await this.client.endProgram(this.state.programID);
+    if (isOk(result)) {
+      const endTime = result.value.end_time;
+      this.setState({ status: 'end', endTime });
+      return;
+    }
+
+    throw result.value;
+  }
+
+  toggleAutoExtension() {
+    const autoExtentionEnabled = !this.state.autoExtentionEnabled;
+    this.setState({ autoExtentionEnabled });
+  }
+
+  async extendProgram(): Promise<void> {
+    const result = await this.client.extendProgram(this.state.programID);
+    if (isOk(result)) {
+      this.setState({
+        endTime: result.value.end_time,
+      });
+      return;
+    }
+
+    if (result.value.meta.status === 400) {
+      this.setState({
+        extendable: false,
+      });
+    }
+
+    throw result.value;
+  }
+
+  private statsTimer: number = 0;
+  refreshStatisticsPolling(prevState: INicoliveProgramState, nextState: INicoliveProgramState): void {
+    const onInitialize = !prevState;
+    const hasNextProgram = Boolean(nextState.programID);
+    const programUpdated = onInitialize || prevState.programID !== nextState.programID;
+    const nextStatusIsOnAir = nextState.status === 'onAir';
+    const statusUpdated = onInitialize || prevState.status !== nextState.status;
+
+    if (hasNextProgram && nextStatusIsOnAir && (programUpdated || statusUpdated)) {
+      clearInterval(this.statsTimer);
+      this.updateStatistics(nextState.programID); // run and forget
+      this.statsTimer = window.setInterval((id: string) => this.updateStatistics(id), 60 * 1000, nextState.programID);
+    } else if (!nextStatusIsOnAir) {
+      clearInterval(this.statsTimer);
+    }
+  }
+
+  updateStatistics(programID: string): void {
+    this.client
+      .fetchStatistics(programID)
+      .then(res => {
+        if (isOk(res)) {
+          this.setState({
+            viewers: res.value.watchCount,
+            comments: res.value.commentCount,
+          });
+        }
+      })
+      .catch(() => null);
+    this.client
+      .fetchNicoadStatistics(programID)
+      .then(res => {
+        if (isOk(res)) {
+          this.setState({
+            adPoint: res.value.totalAdPoint,
+            giftPoint: res.value.totalGiftPoint,
+          });
+        }
+      })
+      .catch(() => null);
+  }
+
+  async sendOperatorComment(text: string, isPermanent: boolean): Promise<void> {
+    const result = await this.client.sendOperatorComment(this.state.programID, { text, isPermanent });
+    if (!isOk(result)) throw result.value;
+  }
+}

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -257,7 +257,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
   static TIMER_PADDING_SECONDS = 3;
   static REFRESH_TARGET_TIME_TABLE = {
-    reserved: 'testStartTime',
+    reserved: 'startTime',
     test: 'startTime',
     onAir: 'endTime',
   };

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -49,9 +49,8 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
    */
   static findSuitableProgram(schedules: Schedules): null | Schedule {
     // テスト中・放送中の番組があればそれで確定
-    const now = Math.floor(Date.now() / 1000);
     const currentProgram = schedules.find(
-      s => s.socialGroupId.startsWith('co') && s.testBeginAt <= now && now < s.onAirEndAt
+      s => s.socialGroupId.startsWith('co') && (s.status === 'test' || s.status === 'onAir')
     );
     if (currentProgram) return currentProgram;
 

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -11,7 +11,6 @@ interface INicoliveProgramState {
   description: string;
   endTime: number;
   startTime: number;
-  testStartTime: number;
   communityID: string;
   communityName: string;
   communitySymbol: string;
@@ -33,7 +32,6 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     description: '',
     endTime: 0,
     startTime: 0,
-    testStartTime: 0,
     communityID: '',
     communityName: '',
     communitySymbol: '',
@@ -76,7 +74,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       if (s.status === 'end') continue;
 
       // 一番近い予約放送を選ぶ
-      if (!nearestReservedProgram || s.testBeginAt < nearestReservedProgram.testBeginAt) {
+      if (!nearestReservedProgram || s.onAirBeginAt < nearestReservedProgram.onAirBeginAt) {
         nearestReservedProgram = s;
       }
     }
@@ -140,7 +138,6 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       title: program.title,
       description: program.description,
       startTime: program.beginAt,
-      testStartTime: programSchedule.testBeginAt,
       endTime: program.endAt,
       communityID: socialGroupId,
       communityName: community.name,

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -304,14 +304,20 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     // 動作すべき状態になる OR 終了時刻が変わったら再設定
     if ((!prev && next) || (next && endTimeUpdated)) {
       clearTimeout(this.autoExtensionTimer);
-      this.autoExtensionTimer = window.setTimeout(() => {
+      const timeout = (nextState.endTime - 5 * 60) * 1000 - now;
+      // 5分前をすでに過ぎていたら即延長
+      if (timeout <= 0) {
         this.extendProgram();
-      }, (nextState.endTime - 5 * 60) * 1000 - now);
-      console.log(
-        '自動延長タイマーが（再）設定されました ',
-        Math.floor(((nextState.endTime - 5 * 60) * 1000 - now) / 1000),
-        '秒後に自動延長します'
-      );
+      } else {
+        this.autoExtensionTimer = window.setTimeout(() => {
+          this.extendProgram();
+        }, timeout);
+        console.log(
+          '自動延長タイマーが（再）設定されました ',
+          Math.floor(((nextState.endTime - 5 * 60) * 1000 - now) / 1000),
+          '秒後に自動延長します'
+        );
+      }
       return;
     }
 

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -85,6 +85,18 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     return state.status === 'onAir' && state.endTime - state.startTime < 6 * 60 * 60;
   }
 
+  static format(timeInSeconds: number): string {
+    const absTime = Math.abs(timeInSeconds);
+    const s = absTime % 60;
+    const m = Math.floor(absTime / 60) % 60;
+    const h = Math.floor(absTime / 3600);
+    const sign = Math.sign(timeInSeconds) > 0 ? '' : '-';
+    const ss = s.toString(10).padStart(2, '0');
+    const mm = m.toString(10).padStart(2, '0');
+    const hh = h.toString(10).padStart(2, '0');
+    return `${sign}${hh}:${mm}:${ss}`;
+  }
+
   get hasProgram(): boolean {
     return Boolean(this.state.programID);
   }

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -191,7 +191,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     this.setState({ status: 'end', endTime });
   }
 
-  toggleAutoExtension() {
+  toggleAutoExtension(): void {
     const autoExtensionEnabled = !this.state.autoExtensionEnabled;
     this.setState({ autoExtensionEnabled });
   }


### PR DESCRIPTION
# このpull requestが解決する内容
ユーザー生放送に関する次の機能を実装します。
- 作成済みの番組を一定規則で取得する
- 番組を作る
- 番組を編集する
- 番組を開始・終了する
- 番組を延長する、自動延長する
- 運営コメントを送る（通常・固定）
- 視聴者数・コメント数・ニコニ広告pt・ギフトptを表示し、自動更新する
- 番組詳細を表示する

# やっていないこと
- コンポーネントの外観（動作確認のための仮置きです）
- 仕様通りの文言配置（雰囲気です）
- 翻訳
- 番組詳細の自動リンク対応
- 自動再生処理のアプリケーション側永続化
    - 多少実装が変わる見込みがあります（なのでテストも書いてない）
- SNSシェア等のURL配置
- 番組状態インジケーターの移動
- （番組ではない方の）配信時間表示
- 細かいエラー系対応
- 多重呼び出しの防止 ref. https://github.com/n-air-app/n-air-app/pull/243#discussion_r268585945

**動作確認手順**
- テスト
- 動かしてみる