### PR TITLE
修正: ニコ生などの操作パネルを開閉するボタンが目立つように修正

### DIFF
--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -36,6 +36,7 @@
   }
   &.opened {
     height: 196px;
+    padding-top: 28px;
     svg {
       width: 140px;
       height: 10px;
@@ -60,8 +61,12 @@
     width: 140px;
     height: 10px;
     transform: rotate(180deg);
-    fill: @bg-secondary;
+    fill: @text-primary;
     transition: .5s;
+  }
+
+  .opened & {
+    margin-top: -28px;
   }
 
   &:hover {

--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -50,9 +50,9 @@
   > svg {
     width: 10px;
     height: 140px;
-    fill: @bg-secondary;
+    fill: @text-primary;
     transition: .5s;
-    transform: rotate(180deg);
+    transform: rotate(0deg);
   }
 
   &:hover {
@@ -65,7 +65,7 @@
 
   &.nicolive-area--opened {
     > svg {
-      transform: rotate(0deg);
+      transform: rotate(180deg);
     }
   }
 }

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -11,7 +11,7 @@ import ProgramInfo from './ProgramInfo.vue';
 import ProgramStatistics from './ProgramStatistics.vue';
 import ToolBar from './ToolBar.vue';
 import TopNav from './TopNav.vue';
-const ControlsArrow = require('../../../media/images/controls-arrow-vertical.svg');
+import ControlsArrow from '../../../media/images/controls-arrow-vertical.svg';
 
 @Component({
   components: {


### PR DESCRIPTION
# このpull requestが解決する内容
収納ボタンを目立つように変更しました。
- 矢印の色を変更（hover時の色）
- OPEN時のボタンの下余白を調整

#### CLOSE
<img width="667" alt="close_new" src="https://user-images.githubusercontent.com/43235200/59651700-c6b75800-91c5-11e9-9a83-455d041afbc4.png">

#### OPEN
<img width="967" alt="open_new" src="https://user-images.githubusercontent.com/43235200/59651701-c9b24880-91c5-11e9-8537-a1db5c351647.png">


# 関連するIssue（あれば）
https://github.com/n-air-app/n-air-app/issues/309
