### PR TITLE
変更: ニコ生パネルの開閉に応じてウィンドウ幅を変更

### DIFF
--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -1,24 +1,7 @@
 import { createSetupFunction } from 'util/test-setup';
+import { Subject } from 'rxjs';
+import { BehaviorSubject } from '../../../node_modules/rxjs/BehaviorSubject';
 type NicoliveProgramService = import('./nicolive-program').NicoliveProgramService;
-
-const initialState = {
-  programID: 'lv1',
-  status: 'end',
-  title: '',
-  description: '',
-  endTime: 0,
-  startTime: 0,
-  isMemberOnly: false,
-  communityID: '',
-  communityName: '',
-  communitySymbol: '',
-  viewers: 0,
-  comments: 0,
-  adPoint: 0,
-  giftPoint: 0,
-  autoExtensionEnabled: false,
-  panelOpened: true,
-};
 
 const schedules = {
   ch: { nicoliveProgramId: 'lv1', socialGroupId: 'ch1', status: 'onAir', onAirBeginAt: 100, onAirEndAt: 150 },
@@ -54,7 +37,9 @@ const programs = {
 
 const setup = createSetupFunction({
   state: {
-    NicoliveProgramService: initialState,
+    NicoliveProgramService: {
+      programID: 'lv1',
+    },
   },
   injectee: {
     NicoliveProgramStateService: {
@@ -399,25 +384,25 @@ describe('refreshStatisticsPolling', () => {
   }[] = [
     {
       name: '初期状態から予約状態の番組を開くとタイマーは止まったまま',
-      prev: initialState,
+      prev: null,
       next: { status: 'reserved', programID: 'lv1' },
       result: 'NOOP',
     },
     {
       name: '初期状態からテスト状態の番組を開くとタイマーは止まったまま',
-      prev: initialState,
+      prev: null,
       next: { status: 'test', programID: 'lv1' },
       result: 'NOOP',
     },
     {
       name: '初期状態から放送中状態の番組を開くとタイマーを更新する',
-      prev: initialState,
+      prev: null,
       next: { status: 'onAir', programID: 'lv1' },
       result: 'REFRESH',
     },
     {
       name: '初期状態から終了状態の番組を開くとタイマーは止まったまま',
-      prev: initialState,
+      prev: null,
       next: { status: 'end', programID: 'lv1' },
       result: 'NOOP',
     },
@@ -473,10 +458,11 @@ describe('refreshStatisticsPolling', () => {
       setup();
       const { NicoliveProgramService } = require('./nicolive-program');
       const instance = NicoliveProgramService.instance as NicoliveProgramService;
+      const state = instance.state;
 
       instance.updateStatistics = jest.fn();
 
-      instance.refreshStatisticsPolling(suite.prev, suite.next);
+      instance.refreshStatisticsPolling({...state, ...suite.prev}, {...state, ...suite.next});
       switch (suite.result) {
         case 'REFRESH':
           expect(window.clearInterval).toHaveBeenCalledTimes(1);
@@ -565,25 +551,25 @@ describe('refreshProgramStatusTimer', () => {
   }[] = [
     {
       name: '初期状態から予約状態の番組を開くとタイマーを更新する',
-      prev: initialState,
+      prev: null,
       next: { status: 'reserved', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
       result: 'REFRESH',
     },
     {
       name: '初期状態からテスト状態の番組を開くとタイマーを更新する',
-      prev: initialState,
+      prev: null,
       next: { status: 'test', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
       result: 'REFRESH',
     },
     {
       name: '初期状態から放送中状態の番組を開くとタイマーを更新する',
-      prev: initialState,
+      prev: null,
       next: { status: 'onAir', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
       result: 'REFRESH',
     },
     {
       name: '初期状態から終了状態の番組を開くとタイマーは止まったまま',
-      prev: initialState,
+      prev: null,
       next: { status: 'end', programID: 'lv1', testStartTime: 100, startTime: 200, endTime: 300 },
       result: 'NOOP',
     },
@@ -661,8 +647,9 @@ describe('refreshProgramStatusTimer', () => {
       jest.spyOn(Date, 'now').mockImplementation(jest.fn().mockReturnValue(50));
 
       instance.updateStatistics = jest.fn();
+      const state = instance.state;
 
-      instance.refreshProgramStatusTimer(suite.prev, suite.next);
+      instance.refreshProgramStatusTimer({...state, ...suite.prev}, {...state, ...suite.next});
       switch (suite.result) {
         case 'REFRESH':
           expect(window.clearTimeout).toHaveBeenCalledTimes(1);

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -62,11 +62,22 @@ const setup = createSetupFunction({
         subscribe() {}
       }
     },
-    WindowsService: {},
+    WindowsService: {
+      getWindow() {
+        return {
+          getMinimumSize: () => [800, 600],
+          setMinimumSize: () => {},
+          getSize: () => [800, 600],
+          setSize: () => {},
+          isMaximized: () => false,
+        }
+      }
+    },
     UserService: {
       userLoginState: {
         subscribe() {}
-      }
+      },
+      isLoggedIn: () => true,
     },
   }
 });

--- a/app/services/persistent-stateful-service.ts
+++ b/app/services/persistent-stateful-service.ts
@@ -24,6 +24,8 @@ export abstract class PersistentStatefulService<
   }
 
   init() {
+    super.init();
+
     this.store.watch(
       () => {
         return JSON.stringify(this.state);

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -66,6 +66,8 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   };
 
   init() {
+    super.init();
+
     this.obsApiService.nodeObs.OBS_service_connectOutputSignals(
       (info: IOBSOutputSignalInfo) => {
         this.handleOBSOutputSignal(info);


### PR DESCRIPTION
# このpull requestが解決する内容
depends on #255, #265
パネルの開閉に伴ってウィンドウ最小幅が縮小する場合、ウィンドウ幅も対応して縮小するようにします。
ウィンドウが最大化されている場合は幅を維持します。
最小幅が大きくなったときの動作が、#265 からさらに変わります。
前：現在ウィンドウ幅が新しい開閉状態の最小幅を満たさない場合だけウィンドウ幅を拡張
後：開閉状態の変化前後における最小幅の変化量をウィンドウ幅に反映（拡張・縮小共に）

変更の本質コミット： https://github.com/n-air-app/n-air-app/pull/266/commits/14ba627022f41aa34d0ced9cd313fddeb72397f8

# 動作確認手順
1. ログインする
2. ニコ生パネルの開閉状態を操作してウィンドウ幅が追従する
