### PR TITLE
追加: 配信ページ・配信コミュニティへのリンクを追加

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -4,8 +4,19 @@
       <img :src="communitySymbol" class="community-thumbnail" :alt="communityName" />
     </div>
     <div class="program-info-description">
-      <h1 class="program-title" v-tooltip.bottom="programTitleTooltip">{{programTitle}}</h1>
-      <h2 class="community-name-wrapper"><i v-if="programIsMemberOnly" class="icon-lock" v-tooltip.bottom="programIsMemberOnlyTooltip"></i><span class="community-name" v-tooltip.bottom="communityNameTooltip">{{communityName}}</span></h2>
+      <h1 class="program-title" v-tooltip.bottom="programTitleTooltip">
+        <a :href="watchPageURL" @click.prevent="openInDefaultBrowser($event)">
+          {{programTitle}}
+        </a>
+      </h1>
+      <h2 class="community-name-wrapper">
+        <i v-if="programIsMemberOnly" class="icon-lock" v-tooltip.bottom="programIsMemberOnlyTooltip"></i>
+        <span class="community-name" v-tooltip.bottom="communityNameTooltip">
+          <a :href="communityPageURL" @click.prevent="openInDefaultBrowser($event)">
+            {{communityName}}
+          </a>
+        </span>
+      </h2>
     </div>
     <div class="program-button">
       <button v-if="programStatus === 'onAir'" @click="endProgram" :disabled="isEnding" class="button button--end-program button--soft-warning">番組終了</button>
@@ -57,7 +68,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-  } 
+  }
 
   .icon-lock {
     font-size: 10px;

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -101,6 +101,10 @@ export default class ProgramInfo extends Vue {
     }
   }
 
+  get programID(): string {
+    return this.nicoliveProgramService.state.programID;
+  }
+
   get programStatus(): string {
     return this.nicoliveProgramService.state.status;
   }
@@ -124,4 +128,21 @@ export default class ProgramInfo extends Vue {
   get communitySymbol(): string {
     return this.nicoliveProgramService.state.communitySymbol;
   }
+
+  openInDefaultBrowser(event: MouseEvent): void {
+    const href = (event.currentTarget as HTMLAnchorElement).href;
+    const url = new URL(href);
+    if (/^https?/.test(url.protocol)) {
+      remote.shell.openExternal(url.toString());
+    }
+  }
+
+  get watchPageURL(): string {
+    return `https://live.nicovideo.jp/watch/${this.programID}`;
+  }
+
+  get communityPageURL(): string {
+    return `https://com.nicovideo.jp/community/${this.communityID}`;
+  }
+
 }


### PR DESCRIPTION
# このpull requestが解決する内容
します

![image](https://user-images.githubusercontent.com/950573/56493937-aa7f9d80-652b-11e9-84ed-c0eff64b2407.png)

# 動作確認手順
1. ログインしていなければログインする
2. 番組を作成OR番組を取得
3. 番組タイトルがwatchページを、コミュニティ名がコミュニティページをそれぞれ既定のブラウザで開くようなリンクになっている