### PR TITLE
番組詳細エリアにスタイルを適用

### DIFF
--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -91,11 +91,21 @@
   overflow-x: hidden;
 
   &.dark-mode {
-    background-color: @bg-secondary;
+    background-color: @bg-tertiary;
   }
 
   &.light-mode {
     background-color: @white;
+
+    &::-webkit-scrollbar-track {
+      background-color: transparent;
+      border: none;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: @grey;
+      border-color: @white;
+    }
   }
 }
 

--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -1,10 +1,119 @@
 <template>
-  <div>
-    <h1>番組詳細</h1>
-    <input type="checkbox" v-model="lightMode" />
-    <div :class="{ 'light-mode': lightMode }" @click="handleAnchorClick" v-html="programDescription"></div>
+  <div class="program-description">
+    <div class="program-description-header">
+      <p class="program-description-title">番組詳細</p>
+      <div class="color-change-wrapper">
+        <span class="color-change-label">背景色</span>　
+        <input class="radio-btn" type="radio" id="dark-color" value="dark-mode" v-model="bgColorMode"><label for="dark-color" class="dark-label"></label>
+        <input class="radio-btn" type="radio" id="light-color" value="light-mode" v-model="bgColorMode"><label for="light-color" class="light-label"></label>
+      </div>
+    </div>
+    <div @click="handleAnchorClick" :class="bgColorMode" class="program-description-body">
+      <div v-html="programDescription" class="program-description-text"></div>
+    </div>
   </div>
 </template>
 
 <script lang="ts" src="./ProgramDescription.vue.ts"></script>
+<style lang="less" scoped>
+@import "../../styles/_colors";
+@import "../../styles/mixins";
 
+.program-description {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  width: 100%;
+}
+
+.program-description-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 40px;
+  padding: 0 16px;
+  background-color: @bg-quinary;
+}
+
+.program-description-title {
+  font-size: 12px;
+  color: @text-primary;
+  margin: 0;
+
+  &.active {
+    padding: 0 16px;
+    border-bottom: 1px solid @text-primary;
+  }
+}
+
+.color-change-wrapper {
+  display: flex;
+  align-items: center;
+
+  .color-change-label {
+    font-size: 11px;
+    color: @text-secondary;
+    margin-right: 12px;
+  }
+
+  .radio-btn {
+    display: none;
+
+    & + label {
+      position: relative;
+      width: 16px;
+      height: 16px;
+      margin: 0;
+      border: 1px solid @white;
+      border-radius: 100%;
+
+      &:not(:last-child) {
+        margin-right: 8px;
+      }
+
+      &.dark-label {
+        background-color: @bg-secondary; 
+      }
+
+      &.light-label {
+       background-color: @white;
+      } 
+    }
+
+    &:checked {
+      & + label {
+        border-color: @text-active;
+      }
+    }
+  }
+}
+
+.program-description-body {
+  flex-grow: 1;
+  flex-basis: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  &.dark-mode {
+    background-color: @bg-secondary;
+  }
+
+  &.light-mode {
+    background-color: @white;
+  }
+}
+
+.program-description-text {
+  padding: 16px;
+
+  .dark-mode & {
+    color: @text-secondary;
+  }
+
+  .light-mode & {
+    color: @black;
+  }
+}
+
+</style>

--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -4,8 +4,8 @@
       <p class="program-description-title">番組詳細</p>
       <div class="color-change-wrapper">
         <span class="color-change-label">背景色</span>　
-        <input class="radio-btn" type="radio" id="dark-color" value="dark-mode" v-model="bgColorMode"><label for="dark-color" class="dark-label"></label>
-        <input class="radio-btn" type="radio" id="light-color" value="light-mode" v-model="bgColorMode"><label for="light-color" class="light-label"></label>
+        <input class="radio-btn" type="radio" id="change-dark-mode-btn" value="dark-mode" v-model="bgColorMode"><label for="change-dark-mode-btn" class="dark-mode-label"></label>
+        <input class="radio-btn" type="radio" id="change-light-mode-btn" value="light-mode" v-model="bgColorMode"><label for="change-light-mode-btn" class="light-mode-label"></label>
       </div>
     </div>
     <div @click="handleAnchorClick" :class="bgColorMode" class="program-description-body">
@@ -67,11 +67,11 @@
         margin-right: 8px;
       }
 
-      &.dark-label {
+      &.dark-mode-label {
         background-color: @bg-secondary; 
       }
 
-      &.light-label {
+      &.light-mode-label {
        background-color: @white;
       } 
     }

--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -40,11 +40,6 @@
   font-size: 12px;
   color: @text-primary;
   margin: 0;
-
-  &.active {
-    padding: 0 16px;
-    border-bottom: 1px solid @text-primary;
-  }
 }
 
 .color-change-wrapper {

--- a/app/components/nicolive-area/ProgramDescription.vue.ts
+++ b/app/components/nicolive-area/ProgramDescription.vue.ts
@@ -10,7 +10,8 @@ export default class ProgramDescription extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
-  lightMode: boolean = false;
+  // デフォルトカラー
+  bgColorMode = 'dark-mode';
 
   get programDescription(): string {
     return applyAutoLink(this.nicoliveProgramService.state.description);

--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -21,6 +21,7 @@
 @bg-secondary: #1F222D;
 @bg-tertiary: #050e18;
 @bg-quaternary: #393e4c;
+@bg-quinary: #272b38;
 
 @nicolive-button: #70A0AF;
 @nicolive-button-hover: #597E8A;


### PR DESCRIPTION
**このpull requestが解決する内容**
番組詳細エリアにスタイルをあてました。

#### 黒背景（デフォルト）
<img width="303" alt="program-description-dark" src="https://user-images.githubusercontent.com/43235200/56422418-2c7c8600-62e2-11e9-9ed1-54764775cb31.png">

#### 白背景
<img width="307" alt="program-description-light" src="https://user-images.githubusercontent.com/43235200/56422422-30a8a380-62e2-11e9-8f40-1564c7a6306a.png">


**動作確認手順**
ログイン後、番組詳細エリアにスタイルがあたっていることを確認する