### PR TITLE
追加: 関連リンクを追加

### DIFF
--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -3,6 +3,9 @@
     <div v-if="hasProgram">
       <button @click="fetchProgram" :disabled="isFetching">番組取得</button>
       <button @click="editProgram" :disabled="isEditing">番組編集</button>
+      <a @click.prevent="openInDefaultBrowser($event)" :href="twitterShareURL">share in twitter</a>
+      <a @click.prevent="openInDefaultBrowser($event)" :href="contentTreeURL">コンテンツツリー</a>
+      <a @click.prevent="openInDefaultBrowser($event)" :href="creatorsProgramURL">クリエイター奨励プログラム</a>
     </div>
   </div>
 </template>

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
+import * as moment from 'moment';
 import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import { remote } from 'electron';
@@ -12,6 +13,66 @@ export default class TopNav extends Vue {
 
   get hasProgram(): boolean {
     return this.nicoliveProgramService.hasProgram;
+  }
+
+  get programID(): string {
+    return this.nicoliveProgramService.state.programID;
+  }
+
+  get programStatus() { // 推論させる
+    return this.nicoliveProgramService.state.status;
+  }
+
+  get contentTreeURL(): string {
+    return `https://commons.nicovideo.jp/tree/${this.programID}`;
+  }
+
+  get creatorsProgramURL(): string {
+    return `https://commons.nicovideo.jp/cpp/application/?site_id=nicolive&creation_id=${this.programID}`;
+  }
+
+  get twitterShareURL(): string {
+    const content = this.twitterShareContent();
+    const url = new URL('https://twitter.com/intent/tweet');
+    url.searchParams.append('text', content.text);
+    url.searchParams.append('url', content.url);
+    return url.toString();
+  }
+
+  private twitterShareContent(): { text: string, url: string } {
+    const title = this.nicoliveProgramService.state.title;
+    const url = `https://live2.nicovideo.jp/watch/${this.programID}?ref=sharetw`;
+    const time = this.nicoliveProgramService.state.startTime;
+    const formattedTime = moment.unix(time).format('YYYY/MM/DD HH:mm');
+
+    if (this.programStatus === 'reserved' || this.programStatus === 'test') {
+      return {
+        text: `【ニコ生(${formattedTime}開始)】${title}`,
+        url,
+      };
+    }
+
+    if (this.programStatus === 'onAir') {
+      return {
+        text: `【ニコ生配信中】${title}`,
+        url,
+      };
+    }
+
+    if (this.programStatus === 'end') {
+      return {
+        text: `【ニコ生タイムシフト視聴中(${formattedTime}放送)】${title}`,
+        url,
+      };
+    }
+  }
+
+  openInDefaultBrowser(event: MouseEvent): void {
+    const href = (event.currentTarget as HTMLAnchorElement).href;
+    const url = new URL(href);
+    if (/^https?/.test(url.protocol)) {
+      remote.shell.openExternal(url.toString());
+    }
   }
 
   isFetching: boolean = false;

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -41,7 +41,7 @@ export default class TopNav extends Vue {
 
   private twitterShareContent(): { text: string, url: string } {
     const title = this.nicoliveProgramService.state.title;
-    const url = `https://live2.nicovideo.jp/watch/${this.programID}?ref=sharetw`;
+    const url = `https://live.nicovideo.jp/watch/${this.programID}?ref=sharetw`;
     const time = this.nicoliveProgramService.state.startTime;
     const formattedTime = moment.unix(time).format('YYYY/MM/DD HH:mm');
 


### PR DESCRIPTION
# このpull requestが解決する内容
次のリンクを追加します

- Twitter共有リンク
- コンテンツツリー
- クリエイター奨励プログラム

コンテンツツリーとクリエイター奨励プログラムのページは、番組開始前に開くとエラーになりますが、ニコ生の配信者画面でも同様でした。

# 動作確認手順
1. ログイン
2. 番組作成あるいは取得
3. 上部に表示されるリンクをクリックして既定のブラウザでそれぞれのページが開く
