### PR TITLE
修正:リリーススクリプト:前バージョン情報取得元をタグからpackage.jsonに変更

### DIFF
--- a/bin/release/configs/type.d.ts
+++ b/bin/release/configs/type.d.ts
@@ -13,5 +13,6 @@ export type ReleaseConfig = {
   upload: {
     githubToken: string;
     s3BucketName: string;
+    s3KeyPrefix: string;
   };
 };

--- a/bin/release/generatePatchNote.js
+++ b/bin/release/generatePatchNote.js
@@ -29,8 +29,8 @@ async function generateRoutine({ githubTokenForReadPullRequest }) {
   info(colors.magenta('| N Air Release Note Generator |'));
   info(colors.magenta('|------------------------------|'));
 
-  info('checking current tag ...');
-  const previousTag = executeCmd('git describe --tags --abbrev=0').stdout.trim();
+  info('checking current version ...');
+  const previousVersion = executeCmd('git describe --tags --abbrev=0').stdout.trim().replace(/^v/, '');
 
   const baseDir = executeCmd('git rev-parse --show-cdup', { silent: true }).stdout.trim();
   const patchNoteFileName = `${baseDir}patch-note.txt`;
@@ -42,19 +42,19 @@ async function generateRoutine({ githubTokenForReadPullRequest }) {
     log(`${previousPatchNote.version}\n${previousPatchNote.lines.join('\n')}`);
 
     info(`patch-note.txt for ${previousPatchNote.version} found`);
-    info(`current version: ${previousTag}`);
+    info(`current version: ${previousVersion}`);
 
     if (!await confirm('overwrite?', false)) {
       sh.exit(1);
     }
   } else {
-    info(`current version: ${previousTag}`);
+    info(`current version: ${previousVersion}`);
   }
 
-  const previousVersionContext = getVersionContext(previousTag);
+  const previousVersionContext = getVersionContext(previousVersion);
   const { channel, environment } = previousVersionContext;
 
-  log('current version', colors.cyan(previousTag));
+  log('current version', colors.cyan(previousVersion));
   log('environment', (environment === 'public' ? colors.red : colors.cyan)(environment));
   log('channel', (channel === 'stable' ? colors.red : colors.cyan)(channel));
 
@@ -71,18 +71,18 @@ async function generateRoutine({ githubTokenForReadPullRequest }) {
   }
 
   const defaultVersion = generateNewVersion({
-    previousTag,
+    previousVersion,
   });
   log('\nestimated version', colors.cyan(defaultVersion));
 
   const newVersion = await input('What should the new version number be?', defaultVersion);
 
-  const newVersionContext = getVersionContext(`v${newVersion}`);
+  const newVersionContext = getVersionContext(newVersion);
   if (!isSameVersionContext(previousVersionContext, newVersionContext)) {
-    log('version', colors.cyan(previousTag), ' -> ', colors.cyan(`v${newVersion}`));
+    log('version', colors.cyan(previousVersion), ' -> ', colors.cyan(newVersion));
     const environmentIsMatched = previousVersionContext.environment === newVersionContext.environment;
     const channelIsMatched = previousVersionContext.channel === newVersionContext.channel;
-    const colorize = flag => flag ? colors.red : colors.cyan;
+    const colorize = flag => (flag ? colors.red : colors.cyan);
     log(
       'environment:',
       colorize(!environmentIsMatched)(environmentIsMatched ? 'matched  ' : 'unmatched'),
@@ -117,10 +117,10 @@ async function generateRoutine({ githubTokenForReadPullRequest }) {
       owner: 'n-air-app',
       repo: 'n-air-app',
     },
-    previousTag
+    previousVersion
   );
 
-  const directCommits = executeCmd(`git log --no-merges --first-parent --pretty=format:"%s (%t)" ${previousTag}..`, {
+  const directCommits = executeCmd(`git log --no-merges --first-parent --pretty=format:"%s (%t)" v${previousVersion}..`, {
     silent: true,
   }).stdout;
   const directCommitsNotes = directCommits ? `\nDirect Commits:\n${directCommits}` : '';

--- a/bin/release/generatePatchNote.js
+++ b/bin/release/generatePatchNote.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const fs = require('fs');
+const path = require('path');
 const OctoKit = require('@octokit/rest');
 const sh = require('shelljs');
 const colors = require('colors/safe');
@@ -23,6 +25,7 @@ const {
   writePatchNoteFile,
   collectPullRequestMerges,
 } = require('./scripts/patchNote');
+const pjson = JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8'));
 
 async function generateRoutine({ githubTokenForReadPullRequest }) {
   info(colors.magenta('|------------------------------|'));
@@ -30,7 +33,7 @@ async function generateRoutine({ githubTokenForReadPullRequest }) {
   info(colors.magenta('|------------------------------|'));
 
   info('checking current version ...');
-  const previousVersion = executeCmd('git describe --tags --abbrev=0').stdout.trim().replace(/^v/, '');
+  const previousVersion = pjson.version;
 
   const baseDir = executeCmd('git rev-parse --show-cdup', { silent: true }).stdout.trim();
   const patchNoteFileName = `${baseDir}patch-note.txt`;

--- a/bin/release/generatePatchNote.js
+++ b/bin/release/generatePatchNote.js
@@ -25,6 +25,7 @@ const {
   writePatchNoteFile,
   collectPullRequestMerges,
 } = require('./scripts/patchNote');
+
 const pjson = JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8'));
 
 async function generateRoutine({ githubTokenForReadPullRequest }) {

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -6,7 +6,6 @@
 const fs = require('fs');
 const path = require('path');
 const OctoKit = require('@octokit/rest');
-const inq = require('inquirer');
 const sh = require('shelljs');
 const colors = require('colors/safe');
 const yaml = require('js-yaml');
@@ -30,8 +29,9 @@ const {
 const {
   uploadS3File,
   uploadToGithub,
-  uploadToSentry
+  uploadToSentry,
 } = require('./scripts/uploadArtifacts');
+
 const pjson = JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8'));
 
 /**

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -309,23 +309,23 @@ async function releaseRoutine() {
     throw new Error(`patchNote is not found in ${patchNoteFileName}.`);
   }
 
-  const versionTag = `v${patchNote.version}`;
-  info(`patch-note.txt for ${versionTag} found`);
+  const nextVersion = patchNote.version;
+  info(`patch-note.txt for ${nextVersion} found`);
 
-  if (getTagCommitId(versionTag)) {
-    error(`Tag "${versionTag}" has already been released.`);
+  if (getTagCommitId(`v${nextVersion}`)) {
+    error(`Tag "v${nextVersion}" has already been released.`);
     info('Generate new patchNote with new version.');
     info('If you want to retry current release, remove the tag and related release commit.');
-    throw new Error(`Tag "${versionTag}" has already been released.`);
+    throw new Error(`Tag "${nextVersion}" has already been released.`);
   }
 
-  info('checking current tag ...');
-  const previousTag = executeCmd('git describe --tags --abbrev=0').stdout.trim();
-  const previousVersionContext = getVersionContext(previousTag);
+  info('checking current version ...');
+  const previousVersion = executeCmd('git describe --tags --abbrev=0').stdout.trim().replace(/^v/, '');
+  const previousVersionContext = getVersionContext(previousVersion);
 
-  const newVersionContext = getVersionContext(versionTag);
+  const newVersionContext = getVersionContext(nextVersion);
   if (!isSameVersionContext(previousVersionContext, newVersionContext)) {
-    const msg = `previous version ${previousTag} and releasing version ${versionTag} have different context.`;
+    const msg = `previous version ${previousVersion} and releasing version ${nextVersion} have different context.`;
     if (process.env.NAIR_IGNORE_VERSION_CONTEXT_CHECK) {
       await confirm(`${msg} Are you sure?`, false);
     } else {

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -32,6 +32,7 @@ const {
   uploadToGithub,
   uploadToSentry
 } = require('./scripts/uploadArtifacts');
+const pjson = JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8'));
 
 /**
  * This is the main function of the script
@@ -320,7 +321,7 @@ async function releaseRoutine() {
   }
 
   info('checking current version ...');
-  const previousVersion = executeCmd('git describe --tags --abbrev=0').stdout.trim().replace(/^v/, '');
+  const previousVersion = pjson.version;
   const previousVersionContext = getVersionContext(previousVersion);
 
   const newVersionContext = getVersionContext(nextVersion);

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -11,9 +11,9 @@ const { getTagCommitId } = require('./util');
 
 // previous tag should be following rule:
 //  v{major}.{minor}.{yyyymmdd}-[{channel}.]{ord}[internalMark]
-const VERSION_REGEXP = /v(?<major>\d+)\.(?<minor>\d+)\.(?<date>\d{8})-((?<channel>\w+)\.)?(?<ord>\d+)(?<internalMark>d)?/;
+const VERSION_REGEXP = /(?<major>\d+)\.(?<minor>\d+)\.(?<date>\d{8})-((?<channel>\w+)\.)?(?<ord>\d+)(?<internalMark>d)?/;
 
-function parseVersionTag(tag) {
+function parseVersion(tag) {
   const result = VERSION_REGEXP.exec(tag);
   if (result && result.groups) return result.groups;
   throw new Error(`cannot parse a given tag: ${tag}`)
@@ -26,7 +26,7 @@ function parseVersionTag(tag) {
  * @returns {VersionContext}
  */
 function getVersionContext(tag) {
-  const result = parseVersionTag(tag);
+  const result = parseVersion(tag);
   if (result.channel === 'stable') {
     throw new Error('stable channel must have no prefix');
   }
@@ -68,12 +68,12 @@ function validateVersionContext({
 }
 
 function generateNewVersion({
-  previousTag,
+  previousVersion,
   now = Date.now(),
 }) {
   const {
     major, minor, date, channel, ord, internalMark
-  } = parseVersionTag(previousTag);
+  } = parseVersion(previousVersion);
 
   const today = moment(now).format('YYYYMMDD');
   const newOrd = date === today ? parseInt(ord, 10) + 1 : 1;
@@ -108,8 +108,8 @@ function writePatchNoteFile(patchNoteFileName, version, contents) {
   fs.writeFileSync(patchNoteFileName, body);
 }
 
-async function collectPullRequestMerges({ octokit, owner, repo }, previousTag) {
-  const merges = executeCmd(`git log --oneline --merges ${previousTag}..`, { silent: true }).stdout;
+async function collectPullRequestMerges({ octokit, owner, repo }, previousVersion) {
+  const merges = executeCmd(`git log --oneline --merges v${previousVersion}..`, { silent: true }).stdout;
 
   const promises = [];
   for (const line of merges.split(/\r?\n/)) {
@@ -223,7 +223,7 @@ function readPatchNote({
 }
 
 module.exports = {
-  parseVersionTag,
+  parseVersion,
   getVersionContext,
   generateNewVersion,
   isSameVersionContext,

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -16,7 +16,7 @@ const VERSION_REGEXP = /(?<major>\d+)\.(?<minor>\d+)\.(?<date>\d{8})-((?<channel
 function parseVersion(tag) {
   const result = VERSION_REGEXP.exec(tag);
   if (result && result.groups) return result.groups;
-  throw new Error(`cannot parse a given tag: ${tag}`)
+  throw new Error(`cannot parse a given tag: ${tag}`);
 }
 
 /** @typedef {{ channel: 'stable' | 'unstable', environment: 'public' | 'internal' }} VersionContext */

--- a/bin/release/scripts/patchNote.test.js
+++ b/bin/release/scripts/patchNote.test.js
@@ -1,13 +1,13 @@
-const { parseVersionTag, getVersionContext, validateVersionContext, generateNewVersion } = require('./patchNote');
+const { parseVersion, getVersionContext, validateVersionContext, generateNewVersion } = require('./patchNote');
 
 const fixtures = {
   public: {
-    stable: 'v1.0.20190826-2',
-    unstable: 'v1.0.20190826-unstable.2',
+    stable: '1.0.20190826-2',
+    unstable: '1.0.20190826-unstable.2',
   },
   internal: {
-    stable: 'v1.0.20190826-2d',
-    unstable: 'v1.0.20190826-unstable.2d',
+    stable: '1.0.20190826-2d',
+    unstable: '1.0.20190826-unstable.2d',
   },
 };
 const TODAY = new Date('2019-08-26');
@@ -46,7 +46,7 @@ for (const fixtureSet of channelEnvironmentSets()) {
 }
 
 test('バージョンがパースできる(public stable)', () => {
-  expect(parseVersionTag(fixtures.public.stable)).toMatchInlineSnapshot(`
+  expect(parseVersion(fixtures.public.stable)).toMatchInlineSnapshot(`
                 Object {
                   "channel": undefined,
                   "date": "20190826",
@@ -58,7 +58,7 @@ test('バージョンがパースできる(public stable)', () => {
         `);
 });
 test('バージョンがパースできる(public unstable)', () => {
-  expect(parseVersionTag(fixtures.public.unstable)).toMatchInlineSnapshot(`
+  expect(parseVersion(fixtures.public.unstable)).toMatchInlineSnapshot(`
                 Object {
                   "channel": "unstable",
                   "date": "20190826",
@@ -70,7 +70,7 @@ test('バージョンがパースできる(public unstable)', () => {
         `);
 });
 test('バージョンがパースできる(internal stable)', () => {
-  expect(parseVersionTag(fixtures.internal.stable)).toMatchInlineSnapshot(`
+  expect(parseVersion(fixtures.internal.stable)).toMatchInlineSnapshot(`
                 Object {
                   "channel": undefined,
                   "date": "20190826",
@@ -82,7 +82,7 @@ test('バージョンがパースできる(internal stable)', () => {
         `);
 });
 test('バージョンがパースできる(internal unstable)', () => {
-  expect(parseVersionTag(fixtures.internal.unstable)).toMatchInlineSnapshot(`
+  expect(parseVersion(fixtures.internal.unstable)).toMatchInlineSnapshot(`
                 Object {
                   "channel": "unstable",
                   "date": "20190826",
@@ -95,11 +95,11 @@ test('バージョンがパースできる(internal unstable)', () => {
 });
 
 test('stableチャンネルの場合はバージョン中のチャンネル部分があったらエラー', () => {
-  expect(() => getVersionContext('v1.0.20190826-stable.2')).toThrow();
+  expect(() => getVersionContext('1.0.20190826-stable.2')).toThrow();
 });
 
 test('知らないチャンネルを名乗っていたらエラー', () => {
-  expect(() => getVersionContext('v1.0.20190826-hogehoge.2')).toThrow();
+  expect(() => getVersionContext('1.0.20190826-hogehoge.2')).toThrow();
 });
 
 test('バージョンがパースできる(public stable)', () => {
@@ -153,43 +153,43 @@ test('ふたつのVersionContextが同じか否か判定できる', () => {
 });
 
 test('次のバージョンを生成する(当日、publicでstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.public.stable, now: TODAY })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.public.stable, now: TODAY })).toMatchInlineSnapshot(
     `"1.0.20190826-3"`
   );
 });
 test('次のバージョンを生成する(当日、publicでunstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.public.unstable, now: TODAY })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.public.unstable, now: TODAY })).toMatchInlineSnapshot(
     `"1.0.20190826-unstable.3"`
   );
 });
 test('次のバージョンを生成する(当日、internalでstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.internal.stable, now: TODAY })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.internal.stable, now: TODAY })).toMatchInlineSnapshot(
     `"1.0.20190826-3d"`
   );
 });
 test('次のバージョンを生成する(当日、internalでunstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.internal.unstable, now: TODAY })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.internal.unstable, now: TODAY })).toMatchInlineSnapshot(
     `"1.0.20190826-unstable.3d"`
   );
 });
 
 test('次のバージョンを生成する(別日、publicでstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.public.stable, now: TOMORROW })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.public.stable, now: TOMORROW })).toMatchInlineSnapshot(
     `"1.0.20190827-1"`
   );
 });
 test('次のバージョンを生成する(別日、publicでunstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.public.unstable, now: TOMORROW })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.public.unstable, now: TOMORROW })).toMatchInlineSnapshot(
     `"1.0.20190827-unstable.1"`
   );
 });
 test('次のバージョンを生成する(別日、internalでstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.internal.stable, now: TOMORROW })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.internal.stable, now: TOMORROW })).toMatchInlineSnapshot(
     `"1.0.20190827-1d"`
   );
 });
 test('次のバージョンを生成する(別日、internalでunstable)', () => {
-  expect(generateNewVersion({ previousTag: fixtures.internal.unstable, now: TOMORROW })).toMatchInlineSnapshot(
+  expect(generateNewVersion({ previousVersion: fixtures.internal.unstable, now: TOMORROW })).toMatchInlineSnapshot(
     `"1.0.20190827-unstable.1d"`
   );
 });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package:internal-stable": "rimraf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && build -w --x64 --config electron-builder/internal-stable.config.js",
     "package:internal-unstable": "rimraf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && build -w --x64 --config electron-builder/internal-unstable.config.js",
     "release": "yarn install --cwd bin && node bin/release/mini-release.js",
-    "patch-note": "node bin/release/generatePatchNote.js",
+    "patch-note": "yarn install --cwd bin && node bin/release/generatePatchNote.js",
     "webfont": "yarn install --cwd bin && node bin/generate-webfont.js",
     "test": "node bin/i18n-early-check.js && tsc -p test && ava -v",
     "test:unit": "yarn test:unit:app && yarn test:unit:bin",


### PR DESCRIPTION
# このpull requestが解決する内容
今まではタグを見ていたが、主にマージによってタグの見え方が変わり思わぬ壊れ方をするので

# 動作確認手順
リリースしてみる

# 関連するIssue（あれば）
