### PR TITLE
add scope parameter to login URL

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -26,7 +26,7 @@ export class HostsService extends Service {
     const scopes = [
       'openid',
       'profile',
-      'user.premium'
+      'user.premium',
     ];
 
     const url = new URL('https://n-air-app.nicovideo.jp/authorize');

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -22,7 +22,16 @@ export class HostsService extends Service {
     if (process.env.NAIR_LOGIN_URL) {
       return process.env.NAIR_LOGIN_URL;
     }
-    return 'https://n-air-app.nicovideo.jp/authorize';
+
+    const scopes = [
+      'openid',
+      'profile',
+      'user.premium'
+    ];
+
+    const url = new URL('https://n-air-app.nicovideo.jp/authorize');
+    url.searchParams.set('scope', scopes.join(' '));
+    return url.toString();
   }
   get niconicoNAirInformationsFeed() {
     return 'https://blog.nicovideo.jp/niconews/category/se_n-air/feed/index.xml';


### PR DESCRIPTION
# このpull requestが解決する内容
プレミアム権限取得が必要なことをログインURLにscopeパラメーターで伝えるようにします。
ただし、まだサーバーは対応してないので、サーバーが今後scopeパラメーターがないときに基本scopeしかとらないようにする前にやっておきます。

# 動作確認手順
authUrlの結果あたりをconsole.logで出してログインしてみる

# 関連するIssue（あれば）
#429 
