### PR TITLE
修正: パフォーマンス優先モードの外観を修正

### DIFF
--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -1,17 +1,17 @@
 <template>
 <div class="studio-page" data-test="Studio">
-  <div class="studio-mode-container" ref="studioModeContainer" :class="{ stacked }">
+  <div v-if="previewEnabled" class="studio-mode-container" ref="studioModeContainer" :class="{ stacked }">
     <studio-mode-controls v-if="studioMode" :stacked="stacked" />
     <div
       class="studio-display-container"
       :class="{ stacked }">
-      <studio-editor v-if="previewEnabled" class="studio-output-display" />
+      <studio-editor class="studio-output-display" />
       <div v-if="studioMode" class="studio-mode-display-container">
         <display class="studio-mode-display" :paddingSize="10" />
       </div>
     </div>
   </div>
-  <div v-if="!previewEnabled" class="no-preview">
+  <div v-else class="no-preview">
     <div class="message">
       {{ $t('scenes.previewIsDisabledInPerformanceMode') }}
       <div class="button button--action button--sm" @click="enablePreview">{{ $t('scenes.disablePerformanceMode') }}</div>
@@ -65,6 +65,7 @@
   flex-grow: 1;
   background-color: @bg-tertiary;
   display: flex;
+  align-items: center;
   justify-content: center;
 
   .message {


### PR DESCRIPTION
# このpull requestが解決する内容
fix #368 
元の見た目も妙なのでセンタリングするようにします

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/66638568-27284480-ec50-11e9-90ad-9e9fd813bd43.png)|![image](https://user-images.githubusercontent.com/950573/66638461-f516e280-ec4f-11e9-895b-76455582d0b1.png)|


# 動作確認手順
1. N Airを起動する
2. エディターの周辺やソースセレクター上で右クリックして「パフォーマンス優先モードをONにする」を選んだときの外観を見る

# 関連するIssue（あれば）
