### PR TITLE
修正: v-forのkeyを指定

### DIFF
--- a/app/components/HotkeyGroup.vue
+++ b/app/components/HotkeyGroup.vue
@@ -17,7 +17,7 @@
       v-show="!collapsed"
       class="section-content section-content--dropdown"
   >
-    <hotkey v-for="hotkey in hotkeys" :hotkey="hotkey" />
+    <hotkey v-for="(hotkey, index) in hotkeys" :hotkey="hotkey" :key="index" />
   </div>
 </div>
 </template>


### PR DESCRIPTION
# このpull requestが解決する内容
ビルド時に出ていたwarningが消えるようにします。

hotkeyの構造から一意な名前を生成してもよかったのですが、
そもそも高頻度に見る場所ではないのでindexを食わせてwarningを黙らせることにしました。

# 動作確認手順
ビルドしてwarningが出ない
devtoolを開いた状態で設定画面からショートカットキーの大項目を表示したとき、vueのエラーが出ていない

# 関連するIssue（あれば）
