### PR TITLE
修正: 番組情報の変化をツールチップに反映

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -4,14 +4,14 @@
       <img :src="communitySymbol" class="community-thumbnail" :alt="communityName" />
     </div>
     <div class="program-info-description">
-      <h1 class="program-title" v-tooltip.bottom="programTitleTooltip">
+      <h1 class="program-title" v-tooltip.bottom="programTitle">
         <a :href="watchPageURL" @click.prevent="openInDefaultBrowser($event)" class="program-title-link" >
           {{programTitle}}
         </a>
       </h1>
       <h2 class="community-name">
         <i v-if="programIsMemberOnly" class="icon-lock" v-tooltip.bottom="programIsMemberOnlyTooltip"></i>
-        <a :href="communityPageURL" @click.prevent="openInDefaultBrowser($event)" class="community-name-link" v-tooltip.bottom="communityNameTooltip">
+        <a :href="communityPageURL" @click.prevent="openInDefaultBrowser($event)" class="community-name-link" v-tooltip.bottom="communityName">
           {{communityName}}
         </a>
       </h2>

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -10,9 +10,6 @@ export default class ProgramInfo extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
-  programTitleTooltip = this.programTitle;
-  communityNameTooltip = this.communityName;
-
   // TODO: 後でまとめる
   programIsMemberOnlyTooltip = 'コミュニティ限定放送';
 


### PR DESCRIPTION
# このpull requestが解決する内容
編集が反映されないとの報告がありましたが、実際には番組が変わってもパネルの開閉を経ないとツールチップが更新されない問題がありました。
この問題を修正し、編集や番組の変化に追従して番組タイトルやコミュニティ名のツールチップが変化するようになります。

# 動作確認手順
1. ログインしていなければログインする
2. 番組を作成OR取得する
3. 番組タイトルにマウスオーバーしてツールチップを確認する
4. 番組情報を編集して番組タイトルを変更する
5. 番組タイトルにマウスオーバーしてツールチップにも変更が反映されていることを確認する

あるいは手順3までを同様にして、

4. 番組を終了する
5. 異なるタイトルで番組を作成OR取得する
6. 番組タイトルにマウスオーバーしてツールチップにも変更が反映されていることを確認する