### PR TITLE
更新: ヘルプへのリンクを更新

### DIFF
--- a/app/components/TopNav.vue.ts
+++ b/app/components/TopNav.vue.ts
@@ -59,7 +59,7 @@ export default class TopNav extends Vue {
   }
 
   openHelp() {
-    electron.remote.shell.openExternal('https://qa.nicovideo.jp/faq/show/11856');
+    electron.remote.shell.openExternal('https://qa.nicovideo.jp/faq/show/11857?site_domain=default');
   }
 
   get isDevMode() {


### PR DESCRIPTION
# このpull requestが解決する内容
fixes #351.

# 動作確認手順
起動し、上部にある `ヘルプ` をクリックすると https://qa.nicovideo.jp/faq/show/11857?site_domain=default がブラウザで開くこと。

# 関連するIssue（あれば）
#351 