### PR TITLE
修正: プロジェクターを2つ以上開けるようにする(obs-studio-nodeを0.3.43に更新)

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,7 +92,7 @@ function startApp() {
     process.env.NAIR_IPC_PATH = "nair-".concat(uuid());
     process.env.NAIR_IPC_USERDATA = app.getPath('userData');
     // Host a new IPC Server and connect to it.
-    obs.IPC.ConnectOrHost(process.env.NAIR_IPC_PATH);
+    obs.IPC.host(process.env.NAIR_IPC_PATH);
     obs.NodeObs.SetWorkingDirectory(path.join(
       app.getAppPath().replace('app.asar', 'app.asar.unpacked'),
       'node_modules',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "DWANGO Co.,Ltd.",
   "license": "GPL-3.0",
   "//": {
-    "version": "0.9.3-preview.3"
+    "version": "0.11.2"
   },
   "version": "1.0.20200909-unstable.1",
   "main": "main.js",
@@ -73,9 +73,10 @@
     "lodash": "^4.17.4",
     "lodash-decorators": "^4.3.1",
     "moment": "^2.17.1",
-    "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.5/iojs-v2.0.5-node-fontinfo.tar.gz",
-    "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.2/iojs-v2.0.5-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.23/iojs-v2.0.8-signed.tar.gz",
+    "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.4/iojs-v2.0.8-font-manager.tar.gz",
+    "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.7/iojs-v2.0.8-node-fontinfo.tar.gz",
+    "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.6/iojs-v2.0.5-node-libuiohook.tar.gz",
+    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.43/iojs-v2.0.8-signed.tar.gz",
     "progress": "^2.0.0",
     "raven-js": "^3.20.1",
     "recursive-readdir": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6115,9 +6115,9 @@ fn-name@^2.0.0, fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
-"font-manager@https://github.com/stream-labs/font-manager/releases/download/v1.0.2/iojs-v2.0.5-font-manager.tar.gz":
+"font-manager@https://github.com/stream-labs/font-manager/releases/download/v1.0.4/iojs-v2.0.8-font-manager.tar.gz":
   version "0.4.0"
-  resolved "https://github.com/stream-labs/font-manager/releases/download/v1.0.2/iojs-v2.0.5-font-manager.tar.gz#bef49d76b44e6309c12ba45b1be46c859cb36c70"
+  resolved "https://github.com/stream-labs/font-manager/releases/download/v1.0.4/iojs-v2.0.8-font-manager.tar.gz#5ef61e39d7e37f9e887bdc244457869109b39fbd"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -9454,9 +9454,9 @@ node-fetch@^2.3.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
-"node-fontinfo@https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.5/iojs-v2.0.5-node-fontinfo.tar.gz":
+"node-fontinfo@https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.7/iojs-v2.0.8-node-fontinfo.tar.gz":
   version "0.0.2"
-  resolved "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.5/iojs-v2.0.5-node-fontinfo.tar.gz#14d72d13faab5db8b61b3ff52b6ccaef14256245"
+  resolved "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.7/iojs-v2.0.8-node-fontinfo.tar.gz#4a2e0f9266de871a16667750a8586575cfc9feb1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -9501,9 +9501,9 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-"node-libuiohook@https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.2/iojs-v2.0.5-node-libuiohook.tar.gz":
+"node-libuiohook@https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.6/iojs-v2.0.5-node-libuiohook.tar.gz":
   version "0.0.1"
-  resolved "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.2/iojs-v2.0.5-node-libuiohook.tar.gz#451c29370e8aa2fd197a1b3c6a11086612283ebf"
+  resolved "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.6/iojs-v2.0.5-node-libuiohook.tar.gz#f8e56033d446ff188c5a5bafca60f88ca26d47e8"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -9821,9 +9821,9 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.23/iojs-v2.0.8-signed.tar.gz":
+"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.43/iojs-v2.0.8-signed.tar.gz":
   version "0.3.21"
-  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.23/iojs-v2.0.8-signed.tar.gz#e2e1f421c045d500a1d0e9b24cd15bc5cdc0ad2e"
+  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.43/iojs-v2.0.8-signed.tar.gz#b499ff01a5df798a2a110a28b5a7d43ff46f04fc"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
# このpull requestが解決する内容
obs-studio-node 0.3.23 -> 0.3.43 (及び周辺moduleの差し替え、connect APIの変更)
主な変更
* IPCの接続数が少なくてProjectorの二つ目が開けなかった問題が解消します。

# 動作確認手順
普通に一通り使えること。Projectorを2つ開けること。(なお、閉じると不安定になる問題はこれでは解消しません)

# 関連するIssue（あれば）
