### PR TITLE
追加: クリップボードメニューを番組作成・編集画面にも追加する

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -1,6 +1,9 @@
 import * as fetchMock from 'fetch-mock';
 const { NicoliveClient } = require('./NicoliveClient');
 
+jest.mock('services/i18n', () => ({
+  $t: (x: any) => x,
+}));
 jest.mock('util/menus/Menu', () => ({}));
 
 afterEach(() => {

--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -1,6 +1,8 @@
 import * as fetchMock from 'fetch-mock';
 const { NicoliveClient } = require('./NicoliveClient');
 
+jest.mock('util/menus/Menu', () => ({}));
+
 afterEach(() => {
   fetchMock.reset();
 });

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -12,6 +12,7 @@ import {
   Filters,
   FilterRecord
 } from './ResponseTypes';
+import { addClipboardMenu } from 'util/addClipboardMenu';
 const { BrowserWindow } = remote;
 
 export enum CreateResult {
@@ -407,6 +408,7 @@ export class NicoliveClient {
       },
     });
     return new Promise<CreateResult>((resolve, _reject) => {
+      addClipboardMenu(win);
       win.on('closed', () => resolve(CreateResult.OTHER));
       win.webContents.on('did-navigate', (_event, url) => {
         if (NicoliveClient.isProgramPage(url)) {
@@ -439,6 +441,7 @@ export class NicoliveClient {
       },
     });
     return new Promise<EditResult>((resolve, _reject) => {
+      addClipboardMenu(win);
       win.on('closed', () => resolve(EditResult.OTHER));
       win.webContents.on('did-navigate', (_event, url) => {
         if (NicoliveClient.isProgramPage(url) || NicoliveClient.isMyPage(url)) {

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -18,6 +18,8 @@ jest.mock('services/nicolive-program/nicolive-program', () => ({ NicoliveProgram
 // NicoliveFailureが依存している
 jest.mock('services/i18n', () => ({}));
 
+jest.mock('util/menus/Menu', () => ({}));
+
 beforeEach(() => {
   jest.doMock('services/stateful-service');
   jest.doMock('util/injector');

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -114,6 +114,7 @@ jest.mock('services/nicolive-program/state', () => ({ NicoliveProgramStateServic
 jest.mock('services/i18n', () => ({
   $t: (x: any) => x,
 }));
+jest.mock('util/menus/Menu', () => ({}));
 
 beforeEach(() => {
   jest.doMock('services/stateful-service');

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -35,7 +35,7 @@ import {
 } from 'os';
 import { memoryUsage as nodeMemUsage } from 'process';
 import { QuestionaireService } from './questionaire';
-import { $t } from './i18n';
+import { addClipboardMenu } from 'util/addClipboardMenu';
 
 // Eventually we will support authing multiple platforms at once
 interface IUserServiceState {
@@ -256,47 +256,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       onAuthClose();
     });
 
-    authWindow.webContents.on('context-menu', (e, params) => {
-      if (params.isEditable) {
-        const menu = new Menu();
-
-        menu.append({
-          id: 'Cut',
-          label: $t('common.cut'),
-          role: 'cut',
-          accelerator: 'CommandOrControl+X',
-          enabled: params.editFlags.canCut,
-        });
-        menu.append({
-          id: 'Copy',
-          label: $t('common.copy'),
-          role: 'copy',
-          accelerator: 'CommandOrControl+C',
-          enabled: params.editFlags.canCopy,
-        });
-        menu.append({
-          id: 'Paste',
-          label: $t('common.paste'),
-          role: 'paste',
-          accelerator: 'CommandOrControl+V',
-          enabled: params.editFlags.canPaste,
-        });
-
-        menu.popup();
-      } else if (params.selectionText) {
-        const menu = new Menu();
-
-        menu.append({
-          id: 'Copy',
-          label: $t('common.copy'),
-          role: 'copy',
-          accelerator: 'CommandOrControl+C',
-          enabled: params.editFlags.canCopy,
-        });
-
-        menu.popup();
-      }
-    });
+    addClipboardMenu(authWindow);
 
     authWindow.setMenu(null);
     authWindow.loadURL(service.authUrl);

--- a/app/util/addClipboardMenu.ts
+++ b/app/util/addClipboardMenu.ts
@@ -1,5 +1,5 @@
 import { Menu } from 'util/menus/Menu';
-import { $t } from '../services/i18n';
+import { $t } from 'services/i18n';
 
 export function addClipboardMenu(window: Electron.BrowserWindow) {
   window.webContents.on('context-menu', (e, params) => {

--- a/app/util/addClipboardMenu.ts
+++ b/app/util/addClipboardMenu.ts
@@ -1,0 +1,43 @@
+import { Menu } from 'util/menus/Menu';
+import { $t } from '../services/i18n';
+
+export function addClipboardMenu(window: Electron.BrowserWindow) {
+  window.webContents.on('context-menu', (e, params) => {
+    if (params.isEditable) {
+      const menu = new Menu();
+      menu.append({
+        id: 'Cut',
+        label: $t('common.cut'),
+        role: 'cut',
+        accelerator: 'CommandOrControl+X',
+        enabled: params.editFlags.canCut,
+      });
+      menu.append({
+        id: 'Copy',
+        label: $t('common.copy'),
+        role: 'copy',
+        accelerator: 'CommandOrControl+C',
+        enabled: params.editFlags.canCopy,
+      });
+      menu.append({
+        id: 'Paste',
+        label: $t('common.paste'),
+        role: 'paste',
+        accelerator: 'CommandOrControl+V',
+        enabled: params.editFlags.canPaste,
+      });
+      menu.popup();
+    }
+    else if (params.selectionText) {
+      const menu = new Menu();
+      menu.append({
+        id: 'Copy',
+        label: $t('common.copy'),
+        role: 'copy',
+        accelerator: 'CommandOrControl+C',
+        enabled: params.editFlags.canCopy,
+      });
+      menu.popup();
+    }
+  });
+}


### PR DESCRIPTION
# このpull requestが解決する内容
#439 と同様に、番組作成画面と編集画面でもクリップボード操作のコンテキストメニューを追加します。

# 動作確認手順
番組作成画面と編集画面で、それぞれ右クリックしてクリップボードが扱えることを確認する

# 関連するIssue（あれば）
#404 