### PR TITLE
追加: コメント種別ごとに別のコンポーネントにする

### DIFF
--- a/app/components/nicolive-area/AreaSwitcher.vue
+++ b/app/components/nicolive-area/AreaSwitcher.vue
@@ -4,7 +4,7 @@
       <slot :name="activeContent.slotName" />
     </div>
     <div class="header">
-      <popper trigger="click" :options="{ placement: 'bottom-end' }">
+      <popper trigger="hover" :options="{ placement: 'bottom-end' }">
         <div class="popper">
           <ul class="selector">
             <li
@@ -79,7 +79,7 @@
 
 .selector {
   border-radius: 4px;
-  margin: 0 0 0 8px; 
+  margin: 0 0 0 8px;
   padding: 8px 1px;
   width: 330px;
   background-color: @bg-primary;

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -7,16 +7,16 @@
     </div>
     <div class="content">
       <div class="list">
-        <div class="row" v-for="(item, index) of items" :key="index" @dblclick="pinnedComment = item" :title="itemToString(item)">
+        <div class="row" v-for="(item, index) of items" :key="index" @dblclick="pin(item)" :title="itemToString(item)">
           <!-- TODO: 種別判定と出し分け -->
-          <div class="comment-number">{{ item.no }}</div>
-          <div class="comment-body">{{ item.content }}</div>
+          <div class="comment-number">{{ item.value.no }}</div>
+          <div class="comment-body">{{ item.value.content }}</div>
           <div class="comment-misc" @click.stop="showCommentMenu(item)"><i class="icon-btn icon-ellipsis-vertical"></i></div>
         </div>
         <div class="sentinel" ref="sentinel"></div>
       </div>
       <div class="pinned" v-if="Boolean(pinnedComment)">
-        <div class="comment-number">{{ pinnedComment.no }}</div>
+        <div class="comment-number">{{ pinnedComment.value.no }}</div>
         <div class="comment-body">
           {{ itemToString(pinnedComment) }}
         </div>
@@ -141,7 +141,7 @@
   right: 8px;
   border: 1px solid @text-secondary;
   background-color: rgba(@border, .9);
-  border-radius: 4px; 
+  border-radius: 4px;
   display: flex;
   padding: 12px 16px;
 

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -14,6 +14,7 @@
           :title="itemToString(item)"
           :is="componentMap[item.type]"
           :chat="item"
+          :commentMenuOpened="commentMenuTarget === item"
           @pinned="pin(item)"
           @commentMenu="showCommentMenu(item)"
         />

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -7,12 +7,16 @@
     </div>
     <div class="content">
       <div class="list">
-        <div class="row" v-for="(item, index) of items" :key="index" @dblclick="pin(item)" :title="itemToString(item)">
-          <!-- TODO: 種別判定と出し分け -->
-          <div class="comment-number">{{ item.value.no }}</div>
-          <div class="comment-body">{{ item.value.content }}</div>
-          <div class="comment-misc" @click.stop="showCommentMenu(item)"><i class="icon-btn icon-ellipsis-vertical"></i></div>
-        </div>
+        <component
+          class="row"
+          v-for="(item, index) of items"
+          :key="index"
+          :title="itemToString(item)"
+          :is="componentMap[item.type]"
+          :chat="item"
+          @pinned="pin(item)"
+          @commentMenu="showCommentMenu(item)"
+        />
         <div class="sentinel" ref="sentinel"></div>
       </div>
       <div class="pinned" v-if="Boolean(pinnedComment)">
@@ -79,51 +83,8 @@
   line-height: 32px;
   width: 100%;
 
-  display: flex;
-  flex-direction: row;
-
-  &:hover {
-    background-color: @hover;
-
-     > .comment-body {
-       color: @white;
-     }
-
-    > .comment-misc {
-      display: flex;
-      align-items: center;
-      padding-left: 8px;
-      color: @light-grey;
-    }
-  }
-
   &:first-child {
     margin-top: 8px;
-  }
-
-  & > .comment-number {
-    min-width: 40px;
-    padding-left: 16px;
-    text-align: right;
-    flex-shrink: 0;
-    box-sizing: border-box;
-    color: @grey;
-  }
-
-  & > .comment-body {
-    margin-left: 16px;
-    overflow-x: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    flex-grow: 1;
-    color: @light-grey;
-  }
-
-  & > .comment-misc {
-    display: none;
-    width: 32px;
-    flex-shrink: 0;
-    text-align: center;
   }
 }
 

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -11,12 +11,33 @@ import { Menu } from 'util/menus/Menu';
 import { clipboard } from 'electron';
 import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { ChatMessageType } from 'services/nicolive-program/ChatMessage/classifier';
+import CommonComment from './comment/CommonComment.vue';
+import SystemMessage from './comment/SystemMessage.vue';
+import GiftComment from './comment/GiftComment.vue';
+import NicoadComment from './comment/NicoadComment.vue';
+
+const componentMap: { [type in ChatMessageType]: Vue.Component } = {
+  normal: CommonComment,
+  operator: CommonComment,
+  nicoad: NicoadComment,
+  gift: GiftComment,
+  spi: SystemMessage,
+  quote: SystemMessage,
+  cruise: SystemMessage,
+  info: SystemMessage,
+  unknown: CommonComment,
+};
 
 @Component({
   components: {
     CommentForm,
     CommentFilter,
     CommentLocalFilter,
+    CommonComment,
+    NicoadComment,
+    GiftComment,
+    SystemMessage,
   }
 })
 export default class CommentViewer extends Vue {
@@ -46,20 +67,20 @@ export default class CommentViewer extends Vue {
     this.pinnedComment = item;
   }
 
+  componentMap = componentMap;
+
   get items() {
     return this.nicoliveCommentViewerService.items.filter(this.applyLocalFilter);
   }
 
   private applyLocalFilter = ({ value }: WrappedChat) => this.nicoliveCommentLocalFilterService.filter(value);
 
-  format = NicoliveProgramService.format;
-
   itemToString(item: WrappedChat) {
     const { vpos, content } = item.value;
     const { vposBaseTime, startTime } = this.nicoliveProgramService.state;
     const vposTime = vposBaseTime + Math.floor(vpos / 100);
     const diffTime = vposTime - startTime;
-    return `${content} (${this.format(diffTime)})`;
+    return `${content} (${NicoliveProgramService.format(diffTime)})`;
   }
 
   showCommentMenu(item: WrappedChat) {

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -153,7 +153,7 @@ export default class CommentViewer extends Vue {
     };
     const ioOptions = {
       rootMargin: '0px',
-      threshold: [0.75, 1],
+      threshold: 0,
     };
     const io = new IntersectionObserver(ioCallback, ioOptions);
     io.observe(sentinelEl);

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -64,7 +64,9 @@ export default class CommentViewer extends Vue {
   isLatestVisible = true;
 
   pin(item: WrappedChat): void {
-    this.pinnedComment = item;
+    if (item.type === 'normal') {
+      this.pinnedComment = item;
+    }
   }
 
   componentMap = componentMap;
@@ -84,6 +86,10 @@ export default class CommentViewer extends Vue {
   }
 
   showCommentMenu(item: WrappedChat) {
+    if (!(item.type === 'normal' || item.type === 'operator')) {
+      return;
+    }
+
     const menu = new Menu();
     menu.append({
       id: 'Copy comment',
@@ -99,30 +105,33 @@ export default class CommentViewer extends Vue {
         clipboard.writeText(item.value.user_id);
       },
     });
-    menu.append({
-      id: 'Pin this comment',
-      label: 'コメントをピン留め',
-      click: () => {
-        this.pin(item);
-      },
-    });
-    menu.append({
-      type: 'separator',
-    });
-    menu.append({
-      id: 'Add ',
-      label: 'コメントをNGに追加',
-      click: () => {
-        this.nicoliveCommentFilterService.addFilter({ type: 'word', body: item.value.content });
-      },
-    });
-    menu.append({
-      id: 'Copy id of comment owner',
-      label: 'ユーザーIDをNGに追加',
-      click: () => {
-        this.nicoliveCommentFilterService.addFilter({ type: 'user_id', body: item.value.user_id });
-      },
-    });
+
+    if (item.type === 'normal') {
+      menu.append({
+        id: 'Pin this comment',
+        label: 'コメントをピン留め',
+        click: () => {
+          this.pin(item);
+        },
+      });
+      menu.append({
+        type: 'separator',
+      });
+      menu.append({
+        id: 'Add ',
+        label: 'コメントをNGに追加',
+        click: () => {
+          this.nicoliveCommentFilterService.addFilter({ type: 'word', body: item.value.content });
+        },
+      });
+      menu.append({
+        id: 'Copy id of comment owner',
+        label: 'ユーザーIDをNGに追加',
+        click: () => {
+          this.nicoliveCommentFilterService.addFilter({ type: 'user_id', body: item.value.user_id });
+        },
+      });
+    }
     menu.popup();
   }
 

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -85,6 +85,7 @@ export default class CommentViewer extends Vue {
     return `${content} (${NicoliveProgramService.format(diffTime)})`;
   }
 
+  commentMenuTarget: WrappedChat | null = null;
   showCommentMenu(item: WrappedChat) {
     if (!(item.type === 'normal' || item.type === 'operator')) {
       return;
@@ -132,6 +133,16 @@ export default class CommentViewer extends Vue {
         },
       });
     }
+
+    // コンテキストメニューが出るとホバー判定が消えるので、外観を維持するために注目している要素を保持しておく
+    menu.menu.once('menu-will-show', () => {
+      this.commentMenuTarget = item;
+    });
+    menu.menu.once('menu-will-close', () => {
+      if (this.commentMenuTarget === item) {
+        this.commentMenuTarget = null;
+      }
+    });
     menu.popup();
   }
 

--- a/app/components/nicolive-area/comment/CommonComment.vue
+++ b/app/components/nicolive-area/comment/CommonComment.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="root" :class="chat.type" @dblclick="$emit('pinned')">
+  <div class="root" :class="[chat.type, { pseudoHover: commentMenuOpened }]" @dblclick="$emit('pinned')">
     <div class="comment-number">{{ chat.value.no }}</div>
     <div class="comment-body">{{ computedContent }}</div>
     <div class="comment-misc" @click.stop="$emit('commentMenu')"><i class="icon-btn icon-ellipsis-vertical"></i></div>
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: row;
 
-  &:hover {
+  &:hover, &.pseudoHover {
     background-color: @hover;
 
     & > .comment-body {

--- a/app/components/nicolive-area/comment/CommonComment.vue
+++ b/app/components/nicolive-area/comment/CommonComment.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="root" :class="chat.type" @dblclick="$emit('pinned')">
+    <div class="comment-number">{{ chat.value.no }}</div>
+    <div class="comment-body">{{ computedContent }}</div>
+    <div class="comment-misc" @click.stop="$emit('commentMenu')"><i class="icon-btn icon-ellipsis-vertical"></i></div>
+  </div>
+</template>
+<script lang="ts" src="./CommonComment.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../../../styles/_colors";
+@import "../../../styles/mixins";
+
+.root {
+  display: flex;
+  flex-direction: row;
+
+  &:hover {
+    background-color: @hover;
+
+    & > .comment-body {
+      color: @white;
+    }
+
+    & > .comment-misc {
+      display: flex;
+      align-items: center;
+      padding-left: 8px;
+      color: @light-grey;
+    }
+  }
+
+  &.operator > .comment-body {
+    color: @accent;
+  }
+}
+
+.comment-number {
+  min-width: 40px;
+  padding-left: 16px;
+  text-align: right;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  color: @grey;
+}
+
+.comment-body {
+  margin-left: 16px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-grow: 1;
+  color: @light-grey;
+}
+
+.comment-misc {
+  display: none;
+  width: 32px;
+  flex-shrink: 0;
+  text-align: center;
+}
+</style>

--- a/app/components/nicolive-area/comment/CommonComment.vue.ts
+++ b/app/components/nicolive-area/comment/CommonComment.vue.ts
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
+import { parseContent } from 'services/nicolive-program/ChatMessage/util';
+
+@Component({})
+export default class CommonComment extends Vue {
+  @Prop() chat: WrappedChat;
+  @Prop({ default: false }) commentMenuOpened: boolean;
+
+  get computedContent() {
+    const parsed = parseContent(this.chat.value);
+    if (this.chat.type === 'unknown') {
+      return `${parsed.commandName} ${parsed.values.join(' ')}`;
+    }
+    return parsed.values.join(' ');
+  }
+}

--- a/app/components/nicolive-area/comment/GiftComment.vue
+++ b/app/components/nicolive-area/comment/GiftComment.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="root" :class="chat.type">
+    <div class="comment-header">ギフト</div>
+    <div class="comment-body">{{ computedContent }}</div>
+  </div>
+</template>
+<script lang="ts" src="./GiftComment.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../../../styles/_colors";
+@import "../../../styles/mixins";
+
+.root {
+  display: flex;
+  flex-direction: row;
+}
+
+.comment-header {
+  min-width: 40px;
+  padding-left: 16px;
+  text-align: right;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  color: @grey;
+}
+
+.comment-body {
+  margin-left: 16px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-grow: 1;
+  color: @light-grey;
+}
+</style>

--- a/app/components/nicolive-area/comment/GiftComment.vue.ts
+++ b/app/components/nicolive-area/comment/GiftComment.vue.ts
@@ -1,0 +1,16 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
+import { parseContent } from 'services/nicolive-program/ChatMessage/util';
+
+@Component({})
+export default class GiftComment extends Vue {
+  @Prop() chat: WrappedChat;
+
+  get computedContent() {
+    const parsed = parseContent(this.chat.value);
+    const [itemId, userId, advertiserName, point, message, itemName, contributionRank] = parsed.values;
+    const contributionMessage = contributionRank ? `（第 ${contributionRank} 位）` : '';
+    return `${advertiserName} さんが「${itemName}」を贈りました。「${message}」${contributionMessage}`;
+  }
+}

--- a/app/components/nicolive-area/comment/NicoadComment.vue
+++ b/app/components/nicolive-area/comment/NicoadComment.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="root" :class="chat.type">
+    <div class="comment-header">広告</div>
+    <div class="comment-body">{{ computedContent }}</div>
+  </div>
+</template>
+<script lang="ts" src="./NicoadComment.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../../../styles/_colors";
+@import "../../../styles/mixins";
+
+.root {
+  display: flex;
+  flex-direction: row;
+}
+
+.comment-header {
+  min-width: 40px;
+  padding-left: 16px;
+  text-align: right;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  color: @grey;
+}
+
+.comment-body {
+  margin-left: 16px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-grow: 1;
+  color: @light-grey;
+}
+</style>

--- a/app/components/nicolive-area/comment/NicoadComment.vue.ts
+++ b/app/components/nicolive-area/comment/NicoadComment.vue.ts
@@ -1,0 +1,14 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
+import { parseJsonContent } from 'services/nicolive-program/ChatMessage/util';
+
+@Component({})
+export default class CommonComment extends Vue {
+  @Prop() chat: WrappedChat;
+
+  get computedContent() {
+    const parsed = parseJsonContent(this.chat.value);
+    return parsed.value.message ?? '';
+  }
+}

--- a/app/components/nicolive-area/comment/SystemMessage.vue
+++ b/app/components/nicolive-area/comment/SystemMessage.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="root" :class="chat.type">
+    <div class="comment-header"></div>
+    <div class="comment-body">{{ computedContent }}</div>
+  </div>
+</template>
+<script lang="ts" src="./SystemMessage.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../../../styles/_colors";
+@import "../../../styles/mixins";
+
+.root {
+  display: flex;
+  flex-direction: row;
+}
+
+.comment-header {
+  min-width: 40px;
+  padding-left: 16px;
+  text-align: right;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  color: @grey;
+}
+
+.comment-body {
+  margin-left: 16px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-grow: 1;
+  color: @light-grey;
+}
+</style>

--- a/app/components/nicolive-area/comment/SystemMessage.vue.ts
+++ b/app/components/nicolive-area/comment/SystemMessage.vue.ts
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
+import { parseContent } from 'services/nicolive-program/ChatMessage/util';
+
+@Component({})
+export default class CommonComment extends Vue {
+  @Prop() chat: WrappedChat;
+
+  get computedContent() {
+    const parsed = parseContent(this.chat.value);
+    if (this.chat.type === 'info') {
+      // info種別を除去
+      parsed.values.shift();
+    }
+    return parsed.values.join(' ');
+  }
+}

--- a/app/services/nicolive-program/ChatMessage/classifier.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.ts
@@ -1,0 +1,26 @@
+import { ChatMessage } from '../MessageServerClient';
+import { isOperatorCommand, parseCommandName, isOperatorComment } from './util';
+
+export function classify(chat: ChatMessage) {
+  if (isOperatorComment(chat)) {
+    return 'operator';
+  }
+  if (isOperatorCommand(chat)) {
+    const commandName = parseCommandName(chat).toLowerCase();
+    switch (commandName) {
+      case 'nicoad':
+      case 'gift':
+      case 'spi':
+      case 'quote':
+      case 'cruise':
+      case 'info':
+        return commandName;
+      case 'perm':
+        return 'operator';
+    }
+    return 'unknown';
+  }
+  return 'normal';
+}
+
+export type ChatMessageType = ReturnType<typeof classify>;

--- a/app/services/nicolive-program/ChatMessage/util.ts
+++ b/app/services/nicolive-program/ChatMessage/util.ts
@@ -1,0 +1,132 @@
+import { ChatMessage } from '../MessageServerClient';
+
+function checkPremiumBit(premiumBit: number | undefined, checkBit: number): boolean {
+  return premiumBit !== undefined && Boolean(premiumBit & checkBit);
+}
+
+export function isPremium(chat: ChatMessage): boolean {
+  return checkPremiumBit(chat.premium, 0b1);
+}
+
+export function isOperator(chat: ChatMessage): boolean {
+  return checkPremiumBit(chat.premium, 0b110);
+}
+
+export function isCommandContent(chat: ChatMessage): boolean {
+  return Boolean(chat.content?.startsWith('/'));
+}
+
+export function isOperatorCommand(chat: ChatMessage): boolean {
+  return isOperator(chat) && isCommandContent(chat);
+}
+
+export function isOperatorComment(chat: ChatMessage): boolean {
+  return isOperator(chat) && !isCommandContent(chat);
+}
+
+export function isAnonymous(chat: ChatMessage): boolean {
+  return chat.anonymity === 1;
+}
+
+export function getScore(chat: ChatMessage): number {
+  return chat.score ?? 0;
+}
+
+export function parseCommandName(chat: ChatMessage): string {
+  const matched = (chat.content ?? '').match(/^\/(\S+)\s*/);
+  return matched && matched[1] ? matched[1] : '';
+}
+
+export function parseJsonContent(chat: ChatMessage): { commandName: string, value: any} | null {
+  const content = chat.content ?? '';
+  const matched = content.match(/(\S+)\s+(.+)/);
+  if (matched && matched.length > 2) {
+    const [, commandName, maybeJsonArg] = matched;
+    try {
+      const parsed = JSON.parse(maybeJsonArg);
+      if (typeof parsed === 'object') {
+        return {
+          commandName,
+          value: parsed,
+        };
+      }
+    } catch (err) {}
+  }
+  return null;
+}
+
+enum ParseState {
+  init,
+  reading,
+  readingEsc,
+  quoted,
+  quotedEsc,
+}
+
+const SPACES = [' ', '\t'];
+
+export function parseContent(chat: ChatMessage): { commandName: string, values: string[] } {
+  const content = chat.content ?? '';
+  const values = [];
+  let currentStr = '';
+
+  let state: ParseState = ParseState.init;
+
+  for (const char of content) {
+    switch (state) {
+      case ParseState.init: {
+        if (SPACES.includes(char)) {
+          state = ParseState.init;
+        } else if (char === '"') {
+          state = ParseState.quoted;
+        } else if (char === '\\') {
+          state = ParseState.readingEsc;
+        } else {
+          state = ParseState.reading;
+          currentStr += char;
+        }
+      } break;
+      case ParseState.reading: {
+        if (SPACES.includes(char)) {
+          values.push(currentStr);
+          currentStr = '';
+          state = ParseState.init;
+        } else if (char === '\\') {
+          state = ParseState.readingEsc;
+        } else {
+          currentStr += char;
+        }
+      } break;
+      case ParseState.readingEsc: {
+        currentStr += char;
+        state = ParseState.reading;
+      } break;
+      case ParseState.quoted: {
+        if (char === '"') {
+          values.push(currentStr);
+          currentStr = '';
+          state = ParseState.init;
+        } else if (char === '\\') {
+          state = ParseState.quotedEsc;
+        } else {
+          currentStr += char;
+        }
+      } break;
+      case ParseState.quotedEsc: {
+        currentStr += char;
+        state = ParseState.quoted;
+      } break;
+    }
+  }
+
+  if (currentStr.length > 0) {
+    values.push(currentStr);
+  }
+
+  const commandName = values[0].startsWith('/') ? values.shift() : '';
+
+  return {
+    commandName,
+    values,
+  };
+}

--- a/app/services/nicolive-program/ChatMessage/util.ts
+++ b/app/services/nicolive-program/ChatMessage/util.ts
@@ -9,7 +9,7 @@ export function isPremium(chat: ChatMessage): boolean {
 }
 
 export function isOperator(chat: ChatMessage): boolean {
-  return checkPremiumBit(chat.premium, 0b110);
+  return checkPremiumBit(chat.premium, 0b10) || checkPremiumBit(chat.premium, 0b100);
 }
 
 export function isCommandContent(chat: ChatMessage): boolean {

--- a/app/services/nicolive-program/nicolive-comment-local-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-local-filter.ts
@@ -1,5 +1,6 @@
 import { mutation, StatefulService } from 'services/stateful-service';
 import { ChatMessage } from './MessageServerClient';
+import { isAnonymous, getScore } from './ChatMessage/util';
 
 export type NGSharingLevel = 'none' | 'low' | 'mid' | 'high';
 
@@ -46,8 +47,8 @@ export class NicoliveCommentLocalFilterService extends StatefulService<INicolive
   }
 
   filter = (message: ChatMessage): boolean => {
-    const ngSharingOk = this.threshold < (message.score ?? 0);
-    const anonymityOk = this.showAnonymous || message.anonymity !== 1;
+    const ngSharingOk = this.threshold < getScore(message);
+    const anonymityOk = this.showAnonymous || !isAnonymous(message);
     return ngSharingOk && anonymityOk;
   };
 


### PR DESCRIPTION
# このpull requestが解決する内容
コメント種別ごとに外観を持つので、別のコンポーネントにわけました。
コメントメニューの種別ごとの出し分けも入れています。

## 見てほしいこと
コメント種別のパターンが十分か確認してほしいです。
コメントメニューを開いたときのホバー状態を維持するようにしてあります。

## やっていないこと
コメントのツールチップはまだ対応していないです。
~パネル切り替え時の操作後にパネルを閉じる動き（使っているライブラリに方法がなさそうなので改めて相談させてください）~ *対処した*

# 動作確認手順
1. N Airを起動
2. ログインしていなければログイン
3. 番組を作成もしくは作成済みの番組を取得
3. コメントエリアを目視

コメント種別が列挙されるブランチを用意してあるのでパターン確認に使ってください
https://github.com/berlysia/n-air-app/tree/tmp/nicolive-comment-pattern

# 関連するIssue（あれば）
