### PR TITLE
開発: crash report送信先をbacktraceからsentryに変更

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -28,22 +28,37 @@ const { ipcRenderer, remote } = electron;
 const nAirVersion = remote.process.env.NAIR_VERSION;
 const isProduction = process.env.NODE_ENV === 'production';
 
+type SentryParams = {
+  organization: string
+  key: string
+  project: string
+}
+const sentryOrg = 'o170115';
+
+function getSentryDsn(p: SentryParams): string {
+  return `https://${p.key}@${p.organization}.ingest.sentry.io/${p.project}`;
+}
+
+function getSentryCrashReportUrl(p: SentryParams): string {
+  return `https://${p.organization}.ingest.sentry.io/api/${p.project}/minidump/?sentry_key=${p.key}`;
+}
+
 // This is the development DSN
-let sentryDsn = 'https://1cb5cdf6a93c466dad570861b8c82b61@sentry.io/1262580';
+let sentryParam: SentryParams = {
+  organization: sentryOrg, project: '1262580', key: '1cb5cdf6a93c466dad570861b8c82b61'
+};
 
 if (isProduction) {
   // This is the production DSN
-  sentryDsn = Utils.isUnstable()
-    ? 'https://7451aaa71b7640a69ee1d31d6fd9ef78@sentry.io/1546758'
-    : 'https://35a02d8ebec14fd3aadc9d95894fabcf@sentry.io/1246812';
+  sentryParam = Utils.isUnstable()
+    ? {organization: sentryOrg, project: '1546758', key: '7451aaa71b7640a69ee1d31d6fd9ef78'}
+    : {organization: sentryOrg, project: '1246812', key: '35a02d8ebec14fd3aadc9d95894fabcf'};
 
   electron.crashReporter.start({
     productName: 'n-air-app',
     companyName: 'n-air-app',
     submitURL:
-      'https://n-air-app.sp.backtrace.io:8443/post?' +
-      'format=minidump&' +
-      'token=66abc2eda8a8ead580b825dd034d9b4f9da4d54eeb312bf8ce713571e1b1d35f',
+      getSentryCrashReportUrl(sentryParam),
     extra: {
       version: nAirVersion,
       processType: 'renderer'
@@ -52,7 +67,7 @@ if (isProduction) {
 }
 
 if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.process.env.NAIR_IPC) {
-  Raven.config(sentryDsn, {
+  Raven.config(getSentryDsn(sentryParam), {
     release: nAirVersion,
     dataCallback: data => {
       // Because our URLs are local files and not publicly

--- a/main.js
+++ b/main.js
@@ -114,8 +114,8 @@ function startApp() {
 
   if (pjson.env === 'production') {
     const params = !!process.env.NAIR_UNSTABLE
-      ? {project: '1546758', key: '7451aaa71b7640a69ee1d31d6fd9ef78'}
-      : {project: '1246812', key: '35a02d8ebec14fd3aadc9d95894fabcf'};
+      ? {project: '5372801', key: '819e76e51864453aafd28c6d0473881f'} // crash-reporter-unstable
+      : {project: '1520076', key: 'd965eea4b2254c2b9f38d2346fb8a472'}; // crash-reporter
 
     Raven.config(`https://${params.key}@o170115.ingest.sentry.io/${params.project}`, {
       release: process.env.NAIR_VERSION

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "archiver": "^2.0.3",
     "aws-sdk": "^2.43.0",
-    "backtrace-node": "^0.7.3",
     "base64-js": "^1.3.0",
     "css-element-queries": "^1.2.1",
     "electron-updater": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3210,15 +3210,6 @@ backo2@1.0.2:
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
   integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
-backtrace-node@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/backtrace-node/-/backtrace-node-0.7.3.tgz#cdc0d1f89f45a1d30fb3b77a2311947eea339e08"
-  integrity sha1-zcDR+J9FodMPs7d6IxGUfuozngg=
-  dependencies:
-    pend "~1.2.0"
-    source-scan "~1.0.1"
-    streamsink "~1.2.0"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -11845,13 +11836,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-scan@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/source-scan/-/source-scan-1.0.1.tgz#0ba9f8c2a9356f9531a65beb48b7bb376504e97b"
-  integrity sha1-C6n4wqk1b5UxplvrSLe7N2UE6Xs=
-  dependencies:
-    streamsink "~1.2.0"
-
 spdx-correct@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
@@ -12000,11 +11984,6 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
-
-streamsink@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/streamsink/-/streamsink-1.2.0.tgz#efafee9f1e22d3591ed7de3dcaa95c3f5e79f73c"
-  integrity sha1-76/unx4i01ke1949yqlcP1559zw=
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
# このpull requestが解決する内容
app.ts の送信先は n-air-app などの通常のsentryへ
main.js の送信先は crash-reporter, crash-reporter-unstable という新しい sentry projectに飛ばします

# 動作確認手順
* main.js, app.ts それぞれ
    * sentryParam を適当に結果が見られる場所に設定して `electron.crashReporter` を `start` させて、 `process.crash() などを呼ぶことで crashさせてsentryに到着することを確認する(手作業)
    * 参考: 起動して1秒でmain.jsをcrashさせる https://github.com/koizuka/n-air-app/commit/090dc0340f73311a9c1bc725e76f8e9cbc4303e8

# 関連するIssue（あれば）
#441 