### PR TITLE
追加: コミュ限フラグを露出

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -99,6 +99,10 @@ export default class ProgramInfo extends Vue {
     return this.nicoliveProgramService.state.title;
   }
 
+  get programIsMemberOnly(): boolean {
+    return this.nicoliveProgramService.state.isMemberOnly;
+  }
+
   get communityID(): string {
     return this.nicoliveProgramService.state.communityID;
   }

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -34,6 +34,7 @@ const programs = {
     description: '番組詳細情報',
     beginAt: schedules.onAir.onAirBeginAt,
     endAt: schedules.onAir.onAirEndAt,
+    isMemberOnly: true,
   },
 };
 
@@ -145,16 +146,7 @@ test('fetchProgram:成功', async () => {
   const instance = NicoliveProgramService.instance as NicoliveProgramService;
 
   instance.client.fetchProgramSchedules = jest.fn().mockResolvedValue({ ok: true, value: [schedules.onAir] });
-  instance.client.fetchProgram = jest.fn().mockResolvedValue({
-    ok: true,
-    value: {
-      status: schedules.onAir.status,
-      title: '番組タイトル',
-      description: '番組詳細情報',
-      beginAt: 100,
-      endAt: 150,
-    },
-  });
+  instance.client.fetchProgram = jest.fn().mockResolvedValue({ ok: true, value: programs.onAir });
   instance.client.fetchCommunity = jest
     .fn()
     .mockResolvedValue({ ok: true, value: { name: 'comunity.name', thumbnailUrl: { small: 'symbol url' } } });
@@ -174,6 +166,7 @@ Array [
     "communitySymbol": "symbol url",
     "description": "番組詳細情報",
     "endTime": 150,
+    "isMemberOnly": true,
     "programID": "lv1",
     "startTime": 100,
     "status": "onAir",
@@ -253,6 +246,7 @@ Array [
   Object {
     "description": "番組詳細情報",
     "endTime": 150,
+    "isMemberOnly": true,
     "startTime": 100,
     "status": "onAir",
     "title": "番組タイトル",

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -11,6 +11,7 @@ interface INicoliveProgramState {
   description: string;
   endTime: number;
   startTime: number;
+  isMemberOnly: boolean;
   communityID: string;
   communityName: string;
   communitySymbol: string;
@@ -32,6 +33,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     description: '',
     endTime: 0,
     startTime: 0,
+    isMemberOnly: false,
     communityID: '',
     communityName: '',
     communitySymbol: '',
@@ -151,6 +153,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       description: program.description,
       startTime: program.beginAt,
       endTime: program.endAt,
+      isMemberOnly: program.isMemberOnly,
       communityID: socialGroupId,
       communityName: community.name,
       communitySymbol: community.thumbnailUrl.small,
@@ -172,6 +175,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       description: program.description,
       startTime: program.beginAt,
       endTime: program.endAt,
+      isMemberOnly: program.isMemberOnly,
     });
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容
ProgramInfoコンポーネントに `programIsMemberOnly` としてコミュ限フラグが出るようにします

# 動作確認手順
1. 何かしらの確認手段を作る（ProgramInfoコンポーネントに適当な表示を仮置きするなど）
ex. `<span>isMemberOnly: {{ programIsMemberOnly }}</span>`

2. コミュ限と非コミュ限の番組でこの値が変化する

上記手順で動作確認済み