### PR TITLE
番組情報エリアにスタイルを適用

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -4,8 +4,8 @@
       <img :src="communitySymbol" />
     </div>
     <div class="program-info-description">
-      <h1 class="program-title">{{programTitle}}</h1>
-      <h2 class="community-name"><i v-if="programIsMemberOnly" class="icon-lock"></i><span>{{communityName}}</span></h2>
+      <h1 class="program-title" v-tooltip.bottom="programTitleTooltip">{{programTitle}}</h1>
+      <h2 class="community-name"><i v-if="programIsMemberOnly" class="icon-lock"></i><span v-tooltip.bottom="communityNameTooltip">{{communityName}}</span></h2>
     </div>
     <!-- <div>status: {{ programStatus }}</div> -->
     <div class="program-button">
@@ -37,7 +37,6 @@
   color: @white;
   font-size: 13px;
   font-weight: bold;
-  width: 100%;
   margin-bottom: 4px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -56,7 +55,6 @@
 
   span {
     font-size: 12px;
-    width: 100%;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -1,13 +1,12 @@
 <template>
   <div class="program-info">
     <div class="community-icon">
-      <img :src="communitySymbol" />
+      <img :src="communitySymbol" class="community-thumbnail" :alt="communityName" />
     </div>
     <div class="program-info-description">
       <h1 class="program-title" v-tooltip.bottom="programTitleTooltip">{{programTitle}}</h1>
-      <h2 class="community-name"><i v-if="programIsMemberOnly" class="icon-lock"></i><span v-tooltip.bottom="communityNameTooltip">{{communityName}}</span></h2>
+      <h2 class="community-name-wrapper"><i v-if="programIsMemberOnly" class="icon-lock" v-tooltip.bottom="programIsMemberOnlyTooltip"></i><span class="community-name" v-tooltip.bottom="communityNameTooltip">{{communityName}}</span></h2>
     </div>
-    <!-- <div>status: {{ programStatus }}</div> -->
     <div class="program-button">
       <button v-if="programStatus === 'onAir'" @click="endProgram" :disabled="isEnding" class="button button--end-program button--soft-warning">番組終了</button>
       <button v-else-if="programStatus === 'end'" @click="createProgram" :disabled="isCreating" class="button button--create-program">番組作成</button>
@@ -47,13 +46,13 @@
   margin-left: 16px;
 }
 
-.community-name {
+.community-name-wrapper {
   display: flex;
   align-items: center;
   color: @light-grey;
   margin: 0;
 
-  span {
+  .community-name {
     font-size: 12px;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -67,15 +66,13 @@
 }
 
 .community-icon {
-  width: 44px;
-  height: 44px;
   margin-right: 10px;
   flex-shrink: 0;
 
-  img {
-    width: 100%;
-    height: 100%;
-    border-radius: 100%;
+  .community-thumbnail {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
   }
 }
 

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -1,13 +1,96 @@
 <template>
-  <div>
-    <img :src="communitySymbol" />
-    <h1>{{programTitle}}</h1>
-    <h2>{{communityName}}</h2>
-    <div>status: {{ programStatus }}</div>
-    <div v-if="programStatus === 'onAir'"><button @click="endProgram" :disabled="isEnding">番組終了</button></div>
-    <div v-else-if="programStatus === 'end'"><button @click="createProgram" :disabled="isCreating">番組作成</button></div>
-    <div v-else><button @click="startProgram" :disabled="isStarting || programStatus === 'reserved'">番組開始</button></div>
+  <div class="program-info">
+    <div class="community-icon">
+      <img :src="communitySymbol" />
+    </div>
+    <div class="program-info-description">
+      <h1 class="program-title">{{programTitle}}</h1>
+      <h2 class="community-name"><i v-if="programIsMemberOnly" class="icon-lock"></i><span>{{communityName}}</span></h2>
+    </div>
+    <!-- <div>status: {{ programStatus }}</div> -->
+    <div class="program-button">
+      <button v-if="programStatus === 'onAir'" @click="endProgram" :disabled="isEnding" class="button button--end-program button--soft-warning">番組終了</button>
+      <button v-else-if="programStatus === 'end'" @click="createProgram" :disabled="isCreating" class="button button--create-program">番組作成</button>
+      <button v-else @click="startProgram" :disabled="isStarting || programStatus === 'reserved'" class="button button--start-program">番組開始</button>
+    </div>
   </div>
 </template>
 
 <script lang="ts" src="./ProgramInfo.vue.ts"></script>
+<style lang="less" scoped>
+@import "../../styles/_colors";
+@import "../../styles/mixins";
+
+.program-info {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 16px;
+}
+
+.program-info-description {
+  min-width: 0;
+  margin-right: auto;
+}
+
+.program-title {
+  color: @white;
+  font-size: 13px;
+  font-weight: bold;
+  width: 100%;
+  margin-bottom: 4px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.program-button {
+  margin-left: 16px;
+}
+
+.community-name {
+  display: flex;
+  align-items: center;
+  color: @light-grey;
+  margin: 0;
+
+  span {
+    font-size: 12px;
+    width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  } 
+
+  .icon-lock {
+    font-size: 10px;
+    margin-right: 6px;
+  }
+}
+
+.community-icon {
+  width: 44px;
+  height: 44px;
+  margin-right: 10px;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 100%;
+  }
+}
+
+.button--start-program {
+  font-size: 12px;
+}
+
+.button--end-program {
+  font-size: 12px;
+}
+
+.button--create-program {
+  font-size: 12px;
+}
+
+</style>

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -13,6 +13,9 @@ export default class ProgramInfo extends Vue {
   programTitleTooltip = this.programTitle;
   communityNameTooltip = this.communityName;
 
+  // TODO: 後でまとめる
+  programIsMemberOnlyTooltip = 'コミュニティ限定放送';
+
   isCreating: boolean = false;
   async createProgram() {
     if (this.isCreating) throw new Error('createProgram is running');

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -10,6 +10,9 @@ export default class ProgramInfo extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
+  programTitleTooltip = this.programTitle;
+  communityNameTooltip = this.communityName;
+
   isCreating: boolean = false;
   async createProgram() {
     if (this.isCreating) throw new Error('createProgram is running');

--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -2,6 +2,7 @@
 @navy: #13242d;
 @white: #ffffff;
 @grey: #91979a;
+@light-grey: #c4c8ca;
 @black: #000;
 
 @accent-light: #2b383f;

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -146,7 +146,8 @@ button,
 }
 
 
-.button--go-live {
+.button--go-live,
+.button--start-program {
   color: @white;
   background: @accent;
   font-size: 20px;
@@ -175,4 +176,26 @@ button,
   background: rgba(255, 255, 255, .1);
   border-color: transparent;
   color: @white;
+}
+
+.button--create-program {
+  font-size: 14px;
+  background-color: @nicolive-button;
+
+  &:hover {
+     background-color: @nicolive-button-hover;
+  }
+}
+
+.button--fetch-program {
+  color:@nicolive-button;
+  background-color: transparent;
+  border-width: 1px;
+  border-style: solid;
+  border-color: @nicolive-button;
+
+   &:hover {
+    color: @white;
+    background-color: @nicolive-button;
+  }
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
番組情報エリアにスタイルをあてました。
（ボタンの意匠は現状にあわせているため要検討）

#### 予約番組
<img width="299" alt="program-info-reserved" src="https://user-images.githubusercontent.com/43235200/56356547-17d1bc80-6214-11e9-9981-448ba7cf1a81.png">

#### 番組開始前
<img width="300" alt="program-info" src="https://user-images.githubusercontent.com/43235200/56356249-3f745500-6213-11e9-9949-40fa12bad3b5.png">

#### 放送中
<img width="301" alt="program-info-live" src="https://user-images.githubusercontent.com/43235200/56356481-f5d83a00-6213-11e9-801b-0c0dd17550fe.png">

#### 番組終了後
<img width="300" alt="program-info-after" src="https://user-images.githubusercontent.com/43235200/56356518-07b9dd00-6214-11e9-9bc1-1a62ef7865c9.png">

#### 限定放送（コミュニティ名の前にアイコンが出る）
<img width="299" alt="program-info-r" src="https://user-images.githubusercontent.com/43235200/56356565-24eeab80-6214-11e9-829e-030a884547fe.png">

#### テキストが長い場合（…で省略）
<img width="299" alt="program-info-ellipsis" src="https://user-images.githubusercontent.com/43235200/56356798-d1c92880-6214-11e9-92b0-09478db44275.png">

**動作確認手順**
ログイン後、各状態でスタイルがあたっていることを確認する