### PR TITLE
追加: 番組URLをクリップボードへコピーする機能を番組情報パネルに追加

### DIFF
--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -7,6 +7,9 @@
       <div class="top-nav-item">
         <a @click="editProgram" :disabled="isEditing" class="link"><i class="icon-edit"></i>番組編集</a>
       </div>
+      <div class="top-nav-item">
+        <a @click="copyProgramURL" :disabled="isFetching" class="link"><i class="icon-clipboard-copy"></i>番組URLをコピー</a>
+      </div>
     </div>  
   </div>
 </template>

--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -8,7 +8,7 @@
         <a @click="editProgram" :disabled="isEditing" class="link"><i class="icon-edit"></i>番組編集</a>
       </div>
       <div class="top-nav-item">
-        <a @click="copyProgramURL" :disabled="isFetching" class="link"><i class="icon-clipboard-copy"></i>番組URLをコピー</a>
+        <a @click="copyProgramURL" class="link"><i class="icon-clipboard-copy"></i>番組URLをコピー</a>
       </div>
     </div>  
   </div>

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { NicoliveProgramService, NicoliveProgramServiceFailure } from 'services/nicolive-program/nicolive-program';
+import { clipboard } from 'electron';
 
 @Component({})
 export default class TopNav extends Vue {
@@ -41,5 +42,10 @@ export default class TopNav extends Vue {
     } finally {
       this.isEditing = false;
     }
+  }
+
+  copyProgramURL() {
+    if (this.isFetching) throw new Error('fetchProgram is running');
+    clipboard.writeText(`https://live.nicovideo.jp/watch/${this.nicoliveProgramService.state.programID}`);
   }
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
ニコ生エリアに番組URLをクリップボードへコピーするリンクを追加し、ワンクリックで番組URLをクリップボードへコピーできるようにします。

![image](https://user-images.githubusercontent.com/24884114/57516025-dd5cca80-734e-11e9-9e50-27a1324a7aca.png)

**背景**
- ニコ生と連携するツールなどで使用するために、番組URLが必要となる場合がある
- 番組タイトルやtwitterシェアボタンをクリックすると既定のブラウザでwatch画面やtwitterのShare画面が出るため、そのアドレスバーや投稿欄からコピーできるといえばできる
  - しかし、「番組タイトルまたはtwitterシェアボタンをクリックし、既定のブラウザが起動するのを待ち、アドレスを選択し、コピーする」という4アクションが必要であり非常に煩雑
- したがって、N Air上での1アクションで番組URLをクリップボードへコピーできるようにしたい

**検討、ブラッシュアップの余地がある点**
- 追加する先はトップナビで良いのか
- クリップボードへ番組URLをコピーした際に視覚的フィードバックがない

**動作確認手順**
1. N Airから番組を作成、または既存番組を取得する
1. 番組情報のトップナビ部にある「番組URLをコピー」をクリックする
1. クリップボードへニコ生のURLがコピーされていることを確認する

related #300 