### PR TITLE
修正: 範囲指定画面キャプチャが下端を指定できなかった

### DIFF
--- a/app/components/windows/OneOffWindow.vue
+++ b/app/components/windows/OneOffWindow.vue
@@ -1,12 +1,12 @@
 <template>
 <div style="height: 100%">
   <title-bar :title="options.title" class="child-window-titlebar" v-if="!options.isFullScreen" />
-  <div class="blank-slate" v-if="!options.hideBlankSlate">
+  <div v-bind:class="['blank-slate', {'no-titlebar': options.isFullScreen}]" v-if="!options.hideBlankSlate">
     <div class="spinner-spacer" />
     <i class="icon-spinner icon-spin modal-layout-spinner"/>
     <div class="spinner-spacer" />
   </div>
-  <div class="child-window-content">
+  <div v-bind:class="['child-window-content', {'no-titlebar': options.isFullScreen}]">
     <component :is="options.componentName"/>
   </div>
 </div>
@@ -37,6 +37,10 @@
 
 .child-window-content {
   height: calc(~"100% - 26px"); // TitleBarぶんの高さを引く
+}
+
+.no-titlebar {
+  height: 100%;
 }
 
 .spinner-spacer {

--- a/app/components/windows/OneOffWindow.vue
+++ b/app/components/windows/OneOffWindow.vue
@@ -1,7 +1,7 @@
 <template>
 <div style="height: 100%">
   <title-bar :title="options.title" class="child-window-titlebar" v-if="!options.isFullScreen" />
-  <div v-bind:class="['blank-slate', {'no-titlebar': options.isFullScreen}]" v-if="!options.hideBlankSlate">
+  <div :class="['blank-slate', {'no-titlebar': options.isFullScreen}]" v-if="!options.hideBlankSlate">
     <div class="spinner-spacer" />
     <i class="icon-spinner icon-spin modal-layout-spinner"/>
     <div class="spinner-spacer" />

--- a/app/components/windows/OneOffWindow.vue
+++ b/app/components/windows/OneOffWindow.vue
@@ -6,7 +6,7 @@
     <i class="icon-spinner icon-spin modal-layout-spinner"/>
     <div class="spinner-spacer" />
   </div>
-  <div v-bind:class="['child-window-content', {'no-titlebar': options.isFullScreen}]">
+  <div :class="['child-window-content', {'no-titlebar': options.isFullScreen}]">
     <component :is="options.componentName"/>
   </div>
 </div>


### PR DESCRIPTION
# このpull requestが解決する内容
範囲指定画面キャプチャの指定可能範囲を正しくモニタ全体に広げます。

# 動作確認手順
範囲指定画面キャプチャをして下端が指定できることを確認する

# 関連するIssue（あれば）
ついでに #456 も直ると思われる