### PR TITLE
修正: ニコ生コメント最新100件を超えた分の保持を修正

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -179,7 +179,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
 
   private onMessage(values: WrappedChat[]) {
     const concatMessages = this.state.messages.concat(values);
-    const popoutMessages = concatMessages.slice(100);
+    const popoutMessages = concatMessages.slice(0, -100);
     this.SET_STATE({
       messages: concatMessages.slice(-100),
       popoutMessages,


### PR DESCRIPTION
# このpull requestが解決する内容
nicolive-comment-viewerのスクロール位置チェック用のpopoutMessages (今回の追加で最新100件を超えた内容の保持)の内容が意図した物になっていかったので修正し、unit testを追加しました。
なお、現状はこの内容を使っていないため、動作は特にバグになっていません。

# 動作確認手順
`yarn test:unit`
