### PR TITLE
変更: アップデーターのボタン文言を簡潔にする

### DIFF
--- a/updater/ui.js
+++ b/updater/ui.js
@@ -51,8 +51,8 @@ const i18n = new VueI18n({
         changeLog: `更新内容`,
         mandatoryUpdate: `必須アップデートです`,
         skippableUpdate: `スキップ可能なアップデートです`,
-        download: 'ダウンロードして更新',
-        skip: '更新せずに N Air を起動'
+        download: '更新する',
+        skip: 'あとで'
       },
       downloading: {
         message: 'バージョン{version}を{br}ダウンロードしています'


### PR DESCRIPTION
# このpull requestが解決する内容
アップデーターに表示するボタンの文言をより簡潔にします

|\\ |before|after|
|----|----|----|
|download|ダウンロードして更新|更新する|
|skip|更新せずに N Air を起動|あとで|

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/58225318-6a931c80-7d5c-11e9-868b-af2719ebd962.png)|![image](https://user-images.githubusercontent.com/950573/58225336-7848a200-7d5c-11e9-88f6-abac876f3160.png)|


# 動作確認手順
必ずアップデーターが更新があると伝えるように変更して https://github.com/berlysia/n-air-app/tree/tmp/reword-updater

```
yarn compile && NAIR_FORCE_AUTO_UPDATE=1 yarn start
```