### PR TITLE
追加: 録画開始時にSentryに録画種別を送信する

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -309,6 +309,16 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
         alert($t('streaming.badPathError'));
         return;
       }
+
+      if (this.userService.isNiconicoLoggedIn()) {
+        const recordingSettings = this.settingsService.getRecordingSettings();
+        if (recordingSettings) {
+          // send Recording type to Sentry (どれぐらいURL出力が使われているかの比率を調査する)
+          console.error('Recording / recType:' + recordingSettings.recType);
+          console.log('Recording / path:' + JSON.stringify(recordingSettings.path));
+        }
+      }
+
       this.obsApiService.nodeObs.OBS_service_startRecording();
       return;
     }


### PR DESCRIPTION
# このpull requestが解決する内容
URLへの録画機能の利用比率を調査したい

# 動作確認手順
録画開始時に console.error (Sentry送信対象)で Recording 種別情報が出力される(開発モードならconsoleで見られる)

# 関連するIssue（あれば）
#381 