### PR TITLE
変更: NG追加した際に取得済みコメントを隠す

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -9,7 +9,7 @@ import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nic
 import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
 import { Menu } from 'util/menus/Menu';
 import { clipboard } from 'electron';
-import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
+import { NicoliveCommentFilterService, getContentWithFilter } from 'services/nicolive-program/nicolive-comment-filter';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import { ChatMessageType } from 'services/nicolive-program/ChatMessage/classifier';
 import CommonComment from './comment/CommonComment.vue';
@@ -88,7 +88,7 @@ export default class CommentViewer extends Vue {
   }
 
   pinnedItemComtent(item: WrappedChat): string {
-    return `${item.value.content}  (${this.getFormattedLiveTime(item.value)})`;
+    return `${getContentWithFilter(item)}  (${this.getFormattedLiveTime(item.value)})`;
   }
 
   componentMap = componentMap;

--- a/app/components/nicolive-area/comment/CommonComment.vue.ts
+++ b/app/components/nicolive-area/comment/CommonComment.vue.ts
@@ -3,22 +3,26 @@ import { Component, Prop } from 'vue-property-decorator';
 import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
 import { parseContent } from 'services/nicolive-program/ChatMessage/util';
 import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { getContentWithFilter } from 'services/nicolive-program/nicolive-comment-filter';
 
 @Component({})
 export default class CommonComment extends Vue {
-  @Prop() chat: WrappedChat;
-  @Prop({ default: false }) commentMenuOpened: boolean;
-  @Prop() getFormattedLiveTime: (chat: ChatMessage) => string;
+  @Prop()
+  chat: WrappedChat;
+  @Prop({ default: false })
+  commentMenuOpened: boolean;
+  @Prop()
+  getFormattedLiveTime: (chat: ChatMessage) => string;
 
   get computedContent() {
     if (this.chat.type === 'normal') {
-      return this.chat.value.content ?? '';
+      return getContentWithFilter(this.chat);
     }
     const parsed = parseContent(this.chat.value);
     return parsed.values.join(' ');
   }
 
   get computedTitle() {
-    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`
+    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`;
   }
 }

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -177,3 +177,30 @@ test('deleteFilters/失敗', async () => {
 
   expect(UPDATE_FILTERS).toHaveBeenCalledTimes(0);
 });
+
+test('applyFilter', async () => {
+  setup();
+  const { NicoliveCommentFilterService } = require('./nicolive-comment-filter');
+  const instance = NicoliveCommentFilterService.instance as NicoliveCommentFilterService;
+  instance.state.filters = [
+    { type: 'word', body: 'needle', id: 1 },
+    { type: 'command', body: 'needle', id: 2 },
+    { type: 'user', body: 'user needle', id: 3 },
+  ];
+
+  const chats = [
+    { seqId: 0, type: 'normal', value: { content: 'content needle' } },
+    { seqId: 1, type: 'normal', value: { user_id: 'user needle' } },
+    { seqId: 2, type: 'normal', value: { mail: 'mail needle' } },
+    { seqId: 3, type: 'operator', value: { content: 'content needle' } },
+    { seqId: 4, type: 'operator', value: { user_id: 'user needle' } },
+  ] as const;
+
+  const after = chats.map(c => instance.applyFilter(c));
+
+  expect(after[0].filtered).toBe(true);
+  expect(after[1].filtered).toBe(true);
+  expect(after[2].filtered).toBe(true);
+  expect(after[3].filtered).toBeFalsy();
+  expect(after[4].filtered).toBeFalsy();
+});

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -2,9 +2,16 @@ import { createSetupFunction } from 'util/test-setup';
 import { Subject } from 'rxjs';
 type NicoliveCommentViewerService = import('./nicolive-comment-viewer').NicoliveCommentViewerService;
 
-const setup = createSetupFunction();
+const setup = createSetupFunction({
+  injectee: {
+    NicoliveCommentFilterService: {
+      stateChange: new Subject(),
+    },
+  },
+});
 
-jest.mock('services/nicolive-program/nicolive-program', () => ({ NicoliveProgramStateService: {} }));
+jest.mock('services/nicolive-program/nicolive-program', () => ({ NicoliveProgramService: {} }));
+jest.mock('services/nicolive-program/nicolive-comment-filter', () => ({ NicoliveCommentFilterService: {} }));
 
 beforeEach(() => {
   jest.doMock('services/stateful-service');


### PR DESCRIPTION
# このpull requestが解決する内容
resolve #438 

NGを追加したときに既にリストに表示されているコメントを `##このコメントは表示されません##` 表示にします。
ピン止めしてあるコメントは再度ピン止めすると状態が更新されます（特に意図はない）。

|before|after|
|----|----|
|![image](https://user-images.githubusercontent.com/950573/77758424-4b4cd600-7076-11ea-8782-7eae28567f26.png)|![image](https://user-images.githubusercontent.com/950573/77758456-57d12e80-7076-11ea-93b8-7ff9f4c67b1b.png)|



# 動作確認手順
1. N Airを起動する
2. ログインしていなければログインする
3. 番組を取得または作成し、番組を開始する
4. 放送しているアカウントと別のアカウントを使ってNGにならない通常コメントを投稿する
5. 投稿した通常コメントが該当するようなNG設定を追加する
6. コメントリストに戻ると`##このコメントは表示されません##` 表示になる
7. 追加したNG設定を解除する
8. コメントリストに戻るとコメントが元の文に戻る

# 関連するIssue（あれば）
#438 