### PR TITLE
追加: 番組統計エリアを追加

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -4,6 +4,7 @@
     <template v-if="hasProgram">
       <program-info />
       <tool-bar />
+      <program-statistics />
       <program-description />
       <comment-form />
     </template>

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -8,6 +8,7 @@ import { $t } from 'services/i18n';
 import CommentForm from './CommentForm.vue';
 import ProgramDescription from './ProgramDescription.vue';
 import ProgramInfo from './ProgramInfo.vue';
+import ProgramStatistics from './ProgramStatistics.vue';
 import ToolBar from './ToolBar.vue';
 import TopNav from './TopNav.vue';
 
@@ -16,6 +17,7 @@ import TopNav from './TopNav.vue';
     TopNav,
     ProgramInfo,
     ProgramDescription,
+    ProgramStatistics,
     ToolBar,
     CommentForm,
   },

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -3,12 +3,6 @@
     <img :src="communitySymbol" />
     <h1>{{programTitle}}</h1>
     <h2>{{communityName}}</h2>
-    <div>
-      <span>視聴者数: {{ viewers }}</span>
-      <span>コメント数: {{ comments }}</span>
-      <span>ニコニ広告pt: {{ adPoint }}</span>
-      <span>ギフトpt: {{ giftPoint }}</span>
-    </div>
     <div>status: {{ programStatus }}</div>
     <div v-if="programStatus === 'onAir'"><button @click="endProgram" :disabled="isEnding">番組終了</button></div>
     <div v-else-if="programStatus === 'end'"><button @click="createProgram" :disabled="isCreating">番組作成</button></div>

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -114,20 +114,4 @@ export default class ProgramInfo extends Vue {
   get communitySymbol(): string {
     return this.nicoliveProgramService.state.communitySymbol;
   }
-
-  get viewers(): number {
-    return this.nicoliveProgramService.state.viewers;
-  }
-
-  get comments(): number {
-    return this.nicoliveProgramService.state.comments;
-  }
-
-  get adPoint(): number {
-    return this.nicoliveProgramService.state.adPoint;
-  }
-
-  get giftPoint(): number {
-    return this.nicoliveProgramService.state.giftPoint;
-  }
 }

--- a/app/components/nicolive-area/ProgramStatistics.vue
+++ b/app/components/nicolive-area/ProgramStatistics.vue
@@ -1,0 +1,17 @@
+<template>
+    <div>
+        <div>
+            <span>視聴者数: {{ viewers }}</span>
+            <span>コメント数: {{ comments }}</span>
+            <span>ニコニ広告pt: {{ adPoint }}</span>
+            <span>ギフトpt: {{ giftPoint }}</span>
+        </div>
+        <div>
+            <a @click.prevent="openInDefaultBrowser($event)" :href="twitterShareURL">share in twitter</a>
+            <a @click.prevent="openInDefaultBrowser($event)" :href="contentTreeURL">コンテンツツリー</a>
+            <a @click.prevent="openInDefaultBrowser($event)" :href="creatorsProgramURL">クリエイター奨励プログラム</a>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" src="./ProgramStatistics.vue.ts"></script>

--- a/app/components/nicolive-area/ProgramStatistics.vue.ts
+++ b/app/components/nicolive-area/ProgramStatistics.vue.ts
@@ -1,0 +1,88 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import * as moment from 'moment';
+import { Inject } from 'util/injector';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { remote } from 'electron';
+
+@Component({})
+export default class ProgramStatistics extends Vue {
+  @Inject()
+  nicoliveProgramService: NicoliveProgramService;
+
+  get programID(): string {
+    return this.nicoliveProgramService.state.programID;
+  }
+
+  get programStatus() { // 推論させる
+    return this.nicoliveProgramService.state.status;
+  }
+
+  get contentTreeURL(): string {
+    return `https://commons.nicovideo.jp/tree/${this.programID}`;
+  }
+
+  get creatorsProgramURL(): string {
+    return `https://commons.nicovideo.jp/cpp/application/?site_id=nicolive&creation_id=${this.programID}`;
+  }
+
+  get twitterShareURL(): string {
+    const content = this.twitterShareContent();
+    const url = new URL('https://twitter.com/intent/tweet');
+    url.searchParams.append('text', content.text);
+    url.searchParams.append('url', content.url);
+    return url.toString();
+  }
+
+  private twitterShareContent(): { text: string, url: string } {
+    const title = this.nicoliveProgramService.state.title;
+    const url = `https://live.nicovideo.jp/watch/${this.programID}?ref=sharetw`;
+    const time = this.nicoliveProgramService.state.startTime;
+    const formattedTime = moment.unix(time).format('YYYY/MM/DD HH:mm');
+
+    if (this.programStatus === 'reserved' || this.programStatus === 'test') {
+      return {
+        text: `【ニコ生(${formattedTime}開始)】${title}`,
+        url,
+      };
+    }
+
+    if (this.programStatus === 'onAir') {
+      return {
+        text: `【ニコ生配信中】${title}`,
+        url,
+      };
+    }
+
+    if (this.programStatus === 'end') {
+      return {
+        text: `【ニコ生タイムシフト視聴中(${formattedTime}放送)】${title}`,
+        url,
+      };
+    }
+  }
+
+  openInDefaultBrowser(event: MouseEvent): void {
+    const href = (event.currentTarget as HTMLAnchorElement).href;
+    const url = new URL(href);
+    if (/^https?/.test(url.protocol)) {
+      remote.shell.openExternal(url.toString());
+    }
+  }
+
+  get viewers(): number {
+    return this.nicoliveProgramService.state.viewers;
+  }
+
+  get comments(): number {
+    return this.nicoliveProgramService.state.comments;
+  }
+
+  get adPoint(): number {
+    return this.nicoliveProgramService.state.adPoint;
+  }
+
+  get giftPoint(): number {
+    return this.nicoliveProgramService.state.giftPoint;
+  }
+}

--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -3,9 +3,6 @@
     <div v-if="hasProgram">
       <button @click="fetchProgram" :disabled="isFetching">番組取得</button>
       <button @click="editProgram" :disabled="isEditing">番組編集</button>
-      <a @click.prevent="openInDefaultBrowser($event)" :href="twitterShareURL">share in twitter</a>
-      <a @click.prevent="openInDefaultBrowser($event)" :href="contentTreeURL">コンテンツツリー</a>
-      <a @click.prevent="openInDefaultBrowser($event)" :href="creatorsProgramURL">クリエイター奨励プログラム</a>
     </div>
   </div>
 </template>

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
-import * as moment from 'moment';
 import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import { remote } from 'electron';
@@ -13,66 +12,6 @@ export default class TopNav extends Vue {
 
   get hasProgram(): boolean {
     return this.nicoliveProgramService.hasProgram;
-  }
-
-  get programID(): string {
-    return this.nicoliveProgramService.state.programID;
-  }
-
-  get programStatus() { // 推論させる
-    return this.nicoliveProgramService.state.status;
-  }
-
-  get contentTreeURL(): string {
-    return `https://commons.nicovideo.jp/tree/${this.programID}`;
-  }
-
-  get creatorsProgramURL(): string {
-    return `https://commons.nicovideo.jp/cpp/application/?site_id=nicolive&creation_id=${this.programID}`;
-  }
-
-  get twitterShareURL(): string {
-    const content = this.twitterShareContent();
-    const url = new URL('https://twitter.com/intent/tweet');
-    url.searchParams.append('text', content.text);
-    url.searchParams.append('url', content.url);
-    return url.toString();
-  }
-
-  private twitterShareContent(): { text: string, url: string } {
-    const title = this.nicoliveProgramService.state.title;
-    const url = `https://live.nicovideo.jp/watch/${this.programID}?ref=sharetw`;
-    const time = this.nicoliveProgramService.state.startTime;
-    const formattedTime = moment.unix(time).format('YYYY/MM/DD HH:mm');
-
-    if (this.programStatus === 'reserved' || this.programStatus === 'test') {
-      return {
-        text: `【ニコ生(${formattedTime}開始)】${title}`,
-        url,
-      };
-    }
-
-    if (this.programStatus === 'onAir') {
-      return {
-        text: `【ニコ生配信中】${title}`,
-        url,
-      };
-    }
-
-    if (this.programStatus === 'end') {
-      return {
-        text: `【ニコ生タイムシフト視聴中(${formattedTime}放送)】${title}`,
-        url,
-      };
-    }
-  }
-
-  openInDefaultBrowser(event: MouseEvent): void {
-    const href = (event.currentTarget as HTMLAnchorElement).href;
-    const url = new URL(href);
-    if (/^https?/.test(url.protocol)) {
-      remote.shell.openExternal(url.toString());
-    }
   }
 
   isFetching: boolean = false;


### PR DESCRIPTION
**このpull requestが解決する内容**
下記イメージのレイアウトを実現するために `ProgramStatistics` エリア（仮）を作成しました。

<img width="399" alt="スクリーンショット 2019-04-04 16 08 48" src="https://user-images.githubusercontent.com/43235200/55542093-4c685300-5701-11e9-80bf-26ffe83294e2.png">

**動作確認手順**
番組統計情報とメニュー系が `ToolBar` の下に移動しているのを確認する