### PR TITLE
修正: トランジションをシーン切り替えに統一

### DIFF
--- a/app/components/TransitionSettings.vue.ts
+++ b/app/components/TransitionSettings.vue.ts
@@ -46,7 +46,7 @@ export default class SceneTransitions extends Vue {
 
   get nameModel(): IObsInput<string> {
     return {
-      description: $t('transitions.name'),
+      description: $t('transitions.transitionName'),
       name: 'name',
       value: this.transition.name
     };

--- a/app/i18n/ja-JP/transitions.json
+++ b/app/i18n/ja-JP/transitions.json
@@ -13,13 +13,13 @@
   "connectionFrom": "開始シーン",
   "connectionTo": "終了シーン",
   "default": "既定",
-  "transitions": "トランジション",
+  "transitions": "シーン切り替え",
   "connections": "コネクション",
-  "addTransition": "新規トランジション",
+  "addTransition": "新規シーン切り替え",
   "addConnection": "新規コネクション",
-  "mustHaveLeastTwoScenes": "トランジションを編集するには2つ以上のシーンが必要です",
-  "mustHaveLeastOneTransition": "1つ以上のトランジションが必要です",
+  "mustHaveLeastTwoScenes": "シーン切り替えを編集するには2つ以上のシーンが必要です",
+  "mustHaveLeastOneTransition": "1つ以上のシーン切り替えが必要です",
   "redundantConnectionTooltip": "このコネクションは冗長です。他のコネクションとシーンの指定が一致しています。",
-  "newTransition": "トランジション",
+  "newTransition": "シーン切り替え",
   "deleted": "削除済み"
 }

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -406,7 +406,7 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   showSceneTransitions() {
     this.windowsService.showWindow({
       componentName: 'SceneTransitions',
-      title: $t('Scene Transitions'),
+      title: $t('transitions.sceneTransition'),
       size: {
         width: 800,
         height: 650


### PR DESCRIPTION
# このpull requestが解決する内容
resolves https://github.com/n-air-app/n-air-app/issues/363

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/66891901-2cf1a180-f025-11e9-9265-82793b1e1e01.png)|![image](https://user-images.githubusercontent.com/950573/66891688-c5d3ed00-f024-11e9-8683-ad44e4c5bca9.png)|

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/66891943-485cac80-f025-11e9-86fc-393617c69201.png)|![image](https://user-images.githubusercontent.com/950573/66891743-ddab7100-f024-11e9-9b5c-bd0a39760012.png)|

※新規シーン切り替えの名前も「トランジション」から「シーン切り替え」に変わっています

# 動作確認手順
1. N Airを起動
2. 2つ以上のシーンが存在する状態でシーンセレクター上部の歯車マークをクリック
3. 差分を確認
4. 「新規トランジション」「新規シーン切り替え」をクリック
5. 差分を確認
