### PR TITLE
追加: プレミアム会員か否かを取得

### DIFF
--- a/app/components/pages/onboarding_steps/Connect.vue.ts
+++ b/app/components/pages/onboarding_steps/Connect.vue.ts
@@ -19,18 +19,18 @@ export default class Connect extends Vue {
 
   authPlatform(platform: TPlatform) {
     this.loadingState = true;
-    this.userService.startAuth(
+    this.userService.startAuth({
       platform,
-      () => {
+      onAuthStart: () => {
         this.loadingState = true;
       },
-      () => {
+      onAuthCancel: () => {
         this.loadingState = false;
       },
-      () => {
+      onAuthFinish: () => {
         this.onboardingService.next();
       }
-    );
+    });
   }
 
   iconForPlatform(platform: TPlatform) {

--- a/app/components/pages/onboarding_steps/Connect.vue.ts
+++ b/app/components/pages/onboarding_steps/Connect.vue.ts
@@ -21,7 +21,6 @@ export default class Connect extends Vue {
     this.loadingState = true;
     this.userService.startAuth(
       platform,
-      () => {},
       () => {
         this.loadingState = true;
       },

--- a/app/components/pages/onboarding_steps/Connect.vue.ts
+++ b/app/components/pages/onboarding_steps/Connect.vue.ts
@@ -21,10 +21,7 @@ export default class Connect extends Vue {
     this.loadingState = true;
     this.userService.startAuth({
       platform,
-      onAuthStart: () => {
-        this.loadingState = true;
-      },
-      onAuthCancel: () => {
+      onAuthClose: () => {
         this.loadingState = false;
       },
       onAuthFinish: () => {

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -10,7 +10,7 @@ export class HostsService extends Service {
     return 'https://account.nicovideo.jp';
   }
   get niconicoOAuth() {
-    return 'https://oauth.nicovideo.jp/oauth2';
+    return 'https://oauth.nicovideo.jp';
   }
   get niconicoFlapi() {
     return 'http://flapi.nicovideo.jp/api';

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -26,7 +26,7 @@ export class HostsService extends Service {
     const scopes = [
       'openid',
       'profile',
-      'user.premium'
+      'user.premium',
     ];
 
     const url = new URL('https://n-air-app.nicovideo.jp/authorize');

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -22,7 +22,16 @@ export class HostsService extends Service {
     if (process.env.NAIR_LOGIN_URL) {
       return process.env.NAIR_LOGIN_URL;
     }
-    return 'https://n-air-app.nicovideo.jp/authorize';
+
+    const scopes = [
+      'openid',
+      'profile',
+      'user.premium'
+    ];
+
+    const url = new URL('https://n-air-app.nicovideo.jp/authorize');
+    url.searchParams.set('scope', scopes.join(' '));
+    return url.toString();
   }
   get niconicoNAirInformationsFeed() {
     return 'https://blog.nicovideo.jp/niconews/category/se_n-air/feed/index.xml';

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -25,6 +25,7 @@ export interface IPlatformService {
   logout?: () => Promise<void>;
 
   getUserPageURL?: () => string;
+  isPremium?: (token: string) => Promise<boolean>;
 }
 
 export interface IPlatformAuth {
@@ -36,6 +37,7 @@ export interface IPlatformAuth {
     id: string;
     channelId?: string;
     userIcon?: string;
+    isPremium?: boolean;
   };
 }
 

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -149,6 +149,17 @@ export class NiconicoService extends Service implements IPlatformService {
     return this.getUserKey().then(userkey => userkey !== '');
   }
 
+  isPremium(token: string): Promise<boolean> {
+    const url = `${this.hostsService.niconicoOAuth}/v1/user/premium.json`;
+    const headers = authorizedHeaders(token);
+    const request = new Request(url, { headers });
+    return fetch(request)
+      .then(res => res.json())
+      .then(({ data }) => {
+        return data.type === 'premium';
+      });
+  }
+
   logout(): Promise<void> {
     const url = `${this.hostsService.niconicoAccount}/logout`;
     const request = new Request(url, { credentials: 'same-origin' });
@@ -298,7 +309,7 @@ export class NiconicoService extends Service implements IPlatformService {
 
   // TODO ニコニコOAuthのtoken更新に使う
   fetchNewToken(): Promise<void> {
-    const url = `${this.hostsService.niconicoOAuth}/token`;
+    const url = `${this.hostsService.niconicoOAuth}/oauth2/token`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers });
 

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -203,7 +203,6 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
    */
   startAuth(
     platform: TPlatform,
-    onWindowShow: (...args: any[]) => any,
     onAuthStart: (...args: any[]) => any,
     onAuthCancel: (...args: any[]) => any,
     onAuthFinish: (...args: any[]) => any
@@ -236,7 +235,6 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
 
     authWindow.once('ready-to-show', () => {
       authWindow.show();
-      defer(onWindowShow);
     });
 
     authWindow.once('close', () => {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -201,12 +201,17 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
    * Starts the authentication process.  Multiple callbacks
    * can be passed for various events.
    */
-  startAuth(
+  startAuth({
+    platform,
+    onAuthStart,
+    onAuthCancel,
+    onAuthFinish,
+  }: {
     platform: TPlatform,
     onAuthStart: (...args: any[]) => any,
     onAuthCancel: (...args: any[]) => any,
     onAuthFinish: (...args: any[]) => any
-  ) {
+  }) {
     const service = getPlatformService(platform);
     console.log('startAuth service = ' + JSON.stringify(service));
 


### PR DESCRIPTION
# このpull requestが解決する内容
- 重複していたログイン処理を統合する
- UserServiceがプレミアムか否かを保持するようにする
- ログイン時にプレミアム状態を取得する

# 動作確認手順
プレミアム会員状態が取れているか否かの確認方法がないのでconsole.logなどを仕込んでください。

# 関連するIssue（あれば）
