### PR TITLE
修正: 配信最適化時に出力が詳細になっているとハードウェアエンコーダーが選択されなかった(エンコーダー名称もおかしかった)

### DIFF
--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -110,6 +110,9 @@
       },
       "StreamEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
+        "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
+        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11",
+        "ffmpeg_nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc",
         "x264": "@:settings.Output.Streaming.Encoder.obs_x264",
         "qsv": "@:settings.Output.Streaming.Encoder.obs_qsv11",
         "nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc"

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -110,6 +110,9 @@
       },
       "StreamEncoder": {
         "name": "@:settings.Output.Streaming.Encoder.name",
+        "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
+        "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11",
+        "ffmpeg_nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc",
         "x264": "@:settings.Output.Streaming.Encoder.obs_x264",
         "qsv": "@:settings.Output.Streaming.Encoder.obs_qsv11",
         "nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc"

--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -37,13 +37,15 @@ export function getBestSettingsForNiconico(
         encoderPreset: 'ultrafast',
     };
     if (!('useHardwareEncoder' in options) || options.useHardwareEncoder) {
-        if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.nvenc)) {
+        if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.nvenc) ||
+            settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.advancedNvenc)) {
             encoderSettings = {
                 encoder: EncoderType.nvenc,
                 simpleUseAdvanced: true,
                 NVENCPreset: 'llhq',
             };
-        } else if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.qsv)) {
+        } else if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.qsv) ||
+            settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.advancedQsv)) {
             encoderSettings = {
                 encoder: EncoderType.qsv,
                 simpleUseAdvanced: true,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -5,7 +5,9 @@ export enum EncoderType {
   x264 = 'obs_x264',
   nvenc = 'nvenc',
   amd = 'amd_amf_h264',
-  qsv = 'qsv'
+  qsv = 'qsv',
+  advancedQsv = 'obs_qsv11',
+  advancedNvenc = 'ffmpeg_nvenc',
 }
 
 export enum OptimizationKey {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11743,8 +11743,8 @@ sisteransi@^1.0.0:
   integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
 
 "sl-vue-tree@https://github.com/stream-labs/sl-vue-tree":
-  version "1.5.1"
-  resolved "https://github.com/stream-labs/sl-vue-tree#03ff989b20e4d3441afa3f9c47839d4b7fcc37d8"
+  version "1.8.3"
+  resolved "https://github.com/stream-labs/sl-vue-tree#30627b72cdac4755e82816a2bf00737a7c5806e4"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# このpull requestが解決する内容
実験版ではエンコーダーの識別子が出力:基本と出力:詳細で異なっているため、現在詳細のときに基本へ移行させながら配信最適化を行うときに現在のエンコーダーの候補を取りこぼしてソフトウェアエンコードにフォールバックしてしまっていた。
あと、同じ理由で最適化確認ダイアログのエンコーダー名称も正しく表示されなかった。
以上2点を修正します。

TODO
- [x] qsv で動作確認
- [x] nvencで動作確認

# 動作確認手順
1. 出力モードを詳細にする
2. 出力のエンコーダをx264にする
3. ニコ生出番組を作成し、配信開始を押して、最適化確認ダイアログで、正しく現在の環境のハードウェアエンコーダを選択するように最適化する表示になっていることを確認する。
4. 設定画面を確認し、出力のエンコーダが最適化の表示通りになっていることを確認する。
5. 出力モードを基本にしたり、エンコーダを変更した組み合わせからの最適化も確認する(何かしら最適化で変化が起きるような設定にしていないとダイアログ自体出ないことに注意)。

# 関連するIssue（あれば）
fixes #403 
fixes #455 