### PR TITLE
変更: 自動延長状態を永続化

### DIFF
--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -61,6 +61,7 @@ import { OutageNotificationsService } from 'services/outage-notifications';
 import { QuestionaireService } from 'services/questionaire';
 import { MonitorCaptureCroppingService } from 'services/sources/monitor-capture-cropping';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { NicoliveProgramStateService } from 'services/nicolive-program/state';
 
 const { ipcRenderer } = electron;
 
@@ -125,6 +126,7 @@ export class ServicesManager extends Service {
     QuestionaireService,
     MonitorCaptureCroppingService,
     NicoliveProgramService,
+    NicoliveProgramStateService,
   };
 
   private instances: Dictionary<Service> = {};

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -57,6 +57,11 @@ const setup = createSetupFunction({
     NicoliveProgramService: initialState,
   },
   injectee: {
+    NicoliveProgramStateService: {
+      updated: {
+        subscribe() {}
+      }
+    },
     WindowsService: {},
     UserService: {
       userLoginState: {
@@ -68,6 +73,7 @@ const setup = createSetupFunction({
 
 jest.mock('services/windows', () => ({ WindowsService: {} }));
 jest.mock('services/user', () => ({ UserService: {} }));
+jest.mock('services/nicolive-program/state', () => ({ NicoliveProgramStateService: {} }));
 
 beforeEach(() => {
   jest.doMock('services/stateful-service');

--- a/app/services/nicolive-program/state.ts
+++ b/app/services/nicolive-program/state.ts
@@ -1,0 +1,36 @@
+import { PersistentStatefulService } from 'services/persistent-stateful-service';
+import { mutation } from '../stateful-service';
+import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
+
+interface IState {
+  autoExtensionEnabled: boolean;
+}
+
+/**
+ * ニコ生配信機能に関する永続化したい状態を管理するService
+ */
+export class NicoliveProgramStateService extends PersistentStatefulService<IState> {
+  static defaultState = {
+    autoExtensionEnabled: false,
+  };
+
+  private subject: Subject<IState> = new BehaviorSubject<IState>(this.state);
+  updated: Observable<IState> = this.subject.asObservable();
+
+  toggleAutoExtension(): void {
+    this.setState({ autoExtensionEnabled: !this.state.autoExtensionEnabled });
+  }
+
+  private setState(nextState: Partial<IState>): void {
+    const newState = { ...this.state, ...nextState };
+    this.SET_STATE(newState);
+    this.subject.next(newState);
+  }
+
+  @mutation()
+  private SET_STATE(nextState: IState): void {
+    this.state = nextState;
+  }
+}


### PR DESCRIPTION
# このpull requestが解決する内容
自動延長状態を永続化（閉じても保存されるように）します。
ニコ生の配信ページと同様、アプリケーションサイドの保存です。

# 動作確認手順
1. ログインする
2. 番組を作成していない場合は番組を作成する、作成済みの場合は再取得する
3. ニコ生パネルで自動延長状態を変更する（初期値無効なので有効にする）
4. N Airを終了する
5. N Airを起動する
6. （ログインしていない場合は）ログインする
7. 番組を作成していない場合は番組を作成する、作成済みの場合は再取得する
8. 自動延長状態が保存されていることを確認する
