### PR TITLE
変更: ニコ生エリアの開閉状態を永続化

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -33,7 +33,7 @@ export default class NicolivePanelRoot extends Vue {
   }
 
   onToggle(): void {
-    this.nicoliveProgramService.updatePanelOpened(!this.opened);
+    this.nicoliveProgramService.togglePanelOpened();
   }
 
   isCreating: boolean = false;

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -24,7 +24,7 @@ interface INicoliveProgramState {
   adPoint: number;
   giftPoint: number;
   /**
-   * 自動延長状態をコンポーネントに伝えるための一時置き場
+   * 永続化された状態をコンポーネントに伝えるための一時置き場
    * 直接ここを編集してはいけない、stateServiceの操作結果を反映するだけにする
    */
   autoExtensionEnabled: boolean;
@@ -75,8 +75,8 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     super.init();
 
     this.stateService.updated.subscribe({
-      next: ({ autoExtensionEnabled }) => {
-        this.setState({ autoExtensionEnabled });
+      next: (persistentState) => {
+        this.setState(persistentState);
       }
     });
 
@@ -378,8 +378,8 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     }
   }
 
-  updatePanelOpened(panelOpened: boolean): void {
-    this.setState({ panelOpened });
+  togglePanelOpened(): void {
+    this.stateService.togglePanelOpened();
   }
 
   static getPanelState(panelOpened: boolean, isLoggedIn: boolean): PanelState {

--- a/app/services/nicolive-program/state.ts
+++ b/app/services/nicolive-program/state.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs/Observable';
 
 interface IState {
   autoExtensionEnabled: boolean;
+  panelOpened: boolean;
 }
 
 /**
@@ -14,6 +15,7 @@ interface IState {
 export class NicoliveProgramStateService extends PersistentStatefulService<IState> {
   static defaultState = {
     autoExtensionEnabled: false,
+    panelOpened: true,
   };
 
   private subject: Subject<IState> = new BehaviorSubject<IState>(this.state);
@@ -21,6 +23,10 @@ export class NicoliveProgramStateService extends PersistentStatefulService<IStat
 
   toggleAutoExtension(): void {
     this.setState({ autoExtensionEnabled: !this.state.autoExtensionEnabled });
+  }
+
+  togglePanelOpened(): void {
+    this.setState({ panelOpened: !this.state.panelOpened });
   }
 
   private setState(nextState: Partial<IState>): void {


### PR DESCRIPTION
# このpull requestが解決する内容
depends on #264
ニコ生エリアの開閉状態を永続化します。

# 動作確認手順
1. ログインしてニコ生エリアを表示する
2. ニコ生エリアの開閉状態を操作する
3. N Airを終了する
4. N Airを起動する
5. （ログインしていなければログインする）
6. 手順2で操作した結果が復元される