### PR TITLE
コード署名用のタイムスタンプサーバー指定を修正する

### DIFF
--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -38,7 +38,8 @@ const config = {
     publisherName: [
       'DWANGO Co.,Ltd.'
     ],
-    rfc3161TimeStampServer: 'http://timestamp.digicert.com'
+    rfc3161TimeStampServer: 'http://timestamp.digicert.com/?alg=sha1',
+    timeStampServer: 'http://timestamp.digicert.com'
   },
   extraMetadata: {
     env: 'production'


### PR DESCRIPTION
# このpull requestが解決する内容
リリースパッケージを作る時のコード署名に使うtimestamp serverを指定しそこねていて、無指定のときのサーバーが廃止されてしまって署名できなくなっているのを修正する(electron buildが古いともいう)

https://knowledge.digicert.com/ja/jp/alerts/ALERT2672.html

# 動作確認手順
`yarn package` が正常に終わる
