### PR TITLE
変更: 4xx、5xxのエラーで文言未定義の場合に400、500にフォールバックする

### DIFF
--- a/app/services/nicolive-program/NicoliveFailure.test.ts
+++ b/app/services/nicolive-program/NicoliveFailure.test.ts
@@ -1,0 +1,69 @@
+type NicoliveFailureType = typeof import('./NicoliveFailure').NicoliveFailure;
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('4xxで未定義文言だったら400にフォールバックする', async () => {
+  const showMessageBox = jest.fn().mockImplementation((_window, _option, callback) => {
+    callback();
+  });
+  jest.doMock('electron', () => ({
+    remote: {
+      dialog: {
+        showMessageBox,
+      },
+      getCurrentWindow: () => {},
+    },
+  }));
+  jest.doMock('services/i18n', () => ({
+    $t: jest.fn().mockImplementation((key, { fallback } = {}) => {
+      const keys = key.split('.');
+      const code = keys[keys.length - 2];
+      const value = keys[keys.length - 1];
+      if (code === '400') return value;
+      return fallback;
+    }),
+  }));
+
+  const m = require('./NicoliveFailure');
+  const NicoliveFailure = m.NicoliveFailure as NicoliveFailureType;
+  const openErrorDialogFromFailure = m.openErrorDialogFromFailure;
+  const failure = NicoliveFailure.fromClientError('method', { ok: false, value: { meta: { status: 403 } } });
+
+  await openErrorDialogFromFailure(failure);
+  expect(showMessageBox.mock.calls[0][1].title).toBe('title');
+  expect(showMessageBox.mock.calls[0][1].message).toBe('message');
+});
+
+test('5xxで未定義文言だったら500にフォールバックする', async () => {
+  const showMessageBox = jest.fn().mockImplementation((_window, _option, callback) => {
+    callback();
+  });
+  jest.doMock('electron', () => ({
+    remote: {
+      dialog: {
+        showMessageBox,
+      },
+      getCurrentWindow: () => {},
+    },
+  }));
+  jest.doMock('services/i18n', () => ({
+    $t: jest.fn().mockImplementation((key, { fallback } = {}) => {
+      const keys = key.split('.');
+      const code = keys[keys.length - 2];
+      const value = keys[keys.length - 1];
+      if (code === '500') return value;
+      return fallback;
+    }),
+  }));
+
+  const m = require('./NicoliveFailure');
+  const NicoliveFailure = m.NicoliveFailure as NicoliveFailureType;
+  const openErrorDialogFromFailure = m.openErrorDialogFromFailure;
+  const failure = NicoliveFailure.fromClientError('method', { ok: false, value: { meta: { status: 503 } } });
+
+  await openErrorDialogFromFailure(failure);
+  expect(showMessageBox.mock.calls[0][1].title).toBe('title');
+  expect(showMessageBox.mock.calls[0][1].message).toBe('message');
+});

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -39,6 +39,14 @@ async function openErrorDialog({ title, message }: { title: string; message: str
   });
 }
 
+function fallbackToX00(reason: string): string {
+  const matched = reason.match(/^(\d)\d\d$/);
+  if (matched) {
+    return `${matched[1]}00`;
+  }
+  return reason;
+}
+
 export async function openErrorDialogFromFailure(failure: NicoliveFailure): Promise<void> {
   if (failure.type === 'logic') {
     return openErrorDialog({
@@ -47,10 +55,16 @@ export async function openErrorDialogFromFailure(failure: NicoliveFailure): Prom
     });
   }
 
+  /** 4xx, 5xxエラーに対する文言がなかったら400や500向けの文言を出す */
   return openErrorDialog({
-    title: $t(`nicolive-program.errors.api.${failure.method}.${failure.reason}.title`),
+    title: $t(`nicolive-program.errors.api.${failure.method}.${failure.reason}.title`, {
+      fallback: $t(`nicolive-program.errors.api.${failure.method}.${fallbackToX00(failure.reason)}.title`),
+    }),
     message: $t(`nicolive-program.errors.api.${failure.method}.${failure.reason}.message`, {
       additionalMessage: failure.additionalMessage,
+      fallback: $t(`nicolive-program.errors.api.${failure.method}.${fallbackToX00(failure.reason)}.message`, {
+        additionalMessage: failure.additionalMessage,
+      }),
     }),
   });
 }


### PR DESCRIPTION
# このpull requestが解決する内容
400番台、500番台のエラーで文言定義がないときに400番、500番にフォールバックするようにします

# 動作確認手順
（現時点で未定義かつ400,500の定義はあるエラーを起こさないといけない……？）

# 関連するIssue（あれば）
