### PR TITLE
変更: ニコ生以外の画面に遷移したら既定のブラウザで開いてwebviewは閉じる

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -210,14 +210,20 @@ function setupMock() {
     }
   }
 
+  const openExternal = jest.fn();
   let wrapper: {
     browserWindow: BrowserWindow;
+    openExternal: jest.Mock;
   } = {
     browserWindow: null,
+    openExternal,
   };
   jest.doMock('electron', () => ({
     remote: {
       BrowserWindow,
+      shell: {
+        openExternal
+      }
     },
     ipcRenderer: {
       send() {},
@@ -260,7 +266,8 @@ describe('webviews', () => {
     expect(mock.browserWindow.close).toHaveBeenCalled();
   });
 
-  test('createProgramでニコ生外に出ると画面を閉じる', async () => {
+  test('createProgramでニコ生外に出ると既定のブラウザで開いてwebviewは閉じる', async () => {
+    const openExternal = jest.fn();
     const mock = setupMock();
 
     const { NicoliveClient } = require('./NicoliveClient');
@@ -272,6 +279,7 @@ describe('webviews', () => {
 
     await result;
     expect(mock.browserWindow.close).toHaveBeenCalled();
+    expect(mock.openExternal).toHaveBeenCalledWith('https://example.com');
   });
 
   test('createProgramで何もせず画面を閉じても結果が返る', async () => {
@@ -316,7 +324,7 @@ describe('webviews', () => {
     expect(mock.browserWindow.close).toHaveBeenCalled();
   });
 
-  test('editProgramでニコ生外に出ると画面を閉じる', async () => {
+  test('editProgramでニコ生外に出ると既定のブラウザで開いてwebviewは閉じる', async () => {
     const mock = setupMock();
 
     const { NicoliveClient } = require('./NicoliveClient');
@@ -328,6 +336,7 @@ describe('webviews', () => {
 
     await result;
     expect(mock.browserWindow.close).toHaveBeenCalled();
+    expect(mock.openExternal).toHaveBeenCalledWith('https://example.com');
   });
 
   test('editProgramで何もせず画面を閉じても結果が返る', async () => {

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -72,10 +72,8 @@ export class NicoliveClient {
   }
 
   static isAllowedURL(url: string): boolean {
-    // メンテ中は作成画面に http://blog.nicovideo.jp/niconews/category/nicolivemainte/ へのリンクが表示されるので表示を許す
     return (
-      /^https?:\/\/live2?.nicovideo.jp\//.test(url) ||
-      /^https?:\/\/blog\.nicovideo\.jp\/niconews\//.test(url)
+      /^https?:\/\/live2?.nicovideo.jp\//.test(url)
     );
   }
 
@@ -342,6 +340,7 @@ export class NicoliveClient {
           win.close();
         } else if (!NicoliveClient.isAllowedURL(url)) {
           resolve(CreateResult.OTHER);
+          remote.shell.openExternal(url);
           win.close();
         }
       });
@@ -370,6 +369,7 @@ export class NicoliveClient {
           win.close();
         } else if (!NicoliveClient.isAllowedURL(url)) {
           resolve(EditResult.OTHER);
+          remote.shell.openExternal(url);
           win.close();
         }
       });


### PR DESCRIPTION
# このpull requestが解決する内容
これまで番組作成画面・番組編集画面のwebviewからは、ニコ生とニコニコインフォだけは直接開けていましたが、それ以外のページに遷移しようとすると黙って閉じていました。
この変更により、ニコ生以外のページに遷移しようとした場合はwebviewを閉じて既定のブラウザで開くようになります。

https://github.com/n-air-app/n-air-app/pull/327 と合わせて、webviewからの遷移の自由度が高まります。ログアウト以外はなんでもできるはず？

# 動作確認手順
1. ログインしていなければログインする
2. 番組作成画面を開く
3. 左上のニコ生のロゴをクリックして生トップに遷移する
4. 適当な生以外のリンク、たとえばファミリーサービスを開こうとする
5. webviewが閉じ、既定のブラウザでリンク先を開く

# 関連するIssue（あれば）
