### PR TITLE
修正: (unstable) ニコ生最適化: QSVとNVENCについてobs-studio-nodeの識別子変更に追従

### DIFF
--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -163,7 +163,7 @@
         "name": "@:settings.Output.Streaming.StreamEncoder.name",
         "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
         "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
-        "nvenc": "@:settings.Output.Streaming.StreamEncoder.ffmpeg_nvenc"
+        "nvenc": "@:settings.Output.Streaming.StreamEncoder.nvenc"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -111,7 +111,7 @@
       "StreamEncoder": {
         "name": "Encoder",
         "obs_x264": "Software (x264)",
-        "qsv11": "Hardware (QSV)",
+        "qsv": "Hardware (QSV)",
         "nvenc": "Hardware (NVENC)"
       },
       "ABitrate": {
@@ -162,8 +162,8 @@
       "Encoder": {
         "name": "@:settings.Output.Streaming.StreamEncoder.name",
         "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.StreamEncoder.obs_qsv11",
-        "ffmpeg_nvenc": "@:settings.Output.Streaming.StreamEncoder.ffmpeg_nvenc"
+        "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
+        "nvenc": "@:settings.Output.Streaming.StreamEncoder.ffmpeg_nvenc"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"
@@ -279,7 +279,7 @@
       "RecEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11"
+        "qsv": "@:settings.Output.Streaming.Encoder.qsv"
       },
       "RecRescale": {
         "name": "@:settings.Output.Streaming.Rescale.name"

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -111,8 +111,8 @@
       "StreamEncoder": {
         "name": "Encoder",
         "obs_x264": "Software (x264)",
-        "obs_qsv11": "Hardware (QSV)",
-        "ffmpeg_nvenc": "Hardware (NVENC)"
+        "qsv11": "Hardware (QSV)",
+        "nvenc": "Hardware (NVENC)"
       },
       "ABitrate": {
         "name": null

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -111,8 +111,8 @@
       "StreamEncoder": {
         "name": "エンコーダ",
         "obs_x264": "ソフトウェア（x264）",
-        "obs_qsv11": "ハードウェア（QSV）",
-        "ffmpeg_nvenc": "ハードウェア (NVENC)"
+        "qsv11": "ハードウェア（QSV）",
+        "nvenc": "ハードウェア (NVENC)"
       },
       "ABitrate": {
         "name": "音声ビットレート（kbps）"

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -111,7 +111,7 @@
       "StreamEncoder": {
         "name": "エンコーダ",
         "obs_x264": "ソフトウェア（x264）",
-        "qsv11": "ハードウェア（QSV）",
+        "qsv": "ハードウェア（QSV）",
         "nvenc": "ハードウェア (NVENC)"
       },
       "ABitrate": {
@@ -162,8 +162,8 @@
       "Encoder": {
         "name": "@:settings.Output.Streaming.StreamEncoder.name",
         "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.StreamEncoder.obs_qsv11",
-        "ffmpeg_nvenc": "@:settings.Output.Streaming.StreamEncoder.ffmpeg_nvenc"
+        "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
+        "nvenc": "@:settings.Output.Streaming.StreamEncoder.nvenc"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"
@@ -279,7 +279,7 @@
       "RecEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11"
+        "qsv": "@:settings.Output.Streaming.Encoder.qsv"
       },
       "RecRescale": {
         "name": "@:settings.Output.Streaming.Rescale.name"

--- a/app/services/settings/__snapshots__/optimizer.test.ts.snap
+++ b/app/services/settings/__snapshots__/optimizer.test.ts.snap
@@ -96,7 +96,7 @@ Array [
                     "subCategory": "Streaming",
                   },
                 ],
-                "value": "obs_qsv11",
+                "value": "qsv11",
               },
               Object {
                 "params": Array [

--- a/app/services/settings/__snapshots__/optimizer.test.ts.snap
+++ b/app/services/settings/__snapshots__/optimizer.test.ts.snap
@@ -96,7 +96,7 @@ Array [
                     "subCategory": "Streaming",
                   },
                 ],
-                "value": "qsv11",
+                "value": "qsv",
               },
               Object {
                 "params": Array [

--- a/app/services/settings/__snapshots__/optimizer.test.ts.snap
+++ b/app/services/settings/__snapshots__/optimizer.test.ts.snap
@@ -108,7 +108,7 @@ Array [
                     "subCategory": "Streaming",
                   },
                 ],
-                "value": "ffmpeg_nvenc",
+                "value": "nvenc",
               },
             ],
             "key": "encoder",

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -139,7 +139,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                                 ]
                             },
                             {
-                                value: 'obs_qsv11',
+                                value: 'qsv',
                                 params: [
                                     {
                                         key: OptimizationKey.targetUsage,
@@ -316,7 +316,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                                 ]
                             },
                             {
-                                value: 'obs_qsv11',
+                                value: 'qsv',
                                 params: [
                                     {
                                         key: OptimizationKey.simpleUseAdvanced,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -191,7 +191,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                                 ]
                             },
                             {
-                                value: 'ffmpeg_nvenc',
+                                value: 'nvenc',
                                 params: [
                                     // 'Rescale' // bool
                                     //    'RescaleRes' // '1920x1200' ... '640x400' (10個)
@@ -341,7 +341,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                                 ]
                             },
                             {
-                                value: 'ffmpeg_nvenc',
+                                value: 'nvenc',
                                 params: [
                                     {
                                         key: OptimizationKey.simpleUseAdvanced,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -3,9 +3,9 @@ import { ISettingsSubCategory } from './settings-api';
 
 export enum EncoderType {
   x264 = 'obs_x264',
-  nvenc = 'ffmpeg_nvenc',
+  nvenc = 'nvenc',
   amd = 'amd_amf_h264',
-  qsv = 'obs_qsv11'
+  qsv = 'qsv'
 }
 
 export enum OptimizationKey {

--- a/app/services/video-encoding-optimizations/definitions.ts
+++ b/app/services/video-encoding-optimizations/definitions.ts
@@ -4,7 +4,7 @@ enum EncoderType {
   x264 = 'obs_x264',
   nvenc = 'nvenc',
   amd = 'amd_amf_h264',
-  qsv = 'qsv11'
+  qsv = 'qsv'
 }
 
 enum GameType {

--- a/app/services/video-encoding-optimizations/definitions.ts
+++ b/app/services/video-encoding-optimizations/definitions.ts
@@ -2,9 +2,9 @@ import { $t } from 'services/i18n';
 
 enum EncoderType {
   x264 = 'obs_x264',
-  nvenc = 'ffmpeg_nvenc',
+  nvenc = 'nvenc',
   amd = 'amd_amf_h264',
-  qsv = 'obs_qsv11'
+  qsv = 'qsv11'
 }
 
 enum GameType {


### PR DESCRIPTION
# このpull requestが解決する内容
ニコニコ最適化で、ハードウェアエンコードを有効にしているのにハードウェアエンコーダ(QSV, NVENC)が選択されない問題を修正します。

# 動作確認手順
ハードウェアエンコードを有効にして、エンコーダをソフトウェア(x264)にしてニコニコ最適化をすると、QSVかNVENCの搭載しているエンコーダーに変更されること。

[koizuka:debug/optimize-use-hardware-unstable](https://github.com/koizuka/n-air-app/tree/debug/optimize-use-hardware-unstable) ブランチにデバッグコードが入ってるので、これで起動すると番組を作らずに確認できます。

# 関連するIssue（あれば）
