### PR TITLE
修正: 運営コメントフォームの動作を調整

### DIFF
--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="comment-form">
-    <input type="text" :readonly="isCommentSending" :disabled="isCommentSending" placeholder="Ctrl+Enterで固定表示" v-model="operatorCommentValue" @keydown.enter="sendOperatorComment($event)" class="comment-input">
+    <input
+      type="text"
+      :readonly="isCommentSending"
+      :disabled="isCommentSending"
+      placeholder="Ctrl+Enterで固定表示"
+      v-model="operatorCommentValue"
+      @keydown.enter="sendOperatorComment($event)"
+      class="comment-input"
+    />
     <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
     <div class="comment-disabled-message" v-if="programStatus === 'end'">
       番組が終了したため、放送者コメントを投稿できません

--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -8,6 +8,7 @@
       v-model="operatorCommentValue"
       @keydown.enter="sendOperatorComment($event)"
       class="comment-input"
+      maxlength="80"
     />
     <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
     <div class="comment-disabled-message" v-if="programStatus === 'end'">

--- a/app/components/nicolive-area/CommentForm.vue
+++ b/app/components/nicolive-area/CommentForm.vue
@@ -10,7 +10,7 @@
       class="comment-input"
       maxlength="80"
     />
-    <button type="submit" :disabled="isCommentSending" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
+    <button type="submit" :disabled="isCommentSending || operatorCommentValue.length === 0" @click="sendOperatorComment($event)" class="button comment-button">コメント</button>
     <div class="comment-disabled-message" v-if="programStatus === 'end'">
       番組が終了したため、放送者コメントを投稿できません
     </div>

--- a/app/components/nicolive-area/CommentForm.vue.ts
+++ b/app/components/nicolive-area/CommentForm.vue.ts
@@ -13,6 +13,7 @@ export default class CommentForm extends Vue {
 
   async sendOperatorComment(event: KeyboardEvent) {
     const text = this.operatorCommentValue;
+    if (text.length === 0) return;
     const isPermanent = event.ctrlKey;
     if (this.isCommentSending) throw new Error('sendOperatorComment is running');
 


### PR DESCRIPTION
# このpull requestが解決する内容
運営コメントフォームについて、次のように変更します
- 0文字の場合送信しない、ボタンも押せない
- 80文字以上入力させない

# 動作確認手順
1. ログインしていなければログインする
2. 番組作成OR番組情報を取得する
3. 0文字で送信ボタンを押しても送信しない
4. 80文字以上入力できない
