### PR TITLE
番組終了後のコメントフォームをつぶす

### DIFF
--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -3,7 +3,7 @@
     <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="Ctrl+Enterで固定表示" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" class="comment-input">
     <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
     <div class="comment-disabled-message" v-if="programStatus === 'end'">
-      番組を終了したため、放送者コメントを投稿できません
+      番組が終了したため、放送者コメントを投稿できません
     </div>
   </div>
 </template>

--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -2,6 +2,9 @@
   <div class="comment-form">
     <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="Ctrl+Enterで固定表示" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" class="comment-input">
     <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
+    <div class="comment-disabled-message" v-if="programStatus === 'end'">
+      番組を終了したため、放送者コメントを投稿できません
+    </div>
   </div>
 </template>
 
@@ -15,6 +18,7 @@
   justify-content: center;
   padding: 8px;
   background-color: @bg-primary;
+  position: relative;
 }
 
 .comment-input {
@@ -37,5 +41,20 @@
   &:hover {
     background-color: @nicolive-button-hover;
   }
+}
+
+.comment-disabled-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: @white;
+  font-size: 12px;
+  width: 100%;
+  height: 100%;
+  padding: 8px 16px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: rgba(31, 34, 45, .8);
 }
 </style>

--- a/app/components/nicolive-area/CommentForm.vue.ts
+++ b/app/components/nicolive-area/CommentForm.vue.ts
@@ -27,4 +27,8 @@ export default class CommentForm extends Vue {
       this.isCommentSending = false;
     }
   }
+
+  get programStatus(): string {
+    return this.nicoliveProgramService.state.status;
+  }
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
番組終了後のコメントフォーム上にメッセージを出し、使用できないようにしました。

<img width="302" alt="キャプチャ" src="https://user-images.githubusercontent.com/43235200/56713345-8232b180-676c-11e9-8281-156611c92813.PNG">

**動作確認手順**

1. ログインしていない場合はログインする
2. 番組作成OR取得する
3. 番組を開始する
4. 番組を終了する
5. コメントフォームが上記の状態になっていることを確認する