### PR TITLE
変更: ソースプリセットで使用するファイルへの相対参照を独自解決

### DIFF
--- a/app/services/scene-collections/nodes/sources-util.test.ts
+++ b/app/services/scene-collections/nodes/sources-util.test.ts
@@ -1,0 +1,56 @@
+import { convertPresetPath, revertPresetPath } from './sources-util';
+
+jest.mock('electron', () => ({}));
+jest.mock('./sources', () => ({}));
+
+const DUMMY_BASE_PATH = 'c:\\Users\\user';
+
+const ABSOLUTES = [
+  '\\',
+  '\\\\',
+  'c:\\',
+  'd:\\',
+  'c:\\Users\\another',
+  '\\\\server\\file'
+];
+
+const INNER_RELATIVES = [
+  '.',
+  'c:cwd/another',
+  'cwd/another'
+];
+
+const OUTER_RELATIVES = [
+  '..',
+  '../yay'
+];
+
+test('convertPresetPath: as-is', () => {
+  for (const p of ABSOLUTES) {
+    expect(convertPresetPath(p, DUMMY_BASE_PATH)).toBe(p);
+  }
+  for (const p of OUTER_RELATIVES) {
+    expect(convertPresetPath(p, DUMMY_BASE_PATH)).toBe(p);
+  }
+});
+
+test('convertPresetPath: convert', () => {
+  expect(convertPresetPath('file', DUMMY_BASE_PATH)).toBe('c:\\Users\\user\\file');
+  expect(convertPresetPath('./file', DUMMY_BASE_PATH)).toBe('c:\\Users\\user\\file');
+  expect(convertPresetPath('c:cwd/another', DUMMY_BASE_PATH)).toBe('c:\\Users\\user\\cwd\\another');
+  expect(convertPresetPath('cwd/another', DUMMY_BASE_PATH)).toBe('c:\\Users\\user\\cwd\\another');
+});
+
+test('revertPresetPath: as-is', () => {
+  for (const p of ABSOLUTES) {
+    expect(revertPresetPath(p, DUMMY_BASE_PATH)).toBe(p);
+  }
+  for (const p of OUTER_RELATIVES) {
+    expect(revertPresetPath(p, DUMMY_BASE_PATH)).toBe(p);
+  }
+});
+
+test('revertPresetPath: revert', () => {
+  expect(revertPresetPath('c:\\Users\\user\\file', DUMMY_BASE_PATH)).toBe('file');
+  expect(revertPresetPath('c:\\Users\\user\\cwd\\another', DUMMY_BASE_PATH)).toBe('cwd\\another');
+})

--- a/app/services/scene-collections/nodes/sources-util.ts
+++ b/app/services/scene-collections/nodes/sources-util.ts
@@ -1,0 +1,69 @@
+import { isAbsolute, relative, basename, dirname, resolve } from 'path';
+import { remote } from 'electron';
+import { ISourceInfo } from './sources';
+
+function getPresetBasePath() {
+  const execFile = basename(process.execPath).toLowerCase()
+  const isPackaged = execFile !== 'electron.exe';
+
+  const APP_PATH = remote.app.getAppPath();
+  const EXE_DIR_PATH = dirname(remote.app.getPath('exe'));
+  return isPackaged ? EXE_DIR_PATH : APP_PATH;
+}
+
+/** export for testing */
+export function convertPresetPath(pathMaybePreset: string, presetBasePath = getPresetBasePath()): string {
+  if (isAbsolute(pathMaybePreset)) {
+    return pathMaybePreset;
+  }
+
+  const isOuterPath = pathMaybePreset.startsWith('..');
+  if (isOuterPath) {
+    return pathMaybePreset;
+  }
+
+  const absolutePath = resolve(presetBasePath, pathMaybePreset);
+  return absolutePath;
+}
+
+/** export for testing */
+export function revertPresetPath(pathMaybePreset: string, presetBasePath = getPresetBasePath()): string {
+  if (!isAbsolute(pathMaybePreset)) {
+    return pathMaybePreset;
+  }
+
+  const relativePath = relative(presetBasePath, pathMaybePreset);
+  // Files in another drive or in a network drive
+  if (isAbsolute(relativePath)) {
+    return pathMaybePreset;
+  }
+
+  const isOuterPath = relativePath.startsWith('..');
+  if (isOuterPath) {
+    return pathMaybePreset;
+  }
+
+  return relativePath;
+}
+
+/** プリセットのファイル参照をつねにexeから相対パスとして解釈する */
+export function applyPathConvertForPreset(
+  sourceType: ISourceInfo['type'],
+  settings: ISourceInfo['settings']
+): ISourceInfo['settings'] {
+  if (sourceType === 'image_source' && typeof settings.file === 'string') {
+    settings.file = convertPresetPath(settings.file);
+  }
+  return settings;
+}
+
+export function unapplyPathConvertForPreset(
+  sourceType: ISourceInfo['type'],
+  settings: ISourceInfo['settings']
+): ISourceInfo['settings'] {
+  if (sourceType === 'image_source' && typeof settings.file === 'string') {
+    settings.file = revertPresetPath(settings.file);
+  }
+  return settings;
+}
+

--- a/app/services/scene-collections/nodes/sources-util.ts
+++ b/app/services/scene-collections/nodes/sources-util.ts
@@ -17,6 +17,7 @@ export function convertPresetPath(pathMaybePreset: string, presetBasePath = getP
     return pathMaybePreset;
   }
 
+  // This is enough to detect that it's not a preset file
   const isOuterPath = pathMaybePreset.startsWith('..');
   if (isOuterPath) {
     return pathMaybePreset;
@@ -38,6 +39,7 @@ export function revertPresetPath(pathMaybePreset: string, presetBasePath = getPr
     return pathMaybePreset;
   }
 
+  // This is enough to detect that it's not a preset file
   const isOuterPath = relativePath.startsWith('..');
   if (isOuterPath) {
     return pathMaybePreset;

--- a/app/services/scene-collections/nodes/sources-util.ts
+++ b/app/services/scene-collections/nodes/sources-util.ts
@@ -11,7 +11,10 @@ function getPresetBasePath() {
   return isPackaged ? EXE_DIR_PATH : APP_PATH;
 }
 
-/** export for testing */
+/**
+ * export for testing
+ * JSONから読みだしたパスのうちプリセットと判定できるものを、実際にOBSに渡すパスに変換する
+ */
 export function convertPresetPath(pathMaybePreset: string, presetBasePath = getPresetBasePath()): string {
   if (isAbsolute(pathMaybePreset)) {
     return pathMaybePreset;
@@ -27,7 +30,10 @@ export function convertPresetPath(pathMaybePreset: string, presetBasePath = getP
   return absolutePath;
 }
 
-/** export for testing */
+/**
+ * export for testing
+ * プリセットのファイルを参照するパスを、JSONに書き出す用の相対パスに変換する
+ */
 export function revertPresetPath(pathMaybePreset: string, presetBasePath = getPresetBasePath()): string {
   if (!isAbsolute(pathMaybePreset)) {
     return pathMaybePreset;

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -11,6 +11,7 @@ import { Inject } from '../../../util/injector';
 import * as obs from '../../../../obs-api';
 import * as fi from 'node-fontinfo';
 import { $t } from 'services/i18n';
+import { unapplyPathConvertForPreset, applyPathConvertForPreset } from './sources-util';
 
 interface ISchema {
   items: ISourceInfo[];
@@ -82,7 +83,7 @@ export class SourcesNode extends Node<ISchema, {}> {
             id: source.sourceId,
             name: source.name,
             type: source.type,
-            settings: obsInput.settings,
+            settings: unapplyPathConvertForPreset(source.type, obsInput.settings),
             volume: obsInput.volume,
             channel: source.channel,
             hotkeys,
@@ -209,7 +210,7 @@ export class SourcesNode extends Node<ISchema, {}> {
         name: source.id,
         type: source.type,
         muted: source.muted || false,
-        settings: source.settings,
+        settings: applyPathConvertForPreset(source.type, source.settings),
         volume: source.volume,
         filters: source.filters.items.map(filter => {
           return {


### PR DESCRIPTION
# このpull requestが解決する内容
resolves #400

ソースプロパティでファイルを指定する箇所に相対パスを書いていると、実験版と通常版で解決の起点が変わります。この影響でソースプリセット機能に互換性がなくなっていたのが #400 です。

この変更では、ソースプリセットで使用しているソース種別かつファイル指定をするプロパティについて、その値が相対パスで親ディレクトリへの参照を含まないものに対し、アプリケーションディレクトリを起点として絶対パスに変換する処理を追加します。
JSONへの書き出しの際は、アプリケーションディレクトリ配下のファイルは全て相対パスに戻して書き出します。

維持できること：プリセットで生成したソースの互換性
変わること：アプリケーションディレクトリ配下への絶対パス参照は常に相対パスとして保存される

# 動作確認手順
#394 に準ずる、ただし実験版・通常版と開発時・パッケージング後で2x2=4パターンでの動作を見る必要がある。

プリセットで生成したソースと同一の画像を同じように相対パスで参照するソースがあれば、プリセットを毎回再生成しなくてよい。
どのパターンでも画像が表示されていれば問題ない。

# 関連するIssue（あれば）
#400 

# 補足
#400 に関連して、アプリケーションディレクトリ外への相対パス参照が使われていた場合、実験版と通常版間での動作変化は変わらずに発生してしまいます。
この動作を嫌って、一括で相対パスの解釈を変更することは手間で、どの種別のソースのどのプロパティがファイル参照を表現する値かを列挙する必要があります。これは常にobs-studio-nodeやobs側の定義に一致させる必要を伴います。

また、相対パスの解決起点となるワーキングディレクトリを変更することは、obs-studio-nodeの実装に由来して困難だと思われます。