### PR TITLE
不足していた要素を追加

### DIFF
--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <h1>番組詳細</h1>
-    <div @click="handleAnchorClick" v-html="programDescription"></div>
+    <input type="checkbox" v-model="lightMode" />
+    <div :class="{ 'light-mode': lightMode }" @click="handleAnchorClick" v-html="programDescription"></div>
   </div>
 </template>
 

--- a/app/components/nicolive-area/ProgramDescription.vue.ts
+++ b/app/components/nicolive-area/ProgramDescription.vue.ts
@@ -10,6 +10,8 @@ export default class ProgramDescription extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
+  lightMode: boolean = false;
+
   get programDescription(): string {
     return applyAutoLink(this.nicoliveProgramService.state.description);
   }

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -126,40 +126,4 @@ export default class ProgramInfo extends Vue {
   get giftPoint(): number {
     return this.nicoliveProgramService.state.giftPoint;
   }
-
-  get programEndTime(): number {
-    return this.nicoliveProgramService.state.endTime;
-  }
-
-  get programStartTime(): number {
-    return this.nicoliveProgramService.state.startTime;
-  }
-
-  currentTime: number = 0;
-  updateCurrrentTime() {
-    this.currentTime = Math.floor(Date.now() / 1000);
-  }
-
-  get programCurrentTime(): number {
-    return this.currentTime - this.programStartTime;
-  }
-
-  @Watch('programStatus')
-  onStatusChange(newValue: string, oldValue: string) {
-    if (newValue === 'end') {
-      clearInterval(this.timeTimer);
-    } else if (oldValue === 'end') {
-      clearInterval(this.timeTimer);
-      this.startTimer();
-    }
-  }
-
-  startTimer() {
-    this.timeTimer = (setInterval(() => this.updateCurrrentTime(), 1000) as any) as number;
-  }
-
-  timeTimer: number = 0;
-  mounted() {
-    this.startTimer();
-  }
 }

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -5,6 +5,9 @@
     <button @click="extendProgram" :disabled="autoExtensionEnabled || isExtending || !isProgramExtendable">
       30分延長
     </button>
+    <div v-if="programStatus === 'reserved'">
+      番組開始まで {{ format(-programCurrentTime) }}
+    </div>
     <span>自動延長 <input type="checkbox" :checked="autoExtensionEnabled" @click="toggleAutoExtension" /></span>
   </div>
 </template>


### PR DESCRIPTION
# このpull requestが解決する内容
1. 番組説明欄の白背景フラグを追加（雑にcheckboxでトグル、永続化ひとまずなし）
2. 予約番組の開始までのカウントダウンを追加

# 動作確認手順
1について、適当な番組を作成して取得するとチェックボックスが生える
2について、予約番組を作成して取得すると新しく要素が出る