### PR TITLE
修正: 子ウィンドウのタイトルが一部出ていなかった不具合を修正

### DIFF
--- a/app/components/windows/NicoliveProgramSelector.vue
+++ b/app/components/windows/NicoliveProgramSelector.vue
@@ -1,6 +1,5 @@
 <template>
 <modal-layout
-  :title="$t('streaming.nicoliveProgramSelector.title')"
   :show-controls="false"
   :custom-controls="true">
   <div slot="content">

--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -1,6 +1,5 @@
 <template>
 <modal-layout
-  :title="$t('streaming.optimizationForNiconico.title')"
   :show-controls="false"
   :customControls="true">
   <div slot="content">

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -45,6 +45,7 @@ Array [
       "height": 400,
       "width": 700,
     },
+    "title": "streaming.nicoliveProgramSelector.title",
   },
 ]
 `;

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -20,6 +20,9 @@ jest.mock('services/streaming', () => ({}));
 jest.mock('services/user', () => ({}));
 jest.mock('services/settings', () => ({}));
 jest.mock('services/windows', () => ({}));
+jest.mock('services/i18n', () => ({
+  $t: (x: any) => x,
+}));
 jest.mock('util/sleep', () => ({
   sleep: () => jest.requireActual('util/sleep').sleep(0),
 }));

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -9,6 +9,7 @@ import { UserService } from 'services/user';
 import { Builder, parseString } from 'xml2js';
 import { StreamingService, EStreamingState } from 'services/streaming';
 import { WindowsService } from 'services/windows';
+import { $t } from 'services/i18n';
 
 export type INiconicoProgramSelection = {
   info: LiveProgramInfo
@@ -245,6 +246,7 @@ export class NiconicoService extends Service implements IPlatformService {
       // show dialog and select
       this.windowsService.showWindow({
         componentName: 'NicoliveProgramSelector',
+        title: $t('streaming.nicoliveProgramSelector.title'),
         queryParams: info,
         size: {
           width: 700,

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -271,6 +271,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
       if (this.customizationService.showOptimizationDialogForNiconico || mustShowDialog) {
         this.windowsService.showWindow({
           componentName: 'OptimizeForNiconico',
+          title: $t('streaming.optimizationForNiconico.title'),
           queryParams: settings,
           size: {
             width: 500,


### PR DESCRIPTION
# このpull requestが解決する内容
タイトルが一部出ていなかった箇所を修正します

- ニコ生向け配信最適化画面
- ログイン中に配信可能な番組が複数ある場合の選択画面

# 動作確認手順
## 最適化画面
1. `yarn start:unstable` で起動して、ログインしていなければログインする
2. 番組を作成して、最適化画面が出る状態にして「配信開始」を押す
3. タイトルバーにテキストが入っている

## 番組選択画面
1. `yarn start:unstable` で起動して、ログインしていなければログインする
2. ログインしたアカウントから配信可能なように複数コミュニティやチャンネルで番組を作成する
3. 「配信開始」を押す
4. 番組選択画面が出て、タイトルバーに文言が入っている

# 関連するIssue（あれば）
