### PR TITLE
ソースプリセット(#394)の修正

### DIFF
--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -17,8 +17,8 @@ interface IDismissablesServiceState {
 
 
 /**
- * A dismissable is anything that can be dismissed and should
- * never show up again, like a help tip.
+ * A dismissable is anything that is shown by default, can be dismissed and
+ * show up again if needed, like a help tip.
  */
 export class DismissablesService extends PersistentStatefulService<IDismissablesServiceState> {
 

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -7,6 +7,10 @@ export enum EDismissable {
   ScenePresetHelpTip = 'scene_preset_help_tip'
 }
 
+const InitiallyDismissed = new Set<EDismissable>([
+   EDismissable.ScenePresetHelpTip,
+]);
+
 interface IDismissablesServiceState {
   [key: string]: boolean;
 }
@@ -19,6 +23,9 @@ interface IDismissablesServiceState {
 export class DismissablesService extends PersistentStatefulService<IDismissablesServiceState> {
 
   shouldShow(key: EDismissable): boolean {
+    if (!(key in this.state)) {
+      return !InitiallyDismissed.has(key);
+    }
     return !this.state[key];
   }
 

--- a/scene-presets/basic.json
+++ b/scene-presets/basic.json
@@ -7,7 +7,7 @@
     "items": [
       {
         "id": "text_gdiplus_63fcf6f6-7648-404e-bdbf-8bef1d393e8c",
-        "name": "一言メッセージ",
+        "name": "メッセージ内容",
         "type": "text_gdiplus",
         "settings": {
           "align": "left",
@@ -352,7 +352,7 @@
             },
             {
               "id": "4a1cf838-f714-4235-afb8-281f7ee032ac",
-              "name": "吹き出し",
+              "name": "一言メッセージ",
               "sceneNodeType": "folder",
               "sceneId": "scene_d8929ac0-3632-4225-b0ba-59a67227b388",
               "resourceId": "SceneItemFolder[\"scene_d8929ac0-3632-4225-b0ba-59a67227b388\",\"4a1cf838-f714-4235-afb8-281f7ee032ac\"]",

--- a/scene-presets/basic.json
+++ b/scene-presets/basic.json
@@ -241,12 +241,12 @@
           "nodeType": "SceneItemsNode",
           "items": [
             {
-              "id": "72e5b99b-75dd-47b5-957d-0698021426a8",
-              "sourceId": "dshow_input_a1a3e9c4-493b-4b96-a217-19c37f014628",
-              "x": 268.6504004970529,
-              "y": 169.9474397544256,
-              "scaleX": 0.5813714295309904,
-              "scaleY": 0.5813714295309904,
+              "id": "b0253367-7eda-42a9-8758-f38fa038de84",
+              "sourceId": "image_source_f0ec48b4-a492-4706-9f3f-1320e44516d0",
+              "x": 0,
+              "y": 0,
+              "scaleX": 1,
+              "scaleY": 1,
               "visible": true,
               "crop": {
                 "top": 0,
@@ -263,12 +263,12 @@
               "rotation": 0
             },
             {
-              "id": "b0253367-7eda-42a9-8758-f38fa038de84",
-              "sourceId": "image_source_f0ec48b4-a492-4706-9f3f-1320e44516d0",
-              "x": 0,
-              "y": 0,
-              "scaleX": 1,
-              "scaleY": 1,
+              "id": "72e5b99b-75dd-47b5-957d-0698021426a8",
+              "sourceId": "dshow_input_a1a3e9c4-493b-4b96-a217-19c37f014628",
+              "x": 268.6504004970529,
+              "y": 169.9474397544256,
+              "scaleX": 0.5813714295309904,
+              "scaleY": 0.5813714295309904,
               "visible": true,
               "crop": {
                 "top": 0,
@@ -305,62 +305,6 @@
                 "items": []
               },
               "rotation": 0
-            },
-            {
-              "id": "7ca865d8-6c31-4e0a-830d-86a52975d1d7",
-              "sourceId": "image_source_452bc18f-fcc6-4ca6-b70c-c8126fbc8c5a",
-              "x": 776.9328474752733,
-              "y": 39.564195753233776,
-              "scaleX": 1.06752910164254,
-              "scaleY": 1.06752910164254,
-              "visible": true,
-              "crop": {
-                "top": 0,
-                "bottom": 0,
-                "left": 0,
-                "right": 0
-              },
-              "locked": false,
-              "hotkeys": {
-                "schemaVersion": 2,
-                "nodeType": "HotkeysNode",
-                "items": []
-              },
-              "rotation": 0
-            },
-            {
-              "id": "8e462f67-86ba-4957-9dba-b7934593314f",
-              "sourceId": "text_gdiplus_63fcf6f6-7648-404e-bdbf-8bef1d393e8c",
-              "x": 862.713170223842,
-              "y": 187.7596903429955,
-              "scaleX": 1,
-              "scaleY": 1,
-              "visible": true,
-              "crop": {
-                "top": 0,
-                "bottom": 0,
-                "left": 0,
-                "right": 0
-              },
-              "locked": false,
-              "hotkeys": {
-                "schemaVersion": 2,
-                "nodeType": "HotkeysNode",
-                "items": []
-              },
-              "rotation": 0
-            },
-            {
-              "id": "4a1cf838-f714-4235-afb8-281f7ee032ac",
-              "name": "一言メッセージ",
-              "sceneNodeType": "folder",
-              "sceneId": "scene_d8929ac0-3632-4225-b0ba-59a67227b388",
-              "resourceId": "SceneItemFolder[\"scene_d8929ac0-3632-4225-b0ba-59a67227b388\",\"4a1cf838-f714-4235-afb8-281f7ee032ac\"]",
-              "parentId": "",
-              "childrenIds": [
-                "8e462f67-86ba-4957-9dba-b7934593314f",
-                "7ca865d8-6c31-4e0a-830d-86a52975d1d7"
-              ]
             },
             {
               "id": "463c8340-7bc5-40c9-949f-ad2d9f2fbd77",
@@ -416,6 +360,62 @@
               "childrenIds": [
                 "6a8c43db-cbd0-405a-bb41-6199f7f4848c",
                 "463c8340-7bc5-40c9-949f-ad2d9f2fbd77"
+              ]
+            },
+            {
+              "id": "7ca865d8-6c31-4e0a-830d-86a52975d1d7",
+              "sourceId": "image_source_452bc18f-fcc6-4ca6-b70c-c8126fbc8c5a",
+              "x": 776.9328474752733,
+              "y": 39.564195753233776,
+              "scaleX": 1.06752910164254,
+              "scaleY": 1.06752910164254,
+              "visible": true,
+              "crop": {
+                "top": 0,
+                "bottom": 0,
+                "left": 0,
+                "right": 0
+              },
+              "locked": false,
+              "hotkeys": {
+                "schemaVersion": 2,
+                "nodeType": "HotkeysNode",
+                "items": []
+              },
+              "rotation": 0
+            },
+            {
+              "id": "8e462f67-86ba-4957-9dba-b7934593314f",
+              "sourceId": "text_gdiplus_63fcf6f6-7648-404e-bdbf-8bef1d393e8c",
+              "x": 862.713170223842,
+              "y": 187.7596903429955,
+              "scaleX": 1,
+              "scaleY": 1,
+              "visible": true,
+              "crop": {
+                "top": 0,
+                "bottom": 0,
+                "left": 0,
+                "right": 0
+              },
+              "locked": false,
+              "hotkeys": {
+                "schemaVersion": 2,
+                "nodeType": "HotkeysNode",
+                "items": []
+              },
+              "rotation": 0
+            },
+            {
+              "id": "4a1cf838-f714-4235-afb8-281f7ee032ac",
+              "name": "一言メッセージ",
+              "sceneNodeType": "folder",
+              "sceneId": "scene_d8929ac0-3632-4225-b0ba-59a67227b388",
+              "resourceId": "SceneItemFolder[\"scene_d8929ac0-3632-4225-b0ba-59a67227b388\",\"4a1cf838-f714-4235-afb8-281f7ee032ac\"]",
+              "parentId": "",
+              "childrenIds": [
+                "8e462f67-86ba-4957-9dba-b7934593314f",
+                "7ca865d8-6c31-4e0a-830d-86a52975d1d7"
               ]
             }
           ]


### PR DESCRIPTION
# このpull requestが解決する内容
#394 に対してマージ後に指摘された問題を修正する
1. [x] プリセットシーンアイテム名の間違い、順序修正
2. [x] 初期状態でプリセットのバルーンが表示されてしまっていた

# 動作確認手順
1. ![image](https://user-images.githubusercontent.com/864587/69305886-f123aa80-0c68-11ea-8201-ade2d4f93f2a.png) のように生成される
2. キャッシュを削除した上で起動すると
    1. プリセットが生成され、シーンプリセットのバルーンが出ること。
    2. そのままバルーンを消さずにアプリケーションを閉じ、再起動してもバルーンは表示される。
    3. バルーンを消して再起動するとバルーンは消えたまま。
    4. シーンのアイテムを全部削除すると 2-i. に戻る。    

# 関連するIssue（あれば）
#378 