### PR TITLE
修正: 2回目の範囲指定画面キャプチャで操作不能になる問題を回避

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -36,7 +36,11 @@ window['obs'] = window['require']('obs-studio-node');
 
 { // Set up things for IPC
   // Connect to the IPC Server
-  window['obs'].IPC.connect(remote.process.env.NAIR_IPC_PATH);
+  try {
+    window['obs'].IPC.connect(remote.process.env.NAIR_IPC_PATH);
+  } catch (e) {
+    console.log(`obs.IPC.connect failed: ${e}`);
+  }
   document.addEventListener('close', (e) => {
     window['obs'].IPC.disconnect();
   });


### PR DESCRIPTION
# このpull requestが解決する内容
現在2回目の範囲指定画面キャプチャ事に画面が真っ白になって操作不能になる問題があるが、操作不能になるのだけは回避する。

## 原因
* OneOffWindow の app.ts において obs.ipc.connect が obs-studio-node 内で5秒タイムアウトをして例外を発生しているが、これをcatchしていないため後続の初期化が行われないでなにもできないウィンドウが画面最大で残されることが操作不能の原因

## 対処内容
* 例外をcatchして続行されることで操作可能にする

## 注意
* 別途、範囲指定画面が半透明にならない問題もおきているが、こちらは未解明
* 5秒タイムアウト自体は解決しておらず、発生するのを待つため、2回目は範囲指定操作ができるようになるのに5秒かかります。範囲指定動作は機能しています。

# 動作確認手順
起動して、範囲指定キャプチャを2回行う

# 関連するIssue（あれば）
#407 