### PR TITLE
更新: sl-vue-treeの参照を更新

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11620,7 +11620,7 @@ sisteransi@^1.0.0:
 
 "sl-vue-tree@https://github.com/stream-labs/sl-vue-tree.git":
   version "1.5.1"
-  resolved "https://github.com/stream-labs/sl-vue-tree.git#aaa1f528c7ab6f8239a4499bee55e76ea050a65b"
+  resolved "https://github.com/stream-labs/sl-vue-tree.git#03ff989b20e4d3441afa3f9c47839d4b7fcc37d8"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# このpull requestが解決する内容
https://github.com/stream-labs/sl-vue-tree が置き換わっており、ビルドできなくなっていた。
機能や外観に大きく変化がないとみて参照を更新する。

# 動作確認手順
ビルドして利用箇所を触ってみる。
- ソースセレクター（エディタ画面下部）
- ソースフィルター（ソースを右クリックして「フィルター」）

# 関連するIssue（あれば）
