### PR TITLE
修正: 最適化ダイアログから「今後、このダイアログを表示しない」 チェックボックスが消えていたので復活

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -224,13 +224,15 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   private calculateOptimizeWindowSize(settings: OptimizedSettings): number {
     const windowHeader = 6 + 20 + 1;
     const descriptionLabel = 22.4 + 12;
+    const useHardwareCheck = 28 + 12;
     const doNotShowCheck = 28 + 12;
     const contentOverhead = 16;
     const modalControls = 8 + 36 + 8;
     const categoryOverhead = 22.4 + 4 + 8 + 8 + 12;
     const lineHeight = 20.8;
 
-    const overhead = windowHeader + descriptionLabel + doNotShowCheck + contentOverhead + modalControls;
+    const overhead = windowHeader + descriptionLabel + useHardwareCheck + doNotShowCheck
+      + contentOverhead + modalControls;
 
     const numCategories = settings.info.length;
     const numLines = settings.info.reduce((sum, tuple) => sum + tuple[1].length, 0);


### PR DESCRIPTION
# このpull requestが解決する内容
#315 で `今後、このダイアログを表示しない` チェックボックスが消えていたので復活します
![image](https://user-images.githubusercontent.com/864587/59263630-65026580-8c7c-11e9-9bca-6c05517c1607.png)

# 動作確認手順
#315 と同様

# 関連するIssue（あれば）
#304