### PR TITLE
変更: 常にインフォの更新をサーバーに確認する

### DIFF
--- a/app/services/informations/informations.ts
+++ b/app/services/informations/informations.ts
@@ -75,8 +75,11 @@ export class InformationsService extends StatefulService<IInformationsState> {
 
   private async fetchFeed() {
     this.SET_FETCHING(true);
+    const headers = new Headers();
+    headers.append('Cache-Control', 'max-age=0');
+
     try {
-      return await fetch(this.hostsService.niconicoNAirInformationsFeed, { cache: 'no-cache' })
+      return await fetch(this.hostsService.niconicoNAirInformationsFeed, { headers })
         .then(handleErrors)
         .then(response => response.text())
         .then(InformationsService.parseXml);


### PR DESCRIPTION
# このpull requestが解決する内容
ニコニコインフォ再取得時に条件付きリクエストを行うように設定します

# 動作確認手順
DevToolからNetworkタブを開き、お知らせ画面を開閉し、2回目以降は304が返ってくることを確認する
