### PR TITLE
改善: 番組情報パネルで番組URLをコピーしたときにアイコンを変えてコピーしたことをユーザーに示す

### DIFF
--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -8,7 +8,7 @@
         <a @click="editProgram" :disabled="isEditing" class="link"><i class="icon-edit"></i>番組編集</a>
       </div>
       <div class="top-nav-item">
-        <a @click="copyProgramURL" class="link"><i class="icon-clipboard-copy"></i><i class="icon-check is-invisible"></i>番組URLをコピー</a>
+        <a @click="copyProgramURL" class="link"><i :class="hasProgramUrlCopied ? 'icon-check' : 'icon-clipboard-copy'"></i>番組URLをコピー</a>
       </div>
     </div>  
   </div>
@@ -38,9 +38,6 @@
     margin-right: 4px;
     &.icon-dev {
       font-size: 16px;
-    }
-    &.is-invisible::before {
-      display: none;
     }
   }
 }

--- a/app/components/nicolive-area/TopNav.vue
+++ b/app/components/nicolive-area/TopNav.vue
@@ -8,7 +8,7 @@
         <a @click="editProgram" :disabled="isEditing" class="link"><i class="icon-edit"></i>番組編集</a>
       </div>
       <div class="top-nav-item">
-        <a @click="copyProgramURL" class="link"><i class="icon-clipboard-copy"></i>番組URLをコピー</a>
+        <a @click="copyProgramURL" class="link"><i class="icon-clipboard-copy"></i><i class="icon-check is-invisible"></i>番組URLをコピー</a>
       </div>
     </div>  
   </div>
@@ -38,6 +38,9 @@
     margin-right: 4px;
     &.icon-dev {
       font-size: 16px;
+    }
+    &.is-invisible::before {
+      display: none;
     }
   }
 }

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -4,10 +4,6 @@ import { Inject } from 'util/injector';
 import { NicoliveProgramService, NicoliveProgramServiceFailure } from 'services/nicolive-program/nicolive-program';
 import { clipboard } from 'electron';
 
-interface HTMLElementEvent<T extends HTMLElement> extends Event {
-  target: T;
-}
-
 @Component({})
 export default class TopNav extends Vue {
   @Inject()
@@ -48,19 +44,14 @@ export default class TopNav extends Vue {
     }
   }
 
-  copyProgramURL(event: HTMLElementEvent<HTMLInputElement>) {
+  hasProgramUrlCopied: boolean = false;
+  copyProgramURL() {
     if (this.isFetching) throw new Error('fetchProgram is running');
     clipboard.writeText(`https://live.nicovideo.jp/watch/${this.nicoliveProgramService.state.programID}`);
+    this.hasProgramUrlCopied = true;
 
-    const icons = event.target.parentNode.querySelectorAll('i[class^="icon-"]')
-    icons.forEach((element : Element) => {
-      element.classList.toggle('is-invisible')
-    })
-    
     setTimeout(() => {
-      icons.forEach((element : Element) => {
-        element.classList.toggle('is-invisible')
-      })
+      this.hasProgramUrlCopied = false;
     }, 1000)
   }
 }

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -4,6 +4,10 @@ import { Inject } from 'util/injector';
 import { NicoliveProgramService, NicoliveProgramServiceFailure } from 'services/nicolive-program/nicolive-program';
 import { clipboard } from 'electron';
 
+interface HTMLElementEvent<T extends HTMLElement> extends Event {
+  target: T;
+}
+
 @Component({})
 export default class TopNav extends Vue {
   @Inject()
@@ -44,8 +48,19 @@ export default class TopNav extends Vue {
     }
   }
 
-  copyProgramURL() {
+  copyProgramURL(event: HTMLElementEvent<HTMLInputElement>) {
     if (this.isFetching) throw new Error('fetchProgram is running');
     clipboard.writeText(`https://live.nicovideo.jp/watch/${this.nicoliveProgramService.state.programID}`);
+
+    const icons = event.target.parentNode.querySelectorAll('i[class^="icon-"]')
+    icons.forEach((element : Element) => {
+      element.classList.toggle('is-invisible')
+    })
+    
+    setTimeout(() => {
+      icons.forEach((element : Element) => {
+        element.classList.toggle('is-invisible')
+      })
+    }, 1000)
   }
 }

--- a/app/components/nicolive-area/TopNav.vue.ts
+++ b/app/components/nicolive-area/TopNav.vue.ts
@@ -44,14 +44,17 @@ export default class TopNav extends Vue {
     }
   }
 
-  hasProgramUrlCopied: boolean = false;
+  hasProgramUrlCopied : boolean = false;
+  clearTimer : NodeJS.Timer | null = null; 
   copyProgramURL() {
     if (this.isFetching) throw new Error('fetchProgram is running');
     clipboard.writeText(`https://live.nicovideo.jp/watch/${this.nicoliveProgramService.state.programID}`);
     this.hasProgramUrlCopied = true;
+    clearTimeout(this.clearTimer)
 
-    setTimeout(() => {
+    this.clearTimer = setTimeout(() => {
       this.hasProgramUrlCopied = false;
+      this.clearTimer = null;
     }, 1000)
   }
 }


### PR DESCRIPTION
# このpull requestが解決する内容
番組情報パネルで番組URLをコピーしたときにアイコンを変えてコピーしたことをユーザーにフィードバックする動作を追加します。
![2019-06-24 23-04-30](https://user-images.githubusercontent.com/24884114/60025495-b6770f80-96d4-11e9-862d-bef4c3b511de.gif)
( https://github.com/n-air-app/n-air-app/pull/321/commits/f52120c3e08a0d1a46556b7a7607ac8a8b2d8d85 でちょっと見た目の挙動も変わったのでgif差し替え)

# 動作確認手順
番組を作成し、番組情報パネルで番組URLをコピーする

# 関連するIssue（あれば）