### PR TITLE
改善: 一部エラーメッセージを翻訳・修正

### DIFF
--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -7,6 +7,7 @@
   "activeSceneCollection": "Active",
   "sceneCollectionDefaultName": "Scenes",
   "sceneCollectionModified": "Updated %{when}",
+  "failedToLoadSceneCollection": "Failed to load scene collection.  A new one will be created instead.",
   "projectorPrefix": "Projector: ",
   "outputProjector": "Projector: Output",
   "manageAll": "Manage All",

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -7,6 +7,7 @@
   "activeSceneCollection": "選択中",
   "sceneCollectionDefaultName": "シーンコレクション",
   "sceneCollectionModified": "%{when}に更新",
+  "failedToLoadSceneCollection": "シーンコレクションの読み込みに失敗しました。新しいシーンコレクションを作成します。",
   "projectorPrefix": "全画面表示：",
   "outputProjector": "全画面表示",
   "manageAll": "シーンコレクションの管理",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -24,7 +24,7 @@
   "enableThePreviewStream": "配信プレビューを有効にする",
   "recordTooltip": "設定 > 出力で録画パスを指定できます",
   "notBroadcasting": "番組が作成されていません",
-  "notBroadcastingMessage": "番組が作成されていないため、配信ができません。ニコニコ生放送にて番組を作成してください。",
+  "notBroadcastingMessage": "N Airでログインしているアカウントでは番組が作成されていないため、配信ができません。ニコニコ生放送にて番組を作成してください。",
   "broadcastStatusFetchingError": {
     "default": "配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。",
     "httpError": "配信に必要な情報を取得できませんでした。（%{statusText}）"

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -160,7 +160,7 @@ export class SceneCollectionsService extends Service
       console.warn(
         `Unsuccessful recovery of scene collection ${id} attempted`
       );
-      alert('Failed to load scene collection.  A new one will be created instead.');
+      alert($t('scenes.failedToLoadSceneCollection'));
       await this.create();
     }
 


### PR DESCRIPTION
# このpull requestが解決する内容
1. シーンコレクションの読み込みに失敗した際のメッセージを翻訳
2. resolves #314 

# 動作確認手順
1について、シーンコレクションの実ファイルをリネームや削除したり、より新しいスキーマバージョンを持つシーンコレクションを読み込む（ #346 を試した後に戻ってくると環境を作りやすい）
2について、ログインして番組を作成しないまま配信開始を押す

# 関連するIssue（あれば）
#314 