### PR TITLE
修正: ログアウト防止が動作するように

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -275,7 +275,6 @@ export class NicoliveClient {
       webPreferences: {
         nodeIntegration: false,
         nodeIntegrationInWorker: false,
-        sandbox: true,
         nativeWindowOpen: true,
       },
     });
@@ -307,7 +306,6 @@ export class NicoliveClient {
       webPreferences: {
         nodeIntegration: false,
         nodeIntegrationInWorker: false,
-        sandbox: true,
         nativeWindowOpen: true,
       },
     });


### PR DESCRIPTION
# このpull requestが解決する内容
番組作成・編集ウィンドウからログアウトできないようにする処理が動作しておらず、ログアウトできるという現象に対処します。

この現象はElectronの挙動に由来します。
`BrowserWindow` の生成時の `webPreferences` に `sandbox: true` を与えると、当該 `BrowserWindow` オブジェクトの `will-navigate` イベントが発火しなくなります。
`will-navigate` を使ってログアウトを検知していたので、ログアウト防止処理がバイパスされる結果につながっていました。
ref. https://github.com/n-air-app/n-air-app/pull/282#issuecomment-486125635

元々preloadスクリプトを仕込んでいないこと、既存実装部分ではこの記述がされていることをうけて `sandbox: true` を指定するようにしましたが、期待する効果は `nodeIntegration: false` 指定で十分そうでした。
ref. https://electronjs.org/docs/api/sandbox-option#status

# 動作確認手順
1. ログインしていない場合はログインする
2. 番組作成・編集画面の右上に出ている「ログアウト」を押して、反応しないことを確認する