### PR TITLE
追加: 自動リンクを実装

### DIFF
--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -1,8 +1,7 @@
 <template>
   <div>
     <h1>番組詳細</h1>
-    <!-- TODO: 自動リンク等 -->
-    <div v-html="programDescription"></div>
+    <div @click="handleAnchorClick" v-html="programDescription"></div>
   </div>
 </template>
 

--- a/app/components/nicolive-area/ProgramDescription.vue.ts
+++ b/app/components/nicolive-area/ProgramDescription.vue.ts
@@ -2,6 +2,8 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { remote } from 'electron';
+import { apply as applyAutoLink } from 'util/autoLink';
 
 @Component({})
 export default class ProgramDescription extends Vue {
@@ -9,6 +11,25 @@ export default class ProgramDescription extends Vue {
   nicoliveProgramService: NicoliveProgramService;
 
   get programDescription(): string {
-    return this.nicoliveProgramService.state.description;
+    return applyAutoLink(this.nicoliveProgramService.state.description);
+  }
+
+  /**
+   * 番組詳細のリンクを既定のブラウザで開く
+   * anchor要素は自動リンクによってしか生成されないので、anchor要素の子はテキストノードのみ
+   **/
+  handleAnchorClick(event: MouseEvent): void {
+    if (!(event.target instanceof HTMLAnchorElement)) return;
+
+    event.preventDefault();
+    const url = event.target.href;
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol.match(/https?/)) {
+        remote.shell.openExternal(parsed.href);
+      }
+    } catch (e) {
+      console.error(e);
+    }
   }
 }

--- a/app/util/autoLink.test.ts
+++ b/app/util/autoLink.test.ts
@@ -1,0 +1,329 @@
+/* tslint:disable:max-line-length quotemark */
+
+import { apply, splitByRegExpWithMatchedValues } from './autoLink';
+
+test('全部入り', () => {
+  expect(
+    apply(
+      `
+わいわい<br />
+lv1 co1 sm9<br />
+<b>これはbタグで sm9 を含む</b><br />
+https://live.nicovideo.jp<br />
+https://live.nicovideo.jp/<br />
+https://live.nicovideo.jp/my<br />
+<i>user/1</i>
+`
+    )
+  ).toMatchInlineSnapshot(`
+"
+わいわい<br />
+<a href=\\"https://live2.nicovideo.jp/watch/lv1\\">lv1</a> <a href=\\"https://com.nicovideo.jp/community/co1\\">co1</a> <a href=\\"https://www.nicovideo.jp/watch/sm9\\">sm9</a><br />
+<b>これはbタグで <a href=\\"https://www.nicovideo.jp/watch/sm9\\">sm9</a> を含む</b><br />
+<a href=\\"https://live.nicovideo.jp\\">https://live.nicovideo.jp</a><br />
+<a href=\\"https://live.nicovideo.jp/\\">https://live.nicovideo.jp/</a><br />
+<a href=\\"https://live.nicovideo.jp/my\\">https://live.nicovideo.jp/my</a><br />
+<i><a href=\\"https://www.nicovideo.jp/user/1\\">user/1</a></i>
+"
+`);
+});
+
+test('sm9', () => {
+  expect(apply('sm9')).toMatchInlineSnapshot(`"<a href=\\"https://www.nicovideo.jp/watch/sm9\\">sm9</a>"`);
+});
+
+test('watch/1234567890', () => {
+  expect(apply('watch/1234567890')).toMatchInlineSnapshot(
+    `"<a href=\\"https://www.nicovideo.jp/watch/1234567890\\">watch/1234567890</a>"`
+  );
+});
+
+test('user/1', () => {
+  expect(apply('user/1')).toMatchInlineSnapshot(`"<a href=\\"https://www.nicovideo.jp/user/1\\">user/1</a>"`);
+});
+
+test('myvideo/1', () => {
+  expect(apply('myvideo/1')).toMatchInlineSnapshot(`"<a href=\\"https://www.nicovideo.jp/myvideo/1\\">myvideo/1</a>"`);
+});
+
+test('lv1', () => {
+  expect(apply('lv1')).toMatchInlineSnapshot(`"<a href=\\"https://live2.nicovideo.jp/watch/lv1\\">lv1</a>"`);
+});
+
+test('co1', () => {
+  expect(apply('co1')).toMatchInlineSnapshot(`"<a href=\\"https://com.nicovideo.jp/community/co1\\">co1</a>"`);
+});
+
+test('mylist/1', () => {
+  expect(apply('mylist/1')).toMatchInlineSnapshot(`"<a href=\\"https://www.nicovideo.jp/mylist/1\\">mylist/1</a>"`);
+});
+
+test('niconicommons.jp/user/1', () => {
+  expect(apply('niconicommons.jp/user/1')).toMatchInlineSnapshot(
+    `"<a href=\\"https://www.niconicommons.jp/user/1\\">niconicommons.jp/user/1</a>"`
+  );
+});
+
+test('nc1', () => {
+  expect(apply('nc1')).toMatchInlineSnapshot(`"<a href=\\"https://www.niconicommons.jp/material/nc1\\">nc1</a>"`);
+});
+
+test('ch1', () => {
+  expect(apply('ch1')).toMatchInlineSnapshot(`"<a href=\\"https://ch.nicovideo.jp/channel/ch1\\">ch1</a>"`);
+});
+
+test('ch.nicovideo.jp/hoge', () => {
+  expect(apply('ch.nicovideo.jp/hoge')).toMatchInlineSnapshot(
+    `"<a href=\\"https://ch.nicovideo.jp/hoge\\">ch.nicovideo.jp/hoge</a>"`
+  );
+});
+
+test('ar2525', () => {
+  expect(apply('ar2525')).toMatchInlineSnapshot(`"<a href=\\"https://ch.nicovideo.jp/article/ar2525\\">ar2525</a>"`);
+});
+
+test('nw1', () => {
+  expect(apply('nw1')).toMatchInlineSnapshot(`"<a href=\\"https://news.nicovideo.jp/watch/nw1\\">nw1</a>"`);
+});
+
+test('dw1', () => {
+  expect(apply('dw1')).toMatchInlineSnapshot(`"<a href=\\"https://ichiba.nicovideo.jp/item/dw1\\">dw1</a>"`);
+});
+
+test('azABXZ120945', () => {
+  expect(apply('azABXZ120945')).toMatchInlineSnapshot(
+    `"<a href=\\"https://ichiba.nicovideo.jp/item/azABXZ120945\\">azABXZ120945</a>"`
+  );
+});
+
+test('ap2525', () => {
+  expect(apply('ap2525')).toMatchInlineSnapshot(`"<a href=\\"https://app.nicovideo.jp/app/ap2525\\">ap2525</a>"`);
+});
+
+test('im1', () => {
+  expect(apply('im1')).toMatchInlineSnapshot(`"<a href=\\"https://seiga.nicovideo.jp/seiga/im1\\">im1</a>"`);
+});
+
+test('clip/1', () => {
+  expect(apply('clip/1')).toMatchInlineSnapshot(`"<a href=\\"https://seiga.nicovideo.jp/clip/1\\">clip/1</a>"`);
+});
+
+test('user/illust/1', () => {
+  expect(apply('user/illust/1')).toMatchInlineSnapshot(
+    `"<a href=\\"https://seiga.nicovideo.jp/user/illust/1\\">user/illust/1</a>"`
+  );
+});
+
+test('mg1', () => {
+  expect(apply('mg1')).toMatchInlineSnapshot(`"<a href=\\"https://seiga.nicovideo.jp/watch/mg1\\">mg1</a>"`);
+});
+
+test('bk1', () => {
+  expect(apply('bk1')).toMatchInlineSnapshot(`"<a href=\\"https://seiga.nicovideo.jp/watch/bk1\\">bk1</a>"`);
+});
+
+test('sg1', () => {
+  expect(apply('sg1')).toMatchInlineSnapshot(`"<a href=\\"https://seiga.nicovideo.jp/watch/sg1\\">sg1</a>"`);
+});
+
+test('comic/1', () => {
+  expect(apply('comic/1')).toMatchInlineSnapshot(`"<a href=\\"https://seiga.nicovideo.jp/comic/1\\">comic/1</a>"`);
+});
+
+test('td1', () => {
+  expect(apply('td1')).toMatchInlineSnapshot(`"<a href=\\"https://3d.nicovideo.jp/works/td1\\">td1</a>"`);
+});
+
+test('jps1', () => {
+  expect(apply('jps1')).toMatchInlineSnapshot(
+    `"<a href=\\"https://jpstore.dwango.jp/products/detail.php?product_id=1\\">jps1</a>"`
+  );
+});
+
+test('kn1', () => {
+  expect(apply('kn1')).toMatchInlineSnapshot(`"<a href=\\"https://niconare.nicovideo.jp/watch/kn1\\">kn1</a>"`);
+});
+
+test('gm1', () => {
+  expect(apply('gm1')).toMatchInlineSnapshot(`"<a href=\\"https://game.nicovideo.jp/atsumaru/games/gm1\\">gm1</a>"`);
+});
+
+test('mt1', () => {
+  expect(apply('mt1')).toMatchInlineSnapshot(`"<a href=\\"https://mtm.nicovideo.jp/watch/mt1\\">mt1</a>"`);
+});
+
+test('nq1', () => {
+  expect(apply('nq1')).toMatchInlineSnapshot(`"<a href=\\"https://q.nicovideo.jp/watch/nq1\\">nq1</a>"`);
+});
+
+test('https://www.nicovideo.jp/my', () => {
+  expect(apply('https://www.nicovideo.jp/my')).toMatchInlineSnapshot(
+    `"<a href=\\"https://www.nicovideo.jp/my\\">https://www.nicovideo.jp/my</a>"`
+  );
+});
+
+test('https://example.com/', () => {
+  expect(apply('https://example.com/')).toMatchInlineSnapshot(
+    `"<a href=\\"https://example.com/\\">https://example.com/</a>"`
+  );
+});
+
+test('https://example.com', () => {
+  expect(apply('https://example.com')).toMatchInlineSnapshot(
+    `"<a href=\\"https://example.com\\">https://example.com</a>"`
+  );
+});
+
+test('日本語ドメイン', () => {
+  expect(apply('https://日本語.jp')).toMatchInlineSnapshot(`"<a href=\\"https://日本語.jp\\">https://日本語.jp</a>"`);
+  expect(apply('https://はじめよう.みんな')).toMatchInlineSnapshot(
+    `"<a href=\\"https://はじめよう.みんな\\">https://はじめよう.みんな</a>"`
+  );
+});
+
+test('punycode', () => {
+  expect(apply('https://xn--wgv71a119e.jp')).toMatchInlineSnapshot(
+    `"<a href=\\"https://xn--wgv71a119e.jp\\">https://xn--wgv71a119e.jp</a>"`
+  );
+  expect(apply('https://xn--p8j9a0d9c9a.xn--q9jyb4c/index.html')).toMatchInlineSnapshot(
+    `"<a href=\\"https://xn--p8j9a0d9c9a.xn--q9jyb4c/index.html\\">https://xn--p8j9a0d9c9a.xn--q9jyb4c/index.html</a>"`
+  );
+});
+
+test('タグの属性は自動リンクしない', () => {
+  expect(apply('<font color="sm9">不正なcolor指定を含むfontタグ</font>')).toMatchInlineSnapshot(
+    `"<font color=\\"sm9\\">不正なcolor指定を含むfontタグ</font>"`
+  );
+});
+
+test('複雑なURL', () => {
+  expect(
+    apply(
+      'a https://www.google.co.jp/maps/place/%E6%AD%8C%E8%88%9E%E4%BC%8E%E5%BA%A7%E3%82%BF%E3%83%AF%E3%83%BC/@35.6697631,139.7657757,17z/data=!3m1!4b1!4m5!3m4!1s0x60188be0cb909cf5:0x91d7308f4a922dc4!8m2!3d35.6697588!4d139.7679644 b'
+    )
+  ).toMatchInlineSnapshot(
+    `"a <a href=\\"https://www.google.co.jp/maps/place/%E6%AD%8C%E8%88%9E%E4%BC%8E%E5%BA%A7%E3%82%BF%E3%83%AF%E3%83%BC/@35.6697631,139.7657757,17z/data=!3m1!4b1!4m5!3m4!1s0x60188be0cb909cf5:0x91d7308f4a922dc4!8m2!3d35.6697588!4d139.7679644\\">https://www.google.co.jp/maps/place/%E6%AD%8C%E8%88%9E%E4%BC%8E%E5%BA%A7%E3%82%BF%E3%83%AF%E3%83%BC/@35.6697631,139.7657757,17z/data=!3m1!4b1!4m5!3m4!1s0x60188be0cb909cf5:0x91d7308f4a922dc4!8m2!3d35.6697588!4d139.7679644</a> b"`
+  );
+});
+
+describe('splitByRegExpWithMatchedValues', () => {
+  test('マッチするものがひとつだけ', () => {
+    const pattern = /\bsm\d+\b/g;
+    expect(splitByRegExpWithMatchedValues('sm9', pattern)).toMatchInlineSnapshot(`
+Array [
+  "",
+  "sm9",
+]
+`);
+  });
+
+  test('マッチするものが複数', () => {
+    const pattern = /\bsm\d+\b/g;
+    expect(splitByRegExpWithMatchedValues('sm9 a sm175 b sm345', pattern)).toMatchInlineSnapshot(`
+Array [
+  "",
+  "sm9",
+  " a ",
+  "sm175",
+  " b ",
+  "sm345",
+]
+`);
+  });
+
+  test('先頭にマッチしない', () => {
+    const pattern = /\bsm\d+\b/g;
+    const result = splitByRegExpWithMatchedValues('header sm9', pattern);
+    result.forEach((str, idx) => {
+      if (idx % 2) {
+        expect(str).toMatch(pattern);
+      } else {
+        expect(str).not.toMatch(pattern);
+      }
+    });
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  "header ",
+  "sm9",
+]
+`);
+  });
+
+  test('末尾にマッチしない', () => {
+    const pattern = /\bsm\d+\b/g;
+    const result = splitByRegExpWithMatchedValues('sm9 trailer', pattern);
+    result.forEach((str, idx) => {
+      if (idx % 2) {
+        expect(str).toMatch(pattern);
+      } else {
+        expect(str).not.toMatch(pattern);
+      }
+    });
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  "",
+  "sm9",
+  " trailer",
+]
+`);
+  });
+
+  test('マッチしない文字列', () => {
+    const pattern = /\bsm\d+\b/g;
+    const result = splitByRegExpWithMatchedValues('header hoge trailer', pattern);
+    result.forEach((str, idx) => {
+      if (idx % 2) {
+        expect(str).toMatch(pattern);
+      } else {
+        expect(str).not.toMatch(pattern);
+      }
+    });
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  "header hoge trailer",
+]
+`);
+  });
+
+  test('空文字列', () => {
+    const pattern = /\bsm\d+\b/g;
+    const result = splitByRegExpWithMatchedValues('', pattern);
+    result.forEach((str, idx) => {
+      if (idx % 2) {
+        expect(str).toMatch(pattern);
+      } else {
+        expect(str).not.toMatch(pattern);
+      }
+    });
+    expect(result).toMatchInlineSnapshot(`Array []`);
+  });
+
+  test('空文字列にマッチするパターンを含んでも動作する', () => {
+    const pattern = /(?:)/g;
+    const result = splitByRegExpWithMatchedValues('a bc de f', pattern);
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  "",
+  "",
+  "a",
+  "",
+  " ",
+  "",
+  "b",
+  "",
+  "c",
+  "",
+  " ",
+  "",
+  "d",
+  "",
+  "e",
+  "",
+  " ",
+  "",
+  "f",
+  "",
+]
+`);
+  });
+});

--- a/app/util/autoLink.ts
+++ b/app/util/autoLink.ts
@@ -1,0 +1,112 @@
+export function apply(value: string): string {
+  const splitted = splitByRegExpWithMatchedValues(value, autoLinkMatcherPattern);
+  const replaced = splitted.map((str, index) => {
+    if (index % 2) return replaceWithFirstMatch(str);
+    else return str;
+  });
+  return replaced.join('');
+}
+
+// URL検出正規表現生成用
+const punct = "!'#%&\\(\\)\\*\\+,\\-\\./:;<=>\\?@[\\]^_{}~\\$、。　";
+const spaces = '\\s\\u1680\\u180E\\u2000-\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000';
+const invalidChars = '\\u{00}-\\u{2f}\\u{3a}-\\u{40}\\u{5b}-\\u{60}\\u{7b}-\\u{de}\\uFE74-\\uFFFF\\u202A-\\u202E';
+const invalidCharsForDomain = punct + spaces + invalidChars;
+const validCharsForDomain = `[^${invalidCharsForDomain}]`;
+const validDomain = `(?:(?:${validCharsForDomain}+(?:[_-]|${validCharsForDomain})*)?${validCharsForDomain})`;
+const domainPattern = `(?:${validDomain}\\.)+(?:${validDomain})`;
+const urlPattern = `(https?://${domainPattern}(?::\\d+)?(?:/[^\\s<>'"、。　]*)?)`;
+
+const urlRegExp = new RegExp(urlPattern, 'gu');
+
+const autoLinkPatterns = [
+  { matcher: /<[^?]*?>/, replace: '$&' },
+  { matcher: urlRegExp, replace: '<a href="$&">$&</a>' },
+  {
+    matcher: /\b(?:sm|nm|ca|cd|ax|yo|nl|ig|na|cw|za|zb|zc|zd|ze|om|sk|yk|so|am|fz)\d+\b/,
+    replace: '<a href="https://www.nicovideo.jp/watch/$&">$&</a>',
+  },
+  { matcher: /\bwatch\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
+  { matcher: /\bmyvideo\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
+  // negative lookbehindが使えないので user/\d+ より先にニコニコモンズユーザーページを判定させる
+  { matcher: /\bniconicommons\.jp\/user\/\d+\b/, replace: '<a href="https://www.$&">$&</a>' },
+  { matcher: /\buser\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
+  { matcher: /\blv\d+\b/, replace: '<a href="https://live2.nicovideo.jp/watch/$&">$&</a>' },
+  { matcher: /\bco\d+\b/, replace: '<a href="https://com.nicovideo.jp/community/$&">$&</a>' },
+  { matcher: /\bmylist\/\d+(?:\/\d+)?\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
+  { matcher: /\bnc\d+\b/, replace: '<a href="https://www.niconicommons.jp/material/$&">$&</a>' },
+  { matcher: /\bch\d+\b/, replace: '<a href="https://ch.nicovideo.jp/channel/$&">$&</a>' },
+  {
+    matcher: /\bch\.nicovideo\.jp\/[a-zA-Z0-9][-_a-zA-Z0-9]+(?=[^-_a-zA-Z0-9/]|$)\b/,
+    replace: '<a href="https://$&">$&</a>',
+  },
+  { matcher: /\bar\d+\b/, replace: '<a href="https://ch.nicovideo.jp/article/$&">$&</a>' },
+  { matcher: /\bim\d+\b/, replace: '<a href="https://seiga.nicovideo.jp/seiga/$&">$&</a>' },
+  { matcher: /\b(?:clip|comic|user\/illust)\/\d+\b/, replace: '<a href="https://seiga.nicovideo.jp/$&">$&</a>' },
+  { matcher: /\b(?:mg|bk|sg)\d+\b/, replace: '<a href="https://seiga.nicovideo.jp/watch/$&">$&</a>' },
+  { matcher: /\btd\d+\b/, replace: '<a href="https://3d.nicovideo.jp/works/$&">$&</a>' },
+  { matcher: /\bgm\d+\b/, replace: '<a href="https://game.nicovideo.jp/atsumaru/games/$&">$&</a>' },
+  { matcher: /\bnw\d+\b/, replace: '<a href="https://news.nicovideo.jp/watch/$&">$&</a>' },
+  { matcher: /\bap\d+\b/, replace: '<a href="https://app.nicovideo.jp/app/$&">$&</a>' },
+  { matcher: /\bnq\d+\b/, replace: '<a href="https://q.nicovideo.jp/watch/$&">$&</a>' },
+  { matcher: /\bkn\d+\b/, replace: '<a href="https://niconare.nicovideo.jp/watch/$&">$&</a>' },
+  { matcher: /\bmt\d+\b/, replace: '<a href="https://mtm.nicovideo.jp/watch/$&">$&</a>' },
+  {
+    matcher: /\b(?:dw\d+|az[A-Z0-9]{10}|ys[a-zA-Z0-9-]+_[a-zA-Z0-9-]+|ga\d+|ip[\d_]+|gg[a-zA-Z0-9]+-[a-zA-Z0-9-]+)\b/,
+    replace: '<a href="https://ichiba.nicovideo.jp/item/$&">$&</a>',
+  },
+  { matcher: /\bjps(\d+)\b/, replace: '<a href="https://jpstore.dwango.jp/products/detail.php?product_id=$1">$&</a>' },
+];
+
+function replaceWithFirstMatch(value: string): string {
+  for (const pattern of autoLinkPatterns) {
+    if (pattern.matcher.test(value)) {
+      return value.replace(pattern.matcher, pattern.replace);
+    }
+  }
+  throw new Error(`No pattern has matched with ${value}`);
+}
+
+/** 自動リンク対象の全パターンにマッチする正規表現オブジェクト */
+const autoLinkMatcherPattern = new RegExp(
+  autoLinkPatterns.map(p =>
+    p.matcher
+      .toString()
+      .replace(/^\//, '') // 正規表現リテラルの先頭スラッシュを除去
+      .replace(/\/[a-z]*$/, '') // 末尾スラッシュとフラグを除去
+  ).reduce((a, b) => `${a}|${b}`),
+  'gu' // URL検出パターンのためにuフラグが必須、位置保持のためにgフラグが必須
+);
+
+/**
+ * export for testing
+ * 正規表現でマッチする部分としない部分を分割する
+ * マッチした部分は0-indexedで奇数番目に入る
+ */
+export function splitByRegExpWithMatchedValues(value: string, pat: RegExp): string[] {
+  const result = [];
+  let matched = null;
+  let lastIndex = 0;
+
+  while (matched = pat.exec(value)) {
+    // 最後のマッチ位置からマッチしなかった部分があれば結果に追加
+    result.push(value.slice(lastIndex, matched.index));
+
+    // マッチした部分の末尾位置を記憶
+    lastIndex = matched.index + matched[0].length;
+
+    // 空文字列へのマッチが混入した場合、無限ループしないようにひとつ進める
+    if (matched.index === pat.lastIndex) {
+      pat.lastIndex += 1;
+    }
+
+    result.push(matched[0]);
+  }
+
+  const remains = value.slice(lastIndex);
+  if (remains) {
+    result.push(remains);
+  }
+
+  return result;
+}


### PR DESCRIPTION
**このpull requestが解決する内容**
ニコ生の番組説明部分にある自動リンクを実装します。
サーバーサイドである程度毒抜きされた文字列が来る前提で、変換だけしています。
（ `<img src onerror=while(1)alert(1) />` などを食わせてはいけないということです）

**動作確認手順**
- ログインする
- 番組の説明文に自動リンク対象となる文字列を含むような番組を作成・取得する。
- リンクをクリックすると、既定のブラウザで開く。
![image](https://user-images.githubusercontent.com/950573/55068900-2f5ecf00-50c6-11e9-8b9d-67112fba7604.png)
