### PR TITLE
修正: リリーススクリプトのリネーム漏れに対処

### DIFF
--- a/bin/mini-release.js
+++ b/bin/mini-release.js
@@ -469,7 +469,7 @@ async function runScript() {
         const MAX_RETRY = 3;
         for (let retry = 0; retry < MAX_RETRY; ++retry) {
             try {
-                const result = await octokit.repos.uploadAsset({
+                const result = await octokit.repos.uploadReleaseAsset({
                     url,
                     name,
                     file: fs.createReadStream(pathname),

--- a/bin/mini-release.js
+++ b/bin/mini-release.js
@@ -471,16 +471,18 @@ async function runScript() {
             try {
                 const result = await octokit.repos.uploadReleaseAsset({
                     url,
+                    headers: {
+                      'content-length': fs.statSync(pathname).size,
+                      'content-type': contentType
+                    },
                     name,
                     file: fs.createReadStream(pathname),
-                    contentLength: fs.statSync(pathname).size,
-                    contentType
                 });
                 info('done.');
                 return result;
             } catch (e) {
-                if ('code' in e && 'status' in e) {
-                    error(`${e.name}: '${e.message}', code = ${e.code}, status = ${e.status}`);
+                if ('status' in e) {
+                    error(`${e.name}: '${e.message}', status = ${e.status}`);
                     if (e.code === 500 && e.message.indexOf('ECONNRESET') >= 0) {
                         // retry
                     } else {


### PR DESCRIPTION
# このpull requestが解決する内容
> ERROR: TypeError: octokit.repos.uploadAsset is not a function

see: https://github.com/octokit/rest.js/commit/10b4f34fd9dfdab743afe27e98122e777502623c

（一見他に漏れはなさそうに見える）

# 動作確認手順
リリース手順を行う

# 関連するIssue（あれば）
