### PR TITLE
修正: 言語の修正

### DIFF
--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -9,8 +9,7 @@ export default class ToolBar extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
 
-  // TODO: あとでまとめる
-  manualExtentionTooltip = '30分延長する';
+  manualExtentionTooltip = $t('common.manualExtendButton');
 
   format(timeInSeconds: number): string {
     return NicoliveProgramService.format(timeInSeconds);

--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -52,12 +52,13 @@
   "selectAll": "Select All",
   "selectOption": "Select Option",
   "browse": "Browse",
-  "numberOfVisitors": "Number of visitors",
-  "numberOfComments": "Number of comments",
-  "numberOfadPoint": "Number of nicoad point",
-  "numberOfgiftPoint": "Number of gift point",
+  "numberOfVisitors": "Number of Visitors",
+  "numberOfComments": "Number of Comments",
+  "numberOfadPoint": "Niconico Advertisement Point",
+  "numberOfgiftPoint": "Gift Point",
   "notifications": "Notifications",
   "help": "Help",
   "simpleMode": "Simple Mode",
-  "twitter": "Twitter"
+  "twitter": "Post to Twitter",
+  "manualExtendButton": "Extend 30 minutes"
 }

--- a/app/i18n/ja-JP/common.json
+++ b/app/i18n/ja-JP/common.json
@@ -59,5 +59,6 @@
   "notifications": "通知",
   "help": "ヘルプ",
   "simpleMode": "シンプルモード",
-  "twitter": "Twitter"
+  "twitter": "Twitterに投稿する",
+  "manualExtendButton": "30分延長する"
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
ツールチップの言語を下記のように修正しました。

・来場者数：Number of visitors→Number of Visitors
・コメント数：Number of comments→Number of Comments
・ニコニ広告ポイント：Number of nicoad point→Niconico Advertisement Point
・ギフトポイント：Number of gift point→Gift Point
・延長ボタン：Extend 30 minutes（追加）
・Twitterアイコン（日）：Twitter→Twitterに投稿
・Twitterアイコン（英）：Twitter→Post to Twitter

**動作確認手順**

1. ログインしていない場合はログインする
2. 番組作成OR取得する
3. 設定→言語で言語を切り替える
4. 各要素のツールチップを確認
