### PR TITLE
変更: メンテ中の作成画面にあるインフォへのリンクを踏めるようにする

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -70,7 +70,11 @@ export class NicoliveClient {
   }
 
   static isAllowedURL(url: string): boolean {
-    return /^https?:\/\/live2?.nicovideo.jp\//.test(url);
+    // メンテ中は作成画面に http://blog.nicovideo.jp/niconews/category/nicolivemainte/ へのリンクが表示されるので表示を許す
+    return (
+      /^https?:\/\/live2?.nicovideo.jp\//.test(url) ||
+      /^https?:\/\/blog\.nicovideo\.jp\/niconews\//.test(url)
+    );
   }
 
   private static createRequest(method: 'GET' | 'POST' | 'PUT' | 'DELETE', requestInit: RequestInit): RequestInit {


### PR DESCRIPTION
# このpull requestが解決する内容
`/create` にはメンテ中に `http://blog.nicovideo.jp/niconews/category/nicolivemainte/` へのリンクが表示される。
このリンクを踏めるようにし、加えて記事を表示できるようにする。

# 動作確認手順
（メンテ中に確認？）