### PR TITLE
追加: 実験版か否かをアプリケーションに露出

### DIFF
--- a/app/components/TitleBar.vue.ts
+++ b/app/components/TitleBar.vue.ts
@@ -20,6 +20,10 @@ export default class TitleBar extends Vue {
     return electron.remote.getCurrentWindow().isMinimizable();
   }
 
+  get isUnstable() {
+    return Utils.isUnstable();
+  }
+
   minimize() {
     electron.remote.getCurrentWindow().minimize();
   }

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -37,6 +37,10 @@ export default class Utils {
     return process.env.NODE_ENV !== 'production';
   }
 
+  static isUnstable(): boolean {
+    return electron.remote.process.env.NAIR_UNSTABLE;
+  }
+
   static isPreview(): boolean {
     return electron.remote.process.env.NAIR_PREVIEW;
   }

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -38,7 +38,7 @@ export default class Utils {
   }
 
   static isUnstable(): boolean {
-    return electron.remote.process.env.NAIR_UNSTABLE;
+    return !!electron.remote.process.env.NAIR_UNSTABLE;
   }
 
   static isPreview(): boolean {

--- a/main.js
+++ b/main.js
@@ -7,6 +7,9 @@ const pjson = require('./package.json');
 if (pjson.env === 'production') {
   process.env.NODE_ENV = 'production';
 }
+if (pjson.name === 'n-air-app-unstable') {
+  process.env.NAIR_UNSTABLE = true;
+}
 if (pjson.name === 'n-air-app-preview') {
   process.env.NAIR_PREVIEW = true;
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compile:production": "yarn clear && webpack-cli --progress --mode production",
     "watch": "yarn clear && webpack-cli --watch --progress --mode development",
     "start": "electron .",
+    "start:unstable": "cross-env NAIR_UNSTABLE=1 electron .",
     "clear-plugins": "rimraf plugins",
     "package": "yarn package:stable",
     "package:stable": "rimraf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && build -w --x64 --config electron-builder/stable.config.js",


### PR DESCRIPTION
# このpull requestが解決する内容
リリース時にアプリケーション自身が実験版か否かを知る方法を作ります。
実験版として開発時に起動したい場合、 `yarn start` のかわりに `yarn start:unstable` を使ってください。

# 動作確認手順
現時点で特になし、外観の修正で利用します

手元で確認する手順

1. `yarn compile`
2. `yarn start:unstable`

# 関連するIssue（あれば）
