### PR TITLE
修正: 番組作成画面から新しいウィンドウを開こうとしたら既定ブラウザで開く

### DIFF
--- a/main.js
+++ b/main.js
@@ -496,15 +496,16 @@ ipcMain.on('window-preventLogout', (event, id) => {
 });
 
 /**
- * 番組作成・編集画面からの新ウィンドウ表示を封じる処理
+ * 新ウィンドウ表示は既定のブラウザで開かせる処理
  * rendererプロセスからは処理を止められないのでここに実装がある
  * @see https://github.com/electron/electron/pull/11679#issuecomment-359180722
  **/
-function preventNewWindow(e) {
+function preventNewWindow(e, url) {
   e.preventDefault();
+  electron.shell.openExternal(url);
 }
 
-ipcMain.on('window-preventNewWindow', (event, id) => {
+ipcMain.on('window-preventNewWindow', (_event, id) => {
   const window = BrowserWindow.fromId(id);
   window.webContents.on('new-window', preventNewWindow);
 });


### PR DESCRIPTION
# このpull requestが解決する内容
番組作成画面・番組編集画面のリンクが一部意図せず動作していなかった問題のうち、 `target="_blank"` に関連する挙動を修正します。

# 動作確認手順
1. ログインしていなければログインする
2. 番組作成画面を開く
3. `target="_blank"` がついているフッターの各種リンクをクリックして既定のブラウザでリンク先が開く、 `target="_blank"` がついていないリンクをCtrl+クリックでも同様に既定のブラウザで開く

# 関連するIssue（あれば）
resolves https://github.com/n-air-app/n-air-app/issues/311