### PR TITLE
修正: 不要になったNG共有フィルター設定を削除

### DIFF
--- a/app/components/nicolive-area/CommentLocalFilter.vue
+++ b/app/components/nicolive-area/CommentLocalFilter.vue
@@ -9,14 +9,6 @@
         <div class="name">匿名(184)のコメントを表示</div>
         <div class="value"><input type="checkbox" v-model="showAnonymous" class="toggle-button" /></div>
       </div>
-      <div class="row">
-        <div class="name">NG共有設定</div>
-        <div class="value">
-          <select v-model="level" class="nl-select">
-            <option v-for="lv in NG_SHARING_LEVELS" :key="lv" :value="lv" :label="NG_SHARING_LEVEL_LABELS[lv]" :selected="lv === level"></option>
-          </select>
-        </div>
-      </div>
     </div>
   </div>
 </template>

--- a/app/components/nicolive-area/CommentLocalFilter.vue.ts
+++ b/app/components/nicolive-area/CommentLocalFilter.vue.ts
@@ -3,7 +3,6 @@ import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import {
   NicoliveCommentLocalFilterService,
-  NGSharingLevel
 } from 'services/nicolive-program/nicolive-comment-local-filter';
 
 @Component({})
@@ -11,27 +10,8 @@ export default class CommentLocalFilter extends Vue {
   @Inject()
   private nicoliveCommentLocalFilterService: NicoliveCommentLocalFilterService;
 
-  NG_SHARING_LEVEL_LABELS = {
-    none: 'OFF',
-    low: '弱',
-    mid: '中',
-    high: '強',
-  };
-
   close() {
     this.$emit('close');
-  }
-
-  get NG_SHARING_LEVELS() {
-    return NicoliveCommentLocalFilterService.NG_SHARING_LEVELS;
-  }
-
-  get level() {
-    return this.nicoliveCommentLocalFilterService.level;
-  }
-
-  set level(level: NGSharingLevel) {
-    this.nicoliveCommentLocalFilterService.level = level;
   }
 
   get showAnonymous() {


### PR DESCRIPTION
# このpull requestが解決する内容
フィルター設定からNG共有フィルターを削除した

![キャプチャ](https://user-images.githubusercontent.com/43235200/90247571-d71e9d80-de71-11ea-9da0-78169399c0a3.PNG)


# 動作確認手順

1. N Airを起動する
2. ログインする
3. 番組を取得または作成し、番組を開始する
4. フィルター設定を開く
5. NG共有フィルターが削除されていることを確認する

# 関連するIssue（あれば）
https://github.com/n-air-app/n-air-app/issues/457