### PR TITLE
Twitterアイコンのツールチップ文言変更

### DIFF
--- a/app/i18n/ja-JP/common.json
+++ b/app/i18n/ja-JP/common.json
@@ -59,5 +59,5 @@
   "notifications": "通知",
   "help": "ヘルプ",
   "simpleMode": "シンプルモード",
-  "twitter": "ツイッター"
+  "twitter": "Twitter"
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
ツールチップの文言を`ツイッター` → `Twitter` に変更しました。

<img width="76" alt="キャプチャ" src="https://user-images.githubusercontent.com/43235200/56573950-17af3380-65fd-11e9-9a6e-376ee3344d6b.PNG">

**動作確認手順**
1. ログインしていなければログインする
2. 番組を作成OR取得する
3. Twitterアイコンにマウスオーバーしてツールチップを確認する