### PR TITLE
修正: 予約時のボタンのラベルとカラーの修正

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -8,9 +8,9 @@
       <h2 class="community-name-wrapper"><i v-if="programIsMemberOnly" class="icon-lock" v-tooltip.bottom="programIsMemberOnlyTooltip"></i><span class="community-name" v-tooltip.bottom="communityNameTooltip">{{communityName}}</span></h2>
     </div>
     <div class="program-button">
-      <button v-if="programStatus === 'onAir'" @click="endProgram" :disabled="isEnding" class="button button--end-program button--soft-warning">番組終了</button>
+      <button v-if="programStatus === 'onAir' || programStatus === 'reserved'" @click="endProgram" :disabled="isEnding || programStatus === 'reserved'" class="button button--end-program button--soft-warning">番組終了</button>
       <button v-else-if="programStatus === 'end'" @click="createProgram" :disabled="isCreating" class="button button--create-program">番組作成</button>
-      <button v-else @click="startProgram" :disabled="isStarting || programStatus === 'reserved'" class="button button--start-program">番組開始</button>
+      <button v-else @click="startProgram" :disabled="isStarting" class="button button--start-program">番組開始</button>
     </div>
   </div>
 </template>

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -166,6 +166,15 @@ button,
     background: rgba(204, 0, 41, .3);
     border: 1px solid @red;
   }
+
+  &:disabled {
+    background-color: @black;
+    border-color: @black;
+
+    &:hover {
+      background-color: @black;
+    }
+  }
 }
 
 .button--default {


### PR DESCRIPTION
**このpull requestが解決する内容**
予約時に表示されるボタンのラベルを番組開始→番組終了に変更しました。

<img width="300" alt="program-button" src="https://user-images.githubusercontent.com/43235200/56490071-e6f8cc80-651e-11e9-91c7-b8ab126d9b74.PNG">

**動作確認手順**
予約番組作成後のボタンを確認する