### PR TITLE
修正: 非ログイン状態のときにUserExtraContextが正しく取得出来ていなかった問題を修正

### DIFF
--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -343,7 +343,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       ]);
 
       return {
-        platform: this.platform.type,
+        platform: this.platform ? this.platform.type : 'not logged in',
         cpuModel: nodeCpus()[0].model,
         cpuCores: `physical:${cpu.physicalCores} logical:${cpu.cores}`,
         gpus: graphics.controllers,
@@ -355,7 +355,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       };
     } catch (err) {
       return {
-        platform: this.platform.type,
+        platform: this.platform ? this.platform.type : 'not logged in',
         cpuModel: nodeCpus()[0].model,
         cpuCores: `logical:${nodeCpus().length}`,
         os: nodeOsRelease(),


### PR DESCRIPTION
# このpull requestが解決する内容
非ログイン状態のときはthis.platformがundefinedのため、getUserExtraContext関数の中のthis.platform.typeを参照しようとしてCannot read property 'type' of undefinedで死んでしまっていたので修正します。

related #299 

# 動作確認手順

# 関連するIssue（あれば）
