### PR TITLE
修正: 配信時間表示が一瞬異常な値になる問題を修正、他

### DIFF
--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -71,6 +71,7 @@ export default class ToolBar extends Vue {
   onStatusChange(newValue: string, oldValue: string) {
     if (newValue === 'end') {
       clearInterval(this.timeTimer);
+    　this.currentTime = NaN;
     } else if (oldValue === 'end') {
       clearInterval(this.timeTimer);
       this.startTimer();

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -54,7 +54,7 @@ export default class ToolBar extends Vue {
     return this.nicoliveProgramService.state.autoExtensionEnabled;
   }
 
-  currentTime: number = 0;
+  currentTime: number = NaN;
   updateCurrrentTime() {
     this.currentTime = Math.floor(Date.now() / 1000);
   }

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -83,6 +83,8 @@ export default class ToolBar extends Vue {
 
   timeTimer: number = 0;
   mounted() {
-    this.startTimer();
+    if (this.programStatus !== 'end') {
+      this.startTimer();
+    }
   }
 }

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -53,8 +53,8 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     status: 'end',
     title: '',
     description: '',
-    endTime: 0,
-    startTime: 0,
+    endTime: NaN,
+    startTime: NaN,
     isMemberOnly: false,
     communityID: '',
     communityName: '',
@@ -132,6 +132,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   static format(timeInSeconds: number): string {
+    if (Number.isNaN(timeInSeconds)) return '--:--:--';
     const absTime = Math.abs(timeInSeconds);
     const s = absTime % 60;
     const m = Math.floor(absTime / 60) % 60;


### PR DESCRIPTION
# このpull requestが解決する内容
次の現象に対応します
1. ニコ生パネル内の番組時間表示が一番最初だけ異常な値になる
2. 番組終了状態でニコ生パネルを閉じ、再度開くと番組時間が進んでしまう
3. 番組終了状態から番組を作成OR取得すると、前の番組終了時刻からの差が一瞬表示される

次の変更を加えます
- 番組終了状態では番組時間表示を `--:--:--` にする
  - 現象2の対処のために番組終了時に現在時刻の計測を止め、現象3の対処のために初期値に戻すようにした。終了した時点の時間が揮発するので、もっともらしい表示をするようにした。

![image](https://user-images.githubusercontent.com/950573/56636287-3d8f1380-66a3-11e9-9f36-b53f8d07fef3.png)

# 動作確認手順
1. ログインしていない場合はログインする
2. 番組作成OR取得する
3. ニコ生パネルが閉じた状態の場合は手動で開く
4. **番組時間表示の初期値が `--:--:--` であり、そこから変化することを確認する**
5. 番組を終了する
6. **番組時間表示が `--:--:--` になることを確認する**
7. パネルを閉じて、開く
8. **番組時間表示が `--:--:--` になることを確認する**