### PR TITLE
変更: ニコ生エリアの開閉に応じてウィンドウ幅を調整する

### DIFF
--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -1,9 +1,23 @@
 import { createSetupFunction } from 'util/test-setup';
-import { NicoliveProgramService } from './nicolive-program';
+type NicoliveProgramService = import('./nicolive-program').NicoliveProgramService;
 
 const initialState = {
-  ...NicoliveProgramService.initialState,
   programID: 'lv1',
+  status: 'end',
+  title: '',
+  description: '',
+  endTime: 0,
+  startTime: 0,
+  isMemberOnly: false,
+  communityID: '',
+  communityName: '',
+  communitySymbol: '',
+  viewers: 0,
+  comments: 0,
+  adPoint: 0,
+  giftPoint: 0,
+  autoExtensionEnabled: false,
+  panelOpened: true,
 };
 
 const schedules = {
@@ -42,7 +56,18 @@ const setup = createSetupFunction({
   state: {
     NicoliveProgramService: initialState,
   },
+  injectee: {
+    WindowsService: {},
+    UserService: {
+      userLoginState: {
+        subscribe() {}
+      }
+    },
+  }
 });
+
+jest.mock('services/windows', () => ({ WindowsService: {} }));
+jest.mock('services/user', () => ({ UserService: {} }));
 
 beforeEach(() => {
   jest.doMock('services/stateful-service');

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -1,6 +1,8 @@
 import { StatefulService, mutation } from 'services/stateful-service';
 import { NicoliveClient, CreateResult, EditResult, isOk } from './NicoliveClient';
 import { ProgramSchedules } from './ResponseTypes';
+import { Inject } from 'util/injector';
+import { WindowsService } from 'services/windows';
 
 type Schedules = ProgramSchedules['data'];
 type Schedule = Schedules[0];
@@ -24,7 +26,21 @@ interface INicoliveProgramState {
   panelOpened: boolean;
 }
 
+enum PanelState {
+  INACTIVE = 'INACTIVE',
+  OPENED = 'OPENED',
+  CLOSED = 'CLOSED',
+}
+
+const WINDOW_MIN_WIDTH: { [key in PanelState]: number } = {
+  INACTIVE: 800, // 初期値
+  OPENED: 800 + 400 + 24, // +パネル幅+開閉ボタン幅
+  CLOSED: 800 + 24, // +開閉ボタン幅
+};
+
 export class NicoliveProgramService extends StatefulService<INicoliveProgramState> {
+  @Inject()
+  windowsService: WindowsService;
   client: NicoliveClient = new NicoliveClient();
 
   static initialState: INicoliveProgramState = {
@@ -51,6 +67,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     this.refreshStatisticsPolling(this.state, nextState);
     this.refreshProgramStatusTimer(this.state, nextState);
     this.refreshAutoExtensionTimer(this.state, nextState);
+    this.refreshWindowConstraints(this.state, nextState);
     this.SET_STATE(nextState);
   }
 
@@ -339,5 +356,32 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
   updatePanelOpened(panelOpened: boolean): void {
     this.setState({ panelOpened });
+  }
+
+  static getPanelState(panelOpened: boolean, isLoggedIn: boolean): PanelState {
+    if (!isLoggedIn) return 'INACTIVE' as PanelState;
+    return panelOpened ? ('OPENED' as PanelState) : ('CLOSED' as PanelState);
+  }
+
+  /** パネルが出る幅の分だけ画面の最小幅を拡張する */
+  refreshWindowConstraints(prevState: INicoliveProgramState, nextState: INicoliveProgramState): void {
+    if (prevState.panelOpened === nextState.panelOpened) return;
+    const isLoggedIn = this.userService.isLoggedIn();
+    const panelState = NicoliveProgramService.getPanelState(nextState.panelOpened, isLoggedIn);
+    this.updateWindowSize(panelState);
+  }
+
+  /*
+   * TODO: 最小幅が変動するときにその差分だけ実際の幅を操作する（初期状態を考慮するとパネル開閉状態の永続化が必要）
+   * NOTE: 似た処理を他所にも書きたくなったらウィンドウ幅管理する存在を置くこと、おそらくmain側が適している
+   * このコメントを書いている時点でメインウィンドウのウィンドウ幅を操作する存在は他にいない
+   */
+  updateWindowSize(state: PanelState): void {
+    const win = this.windowsService.getWindow('main');
+    const [, minHeight] = win.getMinimumSize();
+    const [width, height] = win.getSize();
+    const newMinWidth = WINDOW_MIN_WIDTH[state];
+    win.setMinimumSize(newMinWidth, minHeight);
+    win.setSize(Math.max(width, newMinWidth), height);
   }
 }

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -89,6 +89,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       return service.isLoggedIn().then(valid => {
         if (!valid) {
           this.LOGOUT();
+          this.userLogout.next();
         }
       });
     }
@@ -261,6 +262,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       if (parsed) {
         authWindow.close();
         this.LOGIN(parsed);
+        this.userLogin.next(parsed);
         this.setRavenContext();
       } else {
         // 認可されていない場合は画面を出して操作可能にする


### PR DESCRIPTION
# このpull requestが解決する内容
<s>depends on #254</s>
ウィンドウの最小幅をニコ生エリアの表示有無および開閉状態に応じて操作します。
現在のウィンドウ幅が最小幅の条件を満たさない場合は、満たす幅まで広がります。

- 未ログイン時は変更なし
- ログイン時でニコ生エリアを開いた状態では、ボタン幅+ニコ生エリア幅分大きくします
- ログイン時でニコ生エリアを閉じた状態では、ボタン幅分大きくします

# 動作確認手順
未ログイン状態からログインする。このときスタジオ部分の幅が変化しない。（この動作は #266 で変わります）
スタジオ部分の幅が最小幅（現時点で800px）を下回る場合はウィンドウサイズ自体が大きくなって幅を維持する。