### PR TITLE
修正: ファイルのドラッグ＆ドロップで操作不能になってしまう可能性がある問題を修正

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -87,6 +87,7 @@ VTooltip.options.defaultContainer = '#mainWrapper';
 
 // Disable chrome default drag/drop behavior
 document.addEventListener('dragover', event => event.preventDefault());
+document.addEventListener('dragenter', event => event.preventDefault());
 document.addEventListener('drop', event => event.preventDefault());
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
**このpull requestが解決する内容**
#242 を修正します。

[MDNのドラッグ＆ドロップについての項](https://developer.mozilla.org/ja/docs/Web/API/HTML_Drag_and_Drop_API#events)を参照したところ、dragoverの項において`ほとんどの場合、イベントリスナは dragenter イベントの時と同じ処理を行うでしょう。`と書かれていますが、app.tsではdragoverとdropは塞がれているものの、dragenterが塞がれていませんでした。
これによって #242 の事象が発生していた可能性があります。

commitメッセージが英語なのは同じ事象がSLOBSでも再現したので同commitをSLOBSにもcherry-pickで持っていくためです。

**動作確認手順**
#242 の再現手順を行い、直接遷移してしまわないことを確認する