### PR TITLE
修正: 範囲指定画面キャプチャ時のタイトルバーと不透明な背景を除去

### DIFF
--- a/app/components/windows/OneOffWindow.vue
+++ b/app/components/windows/OneOffWindow.vue
@@ -1,7 +1,7 @@
 <template>
 <div style="height: 100%">
   <title-bar :title="options.title" class="child-window-titlebar" v-if="!options.isFullScreen" />
-  <div class="blank-slate">
+  <div class="blank-slate" v-if="!options.hideBlankSlate">
     <div class="spinner-spacer" />
     <i class="icon-spinner icon-spin modal-layout-spinner"/>
     <div class="spinner-spacer" />

--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -76,6 +76,7 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
       resizable: false,
       alwaysOnTop: true,
       isFullScreen: true, // hide TitleBar
+      hideBlankSlate: true,
     });
     this.SET_WINDOW_ID(windowId);
 

--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -75,6 +75,7 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
       transparent: true,
       resizable: false,
       alwaysOnTop: true,
+      isFullScreen: true, // hide TitleBar
     });
     this.SET_WINDOW_ID(windowId);
 

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -83,6 +83,7 @@ export interface IWindowOptions {
   preservePrevWindow?: boolean;
   prevWindowOptions? : IWindowOptions;
   isFullScreen?: boolean;
+  hideBlankSlate?: boolean;
 }
 
 interface IWindowsState {


### PR DESCRIPTION
# このpull requestが解決する内容
範囲指定画面キャプチャのときにオーバーレイしている画面に対して
1. ウィンドウのタイトルバーが付いてしまっている(右上に閉じるアイコンなどがある)のを消します。
2. 背景に不透明な塗りつぶしが挟まっているのを消します。

# 動作確認手順
範囲指定画面キャプチャをして、画面右上に閉じるアイコンなどがないこと、画面が半透明ごしに見えること

# 関連するIssue（あれば）
#478 