### PR TITLE
変更: エラーコードもエラーダイアログに表示する

### DIFF
--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -15,7 +15,9 @@ export class NicoliveFailure {
       console.error(res.value);
       return new this('network_error', method, 'network_error');
     }
-    return new this('http_error', method, res.value.meta.status.toString(10), res.value.meta.errorMessage);
+    const { errorCode, errorMessage } = res.value.meta;
+    const additionalMessage = `${errorCode ?? ''}${errorMessage ? `: ${errorMessage}` : ''}`;
+    return new this('http_error', method, res.value.meta.status.toString(10), additionalMessage);
   }
 
   static fromConditionalError(method: string, reason: string) {


### PR DESCRIPTION
# このpull requestが解決する内容
一部のAPIレスポンスを表示しているエラーダイアログで、エラーメッセージだけでなくエラーコードも表示するようにします。
エラーメッセージを持たない場合に少しでも情報量が増えるように配慮するものです。

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/75364050-65bc5400-58fe-11ea-9dd8-780abdd0c9ad.png)|![image](https://user-images.githubusercontent.com/950573/75363842-0b22f800-58fe-11ea-8b8a-848996d11ba8.png)|
|![image](https://user-images.githubusercontent.com/950573/75364021-5b9a5580-58fe-11ea-8192-e6e4d414c12a.png)|![image](https://user-images.githubusercontent.com/950573/75363909-2c83e400-58fe-11ea-9886-a91c640151cd.png)|

# 動作確認手順
1. N Airを起動
2. ログインしていなければログイン
3. 番組を取得または作成
4. 高速にコメントを連投したりスラッシュ始まりの放送者コメントを投稿しようとしたりする

# 関連するIssue（あれば）
