### PR TITLE
追加: ニコ生エリアの開閉ボタンを追加

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -1,18 +1,42 @@
 <template>
-  <div class="nicolive-area">
-    <top-nav />
-    <template v-if="hasProgram">
-      <program-info />
-      <tool-bar />
-      <program-statistics />
-      <program-description />
-      <comment-form />
-    </template>
-    <template v-else>
-      <div><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
-      <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
-    </template>
+  <div class="root">
+    <button @click="onToggle" class="nicolive-area-toggle-button" :class="{ 'nicolive-area--opened': opened }">
+    </button>
+    <div class="nicolive-area" v-if="opened">
+      <top-nav />
+      <template v-if="hasProgram">
+        <program-info />
+        <tool-bar />
+        <program-statistics />
+        <program-description />
+        <comment-form />
+      </template>
+      <template v-else>
+        <div><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
+        <div><button @click="fetchProgram" :disabled="isFetching">番組取得</button></div>
+      </template>
+    </div>
   </div>
 </template>
 
 <script lang="ts" src="./NicoliveArea.vue.ts"></script>
+
+<style lang="less" scoped>
+.root {
+  display: flex;
+  height: 100%;
+}
+
+.nicolive-area-toggle-button {
+  display: block;
+  height: 100%;
+  width: 8px;
+  // debug
+  background-color: white;
+}
+
+.nicolive-area {
+  flex-basis: fill;
+  width: 360px;
+}
+</style>

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -26,6 +26,13 @@ export default class NicolivePanelRoot extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
+  // 永続化？
+  opened: boolean = true;
+
+  onToggle(): void {
+    this.opened = !this.opened;
+  }
+
   isCreating: boolean = false;
   async createProgram(): Promise<void> {
     try {

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -26,11 +26,12 @@ export default class NicolivePanelRoot extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
-  // 永続化？
-  opened: boolean = true;
+  get opened(): boolean {
+    return this.nicoliveProgramService.state.panelOpened;
+  }
 
   onToggle(): void {
-    this.opened = !this.opened;
+    this.nicoliveProgramService.updatePanelOpened(!this.opened);
   }
 
   isCreating: boolean = false;

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -21,6 +21,7 @@ interface INicoliveProgramState {
   giftPoint: number;
   /** TODO: 永続化 */
   autoExtensionEnabled: boolean;
+  panelOpened: boolean;
 }
 
 export class NicoliveProgramService extends StatefulService<INicoliveProgramState> {
@@ -42,6 +43,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     adPoint: 0,
     giftPoint: 0,
     autoExtensionEnabled: false,
+    panelOpened: true,
   };
 
   private setState(partialState: Partial<INicoliveProgramState>) {
@@ -333,5 +335,9 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       clearTimeout(this.autoExtensionTimer);
       console.log('自動延長タイマーが解除されました');
     }
+  }
+
+  updatePanelOpened(panelOpened: boolean): void {
+    this.setState({ panelOpened });
   }
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
ニコ生エリアの開閉ボタンを追加します。
差分単純化のためにウィンドウ幅操作は含んでいません。

**動作確認手順**
ログインする
ニコ生エリアとスタジオ領域の間で右側に白く表示される領域をクリックし、ニコ生エリアが開閉する