### PR TITLE
修正: popperjs由来の外観変化を抑制

### DIFF
--- a/app/components/nicolive-area/AreaSwitcher.vue
+++ b/app/components/nicolive-area/AreaSwitcher.vue
@@ -4,7 +4,7 @@
       <slot :name="activeContent.slotName" />
     </div>
     <div class="header">
-      <popper trigger="hover" :options="{ placement: 'bottom-end' }">
+      <popper trigger="hover" :options="{ placement: 'bottom-start' }">
         <div class="popper">
           <ul class="selector">
             <li
@@ -79,7 +79,7 @@
 
 .selector {
   border-radius: 4px;
-  margin: 0 0 0 8px;
+  margin: 0;
   padding: 8px 1px;
   width: 330px;
   background-color: @bg-primary;
@@ -140,5 +140,17 @@
 
   display: flex;
   flex-direction: column;
+}
+
+.popper {
+  background-color: transparent;
+  padding: 0;
+  margin-left: 8px;
+  border: none;
+  text-align: unset;
+
+  & /deep/ .popper__arrow {
+    border-color: transparent !important;
+  }
 }
 </style>


### PR DESCRIPTION
# このpull requestが解決する内容

|stable|unstable|this fix(for unstable)|
|----|----|----|
|![image](https://user-images.githubusercontent.com/950573/84897721-0ec2d080-b0e1-11ea-8cff-ee45dc72a471.png)|![image](https://user-images.githubusercontent.com/950573/84897692-ff438780-b0e0-11ea-82f5-3fa277184081.png)|![image](https://user-images.githubusercontent.com/950573/84897702-07032c00-b0e1-11ea-8b16-c8c9afa55e59.png)|

# 動作確認手順

1. N Airを起動
2. ログインしていなければログイン
3. 番組を取得または作成
4. 画像を参考に「コメント」の個所にマウスホバーして表示されたものを確認

# 関連するIssue（あれば）
#400 