### PR TITLE
WIP: 再接続を無効にするオプションを設定に追加する

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -56,6 +56,12 @@
       @input="setPollingPerformanceStatistics" />
     <p>{{ $t('settings.pollingPerformanceStatisticsDescription') }}</p>
   </div>
+  <div class="section">
+    <BoolInput
+      :value="reconnectionEnabledModel"
+      @input="setReconnectionEnabled"
+      class="optional-item" />
+  </div>
 </div>
 </template>
 

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -92,6 +92,18 @@ export default class ExtraSettings extends Vue {
     this.customizationService.setPollingPerformanceStatistics(model.value);
   }
 
+  get reconnectionEnabledModel(): IFormInput<boolean> {
+    return {
+      name: 'reconnection',
+      description: $t('settings.reconnectionEnabled'),
+      value: this.customizationService.reconnectionEnabled
+    };
+  }
+
+  setReconnectionEnabled(model: IFormInput<boolean>) {
+    this.customizationService.setReconnectionEnabled(model.value);
+  }
+
   showCacheDir() {
     electron.remote.shell.showItemInFolder(
       electron.remote.app.getPath('userData')

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -578,5 +578,6 @@
   "keyframeInterval": "Keyframe Interval (in seconds)",
   "encoderPreset": "Encoder Preset",
   "pollingPerformanceStatistics": "Activate performance statistics(bitrate, FPS, dropped frames)",
-  "pollingPerformanceStatisticsDescription": "If the streaming is unstable, try disabling this option."
+  "pollingPerformanceStatisticsDescription": "If the streaming is unstable, try disabling this option.",
+  "reconnectionEnabled": "enable reconnecting"
 }

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -578,5 +578,6 @@
   "keyframeInterval": "キーフレーム間隔(秒)",
   "encoderPreset": "エンコーダープリセット",
   "pollingPerformanceStatistics": "パフォーマンス統計情報（ビットレート・FPS・ドロップフレーム数）を取得する",
-  "pollingPerformanceStatisticsDescription": "配信が不安定な場合は無効にしてみてください。"
+  "pollingPerformanceStatisticsDescription": "配信が不安定な場合は無効にしてみてください。",
+  "reconnectionEnabled": "再接続を有効にする"
 }

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -8,6 +8,7 @@ export interface ICustomizationServiceState {
   showOptimizationDialogForNiconico: boolean;
   optimizeWithHardwareEncoder: boolean;
   pollingPerformanceStatistics: boolean;
+  reconnectionEnabled: boolean;
   experimental: any;
 }
 

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -26,6 +26,7 @@ export class CustomizationService
     showOptimizationDialogForNiconico: true,
     optimizeWithHardwareEncoder: true,
     pollingPerformanceStatistics: true,
+    reconnectionEnabled: true,
     experimental: {
       // put experimental features here
     }
@@ -84,6 +85,14 @@ export class CustomizationService
 
   setPollingPerformanceStatistics(activate: boolean) {
     this.setSettings({ pollingPerformanceStatistics: activate });
+  }
+
+  get reconnectionEnabled() {
+    return this.state.reconnectionEnabled;
+  }
+
+  setReconnectionEnabled(enable: boolean) {
+    this.setSettings({ reconnectionEnabled: enable});
   }
 
   getSettingsFormData(): TFormData {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -469,10 +469,18 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           type: 'error',
           message: errorMessage,
           detail: errorDetail,
-          buttons: ['OK'],
+          buttons: ['OK', 'Reconnect'],
           noLink: true,
         },
-        () => {}
+        (button) => {
+          switch (button) {
+            case 0: // ok
+              break;
+            case 1: // reconnect
+              this.toggleStreaming();
+              break;
+          }
+        }
       );
     }
   }

--- a/test/e2e/streaming.js
+++ b/test/e2e/streaming.js
@@ -1,6 +1,8 @@
 import test from 'ava';
 import { useSpectron, focusMain, focusChild } from '../helpers/spectron/index';
-import { setFormInput } from '../helpers/spectron/forms';
+import { setFormInput, checkFormInput } from '../helpers/spectron/forms';
+import { dialogDetail, dialogDismiss } from '../helpers/spectron/dialog';
+import { TcpProxy } from '../helpers/tcp-proxy';
 
 useSpectron();
 
@@ -11,7 +13,7 @@ test('Streaming to custom streaming server', async t => {
   if (!(streamingServerURL && streamingKey)) {
     console.warn(
       'テスト用配信情報が不足しています。配信テストをスキップします。\n' +
-      `NAIR_TEST_STREAM_SERVER: ${process.env.NAIR_TEST_STREAM_SERVER}\n` + 
+      `NAIR_TEST_STREAM_SERVER: ${process.env.NAIR_TEST_STREAM_SERVER}\n` +
       `NAIR_TEST_STREAM_KEY   : ${process.env.NAIR_TEST_STREAM_KEY}`
     );
     t.pass();
@@ -42,5 +44,147 @@ test('Streaming to custom streaming server', async t => {
   await app.client.click('[data-test="StartStreamingButton"]');
 
   await app.client.waitForExist('[data-test="StartStreamingButton"][data-test-status="live"]', 10 * 1000);
+  t.pass();
+});
+
+async function sleep(time) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, time);
+  })
+}
+
+test('Disconnect while streaming(reconnect: on)', async t => {
+  const streamingServerURL = process.env.NAIR_TEST_STREAM_SERVER;
+  const streamingKey = process.env.NAIR_TEST_STREAM_KEY;
+
+  if (!(streamingServerURL && streamingKey)) {
+    console.warn(
+      'テスト用配信情報が不足しています。配信テストをスキップします。\n' +
+      `NAIR_TEST_STREAM_SERVER: ${process.env.NAIR_TEST_STREAM_SERVER}\n` +
+      `NAIR_TEST_STREAM_KEY   : ${process.env.NAIR_TEST_STREAM_KEY}`
+    );
+    t.pass();
+    return;
+  }
+
+  const rtmpPort = 1935;
+  const url = new URL(streamingServerURL);
+  const serverHostname = url.hostname;
+
+  const proxy = new TcpProxy(serverHostname, rtmpPort);
+  const listenPort = await proxy.listen();
+
+  url.hostname = 'localhost';
+  url.port = listenPort;
+  const streamingServerProxyURL = url.href;
+  console.log('Streaming Proxy URL: ', streamingServerProxyURL); // DEBUG
+  console.log('proxy to: ', serverHostname); // DEBUG
+
+  const app = t.context.app;
+
+  await focusMain(t);
+  await app.client.click('[data-test="OpenSettings"]');
+
+  await focusChild(t);
+
+  const allowReconnection = true; ///< 再接続
+  await checkFormInput(
+    t,
+    '[data-test="Form/Bool/reconnection"]',
+    allowReconnection
+  );
+
+  await app.client.click('[data-test="Settings"] [data-test="SideMenu"] [data-test="Stream"]');
+
+  await setFormInput(
+    t,
+    '[data-test="Form/Text/server"]',
+    streamingServerProxyURL
+  );
+  await setFormInput(
+    t,
+    '[data-test="Form/Text/key"]',
+    streamingKey
+  );
+  await app.client.click('[data-test="Done"]');
+
+  await focusMain(t);
+  await app.client.click('[data-test="StartStreamingButton"]');
+
+  await app.client.waitForExist('[data-test="StartStreamingButton"][data-test-status="live"]', 10 * 1000);
+
+  proxy.close();
+
+  await app.client.waitForExist('[data-test="StartStreamingButton"][data-test-status="reconnecting"]', 10 * 1000);
+
+  t.pass();
+});
+
+test('Disconnect while streaming(reconnect: off)', async t => {
+  const streamingServerURL = process.env.NAIR_TEST_STREAM_SERVER;
+  const streamingKey = process.env.NAIR_TEST_STREAM_KEY;
+
+  if (!(streamingServerURL && streamingKey)) {
+    console.warn(
+      'テスト用配信情報が不足しています。配信テストをスキップします。\n' +
+      `NAIR_TEST_STREAM_SERVER: ${process.env.NAIR_TEST_STREAM_SERVER}\n` +
+      `NAIR_TEST_STREAM_KEY   : ${process.env.NAIR_TEST_STREAM_KEY}`
+    );
+    t.pass();
+    return;
+  }
+
+  const rtmpPort = 1935;
+  const url = new URL(streamingServerURL);
+  const serverHostname = url.hostname;
+
+  const proxy = new TcpProxy(serverHostname, rtmpPort);
+  const listenPort = await proxy.listen();
+
+  url.hostname = 'localhost';
+  url.port = listenPort;
+  const streamingServerProxyURL = url.href;
+  console.log('Streaming Proxy URL: ', streamingServerProxyURL); // DEBUG
+  console.log('proxy to: ', serverHostname); // DEBUG
+
+  const app = t.context.app;
+
+  await focusMain(t);
+  await app.client.click('[data-test="OpenSettings"]');
+
+  await focusChild(t);
+
+  const allowReconnection = false; ///< 再接続
+  await checkFormInput(
+    t,
+    '[data-test="Form/Bool/reconnection"]',
+    allowReconnection
+  );
+
+  await app.client.click('[data-test="Settings"] [data-test="SideMenu"] [data-test="Stream"]');
+
+  await setFormInput(
+    t,
+    '[data-test="Form/Text/server"]',
+    streamingServerProxyURL
+  );
+  await setFormInput(
+    t,
+    '[data-test="Form/Text/key"]',
+    streamingKey
+  );
+  await app.client.click('[data-test="Done"]');
+
+  await focusMain(t);
+  await app.client.click('[data-test="StartStreamingButton"]');
+
+  await app.client.waitForExist('[data-test="StartStreamingButton"][data-test-status="live"]', 10 * 1000);
+
+  proxy.close();
+  await sleep(1 * 1000);
+  t.deepEqual(await dialogDetail(t), 'disconnectedError');
+  await dialogDismiss(t, 'OK');
   t.pass();
 });

--- a/test/e2e/tcp-proxy.js
+++ b/test/e2e/tcp-proxy.js
@@ -1,0 +1,70 @@
+// test for tcp-proxy.ts
+import test from 'ava';
+import { TcpProxy } from '../helpers/tcp-proxy';
+import { clearTimeout } from 'timers';
+const net = require('net');
+
+test('TcpProxy', async t => {
+    await new Promise((resolve) => {
+        const server = net.createServer(socket => {
+            socket.on('data', data => {
+                t.deepEqual(data.toString(), 'TEST');
+                resolve();
+            })
+        }).listen();
+        server.on('listening', () => {
+            const serverPort = server.address().port;
+            const proxy = new TcpProxy('localhost', serverPort);
+            proxy.listen().then(proxyPort => {
+                const c = net.createConnection(proxyPort, 'localhost');
+
+                c.on('ready', () => {
+                    c.write('TEST');
+                })
+            });
+        });
+    })
+});
+
+test('TcpProxy close', async t => {
+    await new Promise((resolveServer, reject) => {
+        return new Promise((resolveClient) => {
+            // 3 seconds timeout
+            const TIMEOUT = 3 * 1000;
+            const timer = setTimeout(() => {
+                t.fail('timeout!');
+                reject('TIMEOUT');
+            }, TIMEOUT);
+
+            const server = net.createServer(socket => {
+                socket.on('end', () => {
+                    socket.end();
+                    resolveServer();
+                })
+            }).listen();
+            server.on('listening', () => {
+                const serverPort = server.address().port;
+                const proxy = new TcpProxy(
+                    'localhost',
+                    serverPort,
+                    () => {
+                        t.deepEqual(proxy.connections.length, 1);
+
+                        proxy.close();
+                    }
+                );
+                proxy.listen().then(proxyPort => {
+                    t.deepEqual(proxy.connections.length, 0);
+
+                    const c = net.createConnection(proxyPort, 'localhost');
+                    c.on('end', () => {
+                        clearTimeout(timer);
+                        resolveClient();
+                    });
+
+                });
+            });
+        });
+    });
+    t.pass();
+});

--- a/test/helpers/spectron/dialog-injected.js
+++ b/test/helpers/spectron/dialog-injected.js
@@ -2,16 +2,22 @@ const electron = require('electron');
 
 (() => {
   let currentCb;
-  let currentButtons;
+  let currentOpts;
 
   electron.dialog.showMessageBox = function showMessageBox(win, opts, cb) {
     currentCb = cb;
-    currentButtons = opts.buttons;
+    currentOpts = opts;
   };
 
   electron.ipcMain.on('__SPECTRON_FAKE_MESSAGE_BOX', (e, buttonLabel) => {
-    currentButtons.forEach((button, index) => {
+    currentOpts.buttons.forEach((button, index) => {
       if (button === buttonLabel) currentCb(index);
     });
+  });
+  electron.ipcMain.on('__SPECTRON_FAKE_MESSAGE_BOX_GET_MESSAGE', e => {
+    e.returnValue = currentOpts.message;
+  });
+  electron.ipcMain.on('__SPECTRON_FAKE_MESSAGE_BOX_GET_DETAIL', e => {
+    e.returnValue = currentOpts.detail;
   });
 })();

--- a/test/helpers/spectron/dialog.js
+++ b/test/helpers/spectron/dialog.js
@@ -4,3 +4,15 @@ export async function dialogDismiss(t, buttonLabel) {
     buttonLabel
   );
 }
+
+export async function dialogMessage(t) {
+  return await t.context.app.electron.ipcRenderer.sendSync(
+    '__SPECTRON_FAKE_MESSAGE_BOX_GET_MESSAGE'
+  );
+}
+
+export async function dialogDetail(t) {
+  return await t.context.app.electron.ipcRenderer.sendSync(
+    '__SPECTRON_FAKE_MESSAGE_BOX_GET_DETAIL'
+  );
+}

--- a/test/helpers/spectron/forms.js
+++ b/test/helpers/spectron/forms.js
@@ -28,6 +28,17 @@ export async function clickFormInput(t, label, index = 0) {
     .click();
 }
 
+export async function checkFormInput(t, label, checked, index = 0) {
+  const id = await getNthLabelId(t, label, index);
+
+  const client = t.context.app.client;
+
+  const current = await client.elementIdElement(id, 'input').isSelected();
+  if (current !== checked) {
+    await client.elementIdElement(id, 'input').click();
+  }
+}
+
 export async function setFormDropdown(t, label, value, index = 0) {
   const id = await getNthLabelId(t, label, index);
 

--- a/test/helpers/tcp-proxy.ts
+++ b/test/helpers/tcp-proxy.ts
@@ -1,0 +1,69 @@
+import { Socket, Server, createServer, connect } from 'net';
+
+export class TcpProxyConnection {
+    _local: Socket
+    _remote: Socket
+
+    constructor(local: Socket, remote: Socket) {
+        this._local = local;
+        this._remote = remote;
+        local.pipe(remote).pipe(local);
+    }
+
+    end() {
+        this._remote.unpipe();
+        this._local.unpipe();
+        this._remote.end();
+        this._local.end();
+        this._local.destroy();
+        delete this._remote;
+        delete this._local;
+    }
+}
+
+export class TcpProxy {
+    proxyServer: Server;
+    connections: TcpProxyConnection[] = [];
+    noMoreAccept: boolean = false;
+
+    constructor(
+        remoteHost: string,
+        remotePort: number,
+        onConnect?: (c: TcpProxyConnection) => void
+    ) {
+        this.proxyServer = createServer((socket: Socket) => {
+            if (this.noMoreAccept) {
+                socket.end();
+                return;
+            }
+
+            const client = connect(remotePort, remoteHost);
+            const connection = new TcpProxyConnection(socket, client);
+            this.connections.push(connection);
+            if (onConnect) {
+                onConnect(connection);
+            }
+        });
+    }
+
+    /**
+     * listen.
+     * @param port listen port or 0(omit) to pick unused port automatically
+     * @return Promise<number> bound port
+     */
+    listen(port: number = 0): Promise<number> {
+        return new Promise(resolve => {
+            this.noMoreAccept = false;
+            this.proxyServer.listen(port, () => {
+                resolve(this.proxyServer.address().port);
+            });
+        });
+    }
+
+    close() {
+        this.noMoreAccept = true;
+        this.connections.forEach(c => c.end());
+        this.proxyServer.close();
+        this.connections = [];
+    }
+}


### PR DESCRIPTION
# このpull requestが解決する内容
OBSの自動再接続機能を無効にするためのオプションを追加する
(再接続機能が発動するとフリーズすることがある現象の回避用)

あとやること
* [x] 切断が発生したときに通知/エラーがないと切れたことに気づかないので何か考える
* [ ] 設定画面上でオプションを納める場所を検討する

# 動作確認手順(ハードル高い)
* RTMPを通せるproxy(TCP proxyで良い。portは1935)を立てる
    * 例: https://github.com/jpillora/go-tcp-proxy 
* N Air上のniconicoをログアウトし、配信設定で上記proxyに接続するように設定する
    * RTMPのURLのhostname(FQDN)部分をproxyを立てたアドレス(localhostなど)に変更し、proxy側はその元のホストに中継する設定をする
* 配信開始してからproxyを停止することで、再接続シーケンスに入るかどうかが設定値に従うことを確認する

# 関連するIssue（あれば）
#196 