### PR TITLE
実験版表示をリファクタリング

### DIFF
--- a/app/components/TitleBar.vue
+++ b/app/components/TitleBar.vue
@@ -27,17 +27,15 @@
 
   // 実験版用
   &.isUnstable {
-    &:not(.modal-layout-titlebar) {
-      background-color: #e2c84d;
+    background-color: #e2c84d;
 
-      .titlebar-title {
-        color: @black;
-        font-weight: bold;
-      }
+    .titlebar-title {
+      color: @black;
+      font-weight: bold;
+    }
 
-      .link {
-        color: @black;
-      }
+    .link {
+      color: @black;
     }
   }
 }

--- a/app/components/TitleBar.vue.ts
+++ b/app/components/TitleBar.vue.ts
@@ -21,7 +21,7 @@ export default class TitleBar extends Vue {
   }
 
   get isUnstable() {
-    return Utils.isUnstable();
+    return Utils.isMainWindow() && Utils.isUnstable();
   }
 
   minimize() {


### PR DESCRIPTION
# このpull requestが解決する内容
コンポーネントが親コンポーネントのclassに依存しているので解消します

# 動作確認手順
1. `yarn compile`
2. `yarn start` でメインウィンドウのタイトルバーが既存同様の外観であること（黄色くないこと）
3. `yarn start:unstable` で #344 の修正通りの外観が得られること
    - このとき子ウィンドウの外観が変わらないこと

# 関連するIssue（あれば）
#344
