### PR TITLE
修正: 番組説明文にあるリンクをクリックしたときにアプリの画面が置き換わってしまっていた

### DIFF
--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -2,7 +2,7 @@
   <div class="program-description">
     <div class="program-description-header">
     </div>
-    <div class="program-description-body">
+    <div @click="handleAnchorClick" class="program-description-body">
       <div v-html="programDescription" class="program-description-text"></div>
     </div>
   </div>


### PR DESCRIPTION
# このpull requestが解決する内容
#490 を解決します。
#418 で意図せず削除されていたコードを復旧しました。

# 動作確認手順
番組を作成し、番組説明文にリンクになるものを記入し、N Airでコメントビューを番組説明文に切り替え、リンクをクリックする。
アプリの画面自体が置き換わるのではなく、ブラウザが起動する。


# 関連するIssue（あれば）
fixes #490