### PR TITLE
修正: リスト選択コンポーネントの外観を修正

### DIFF
--- a/app/components/pages/onboarding_steps/ObsImport.vue
+++ b/app/components/pages/onboarding_steps/ObsImport.vue
@@ -45,11 +45,12 @@
 <script lang="ts" src="./ObsImport.vue.ts"></script>
 
 <style lang="less">
-@import '../../../styles/index';
-// 3rd Party Component
-.multiselect__content-wrapper {
-  left: -50%;
-  border-radius: 0 0 3px 3px;
+.onboarding-step {
+  // 3rd Party Component
+  .multiselect__content-wrapper {
+    left: -50%;
+    border-radius: 0 0 3px 3px;
+  }
 }
 </style>
 


### PR DESCRIPTION
# このpull requestが解決する内容
一部にだけ適用したい left: -50%; が全体に影響していた

# 動作確認手順
## OBSインポート画面
- キャッシュクリアしてOBSインポート画面を出し、インポート元を選ぶリストを開く

※変化なし

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/64762084-73f8fc80-d578-11e9-89ca-49e814d90211.png)|![image](https://user-images.githubusercontent.com/950573/64761876-149aec80-d578-11e9-87ff-b5fa7833a47f.png)|

## 他
- 設定画面やソースプロパティから設定を開き、プルダウンになっている部分を見る

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/64761765-cf76ba80-d577-11e9-99d9-3dff0adb4029.png)|![image](https://user-images.githubusercontent.com/950573/64761811-ea492f00-d577-11e9-9547-adb95e2c202d.png)|

※ツールチップが出ているが無視してほしい

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/64762420-1d3ff280-d579-11e9-8f80-98f36745fd85.png)|![image](https://user-images.githubusercontent.com/950573/64762573-5bd5ad00-d579-11e9-8929-9d4a7ea7cfb2.png)|

# 関連するIssue（あれば）
