### PR TITLE
改善: 毎秒最大200個の関数を無駄に生成していたのを修正

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -69,8 +69,10 @@ export default class CommentViewer extends Vue {
   }
 
   private get filterFn() {
+    // getterなので関数内に入れない
+    const { filterFn } = this.nicoliveCommentLocalFilterService;
     return (item: WrappedChat) => {
-      return item.type !== 'invisible' && this.nicoliveCommentLocalFilterService.filterFn(item);
+      return item.type !== 'invisible' && filterFn(item);
     };
   }
 

--- a/app/services/nicolive-program/nicolive-comment-local-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-local-filter.test.ts
@@ -15,7 +15,7 @@ function makeWrapper(value: object, type: 'normal' | 'system' = 'normal') {
     type,
     value,
     seqId: 0,
-  }
+  };
 }
 
 beforeEach(() => {
@@ -35,11 +35,12 @@ test('filterFn/初期値', async () => {
   const { NicoliveCommentLocalFilterService } = require('./nicolive-comment-local-filter');
   const instance = NicoliveCommentLocalFilterService.instance as NicoliveCommentLocalFilterService;
 
-  expect(instance.filterFn(makeWrapper({}))).toBe(true);
-  expect(instance.filterFn(makeWrapper({ score: -4799 }))).toBe(true);
-  expect(instance.filterFn(makeWrapper({ score: -4800 }))).toBe(false);
-  expect(instance.filterFn(makeWrapper({ anonymity: 1 }))).toBe(true);
-  expect(instance.filterFn(makeWrapper({ anonymity: 1 }, 'system'))).toBe(true);
+  const { filterFn } = instance;
+  expect(filterFn(makeWrapper({}))).toBe(true);
+  expect(filterFn(makeWrapper({ score: -4799 }))).toBe(true);
+  expect(filterFn(makeWrapper({ score: -4800 }))).toBe(false);
+  expect(filterFn(makeWrapper({ anonymity: 1 }))).toBe(true);
+  expect(filterFn(makeWrapper({ anonymity: 1 }, 'system'))).toBe(true);
 });
 
 test('filterFn/184非表示', async () => {
@@ -49,7 +50,8 @@ test('filterFn/184非表示', async () => {
 
   instance.showAnonymous = false;
 
-  expect(instance.filterFn(makeWrapper({}))).toBe(true);
-  expect(instance.filterFn(makeWrapper({ anonymity: 1 }))).toBe(false);
-  expect(instance.filterFn(makeWrapper({ anonymity: 1 }, 'system'))).toBe(true);
+  const { filterFn } = instance;
+  expect(filterFn(makeWrapper({}))).toBe(true);
+  expect(filterFn(makeWrapper({ anonymity: 1 }))).toBe(false);
+  expect(filterFn(makeWrapper({ anonymity: 1 }, 'system'))).toBe(true);
 });

--- a/app/services/nicolive-program/nicolive-comment-local-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-local-filter.ts
@@ -27,10 +27,6 @@ export class NicoliveCommentLocalFilterService extends PersistentStatefulService
     return ['none', 'low', 'mid', 'high'];
   }
 
-  private get threshold() {
-    return LEVEL_TABLE[this.state.level];
-  }
-
   get level() {
     return this.state.level;
   }
@@ -48,10 +44,11 @@ export class NicoliveCommentLocalFilterService extends PersistentStatefulService
   }
 
   get filterFn() {
+    const threshold = LEVEL_TABLE[this.state.level];
     return (message: WrappedChat): boolean => {
       if (message.type !== 'normal') return true;
 
-      const ngSharingOk = this.threshold < getScore(message.value);
+      const ngSharingOk = threshold < getScore(message.value);
       if (!ngSharingOk) return false;
 
       const anonymityOk = this.showAnonymous || !isAnonymous(message.value);


### PR DESCRIPTION
# このpull requestが解決する内容
rel. https://github.com/n-air-app/n-air-app/pull/432#discussion_r384448577
Vueのメモ化が効くつもりでgetterをArray.prototype.filterに渡す関数の中で毎回呼び出していた結果、関数をwrapしている動作も併せて、全要素に対して新規のフィルター関数を生成していました。
コメントリストの更新があってもフィルター関数をいい感じに使いまわすようになります。

# 動作確認手順
1. N Airを起動
2. ログインしていなければログイン
3. 番組を取得または作成
4. （目的とする影響がないか）184フィルターの有効無効を切り替えて動作すること

# 関連するIssue（あれば）
