### PR TITLE
コメントフォームにスタイルを適用

### DIFF
--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -1,8 +1,41 @@
 <template>
-  <div>
-    <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="(Ctrl+Enterで固定表示)" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" >
-    <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)">送信</button>
+  <div class="comment-form">
+    <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="Ctrl+Enterで固定表示" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" class="comment-input">
+    <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
   </div>
 </template>
 
 <script lang="ts" src="./CommentForm.vue.ts"></script>
+<style lang="less" scoped>
+@import "../../styles/_colors";
+@import "../../styles/mixins";
+
+.comment-form {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+  background-color: @bg-primary;
+}
+
+.comment-input {
+  flex-grow: 1;
+  width: auto;
+  margin-right: 8px;
+  background-color: @bg-secondary;
+  border-radius: 4px;
+
+  &::placeholder {
+    color: @grey;
+  }
+}
+
+.comment-button {
+  padding: 0 8px;
+  background-color: @nicolive-button;
+  border-radius: 4px;
+
+  &:hover {
+    background-color: @nicolive-button-hover;
+  }
+}
+</style>

--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -19,3 +19,6 @@
 @bg-primary: #2F3340;
 @bg-secondary: #1F222D;
 @bg-tertiary: #050e18;
+
+@nicolive-button: #70A0AF;
+@nicolive-button-hover: #597E8A;


### PR DESCRIPTION
**このpull requestが解決する内容**
コメントフォームにスタイルをあてました。
 
#### 通常時
<img width="301" alt="comment" src="https://user-images.githubusercontent.com/43235200/55715170-23acca00-5a2f-11e9-9aa5-f49cf52de577.PNG">

#### ボタンアクティブ時
<img width="302" alt="comment-hover" src="https://user-images.githubusercontent.com/43235200/55715510-d8df8200-5a2f-11e9-8578-f606f13b7ef7.PNG">

#### コメント入力時
<img width="302" alt="comment-input" src="https://user-images.githubusercontent.com/43235200/55715522-e0069000-5a2f-11e9-877a-ed77b148ea00.PNG">

**動作確認手順**
コメントフォームにスタイルが当たっていることを確認