### PR TITLE
変更: APIの二重呼び出しを防ぐ

### DIFF
--- a/app/components/nicolive-area/CommentForm.vue.ts
+++ b/app/components/nicolive-area/CommentForm.vue.ts
@@ -14,6 +14,7 @@ export default class CommentForm extends Vue {
   async sendOperatorComment(event: KeyboardEvent) {
     const text = this.operatorCommentValue;
     const isPermanent = event.ctrlKey;
+    if (this.isCommentSending) throw new Error('sendOperatorComment is running');
 
     try {
       this.isCommentSending = true;

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -38,6 +38,7 @@ export default class NicolivePanelRoot extends Vue {
 
   isCreating: boolean = false;
   async createProgram(): Promise<void> {
+    if (this.isCreating) throw new Error('createProgram is running');
     try {
       this.isCreating = true;
       await this.nicoliveProgramService.createProgram();
@@ -51,6 +52,7 @@ export default class NicolivePanelRoot extends Vue {
 
   isFetching: boolean = false;
   async fetchProgram(): Promise<void> {
+    if (this.isFetching) throw new Error('fetchProgram is running');
     try {
       this.isFetching = true;
       await this.nicoliveProgramService.fetchProgram();

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -12,6 +12,7 @@ export default class ProgramInfo extends Vue {
 
   isCreating: boolean = false;
   async createProgram() {
+    if (this.isCreating) throw new Error('createProgram is running');
     try {
       this.isCreating = true;
       return await this.nicoliveProgramService.createProgram();
@@ -25,6 +26,7 @@ export default class ProgramInfo extends Vue {
 
   isFetching: boolean = false;
   async fetchProgram() {
+    if (this.isFetching) throw new Error('fetchProgram is running');
     try {
       this.isFetching = true;
       return await this.nicoliveProgramService.fetchProgram();
@@ -51,6 +53,7 @@ export default class ProgramInfo extends Vue {
 
   isStarting: boolean = false;
   async startProgram() {
+    if (this.isStarting) throw new Error('startProgram is running');
     try {
       this.isStarting = true;
       return await this.nicoliveProgramService.startProgram();
@@ -64,6 +67,7 @@ export default class ProgramInfo extends Vue {
 
   isEnding: boolean = false;
   async endProgram() {
+    if (this.isEnding) throw new Error('endProgram is running');
     try {
       this.isEnding = true;
       const isOk = await new Promise(resolve => {

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -14,6 +14,7 @@ export default class ToolBar extends Vue {
 
   isExtending: boolean = false;
   async extendProgram() {
+    if (this.isExtending) throw new Error('extendProgram is running');
     try {
       this.isExtending = true;
       return await this.nicoliveProgramService.extendProgram();

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -16,6 +16,7 @@ export default class TopNav extends Vue {
 
   isFetching: boolean = false;
   async fetchProgram() {
+    if (this.isFetching) throw new Error('fetchProgram is running');
     try {
       this.isFetching = true;
       return await this.nicoliveProgramService.fetchProgram();
@@ -42,6 +43,7 @@ export default class TopNav extends Vue {
 
   isEditing: boolean = false;
   async editProgram() {
+    if (this.isEditing) throw new Error('editProgram is running');
     try {
       this.isEditing = true;
       return await this.nicoliveProgramService.editProgram();


### PR DESCRIPTION
# このpull requestが解決する内容
- ニコ生エリアからAPIを経由した操作を行う部分で、処理中状態を確認して多重呼び出しを防ぎます
- すでにコンポーネント側で同種の呼び出しは塞がれているので、動作の変更はありません

# 動作確認手順
