### PR TITLE
修正:初回起動時に OBS Importしたときにシーンプリセットのバルーンが取り残される問題

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -109,7 +109,7 @@ export class SceneCollectionsService extends Service
     }
 
     const scenes = this.scenesService.scenes;
-    if (scenes.length === 1 && scenes[0].getItems().length === 0) {
+    if (this.collections.length === 1 && scenes.length === 1 && scenes[0].getItems().length === 0) {
       // シーンが一つで空であるため、シーンプリセットをインストールする
       await this.installPresetSceneCollection();
     }
@@ -601,6 +601,9 @@ export class SceneCollectionsService extends Service
     await this.saveCurrentApplicationStateAs(id);
     this.stateService.ADD_COLLECTION(id, name, new Date().toISOString());
     this.collectionAdded.next(this.collections.find(coll => coll.id === id));
+
+    // コレクションが増えたら scene preset help tipを消す
+    this.dismissablesService.dismiss(EDismissable.ScenePresetHelpTip);
   }
 
   /**


### PR DESCRIPTION
# このpull requestが解決する内容
シーンプリセット生成条件に「シーンコレクションが1つしかない」を追加し、
シーンコレクションが追加されるときはバルーンを消す
ことによって、バルーンだけが残る問題を解消する

# 動作確認手順
* シーンコレクションが2つ以上あるときに、アクティブなシーンコレクションのシーンの中身を空にしてから起動してもプリセットが生成されないこと
* シーンコレクションが1つのときに、シーンの中身を空にしてから起動するとプリセットが生成され、バルーンが表示されること
* キャッシュを削除して再起動し、OBS importを行った場合、シーンコレクションは2つであり、シーンプリセットのバルーンが出ないこと

# 関連するIssue（あれば）
#378