### PR TITLE
変更: インフラの構成変更に伴いインストーラなどのS3へのアップロードパスを変更

### DIFF
--- a/bin/mini-release.js
+++ b/bin/mini-release.js
@@ -77,7 +77,7 @@ async function uploadS3File(name, filePath) {
     const upload = new AWS.S3.ManagedUpload({
         params: {
             Bucket: process.env.RELEASE_S3_BUCKET_NAME,
-            Key: `windows/${name}`,
+            Key: `download/windows/${name}`,
             Body: stream
         },
         queueSize: 1


### PR DESCRIPTION
# このpull requestが解決する内容
アップデートを配信するインフラの構成変更に伴い、リリーススクリプト中でインストーラなどをアップロードするパスを変更する必要があります。
cloudfrontを通じてのアクセスはURLが変わらないため問題ありません。

# 動作確認手順

# 関連するIssue（あれば）
