### PR TITLE
追加: ログイン画面にクリップボード操作のコンテキストメニューを追加

### DIFF
--- a/app/services/settings/optimizer.test.ts
+++ b/app/services/settings/optimizer.test.ts
@@ -30,6 +30,7 @@ jest.mock('services-manager', () => ({}));
 jest.mock('services/ipc-server', () => ({}));
 jest.mock('services/jsonrpc/jsonrpc', () => ({}));
 jest.mock('services/jsonrpc', () => ({}));
+jest.mock('util/menus/Menu', () => ({}));
 
 const setup = createSetupFunction({
     injectee: {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -5,6 +5,7 @@ import { PersistentStatefulService } from './persistent-stateful-service';
 import { Inject } from '../util/injector';
 import { mutation } from './stateful-service';
 import electron from 'electron';
+import { Menu } from 'util/menus/Menu';
 import { HostsService } from './hosts';
 import {
   getPlatformService,
@@ -34,6 +35,7 @@ import {
 } from 'os';
 import { memoryUsage as nodeMemUsage } from 'process';
 import { QuestionaireService } from './questionaire';
+import { $t } from './i18n';
 
 // Eventually we will support authing multiple platforms at once
 interface IUserServiceState {
@@ -252,6 +254,48 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
 
     authWindow.once('close', () => {
       onAuthClose();
+    });
+
+    authWindow.webContents.on('context-menu', (e, params) => {
+      if (params.isEditable) {
+        const menu = new Menu();
+
+        menu.append({
+          id: 'Cut',
+          label: $t('common.cut'),
+          role: 'cut',
+          accelerator: 'CommandOrControl+X',
+          enabled: params.editFlags.canCut,
+        });
+        menu.append({
+          id: 'Copy',
+          label: $t('common.copy'),
+          role: 'copy',
+          accelerator: 'CommandOrControl+C',
+          enabled: params.editFlags.canCopy,
+        });
+        menu.append({
+          id: 'Paste',
+          label: $t('common.paste'),
+          role: 'paste',
+          accelerator: 'CommandOrControl+V',
+          enabled: params.editFlags.canPaste,
+        });
+
+        menu.popup();
+      } else if (params.selectionText) {
+        const menu = new Menu();
+
+        menu.append({
+          id: 'Copy',
+          label: $t('common.copy'),
+          role: 'copy',
+          accelerator: 'CommandOrControl+C',
+          enabled: params.editFlags.canCopy,
+        });
+
+        menu.popup();
+      }
     });
 
     authWindow.setMenu(null);


### PR DESCRIPTION
# このpull requestが解決する内容
ログイン画面(WebView)内でクリップボード操作のコンテキストメニューを表示します。

* 編集可能アイテムの場合(日本語)
![image](https://user-images.githubusercontent.com/864587/76084697-d268da00-5ff3-11ea-916e-e33d803f60ed.png)

* 編集可能ではないがテキストを選択している場合(日本語)
![image](https://user-images.githubusercontent.com/864587/76084740-f62c2000-5ff3-11ea-955c-106bed14da37.png)

# 動作確認手順
ログイン画面のテキスト入力欄などで右クリックし、クリップボード操作(cut/copy/paste)，が適宜実際の状態に会わせて有効・無効表示となり、有効の場合は動作することを確認する。

# 関連するIssue（あれば）
#404 