### PR TITLE
追加: 動画のシリーズへの参照を自動リンク化

### DIFF
--- a/app/util/autoLink.test.ts
+++ b/app/util/autoLink.test.ts
@@ -46,6 +46,10 @@ test('myvideo/1', () => {
   expect(apply('myvideo/1')).toMatchInlineSnapshot(`"<a href=\\"https://www.nicovideo.jp/myvideo/1\\">myvideo/1</a>"`);
 });
 
+test('series/1', () => {
+  expect(apply('series/1')).toMatchInlineSnapshot(`"<a href=\\"https://www.nicovideo.jp/series/1\\">series/1</a>"`);
+});
+
 test('lv1', () => {
   expect(apply('lv1')).toMatchInlineSnapshot(`"<a href=\\"https://live2.nicovideo.jp/watch/lv1\\">lv1</a>"`);
 });

--- a/app/util/autoLink.ts
+++ b/app/util/autoLink.ts
@@ -28,6 +28,7 @@ const autoLinkPatterns = [
   },
   { matcher: /\bwatch\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
   { matcher: /\bmyvideo\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
+  { matcher: /\bseries\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },
   // negative lookbehindが使えないので user/\d+ より先にニコニコモンズユーザーページを判定させる
   { matcher: /\bniconicommons\.jp\/user\/\d+\b/, replace: '<a href="https://www.$&">$&</a>' },
   { matcher: /\buser\/\d+\b/, replace: '<a href="https://www.nicovideo.jp/$&">$&</a>' },


### PR DESCRIPTION
# このpull requestが解決する内容
see: https://blog.nicovideo.jp/niconews/110985.html

# 動作確認手順
1. ログインしていなければログイン
2. 番組情報を取得または作成する
    - このとき番組説明文に `series/:id` 形式の文字列を含める
3. `series/:id` 形式の文字列がリンクになっていて、クリックすると規定のブラウザでそのIDに対応するシリーズのページが開くこと

# 関連するIssue（あれば）
