### PR TITLE
番組詳細で英文が折り返されないバグの修正

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -130,6 +130,7 @@
   flex-direction: column;
   flex-grow: 1;
   flex-basis: 0;
+  border-top: 1px solid @bg-secondary;
 }
 
 </style>

--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -107,10 +107,10 @@
       border-color: @white;
     }
   }
-}
 
 .program-description-text {
   padding: 16px;
+  overflow-wrap: break-word;
 
   .dark-mode & {
     color: @text-secondary;

--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -107,6 +107,7 @@
       border-color: @white;
     }
   }
+}
 
 .program-description-text {
   padding: 16px;


### PR DESCRIPTION
**このpull requestが解決する内容**
番組詳細で英文が折り返されないバグを修正しました。
（品証：番組説明文に改行、空白を用いない半角英数文字の長文を設定すると、番組詳細欄の右端で折り返さず全文が表示されない）

#### 修正前
<img width="302" alt="キャプチャ2" src="https://user-images.githubusercontent.com/43235200/56716535-962ee100-6775-11e9-9652-3e42f2a59836.PNG">

#### 修正後
<img width="301" alt="キャプチャ" src="https://user-images.githubusercontent.com/43235200/56716547-97f8a480-6775-11e9-8ebb-262844593715.PNG">

**動作確認手順**

1. ログインしていない場合はログインする
2. 番組作成OR取得する
3. 番組説明文を半角英数で120文字以上入力
4. 番組詳細が折り返されていることを確認する