### PR TITLE
修正: テキスト編集中にショートカットキーが誤爆しないように修正

### DIFF
--- a/app/services/shortcuts.ts
+++ b/app/services/shortcuts.ts
@@ -26,6 +26,9 @@ export class ShortcutsService extends Service {
       // ignore key events from webview
       if ((e.target as HTMLElement).tagName === 'WEBVIEW') return;
 
+      // 入力欄操作中はショートカットキーを反応させない
+      if ((e.target as HTMLElement).tagName === 'INPUT') return;
+
       const shortcutName = ShortcutsService.getShortcutName(e);
       const handler = this.shortcuts.get(shortcutName);
 


### PR DESCRIPTION
# このpull requestが解決する内容
Mainウィンドウにあるテキスト入力欄の値を編集中にショートカットキーが反応し、意図せずシーン中のソースに影響が出ています。

次のような現象が起きていました：
- クリップボードにテキストを保持した状態で、Mainウィンドウのテキスト入力欄に貼り付けるために「Ctrl+V」を操作すると、現在のシーンにテキストソースとして貼り付けられてしまう
- Mainウィンドウのテキスト入力欄を編集する目的で「Delete」キーを押すと、選択中のソースがあった場合にソースを削除してしまう。

input要素がMainウィンドウで使用されているのは、現時点でこの検索窓を含むSceneSelectorコンポーネントのみです。

# 動作確認手順
1. テキストをクリップボードに保持しておく。
2. シーンコレクションの検索プルダウンを開く。
3. 検索窓を選択する。
4. Ctrl+V で貼り付ける。
5. 検索窓に手順1で保持したテキストが貼り付けられる。現在のシーンにテキストソースが増加しない。

または

1. シーン中にソースが存在しなければ作り、適当なソースを選択状態にする。
2. シーンコレクションの検索プルダウンを開く。
3. 検索窓を選択する。
4. 何か文字列を打ち込んで、Deleteで検索窓の文字列を編集する。
5. 選択状態のソースが削除されずに残っている。