### PR TITLE
修正: 初回プリセット設定時にデフォルト音声ソースが消えないようにする

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -151,7 +151,6 @@ export class SceneCollectionsService extends Service
     await root.load();
     this.hotkeysService.bindHotkeys();
 
-    this.collectionLoaded = true;
     await this.save();
 
     this.finishLoadingOperation();

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -176,6 +176,7 @@ export class SceneCollectionsService extends Service
   async deinitialize() {
     this.disableAutoSave();
     await this.save();
+    this.tcpServerService.stopRequestsHandling();
     await this.deloadCurrentApplicationState();
     await this.stateService.flushManifestFile();
   }
@@ -315,7 +316,7 @@ export class SceneCollectionsService extends Service
     name: string,
     progressCallback?: (info: IDownloadProgress) => void
   ) {
-    this.startLoadingOperation();
+    this.startLoadingOperation(); // memo: calling this in loadOverlay() too
 
     const pathName = await this.overlaysPersistenceService.downloadOverlay(
       url,
@@ -518,8 +519,6 @@ export class SceneCollectionsService extends Service
   private async deloadCurrentApplicationState() {
     if (!this.initialized) return;
 
-    this.tcpServerService.stopRequestsHandling();
-
     this.collectionWillSwitch.next();
 
     this.disableAutoSave();
@@ -552,6 +551,7 @@ export class SceneCollectionsService extends Service
    */
   private startLoadingOperation() {
     this.appService.startLoading();
+    this.tcpServerService.stopRequestsHandling();
     this.disableAutoSave();
   }
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -139,7 +139,6 @@ export class SceneCollectionsService extends Service
     // this.load() を参考に
 
     this.startLoadingOperation();
-    await this.deloadCurrentApplicationState();
 
     const jsonData = this.stateService.readCollectionFile(ScenePresetId);
     // Preset file作成上の注意


### PR DESCRIPTION
# このpull requestが解決する内容
#394 で発生したバグ。下記確認手順で環境によって音声ソースがWebカメラだけになってしまっていた。

# 動作確認手順
1. キャッシュクリア再起動
2. niconicoにログイン
3. OBS import スキップ
この手順で環境によってデフォルトの音声ソース2つがなくなってしまっていたが、この修正により消えなくなる。

# 関連するIssue（あれば）
#378