### PR TITLE
追加: sentryのエラーログ内容にCPU, GPU, メモリ, OS情報を追加

### DIFF
--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -27,6 +27,7 @@ import {
   graphics as systemInfoGraphics,
   osInfo as systemInfoOsInfo,
   uuid as systemInfoUuid,
+  Systeminformation,
 } from 'systeminformation';
 import {
   totalmem as nodeTotalMem,
@@ -332,9 +333,9 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }
 
   async getUserExtraContext() {
-    let osInfo, cpu, graphics, osUuid, result;
+    let result;
     try{
-      [graphics, cpu, osInfo, osUuid] = await Promise.all([
+      const [graphics, cpu, osInfo, osUuid] = await Promise.all([
         systemInfoGraphics(),
         systemInfoCpu(),
         systemInfoOsInfo(),
@@ -351,7 +352,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         memTotal: nodeTotalMem(),
         memAvailable: nodeFreeMem(),
         memUsage: nodeMemUsage(),
-      }
+      };
     } catch (err) {
       result = {
         platform: this.platform.type,
@@ -362,9 +363,9 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         memAvailable: nodeFreeMem(),
         memUsage: nodeMemUsage(),
         exceptionWhenGetSystemInfo: err
-      }
+      };
     }
-    return result
+    return result;
   }
 
   popoutRecentEvents() {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -27,7 +27,6 @@ import {
   graphics as systemInfoGraphics,
   osInfo as systemInfoOsInfo,
   uuid as systemInfoUuid,
-  Systeminformation,
 } from 'systeminformation';
 import {
   totalmem as nodeTotalMem,
@@ -333,7 +332,6 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }
 
   async getUserExtraContext() {
-    let result;
     try{
       const [graphics, cpu, osInfo, osUuid] = await Promise.all([
         systemInfoGraphics(),
@@ -342,7 +340,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         systemInfoUuid(),
       ]);
 
-      result = {
+      return {
         platform: this.platform.type,
         cpuModel: nodeCpus()[0].model,
         cpuCores: `physical:${cpu.physicalCores} logical:${cpu.cores}`,
@@ -354,7 +352,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         memUsage: nodeMemUsage(),
       };
     } catch (err) {
-      result = {
+      return {
         platform: this.platform.type,
         cpuModel: nodeCpus()[0].model,
         cpuCores: `logical:${nodeCpus().length}`,
@@ -365,7 +363,6 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         exceptionWhenGetSystemInfo: err
       };
     }
-    return result;
   }
 
   popoutRecentEvents() {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -334,10 +334,12 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   async getUserExtraContext() {
     let osInfo, cpu, graphics, osUuid, result;
     try{
-      graphics = await systemInfoGraphics();
-      cpu = await systemInfoCpu();
-      osInfo = await systemInfoOsInfo();
-      osUuid = await systemInfoUuid();
+      [graphics, cpu, osInfo, osUuid] = await Promise.all([
+        systemInfoGraphics(),
+        systemInfoCpu(),
+        systemInfoOsInfo(),
+        systemInfoUuid(),
+      ]);
 
       result = {
         platform: this.platform.type,

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "rimraf": "^2.6.1",
     "semver": "^5.5.1",
     "socket.io-client": "2.0.3",
+    "systeminformation": "^4.1.6",
     "uuid": "^3.3.2",
     "vue-svg-loader": "^0.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12835,6 +12835,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
+systeminformation@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.1.6.tgz#9ee8883178c4977d1910beb3eef6bf250f7fe3b2"
+  integrity sha512-8Q8wPRvnZX0WRxPVVGN6Q/51GeDBhqruNhFzAjoCPaf4/l0hxTLj8XPjeAME8/Y9I5Y4bdA4fx0QjxvuFhlD8A==
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"


### PR DESCRIPTION
**このpull requestが解決する内容**
現在N Airではsentry.ioを用いてエラー情報を収集していますが、エラーがどのような状況で起きたのかをより詳しく調べるため、Additional Dataとして下記の項目を収集します。

- CPU
  - モデル名
  - コア数
- GPU
  - モデル名
- メモリ
  - 搭載メモリ量
  - 利用可能なメモリ量
  - N Airが占有しているメモリ量
- OS
  - バージョン
  - UUID

GPU情報、およびより詳しいCPUやOSの情報を取得するために[systeminformation](https://www.npmjs.com/package/systeminformation)を追加します。
万が一、取得時に例外が発生した場合にはnodeのAPIを使用して可能な限りの情報を収集します。

**動作確認手順**
1. `NAIR_REPORT_TO_SENTRY=yes yarn start`でN Airを起動する
1. 配信のエンコード設定を推奨設定でないものに変更する
1. テスト用番組を作成し、配信開始ボタンを押す
1. 最適化の確認ダイアログにおいて「最適化して配信を開始する」を押す
1. sentry.ioに届いたログにAdditional Dataとして上記情報が含まれていることを確認する