### PR TITLE
追加: 最適化ダイアログにハードウェアエンコーダーを使うかどうかのオプションを追加

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -12,6 +12,11 @@
       v-show="optimizeForNiconicoModel.value"
       @input="setShowOptimizationDialogForNiconico"
       class="optional-item" />
+    <BoolInput
+      :value="optimizeWithHardwareEncoderModel"
+      v-show="optimizeForNiconicoModel.value"
+      @input="setOptimizeWithHardwareEncoder"
+      class="optional-item" />
   </div>
 
   <div class="section">

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -67,6 +67,19 @@ export default class ExtraSettings extends Vue {
     this.customizationService.setShowOptimizationDialogForNiconico(model.value);
   }
 
+  get optimizeWithHardwareEncoderModel(): IFormInput<boolean> {
+    return {
+      name: 'optimize_with_hardware_encoder',
+      description: $t('settings.optimizeWithHardwareEncoder'),
+      value: this.customizationService.state.optimizeWithHardwareEncoder,
+      enabled: this.streamingService.isStreaming === false
+    };
+  }
+
+  setOptimizeWithHardwareEncoder(model: IFormInput<boolean>) {
+    this.customizationService.setOptimizeWithHardwareEncoder(model.value);
+  }
+
   get pollingPerformanceStatisticsModel(): IFormInput<boolean> {
     return {
       name: 'polling_performance_statistics',

--- a/app/components/windows/NicoliveProgramSelector.vue.ts
+++ b/app/components/windows/NicoliveProgramSelector.vue.ts
@@ -28,7 +28,7 @@ export default class NicoliveProgramSelector extends Vue {
     if (this.disabledOk) {
       return;
     }
-    this.streamingService.toggleStreamingAsync(this.selectedId);
+    this.streamingService.toggleStreamingAsync({programId: this.selectedId});
 
     this.windowsService.closeChildWindow();
   }

--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -17,6 +17,7 @@
         </ul>
       </li>
     </ul>
+    <BoolInput :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
     <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
   </div>
   <div slot="controls">

--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -53,7 +53,7 @@ export default class OptimizeNiconico extends Vue {
     this.customizationService.setOptimizeWithHardwareEncoder(model.value);
     // close the dialog and open again to apply new optimization settings
     this.windowsService.closeChildWindow();
-    this.streamingService.toggleStreamingAsync();
+    this.streamingService.toggleStreamingAsync({mustShowOptimizationDialog: true});
   }
 
   optimizeAndGoLive() {

--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -41,6 +41,21 @@ export default class OptimizeNiconico extends Vue {
     this.customizationService.setShowOptimizationDialogForNiconico(!model.value);
   }
 
+  get useHardwareEncoder(): IFormInput<boolean> {
+    return {
+      name: 'use_hardware_encoder',
+      description: $t('streaming.optimizeWithHardwareEncoder'),
+      value: this.customizationService.optimizeWithHardwareEncoder === true
+    };
+  }
+
+  setUseHardwareEncoder(model: IFormInput<boolean>) {
+    this.customizationService.setOptimizeWithHardwareEncoder(model.value);
+    // close the dialog and open again to apply new optimization settings
+    this.windowsService.closeChildWindow();
+    this.streamingService.toggleStreamingAsync();
+  }
+
   optimizeAndGoLive() {
     this.settingsService.optimizeForNiconico(this.settings.best);
     this.streamingService.toggleStreaming();

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -572,6 +572,7 @@
   "fontSize": "Font Size",
   "optimizeForNiconico": "optimize settings for niconico live service",
   "showOptimizationDialogForNiconico": "show confirmation dialog to check the optimization when starting streams",
+  "optimizeWithHardwareEncoder": "use hardware encoder to optimize settings if available",
   "videoBitrate": "Video Bitrate (kbps)",
   "audioBitrate": "Audio Bitrate (kbps)",
   "keyframeInterval": "Keyframe Interval (in seconds)",

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -47,5 +47,6 @@
   "resolution": "resolution",
   "optimizeAndGoLive": "Optimize & Go Live",
   "skipOptimization": "Skip Optimization",
-  "doNotShowAgainOptimizationDialog": "Do not show this dialog again"
+  "doNotShowAgainOptimizationDialog": "Do not show this dialog again",
+  "optimizeWithHardwareEncoder": "Use hardware encoder if available"
 }

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -572,6 +572,7 @@
   "fontSize": "フォントサイズ",
   "optimizeForNiconico": "配信開始時に配信設定をニコニコ生放送に最適化する",
   "showOptimizationDialogForNiconico": "配信開始時に最適化の確認ダイアログを表示する",
+  "optimizeWithHardwareEncoder": "ハードウェアエンコーダーを利用する",
   "videoBitrate": "映像ビットレート  (kbps)",
   "audioBitrate": "音声ビットレート  (kbps)",
   "keyframeInterval": "キーフレーム間隔(秒)",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -47,5 +47,6 @@
   "resolution": "解像度",
   "optimizeAndGoLive": "最適化して配信を開始する",
   "skipOptimization": "最適化しないで配信を開始する",
-  "doNotShowAgainOptimizationDialog": "今後、このダイアログを表示しない"
+  "doNotShowAgainOptimizationDialog": "今後、このダイアログを表示しない",
+  "optimizeWithHardwareEncoder": "ハードウェアエンコーダーを利用する"
 }

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -6,6 +6,7 @@ export interface ICustomizationServiceState {
   studioControlsOpened: boolean;
   optimizeForNiconico: boolean;
   showOptimizationDialogForNiconico: boolean;
+  optimizeWithHardwareEncoder: boolean;
   pollingPerformanceStatistics: boolean;
   experimental: any;
 }

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -24,6 +24,7 @@ export class CustomizationService
     studioControlsOpened: true,
     optimizeForNiconico: true,
     showOptimizationDialogForNiconico: true,
+    optimizeWithHardwareEncoder: true,
     pollingPerformanceStatistics: true,
     experimental: {
       // put experimental features here
@@ -67,6 +68,14 @@ export class CustomizationService
 
   setShowOptimizationDialogForNiconico(optimize: boolean) {
     this.setSettings({ showOptimizationDialogForNiconico: optimize });
+  }
+
+  get optimizeWithHardwareEncoder() {
+    return this.state.optimizeWithHardwareEncoder;
+  }
+
+  setOptimizeWithHardwareEncoder(useHardwareEncoder: boolean) {
+    this.setSettings({ optimizeWithHardwareEncoder: useHardwareEncoder });
   }
 
   get pollingPerformanceStatistics() {

--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -4,7 +4,6 @@ import {
 
 /**
  * niconicoに最適な設定値を返す。
- * @param options ビットレート
  */
 export function getBestSettingsForNiconico(
     options: {

--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -7,7 +7,10 @@ import {
  * @param options ビットレート
  */
 export function getBestSettingsForNiconico(
-    options: { bitrate: number },
+    options: {
+        bitrate: number,
+        useHardwareEncoder?: boolean
+    },
     settings: SettingsKeyAccessor
 ): OptimizeSettings {
     let audioBitrate: number;
@@ -34,18 +37,20 @@ export function getBestSettingsForNiconico(
         simpleUseAdvanced: true,
         encoderPreset: 'ultrafast',
     };
-    if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.nvenc)) {
-        encoderSettings = {
-            encoder: EncoderType.nvenc,
-            simpleUseAdvanced: true,
-            NVENCPreset: 'llhq',
-        };
-    } else if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.qsv)) {
-        encoderSettings = {
-            encoder: EncoderType.qsv,
-            simpleUseAdvanced: true,
-            targetUsage: 'speed',
-        };
+    if (!('useHardwareEncoder' in options) || options.useHardwareEncoder) {
+        if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.nvenc)) {
+            encoderSettings = {
+                encoder: EncoderType.nvenc,
+                simpleUseAdvanced: true,
+                NVENCPreset: 'llhq',
+            };
+        } else if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.qsv)) {
+            encoderSettings = {
+                encoder: EncoderType.qsv,
+                simpleUseAdvanced: true,
+                targetUsage: 'speed',
+            };
+        }
     }
 
     const commonSettings: OptimizeSettings = {

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -412,6 +412,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
 export interface OptimizedSettings {
     best: OptimizeSettings;
     current: OptimizeSettings;
+    delta: OptimizeSettings;
     info: [CategoryName, {
         key: string,
         name: string,

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -446,8 +446,7 @@ export class SettingsService extends StatefulService<ISettingsState>
     options: {
       bitrate: number,
       useHardwareEncoder?: boolean,
-    },
-    getSettingsEvenIfNothingChanged: boolean = false
+    }
   ): OptimizedSettings {
     const accessor = new SettingsKeyAccessor(this);
     const best = getBestSettingsForNiconico(options, accessor);
@@ -458,11 +457,12 @@ export class SettingsService extends StatefulService<ISettingsState>
     // 最適化の必要な値を抽出する
     const delta: OptimizeSettings = Object.assign({}, ...Optimizer.getDifference(current, best));
 
-    return Object.keys(delta).length > 0 || getSettingsEvenIfNothingChanged ? {
+    return {
       current,
       best,
+      delta,
       info: opt.optimizeInfo(current, delta)
-    } : undefined;
+    };
   }
 
   optimizeForNiconico(best: OptimizeSettings) {

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -442,7 +442,13 @@ export class SettingsService extends StatefulService<ISettingsState>
     };
   }
 
-  diffOptimizedSettings(options: {bitrate: number, useHardwareEncoder?: boolean}): OptimizedSettings {
+  diffOptimizedSettings(
+    options: {
+      bitrate: number,
+      useHardwareEncoder?: boolean,
+    },
+    getSettingsEvenIfNothingChanged: boolean = false
+  ): OptimizedSettings {
     const accessor = new SettingsKeyAccessor(this);
     const best = getBestSettingsForNiconico(options, accessor);
     const opt = new Optimizer(accessor, best);
@@ -452,7 +458,7 @@ export class SettingsService extends StatefulService<ISettingsState>
     // 最適化の必要な値を抽出する
     const delta: OptimizeSettings = Object.assign({}, ...Optimizer.getDifference(current, best));
 
-    return Object.keys(delta).length > 0 ? {
+    return Object.keys(delta).length > 0 || getSettingsEvenIfNothingChanged ? {
       current,
       best,
       info: opt.optimizeInfo(current, delta)

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -442,9 +442,9 @@ export class SettingsService extends StatefulService<ISettingsState>
     };
   }
 
-  diffOptimizedSettings(bitrate: number): OptimizedSettings {
+  diffOptimizedSettings(options: {bitrate: number, useHardwareEncoder?: boolean}): OptimizedSettings {
     const accessor = new SettingsKeyAccessor(this);
-    const best = getBestSettingsForNiconico({ bitrate }, accessor);
+    const best = getBestSettingsForNiconico(options, accessor);
     const opt = new Optimizer(accessor, best);
 
     const current = opt.getCurrentSettings();

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -446,7 +446,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   const { instance } = StreamingService;
 
   instance.toggleStreaming = jest.fn();
-  instance.optimizeForNiconico = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
 
   jest
     .spyOn(electron.remote.dialog, 'showMessageBox')
@@ -457,7 +457,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   await instance.toggleStreamingAsync();
 
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
-  expect(instance.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
 });
 
 test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログインしていて、番組が定まり、最適化を行う場合', async () => {
@@ -478,12 +478,12 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
 
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
-  instance.optimizeForNiconico = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
   instance.toggleStreaming = jest.fn();
 
   await instance.toggleStreamingAsync();
 
-  expect(instance.optimizeForNiconico).toHaveBeenCalledTimes(1);
+  expect(instance.optimizeForNiconicoAndStartStreaming).toHaveBeenCalledTimes(1);
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
 });
 
@@ -505,11 +505,11 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
   instance.toggleStreaming = jest.fn();
-  instance.optimizeForNiconico = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
 
   await instance.toggleStreamingAsync();
 
-  expect(instance.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
   expect(instance.toggleStreaming).toHaveBeenCalledTimes(1);
 });
 
@@ -537,11 +537,11 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
   instance.toggleStreaming = jest.fn();
-  instance.optimizeForNiconico = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
 
   await instance.toggleStreamingAsync();
 
-  expect(instance.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
 });
 
@@ -572,10 +572,10 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   const { StreamingService } = require('./streaming');
   const { instance } = StreamingService;
   instance.toggleStreaming = jest.fn();
-  instance.optimizeForNiconico = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
 
   await instance.toggleStreamingAsync();
 
-  expect(instance.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
 });

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -244,7 +244,10 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
         );
       });
     }
-    const settings = this.settingsService.diffOptimizedSettings(streamingSetting.bitrate);
+    const settings = this.settingsService.diffOptimizedSettings({
+      bitrate: streamingSetting.bitrate,
+      useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
+    });
     if (settings) {
       if (this.customizationService.showOptimizationDialogForNiconico) {
         this.windowsService.showWindow({

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -143,7 +143,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           });
         }
         if (this.customizationService.optimizeForNiconico) {
-          return this.optimizeForNiconico(setting, opts.mustShowOptimizationDialog);
+          return this.optimizeForNiconicoAndStartStreaming(setting, opts.mustShowOptimizationDialog);
         }
       } catch (e) {
         const message = e instanceof Response
@@ -238,7 +238,12 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     return Math.floor(height); // floorしないと死ぬ
   }
 
-  private async optimizeForNiconico(streamingSetting: IStreamingSetting, mustShowDialog: boolean) {
+  /**
+   * ニコニコ生放送用設定最適化を行い、配信を開始する。この際、必要なら最適化ダイアログ表示を行う。
+   * @param streamingSetting 番組の情報から得られる最適化の前提となる情報
+   * @param mustShowDialog trueなら、設定に変更が必要ない場合や、最適化ダイアログを表示しない接敵のときであっても最適化ダイアログを表示する。
+   */
+  private async optimizeForNiconicoAndStartStreaming(streamingSetting: IStreamingSetting, mustShowDialog: boolean) {
     if (streamingSetting.bitrate === undefined) {
       return new Promise(resolve => {
         electron.remote.dialog.showMessageBox(

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -262,8 +262,8 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     const settings = this.settingsService.diffOptimizedSettings({
       bitrate: streamingSetting.bitrate,
       useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
-    }, mustShowDialog);
-    if (settings) {
+    });
+    if (Object.keys(settings.delta).length > 0 || mustShowDialog) {
       if (this.customizationService.showOptimizationDialogForNiconico || mustShowDialog) {
         this.windowsService.showWindow({
           componentName: 'OptimizeForNiconico',

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -102,7 +102,17 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   }
 
   // 配信開始ボタンまたはショートカットキーによる配信開始(対話可能)
-  async toggleStreamingAsync(programId: string = '') {
+  async toggleStreamingAsync(
+    options: {
+      programId?: string,
+      mustShowOptimizationDialog?: boolean
+    } = {}
+  ) {
+    const opts = Object.assign({
+      programId: '',
+      mustShowOptimizationDialog: false
+    }, options);
+
     if (this.isStreaming) {
       this.toggleStreaming();
       return;
@@ -112,7 +122,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     if (this.userService.isNiconicoLoggedIn()) {
       try {
         this.SET_PROGRAM_FETCHING(true);
-        const setting = await this.userService.updateStreamSettings(programId);
+        const setting = await this.userService.updateStreamSettings(opts.programId);
         if (setting.asking) {
           return;
         }
@@ -133,7 +143,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           });
         }
         if (this.customizationService.optimizeForNiconico) {
-          return this.optimizeForNiconico(setting);
+          return this.optimizeForNiconico(setting, opts.mustShowOptimizationDialog);
         }
       } catch (e) {
         const message = e instanceof Response
@@ -228,7 +238,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     return Math.floor(height); // floorしないと死ぬ
   }
 
-  private async optimizeForNiconico(streamingSetting: IStreamingSetting) {
+  private async optimizeForNiconico(streamingSetting: IStreamingSetting, mustShowDialog: boolean) {
     if (streamingSetting.bitrate === undefined) {
       return new Promise(resolve => {
         electron.remote.dialog.showMessageBox(
@@ -247,9 +257,9 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     const settings = this.settingsService.diffOptimizedSettings({
       bitrate: streamingSetting.bitrate,
       useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
-    });
+    }, mustShowDialog);
     if (settings) {
-      if (this.customizationService.showOptimizationDialogForNiconico) {
+      if (this.customizationService.showOptimizationDialogForNiconico || mustShowDialog) {
         this.windowsService.showWindow({
           componentName: 'OptimizeForNiconico',
           queryParams: settings,


### PR DESCRIPTION
最適化ダイアログに `ハードウェアエンコーダを利用する` チェックボックスを追加し、クリックごとにダイアログを開き直して新しい最適化提案内容を更新します。
ローカルテストには、番組を作っていなくても配信開始ボタンで配信開始ができるブランチ https://github.com/koizuka/n-air-app/tree/debug/optimize-niconico-use-hardware-encoder-optionally を使うと便利です。(最適化ダイアログを表示しない設定だと出ないので注意)

![image](https://user-images.githubusercontent.com/864587/58935813-36324e00-87a9-11e9-840f-ed6a4095decd.png)
![image](https://user-images.githubusercontent.com/864587/58935840-421e1000-87a9-11e9-98d0-08936dbd68c4.png)

# 関連するIssue（あれば）
fixed #304 