### PR TITLE
修正: 予約されたユーザー生放送でテスト配信できない不具合を修正

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -176,17 +176,19 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           }
 
           // 配信可能チャンネルがなく、配信できるユーザー生放送もない場合
-          if (!broadcastableUserProgram.programId) {
+          if (!broadcastableUserProgram.programId && !broadcastableUserProgram.nextProgramId) {
             return this.showNotBroadcastingMessageBox();
           }
         }
 
-        // 配信番組選択ウィンドウでチャンネル番組が選ばれた時はそのチャンネル番組を, それ以外の場合は放送中のユーザー番組を代入
+        // 配信番組選択ウィンドウでチャンネル番組が選ばれた時はそのチャンネル番組を, それ以外の場合は放送中のユーザー番組のIDを代入
+        // ユーザー番組については、即時番組があればそれを優先し、なければ予約番組の番組IDを採用する。
         const programId = 
             opts.nicoliveProgramSelectorResult &&
             opts.nicoliveProgramSelectorResult.providerType === 'channel' &&
             opts.nicoliveProgramSelectorResult.channelProgramId ?
-            opts.nicoliveProgramSelectorResult.channelProgramId : broadcastableUserProgram.programId;
+            opts.nicoliveProgramSelectorResult.channelProgramId :
+            (broadcastableUserProgram.programId || broadcastableUserProgram.nextProgramId)
 
         // 配信番組選択ウィンドウでユーザー番組を選んだが、配信可能なユーザー番組がない場合
         if (!programId) {


### PR DESCRIPTION
# このpull requestが解決する内容
予約されたユーザー番組で、放送開始30分前〜放送開始までの間の場合は、テスト放送時間としてストリームが流せるべきですが、そのような番組のIDを無視してしまっていたため流せなくなっていたので修正します。

# 動作確認手順
1. N Air にログインしておく
2. 番組を予約する
3. 放送開始30分前を切ったらN Airで「配信開始」を押す

# 関連するIssue（あれば）
#475 