### PR TITLE
修正: エンコーダー名の変更を反映

### DIFF
--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -111,6 +111,8 @@
       "StreamEncoder": {
         "name": "Encoder",
         "obs_x264": "Software (x264)",
+        "obs_qsv11": "Hardware (QSV)",
+        "x264": "Software (x264)",
         "qsv": "Hardware (QSV)",
         "nvenc": "Hardware (NVENC)"
       },
@@ -162,6 +164,8 @@
       "Encoder": {
         "name": "@:settings.Output.Streaming.StreamEncoder.name",
         "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
+        "obs_qsv11": "@:settings.Output.Streaming.StreamEncoder.obs_qsv11",
+        "x264": "@:settings.Output.Streaming.StreamEncoder.x264",
         "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
         "nvenc": "@:settings.Output.Streaming.StreamEncoder.nvenc"
       },
@@ -279,7 +283,7 @@
       "RecEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
-        "qsv": "@:settings.Output.Streaming.Encoder.qsv"
+        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11"
       },
       "RecRescale": {
         "name": "@:settings.Output.Streaming.Rescale.name"

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -109,12 +109,10 @@
         "name": null
       },
       "StreamEncoder": {
-        "name": "Encoder",
-        "obs_x264": "Software (x264)",
-        "obs_qsv11": "Hardware (QSV)",
-        "x264": "Software (x264)",
-        "qsv": "Hardware (QSV)",
-        "nvenc": "Hardware (NVENC)"
+        "name": "@:settings.Output.Streaming.Encoder.name",
+        "x264": "@:settings.Output.Streaming.Encoder.obs_x264",
+        "qsv": "@:settings.Output.Streaming.Encoder.obs_qsv11",
+        "nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc"
       },
       "ABitrate": {
         "name": null
@@ -162,12 +160,10 @@
         "name": null
       },
       "Encoder": {
-        "name": "@:settings.Output.Streaming.StreamEncoder.name",
-        "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.StreamEncoder.obs_qsv11",
-        "x264": "@:settings.Output.Streaming.StreamEncoder.x264",
-        "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
-        "nvenc": "@:settings.Output.Streaming.StreamEncoder.nvenc"
+        "name": "Encoder",
+        "obs_x264": "Software (x264)",
+        "obs_qsv11": "Hardware (QSV)",
+        "ffmpeg_nvenc": "Hardware (NVENC)"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"
@@ -283,7 +279,8 @@
       "RecEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11"
+        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11",
+        "ffmpeg_nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc"
       },
       "RecRescale": {
         "name": "@:settings.Output.Streaming.Rescale.name"

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -109,12 +109,10 @@
         "name": "映像ビットレート（kbps）"
       },
       "StreamEncoder": {
-        "name": "エンコーダ",
-        "obs_x264": "ソフトウェア（x264）",
-        "obs_qsv11": "ハードウェア（QSV）",
-        "x264": "ソフトウェア（x264）",
-        "qsv": "ハードウェア（QSV）",
-        "nvenc": "ハードウェア (NVENC)"
+        "name": "@:settings.Output.Streaming.Encoder.name",
+        "x264": "@:settings.Output.Streaming.Encoder.obs_x264",
+        "qsv": "@:settings.Output.Streaming.Encoder.obs_qsv11",
+        "nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc"
       },
       "ABitrate": {
         "name": "音声ビットレート（kbps）"
@@ -162,12 +160,10 @@
         "name": "音声トラック"
       },
       "Encoder": {
-        "name": "@:settings.Output.Streaming.StreamEncoder.name",
-        "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.StreamEncoder.obs_qsv11",
-        "x264": "@:settings.Output.Streaming.StreamEncoder.x264",
-        "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
-        "nvenc": "@:settings.Output.Streaming.StreamEncoder.nvenc"
+        "name": "エンコーダ",
+        "obs_x264": "ソフトウェア（x264）",
+        "obs_qsv11": "ハードウェア（QSV）",
+        "ffmpeg_nvenc": "ハードウェア (NVENC)"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"
@@ -283,7 +279,8 @@
       "RecEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
-        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11"
+        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11",
+        "ffmpeg_nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc"
       },
       "RecRescale": {
         "name": "@:settings.Output.Streaming.Rescale.name"

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -111,6 +111,8 @@
       "StreamEncoder": {
         "name": "エンコーダ",
         "obs_x264": "ソフトウェア（x264）",
+        "obs_qsv11": "ハードウェア（QSV）",
+        "x264": "ソフトウェア（x264）",
         "qsv": "ハードウェア（QSV）",
         "nvenc": "ハードウェア (NVENC)"
       },
@@ -162,6 +164,8 @@
       "Encoder": {
         "name": "@:settings.Output.Streaming.StreamEncoder.name",
         "obs_x264": "@:settings.Output.Streaming.StreamEncoder.obs_x264",
+        "obs_qsv11": "@:settings.Output.Streaming.StreamEncoder.obs_qsv11",
+        "x264": "@:settings.Output.Streaming.StreamEncoder.x264",
         "qsv": "@:settings.Output.Streaming.StreamEncoder.qsv",
         "nvenc": "@:settings.Output.Streaming.StreamEncoder.nvenc"
       },
@@ -279,7 +283,7 @@
       "RecEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
-        "qsv": "@:settings.Output.Streaming.Encoder.qsv"
+        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11"
       },
       "RecRescale": {
         "name": "@:settings.Output.Streaming.Rescale.name"


### PR DESCRIPTION
# このpull requestが解決する内容
resolves https://github.com/n-air-app/n-air-app/issues/367

~TODO: NVENC~

## 詳細

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/66912778-317e8000-f04e-11e9-830c-7c1560670b54.png)|![image](https://user-images.githubusercontent.com/950573/66912896-815d4700-f04e-11e9-9825-1e1b98e6be4b.png)|

## 基本

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/66912801-3f340580-f04e-11e9-8cd6-640e85888642.png)|![image](https://user-images.githubusercontent.com/950573/66912949-989c3480-f04e-11e9-98f9-824ad3cef2c7.png)|

# 動作確認手順
1. N Airを起動
2. 設定画面を開く
3. 出力の大項目を開く
4. 「出力モード」を「詳細」にする
5. 「配信品質」の「エンコーダ」のプルダウン内を見る
6. 「録画」の「エンコーダ」のプルダウン内を見る
4. 「出力モード」を「基本」にする
5. 「配信品質」の「エンコーダ」のプルダウン内を見る
