### PR TITLE
追加: ニコニコ生放送のコメント読み上げ機能

### DIFF
--- a/app/components/nicolive-area/CommentLocalFilter.vue
+++ b/app/components/nicolive-area/CommentLocalFilter.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="container">
-    <div class="header">
-      <div class="header-item-center">フィルター設定</div>
-    </div>
-    <div class="content">
-      <div class="row">
-        <div class="name">匿名(184)のコメントを表示</div>
-        <div class="value"><input type="checkbox" v-model="showAnonymous" class="toggle-button" /></div>
+  <div class="setting-section">
+    <div class="section-heading">フィルター設定</div>
+    <div class="section-content">
+      <div class="section-item">
+        <div class="row">
+          <div class="name">匿名(184)のコメントを表示</div>
+          <div class="value"><input type="checkbox" v-model="showAnonymous" class="toggle-button" /></div>
+        </div>
       </div>
     </div>
   </div>
@@ -17,48 +17,21 @@
 @import "../../styles/_colors";
 @import "../../styles/mixins";
 
-.container {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  flex-grow: 1;
-  flex-basis: 0;
-  overflow-y: auto;
+.setting-section {
+  border-bottom: 1px solid @bg-quinary;
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 48px;
-  padding: 4px 16px;
-  background-color: rgba(@black,.5);
-  border-bottom: 1px solid rgba(@black,.5);
-
-  > .header-item-center {
-    font-size: 12px;
-    color: @white;
-    text-align: center;
-  }
-
-  > .header-item-right {
-    display: flex;
-    align-items: center;
-    position: absolute;
-    right: 16px;
-  }
+.section-heading {
+  color: @grey;
+  padding: 16px 16px 8px;
 }
 
-.content {
-  flex-grow: 1;
-  padding-top: 8px;
-  background-color: rgba(@black,.5);
+.section-item {
+  padding: 16px;
 }
 
 .row {
   width: 100%;
-  padding: 16px;
-
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/app/components/nicolive-area/CommentSettings.vue
+++ b/app/components/nicolive-area/CommentSettings.vue
@@ -50,7 +50,7 @@
 
 .content {
   flex-grow: 1;
-  padding-top: 8px;
+  overflow: auto;
   background-color: rgba(@black,.5);
 }
 

--- a/app/components/nicolive-area/CommentSettings.vue
+++ b/app/components/nicolive-area/CommentSettings.vue
@@ -1,18 +1,17 @@
 <template>
   <div class="container">
     <div class="header">
-      <div class="header-item-center">フィルター設定</div>
+      <div class="header-item-center">コメント設定</div>
+      <div class="header-item-right"><i class="icon-close icon-btn" @click="close"></i></div>
     </div>
     <div class="content">
-      <div class="row">
-        <div class="name">匿名(184)のコメントを表示</div>
-        <div class="value"><input type="checkbox" v-model="showAnonymous" class="toggle-button" /></div>
-      </div>
+      <comment-local-filter />
+      <comment-synthesizer />
     </div>
   </div>
 </template>
 
-<script lang="ts" src="./CommentLocalFilter.vue.ts"></script>
+<script lang="ts" src="./CommentSettings.vue.ts"></script>
 <style lang="less" scoped>
 @import "../../styles/_colors";
 @import "../../styles/mixins";

--- a/app/components/nicolive-area/CommentSettings.vue
+++ b/app/components/nicolive-area/CommentSettings.vue
@@ -29,6 +29,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   height: 48px;
   padding: 4px 16px;
   background-color: rgba(@black,.5);
@@ -50,7 +51,8 @@
 
 .content {
   flex-grow: 1;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   background-color: rgba(@black,.5);
 }
 

--- a/app/components/nicolive-area/CommentSettings.vue.ts
+++ b/app/components/nicolive-area/CommentSettings.vue.ts
@@ -1,0 +1,16 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import CommentLocalFilter from './CommentLocalFilter.vue';
+import CommentSynthesizer from './CommentSynthesizer.vue';
+
+@Component({
+  components: {
+    CommentLocalFilter,
+    CommentSynthesizer,
+  }
+})
+export default class CommentSettings extends Vue {
+  close() {
+    this.$emit('close');
+  }
+}

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -2,7 +2,6 @@
   <div class="container">
     <div class="header">
       <div class="header-item-center">コメント読み上げ設定</div>
-      <div class="header-item-right"><i class="icon-close icon-btn" @click="close"></i></div>
     </div>
     <div class="content">
       <div class="row">
@@ -12,20 +11,18 @@
       <div class="row">
         <div class="name">声の高さ(基本=1.0)</div>
         <div class="value"><VueSlider :disabled="!enabled" :data="pitchCandidates" :width="128" v-model="pitch" /></div>
-        <button type="button" :disabled="!enabled" @click="resetPitch">リセット</button>
       </div>
       <div class="row">
         <div class="name">読み上げ速度(基本=1.0)</div>
         <div class="value"><VueSlider :disabled="!enabled" :data="rateCandidates" :width="128" v-model="rate" /></div>
-        <button type="button" :disabled="!enabled" @click="resetRate">リセット</button>
       </div>
       <div class="row">
         <div class="name">読み上げ音量(最大=1.0)</div>
         <div class="value"><VueSlider :disabled="!enabled" :data="volumeCandidates" :max="1" :width="128" v-model="volume" /></div>
-        <button type="button" :disabled="!enabled" @click="resetVolume">リセット</button>
       </div>
       <div class="row">
-          <button class="button" :disabled="!enabled" @click="play">テスト再生</button>
+        <button class="button" :disabled="!enabled" @click="play">テスト再生</button>
+        <button class="button" :disabled="!enabled" @click="reset">リセット</button>
       </div>
     </div>
   </div>

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -27,9 +27,6 @@
       <div class="row">
           <button class="button" @click="play">テスト再生</button>
       </div>
-      <div class="row">
-          <button class="button button--go-live" @click="apply(); close();">OK</button>
-      </div>
     </div>
   </div>
 </template>
@@ -113,11 +110,6 @@
   &:focus {
     border: 1px solid @text-primary;
   }
-}
-
-
-.button--go-live {
-  font-size: 12px;
 }
 </style>
 

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -20,6 +20,11 @@
         <button type="button" @click="resetRate">リセット</button>
       </div>
       <div class="row">
+        <div class="name">読み上げ音量(最大=1.0)</div>
+        <div class="value"><VueSlider :data="volumeCandidates" :max="1" :width="128" v-model="volume" /></div>
+        <button type="button" @click="resetVolume">リセット</button>
+      </div>
+      <div class="row">
           <button class="button" @click="play">テスト再生</button>
       </div>
       <div class="row">

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -31,7 +31,7 @@
       </div>
       <div class="section-item">
         <div class="row">
-          <button class="button button-nicolive--action" :disabled="!enabled" @click="play">読み上げテスト</button>
+          <button class="button button-nicolive--action" :disabled="!enabled" @click="testSpeechPlay">読み上げテスト</button>
           <button class="button button--default" :disabled="!enabled" @click="reset">リセット</button>
         </div>
       </div>

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -11,21 +11,21 @@
       </div>
       <div class="row">
         <div class="name">声の高さ(基本=1.0)</div>
-        <div class="value"><VueSlider :data="pitchCandidates" :width="128" v-model="pitch" /></div>
-        <button type="button" @click="resetPitch">リセット</button>
+        <div class="value"><VueSlider :disabled="!enabled" :data="pitchCandidates" :width="128" v-model="pitch" /></div>
+        <button type="button" :disabled="!enabled" @click="resetPitch">リセット</button>
       </div>
       <div class="row">
         <div class="name">読み上げ速度(基本=1.0)</div>
-        <div class="value"><VueSlider :data="rateCandidates" :width="128" v-model="rate" /></div>
-        <button type="button" @click="resetRate">リセット</button>
+        <div class="value"><VueSlider :disabled="!enabled" :data="rateCandidates" :width="128" v-model="rate" /></div>
+        <button type="button" :disabled="!enabled" @click="resetRate">リセット</button>
       </div>
       <div class="row">
         <div class="name">読み上げ音量(最大=1.0)</div>
-        <div class="value"><VueSlider :data="volumeCandidates" :max="1" :width="128" v-model="volume" /></div>
-        <button type="button" @click="resetVolume">リセット</button>
+        <div class="value"><VueSlider :disabled="!enabled" :data="volumeCandidates" :max="1" :width="128" v-model="volume" /></div>
+        <button type="button" :disabled="!enabled" @click="resetVolume">リセット</button>
       </div>
       <div class="row">
-          <button class="button" @click="play">テスト再生</button>
+          <button class="button" :disabled="!enabled" @click="play">テスト再生</button>
       </div>
     </div>
   </div>

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -12,10 +12,12 @@
       <div class="row">
         <div class="name">声の高さ(基本=1.0)</div>
         <div class="value"><VueSlider :data="pitchCandidates" :width="128" v-model="pitch" /></div>
+        <button type="button" @click="resetPitch">リセット</button>
       </div>
       <div class="row">
         <div class="name">読み上げ速度(基本=1.0)</div>
         <div class="value"><VueSlider :data="rateCandidates" :width="128" v-model="rate" /></div>
+        <button type="button" @click="resetRate">リセット</button>
       </div>
       <div class="row">
           <button type="button" class="item-misc icon-btn icon-play" @click="play">テスト再生</button>

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -20,7 +20,10 @@
         <button type="button" @click="resetRate">リセット</button>
       </div>
       <div class="row">
-          <button type="button" class="item-misc icon-btn icon-play" @click="play">テスト再生</button>
+          <button class="button" @click="play">テスト再生</button>
+      </div>
+      <div class="row">
+          <button class="button button--go-live" @click="apply(); close();">OK</button>
       </div>
     </div>
   </div>
@@ -105,6 +108,11 @@
   &:focus {
     border: 1px solid @text-primary;
   }
+}
+
+
+.button--go-live {
+  font-size: 12px;
 }
 </style>
 

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -11,15 +11,11 @@
       </div>
       <div class="row">
         <div class="name">声の高さ(基本=1.0)</div>
-        <div class="value"><VueSlider
-          :data="[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2]"
-          :width="128" v-model="pitch" /></div>
+        <div class="value"><VueSlider :data="pitchCandidates" :width="128" v-model="pitch" /></div>
       </div>
       <div class="row">
         <div class="name">読み上げ速度(基本=1.0)</div>
-        <div class="value"><VueSlider
-          :data="[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
-          :width="128" v-model="rate" /></div>
+        <div class="value"><VueSlider :data="rateCandidates" :width="128" v-model="rate" /></div>
       </div>
       <div class="row">
           <button type="button" class="item-misc icon-btn icon-play" @click="play">テスト再生</button>

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -1,28 +1,39 @@
 <template>
-  <div class="container">
-    <div class="header">
-      <div class="header-item-center">コメント読み上げ設定</div>
-    </div>
-    <div class="content">
-      <div class="row">
-        <div class="name">コメントを読み上げる</div>
-        <div class="value"><input type="checkbox" v-model="enabled" class="toggle-button" /></div>
+  <div class="setting-section">
+    <div class="section-heading">コメント読み上げ設定</div>
+    <div class="section-content">
+      <div class="section-item">
+        <div class="row">
+          <div class="name">コメントを読み上げる</div>
+          <div class="value"><input type="checkbox" v-model="enabled" class="toggle-button" /></div>
+        </div>
       </div>
-      <div class="row">
-        <div class="name">声の高さ(基本=1.0)</div>
-        <div class="value"><VueSlider :disabled="!enabled" :data="pitchCandidates" :width="128" v-model="pitch" /></div>
+      <div class="section-item">
+        <div class="row">
+          <div class="name">声の高さ</div>
+          <div class="value">{{ pitch }}<span v-if="pitch==1.0">（規定）</span></div>
+        </div>
+        <VueSlider class="slider" :disabled="!enabled" :data="pitchCandidates" :height="4" v-model="pitch" tooltip="hover" :lazy="true" /> 
       </div>
-      <div class="row">
-        <div class="name">読み上げ速度(基本=1.0)</div>
-        <div class="value"><VueSlider :disabled="!enabled" :data="rateCandidates" :width="128" v-model="rate" /></div>
+      <div class="section-item">
+        <div class="row">
+          <div class="name">速度</div>
+          <div class="value">×{{ rate }}<span v-if="rate==1.0">（規定）</span></div>
+        </div>
+        <VueSlider class="slider" :disabled="!enabled" :data="rateCandidates" :height="4" v-model="rate" tooltip="hover" :lazy="true" />
       </div>
-      <div class="row">
-        <div class="name">読み上げ音量(最大=1.0)</div>
-        <div class="value"><VueSlider :disabled="!enabled" :data="volumeCandidates" :max="1" :width="128" v-model="volume" /></div>
+      <div class="section-item">
+        <div class="row">
+          <div class="name">音量</div>
+          <div class="value">{{ volume }}<span v-if="volume==1.0">（規定）</span></div>
+        </div>
+        <VueSlider class="slider" :disabled="!enabled" :data="volumeCandidates" :height="4" :max="1" v-model="volume" tooltip="hover" :lazy="true" />
       </div>
-      <div class="row">
-        <button class="button" :disabled="!enabled" @click="play">テスト再生</button>
-        <button class="button" :disabled="!enabled" @click="reset">リセット</button>
+      <div class="section-item">
+        <div class="row">
+          <button class="button button-nicolive--action" :disabled="!enabled" @click="play">読み上げテスト</button>
+          <button class="button button--default" :disabled="!enabled" @click="reset">リセット</button>
+        </div>
       </div>
     </div>
   </div>
@@ -33,51 +44,24 @@
 @import "../../styles/_colors";
 @import "../../styles/mixins";
 
-.container {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  flex-grow: 1;
-  flex-basis: 0;
-  overflow-y: auto;
+.section-heading {
+  color: @grey;
+  padding: 16px 16px 8px;
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 48px;
-  padding: 4px 16px;
-  background-color: rgba(@black,.5);
-  border-bottom: 1px solid rgba(@black,.5);
-
-  > .header-item-center {
-    font-size: 12px;
-    color: @white;
-    text-align: center;
-  }
-
-  > .header-item-right {
-    display: flex;
-    align-items: center;
-    position: absolute;
-    right: 16px;
-  }
-}
-
-.content {
-  flex-grow: 1;
-  padding-top: 8px;
-  background-color: rgba(@black,.5);
+.section-item {
+  padding: 16px;
 }
 
 .row {
   width: 100%;
-  padding: 16px;
-
   display: flex;
   flex-direction: row;
   align-items: center;
+}
+
+.slider-wrapper {
+  margin-bottom: 32px;
 }
 
 .name {
@@ -89,6 +73,11 @@
 .value {
   display: flex;
   align-items: center;
+  color: @light-grey;
+}
+
+.slider {
+  margin-top: 16px;
 }
 
 .nl-select {
@@ -106,6 +95,12 @@
 
   &:focus {
     border: 1px solid @text-primary;
+  }
+}
+
+.button {
+  & + & {
+    margin-left: 8px;
   }
 }
 </style>

--- a/app/components/nicolive-area/CommentSynthesizer.vue
+++ b/app/components/nicolive-area/CommentSynthesizer.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="container">
+    <div class="header">
+      <div class="header-item-center">コメント読み上げ設定</div>
+      <div class="header-item-right"><i class="icon-close icon-btn" @click="close"></i></div>
+    </div>
+    <div class="content">
+      <div class="row">
+        <div class="name">コメントを読み上げる</div>
+        <div class="value"><input type="checkbox" v-model="enabled" class="toggle-button" /></div>
+      </div>
+      <div class="row">
+        <div class="name">声の高さ(基本=1.0)</div>
+        <div class="value"><VueSlider
+          :data="[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2]"
+          :width="128" v-model="pitch" /></div>
+      </div>
+      <div class="row">
+        <div class="name">読み上げ速度(基本=1.0)</div>
+        <div class="value"><VueSlider
+          :data="[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+          :width="128" v-model="rate" /></div>
+      </div>
+      <div class="row">
+          <button type="button" class="item-misc icon-btn icon-play" @click="play">テスト再生</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" src="./CommentSynthesizer.vue.ts"></script>
+<style lang="less" scoped>
+@import "../../styles/_colors";
+@import "../../styles/mixins";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  flex-grow: 1;
+  flex-basis: 0;
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  padding: 4px 16px;
+  background-color: rgba(@black,.5);
+  border-bottom: 1px solid rgba(@black,.5);
+
+  > .header-item-center {
+    font-size: 12px;
+    color: @white;
+    text-align: center;
+  }
+
+  > .header-item-right {
+    display: flex;
+    align-items: center;
+    position: absolute;
+    right: 16px;
+  }
+}
+
+.content {
+  flex-grow: 1;
+  padding-top: 8px;
+  background-color: rgba(@black,.5);
+}
+
+.row {
+  width: 100%;
+  padding: 16px;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.name {
+  font-size: 12px;
+  color: @light-grey;
+  flex-grow: 1;
+}
+
+.value {
+  display: flex;
+  align-items: center;
+}
+
+.nl-select {
+  font-size: 12px;
+  color: @white;
+  min-width: 80px;
+  height: 32px;
+  line-height: 32px;
+  margin: 0;
+  padding: 0 24px 0 8px;
+  background-color: @bg-primary;
+  border-color: transparent;
+  outline: none;
+  cursor: pointer;
+
+  &:focus {
+    border: 1px solid @text-primary;
+  }
+}
+</style>
+

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -1,0 +1,64 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import VueSlider from 'vue-slider-component';
+import { Inject } from 'util/injector';
+import {
+  NicoliveCommentSynthesizerService,
+} from 'services/nicolive-program/nicolive-comment-synthesizer';
+import { sleep } from 'util/sleep';
+
+@Component({
+  components: {
+    VueSlider,
+  }
+})
+export default class CommentSynthesizer extends Vue {
+  @Inject()
+  private nicoliveCommentSynthesizerService: NicoliveCommentSynthesizerService;
+
+  close() {
+    this.$emit('close');
+  }
+
+  private index: number = 0;
+
+  async play() {
+      const service = this.nicoliveCommentSynthesizerService;
+
+      const speech = service.makeSimpleTextSpeech('これは読み上げ設定のテスト音声です');
+      if (speech) {
+        this.index++;
+        if (service.speaking) {
+            service.cancelSpeak();
+            await sleep(200);
+        }
+        service.speakText(speech,
+            (e) => {
+                console.log(`#${this.index}: onstart`, e);
+            }, (e) => {
+                console.log(`#${this.index}: onend`, e);
+            } );
+      }
+  }
+
+  get enabled(): boolean {
+    return this.nicoliveCommentSynthesizerService.enabled;
+  }
+  set enabled(e: boolean) {
+    this.nicoliveCommentSynthesizerService.enabled = e;
+  }
+
+  get pitch(): number {
+    return this.nicoliveCommentSynthesizerService.pitch;
+  }
+  set pitch(e: number) {
+    this.nicoliveCommentSynthesizerService.pitch = e;
+  }
+
+  get rate(): number {
+    return this.nicoliveCommentSynthesizerService.rate;
+  }
+  set rate(e: number) {
+    this.nicoliveCommentSynthesizerService.rate = e;
+  }
+}

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -87,4 +87,10 @@ export default class CommentSynthesizer extends Vue {
   resetVolume() {
     this.volume = 1.0;
   }
+
+  reset() {
+    this.resetPitch();
+    this.resetRate();
+    this.resetVolume();
+  }
 }

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -57,6 +57,9 @@ export default class CommentSynthesizer extends Vue {
   get pitchCandidates(): number[] {
     return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2]
   }
+  resetPitch() {
+    this.pitch = 1.0
+  }
 
   get rate(): number {
     return this.nicoliveCommentSynthesizerService.rate;
@@ -66,5 +69,8 @@ export default class CommentSynthesizer extends Vue {
   }
   get rateCandidates(): number[] {
     return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+  resetRate() {
+    this.rate = 1.0
   }
 }

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -82,7 +82,7 @@ export default class CommentSynthesizer extends Vue {
     this.nicoliveCommentSynthesizerService.volume = v;
   }
   get volumeCandidates(): number[] {
-    return [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
+    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
   }
   resetVolume() {
     this.volume = 1.0;

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -16,22 +16,6 @@ export default class CommentSynthesizer extends Vue {
   @Inject()
   private nicoliveCommentSynthesizerService: NicoliveCommentSynthesizerService;
 
-  pitch: number = 0;
-  rate: number = 0;
-  volume: number = 0;
-
-  mounted() {
-    this.pitch = this.nicoliveCommentSynthesizerService.pitch;
-    this.rate = this.nicoliveCommentSynthesizerService.rate;
-    this.volume = this.nicoliveCommentSynthesizerService.volume;
-  }
-
-  apply() {
-    this.nicoliveCommentSynthesizerService.pitch = this.pitch;
-    this.nicoliveCommentSynthesizerService.rate = this.rate;
-    this.nicoliveCommentSynthesizerService.volume = this.volume;
-  }
-
   close() {
     this.$emit('close');
   }
@@ -49,10 +33,6 @@ export default class CommentSynthesizer extends Vue {
         await sleep(200);
       }
 
-      speech.pitch = this.pitch;
-      speech.rate = this.rate;
-      speech.volume = this.volume;
-
       service.speakText(speech,
         (e) => {
           console.log(`#${this.index}: onstart`, e);
@@ -69,6 +49,12 @@ export default class CommentSynthesizer extends Vue {
     this.nicoliveCommentSynthesizerService.enabled = e;
   }
 
+  get pitch(): number {
+    return this.nicoliveCommentSynthesizerService.pitch;
+  }
+  set pitch(v: number) {
+    this.nicoliveCommentSynthesizerService.pitch = v;
+  }
   get pitchCandidates(): number[] {
     return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2];
   }
@@ -76,6 +62,12 @@ export default class CommentSynthesizer extends Vue {
     this.pitch = 1.0;
   }
 
+  get rate(): number {
+    return this.nicoliveCommentSynthesizerService.rate;
+  }
+  set rate(v: number) {
+    this.nicoliveCommentSynthesizerService.rate = v;
+  }
   get rateCandidates(): number[] {
     return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   }
@@ -83,6 +75,12 @@ export default class CommentSynthesizer extends Vue {
     this.rate = 1.0;
   }
 
+  get volume(): number {
+    return this.nicoliveCommentSynthesizerService.volume;
+  }
+  set volume(v: number) {
+    this.nicoliveCommentSynthesizerService.volume = v;
+  }
   get volumeCandidates(): number[] {
     return [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
   }

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -18,15 +18,18 @@ export default class CommentSynthesizer extends Vue {
 
   pitch: number = 0;
   rate: number = 0;
+  volume: number = 0;
 
   mounted() {
     this.pitch = this.nicoliveCommentSynthesizerService.pitch;
     this.rate = this.nicoliveCommentSynthesizerService.rate;
+    this.volume = this.nicoliveCommentSynthesizerService.volume;
   }
 
   apply() {
     this.nicoliveCommentSynthesizerService.pitch = this.pitch;
     this.nicoliveCommentSynthesizerService.rate = this.rate;
+    this.nicoliveCommentSynthesizerService.volume = this.volume;
   }
 
   close() {
@@ -48,6 +51,7 @@ export default class CommentSynthesizer extends Vue {
 
       speech.pitch = this.pitch;
       speech.rate = this.rate;
+      speech.volume = this.volume;
 
       service.speakText(speech,
         (e) => {
@@ -66,16 +70,23 @@ export default class CommentSynthesizer extends Vue {
   }
 
   get pitchCandidates(): number[] {
-    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2]
+    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2];
   }
   resetPitch() {
     this.pitch = 1.0;
   }
 
   get rateCandidates(): number[] {
-    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   }
   resetRate() {
     this.rate = 1.0;
+  }
+
+  get volumeCandidates(): number[] {
+    return [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
+  }
+  resetVolume() {
+    this.volume = 1.0;
   }
 }

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -20,25 +20,17 @@ export default class CommentSynthesizer extends Vue {
     this.$emit('close');
   }
 
-  private index: number = 0;
-
-  async play() {
+  async testSpeechPlay() {
     const service = this.nicoliveCommentSynthesizerService;
 
     const speech = service.makeSimpleTextSpeech('これは読み上げ設定のテスト音声です');
     if (speech) {
-      this.index++;
       if (service.speaking) {
         service.cancelSpeak();
         await sleep(200);
       }
 
-      service.speakText(speech,
-        (e) => {
-          console.log(`#${this.index}: onstart`, e);
-        }, (e) => {
-          console.log(`#${this.index}: onend`, e);
-        });
+      service.speakText(speech, () => {}, () => {});
     }
   }
 

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -16,6 +16,19 @@ export default class CommentSynthesizer extends Vue {
   @Inject()
   private nicoliveCommentSynthesizerService: NicoliveCommentSynthesizerService;
 
+  pitch: number = 0;
+  rate: number = 0;
+
+  mounted() {
+    this.pitch = this.nicoliveCommentSynthesizerService.pitch;
+    this.rate = this.nicoliveCommentSynthesizerService.rate;
+  }
+
+  apply() {
+    this.nicoliveCommentSynthesizerService.pitch = this.pitch;
+    this.nicoliveCommentSynthesizerService.rate = this.rate;
+  }
+
   close() {
     this.$emit('close');
   }
@@ -32,6 +45,10 @@ export default class CommentSynthesizer extends Vue {
         service.cancelSpeak();
         await sleep(200);
       }
+
+      speech.pitch = this.pitch;
+      speech.rate = this.rate;
+
       service.speakText(speech,
         (e) => {
           console.log(`#${this.index}: onstart`, e);
@@ -48,29 +65,17 @@ export default class CommentSynthesizer extends Vue {
     this.nicoliveCommentSynthesizerService.enabled = e;
   }
 
-  get pitch(): number {
-    return this.nicoliveCommentSynthesizerService.pitch;
-  }
-  set pitch(e: number) {
-    this.nicoliveCommentSynthesizerService.pitch = e;
-  }
   get pitchCandidates(): number[] {
     return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2]
   }
   resetPitch() {
-    this.pitch = 1.0
+    this.pitch = 1.0;
   }
 
-  get rate(): number {
-    return this.nicoliveCommentSynthesizerService.rate;
-  }
-  set rate(e: number) {
-    this.nicoliveCommentSynthesizerService.rate = e;
-  }
   get rateCandidates(): number[] {
     return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   }
   resetRate() {
-    this.rate = 1.0
+    this.rate = 1.0;
   }
 }

--- a/app/components/nicolive-area/CommentSynthesizer.vue.ts
+++ b/app/components/nicolive-area/CommentSynthesizer.vue.ts
@@ -23,22 +23,22 @@ export default class CommentSynthesizer extends Vue {
   private index: number = 0;
 
   async play() {
-      const service = this.nicoliveCommentSynthesizerService;
+    const service = this.nicoliveCommentSynthesizerService;
 
-      const speech = service.makeSimpleTextSpeech('これは読み上げ設定のテスト音声です');
-      if (speech) {
-        this.index++;
-        if (service.speaking) {
-            service.cancelSpeak();
-            await sleep(200);
-        }
-        service.speakText(speech,
-            (e) => {
-                console.log(`#${this.index}: onstart`, e);
-            }, (e) => {
-                console.log(`#${this.index}: onend`, e);
-            } );
+    const speech = service.makeSimpleTextSpeech('これは読み上げ設定のテスト音声です');
+    if (speech) {
+      this.index++;
+      if (service.speaking) {
+        service.cancelSpeak();
+        await sleep(200);
       }
+      service.speakText(speech,
+        (e) => {
+          console.log(`#${this.index}: onstart`, e);
+        }, (e) => {
+          console.log(`#${this.index}: onend`, e);
+        });
+    }
   }
 
   get enabled(): boolean {
@@ -54,11 +54,17 @@ export default class CommentSynthesizer extends Vue {
   set pitch(e: number) {
     this.nicoliveCommentSynthesizerService.pitch = e;
   }
+  get pitchCandidates(): number[] {
+    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2]
+  }
 
   get rate(): number {
     return this.nicoliveCommentSynthesizerService.rate;
   }
   set rate(e: number) {
     this.nicoliveCommentSynthesizerService.rate = e;
+  }
+  get rateCandidates(): number[] {
+    return [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   }
 }

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -3,6 +3,7 @@
     <div class="header">
       <i class="icon-reload icon-btn" v-tooltip.bottom="commentReloadTooltip" @click="refreshConnection"></i>
       <i :class="['icon-btn', speakingEnabled ? 'icon-speaker' : 'icon-mute']" v-tooltip.bottom="commentSynthesizerTooltip" @click="speakingEnabled = !speakingEnabled"></i>
+      <div class="icon-border"></div>
       <i class="icon-ng icon-btn" v-tooltip.bottom="filterTooltip" @click="isFilterOpened = true"></i>
       <i class="icon-settings icon-btn" v-tooltip.bottom="settingsTooltip" @click="isSettingsOpened = true"></i>
     </div>
@@ -167,5 +168,12 @@
   height: 100%;
   width: 100%;
   background-color: @bg-primary;
+}
+
+.icon-border {
+  width: 1px;
+  height: 60%;
+  background-color: @bg-primary;
+  margin-left: 16px;
 }
 </style>

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -2,9 +2,9 @@
   <div class="container">
     <div class="header">
       <i class="icon-reload icon-btn" v-tooltip.bottom="commentReloadTooltip" @click="refreshConnection"></i>
+      <i :class="['icon-btn', speakingEnabled ? 'icon-speaker' : 'icon-mute']" v-tooltip.bottom="commentSynthesizerTooltip" @click="speakingEnabled = !speakingEnabled"></i>
       <i class="icon-ng icon-btn" v-tooltip.bottom="filterTooltip" @click="isFilterOpened = true"></i>
-      <i class="icon-settings icon-btn" v-tooltip.bottom="localFilterTooltip" @click="isLocalFilterOpened = true"></i>
-      <i :class="['icon-btn', speakingEnabled ? 'icon-settings' : 'icon-mute']" v-tooltip.bottom="commentSynthesizerTooltip" @click="isCommentSynthesizerOpened = true"></i>
+      <i class="icon-settings icon-btn" v-tooltip.bottom="settingsTooltip" @click="isSettingsOpened = true"></i>
     </div>
     <div class="content">
       <div class="list" ref="scroll">
@@ -33,8 +33,7 @@
     </div>
     <comment-form class="comment-form" />
     <comment-filter class="overlay" @close="isFilterOpened = false" v-if="isFilterOpened"/>
-    <comment-local-filter class="overlay" @close="isLocalFilterOpened = false" v-if="isLocalFilterOpened" />
-    <comment-synthesizer class="overlay" @close="isCommentSynthesizerOpened = false" v-if="isCommentSynthesizerOpened" />
+    <comment-settings class="overlay" @close="isSettingsOpened = false" v-if="isSettingsOpened" />
   </div>
 </template>
 
@@ -166,6 +165,7 @@
   z-index: 2; // AreaSwitcherのheaderより大きく
   position: absolute;
   height: 100%;
+  width: 100%;
   background-color: @bg-primary;
 }
 </style>

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -15,6 +15,7 @@
           :chat="item"
           :getFormattedLiveTime="getFormattedLiveTime"
           :commentMenuOpened="commentMenuTarget === item"
+          :speaking="speakingSeqId === item.seqId"
           @pinned="pin(item)"
           @commentMenu="showCommentMenu(item)"
         />

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -4,7 +4,7 @@
       <i class="icon-reload icon-btn" v-tooltip.bottom="commentReloadTooltip" @click="refreshConnection"></i>
       <i class="icon-ng icon-btn" v-tooltip.bottom="filterTooltip" @click="isFilterOpened = true"></i>
       <i class="icon-settings icon-btn" v-tooltip.bottom="localFilterTooltip" @click="isLocalFilterOpened = true"></i>
-      <i class="icon-settings icon-btn" v-tooltip.bottom="commentSynthesizerTooltip" @click="isCommentSynthesizerOpened = true"></i>
+      <i :class="['icon-btn', speakingEnabled ? 'icon-settings' : 'icon-mute']" v-tooltip.bottom="commentSynthesizerTooltip" @click="isCommentSynthesizerOpened = true"></i>
     </div>
     <div class="content">
       <div class="list" ref="scroll">

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -4,6 +4,7 @@
       <i class="icon-reload icon-btn" v-tooltip.bottom="commentReloadTooltip" @click="refreshConnection"></i>
       <i class="icon-ng icon-btn" v-tooltip.bottom="filterTooltip" @click="isFilterOpened = true"></i>
       <i class="icon-settings icon-btn" v-tooltip.bottom="localFilterTooltip" @click="isLocalFilterOpened = true"></i>
+      <i class="icon-settings icon-btn" v-tooltip.bottom="commentSynthesizerTooltip" @click="isCommentSynthesizerOpened = true"></i>
     </div>
     <div class="content">
       <div class="list" ref="scroll">
@@ -33,6 +34,7 @@
     <comment-form class="comment-form" />
     <comment-filter class="overlay" @close="isFilterOpened = false" v-if="isFilterOpened"/>
     <comment-local-filter class="overlay" @close="isLocalFilterOpened = false" v-if="isLocalFilterOpened" />
+    <comment-synthesizer class="overlay" @close="isCommentSynthesizerOpened = false" v-if="isCommentSynthesizerOpened" />
   </div>
 </template>
 

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -13,7 +13,7 @@
           class="row"
           v-for="item of items"
           :key="item.seqId"
-          :is="componentMap[item.type]"
+          :is="componentMap[item.component]"
           :chat="item"
           :getFormattedLiveTime="getFormattedLiveTime"
           :commentMenuOpened="commentMenuTarget === item"

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -1,7 +1,11 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
-import { NicoliveCommentViewerService, WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
+import {
+  NicoliveCommentViewerService,
+  WrappedChat,
+  WrappedChatWithComponent,
+} from 'services/nicolive-program/nicolive-comment-viewer';
 import CommentForm from './CommentForm.vue';
 import CommentFilter from './CommentFilter.vue';
 import CommentSettings from './CommentSettings.vue';
@@ -9,27 +13,22 @@ import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nic
 import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
 import { Menu } from 'util/menus/Menu';
 import { clipboard } from 'electron';
-import { NicoliveCommentFilterService, getContentWithFilter } from 'services/nicolive-program/nicolive-comment-filter';
+import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
+import { getContentWithFilter } from 'services/nicolive-program/getContentWithFilter';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
-import { ChatMessageType } from 'services/nicolive-program/ChatMessage/classifier';
 import CommonComment from './comment/CommonComment.vue';
 import SystemMessage from './comment/SystemMessage.vue';
 import GiftComment from './comment/GiftComment.vue';
 import NicoadComment from './comment/NicoadComment.vue';
 import EmotionComment from './comment/EmotionComment.vue';
+import { ChatComponentType } from 'services/nicolive-program/ChatMessage/ChatComponentType';
 
-const componentMap: { [type in ChatMessageType]: Vue.Component } = {
-  normal: CommonComment,
-  operator: CommonComment,
+const componentMap: { [type in ChatComponentType]: Vue.Component } = {
+  common: CommonComment,
   nicoad: NicoadComment,
   gift: GiftComment,
   emotion: EmotionComment,
   system: SystemMessage,
-  info: SystemMessage,
-  unknown: SystemMessage,
-  'n-air-emulated': SystemMessage,
-  // コンポーネントに届く前にフィルタされて表示されないが念のため対応させておく
-  invisible: SystemMessage,
 };
 
 @Component({
@@ -40,6 +39,7 @@ const componentMap: { [type in ChatMessageType]: Vue.Component } = {
     CommonComment,
     NicoadComment,
     GiftComment,
+    EmotionComment,
     SystemMessage,
   }
 })
@@ -84,7 +84,7 @@ export default class CommentViewer extends Vue {
     scrollEl.scrollTop = scrollEl.scrollHeight;
   }
 
-  pin(item: WrappedChat | null): void {
+  pin(item: WrappedChatWithComponent | null): void {
     if (!item || item.type === 'normal') {
       this.nicoliveCommentViewerService.pinComment(item);
     }
@@ -124,8 +124,8 @@ export default class CommentViewer extends Vue {
     };
   }
 
-  commentMenuTarget: WrappedChat | null = null;
-  showCommentMenu(item: WrappedChat) {
+  commentMenuTarget: WrappedChatWithComponent | null = null;
+  showCommentMenu(item: WrappedChatWithComponent) {
     if (!(item.type === 'normal' || item.type === 'operator')) {
       return;
     }

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -11,7 +11,6 @@ import {
 import CommentForm from './CommentForm.vue';
 import CommentFilter from './CommentFilter.vue';
 import CommentSettings from './CommentSettings.vue';
-import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
 import { ChatMessage } from 'services/nicolive-program/ChatMessage';
 import { Menu } from 'util/menus/Menu';
 import { clipboard } from 'electron';
@@ -53,9 +52,6 @@ export default class CommentViewer extends Vue {
   private nicoliveCommentViewerService: NicoliveCommentViewerService;
 
   @Inject()
-  private nicoliveCommentLocalFilterService: NicoliveCommentLocalFilterService;
-
-  @Inject()
   private nicoliveCommentFilterService: NicoliveCommentFilterService;
 
   // TODO: 後で言語ファイルに移動する
@@ -71,14 +67,6 @@ export default class CommentViewer extends Vue {
 
   get pinnedComment(): WrappedChat | null {
     return this.nicoliveCommentViewerService.state.pinnedMessage;
-  }
-
-  private get filterFn() {
-    // getterなので関数内に入れない
-    const { filterFn } = this.nicoliveCommentLocalFilterService;
-    return (item: WrappedChat) => {
-      return item.type !== 'invisible' && filterFn(item);
-    };
   }
 
   scrollToLatest() {
@@ -99,7 +87,7 @@ export default class CommentViewer extends Vue {
   componentMap = componentMap;
 
   get items() {
-    return this.nicoliveCommentViewerService.items.filter(this.filterFn);
+    return this.nicoliveCommentViewerService.itemsLocalFiltered;
   }
 
   get speakingEnabled(): boolean {
@@ -205,7 +193,7 @@ export default class CommentViewer extends Vue {
     if (this.isLatestVisible) {
       this.scrollToLatest();
     } else {
-      const popouts = this.nicoliveCommentViewerService.recentPopouts.filter(this.filterFn);
+      const popouts = this.nicoliveCommentViewerService.recentPopoutsLocalFiltered;
       const opt = {
         top: -popouts.length * 32 /* item's height */
       };

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -103,6 +103,10 @@ export default class CommentViewer extends Vue {
     return this.nicoliveCommentViewerService.items.filter(this.filterFn);
   }
 
+  get speakingEnabled(): boolean {
+    return this.nicoliveCommentViewerService.speakingEnabled;
+  }
+
   get speakingSeqId() {
     return this.nicoliveCommentViewerService.speakingSeqId;
   }

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -4,8 +4,7 @@ import { Inject } from 'util/injector';
 import { NicoliveCommentViewerService, WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
 import CommentForm from './CommentForm.vue';
 import CommentFilter from './CommentFilter.vue';
-import CommentLocalFilter from './CommentLocalFilter.vue';
-import CommentSynthesizer from './CommentSynthesizer.vue';
+import CommentSettings from './CommentSettings.vue';
 import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
 import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
 import { Menu } from 'util/menus/Menu';
@@ -37,8 +36,7 @@ const componentMap: { [type in ChatMessageType]: Vue.Component } = {
   components: {
     CommentForm,
     CommentFilter,
-    CommentLocalFilter,
-    CommentSynthesizer,
+    CommentSettings,
     CommonComment,
     NicoadComment,
     GiftComment,
@@ -60,14 +58,13 @@ export default class CommentViewer extends Vue {
 
   // TODO: 後で言語ファイルに移動する
   commentReloadTooltip = 'コメント再取得';
+  commentSynthesizerTooltip = 'コメント読み上げ';
   filterTooltip = 'NG設定';
-  localFilterTooltip = 'フィルター設定';
-  commentSynthesizerTooltip = 'コメント読み上げ設定';
+  settingsTooltip = 'コメント設定';
 
   isFilterOpened = false;
 
-  isLocalFilterOpened = false;
-  isCommentSynthesizerOpened = false;
+  isSettingsOpened = false;
   isLatestVisible = true;
 
   get pinnedComment(): WrappedChat | null {
@@ -105,6 +102,9 @@ export default class CommentViewer extends Vue {
 
   get speakingEnabled(): boolean {
     return this.nicoliveCommentViewerService.speakingEnabled;
+  }
+  set speakingEnabled(e: boolean) {
+    this.nicoliveCommentViewerService.speakingEnabled = e;
   }
 
   get speakingSeqId() {

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -3,14 +3,16 @@ import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import {
   NicoliveCommentViewerService,
-  WrappedChat,
-  WrappedChatWithComponent,
 } from 'services/nicolive-program/nicolive-comment-viewer';
+import {
+  WrappedChat,
+  WrappedChatWithComponent
+} from 'services/nicolive-program/WrappedChat';
 import CommentForm from './CommentForm.vue';
 import CommentFilter from './CommentFilter.vue';
 import CommentSettings from './CommentSettings.vue';
 import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { ChatMessage } from 'services/nicolive-program/ChatMessage';
 import { Menu } from 'util/menus/Menu';
 import { clipboard } from 'electron';
 import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -99,6 +99,10 @@ export default class CommentViewer extends Vue {
     return this.nicoliveCommentViewerService.items.filter(this.filterFn);
   }
 
+  get speakingSeqId() {
+    return this.nicoliveCommentViewerService.speakingSeqId;
+  }
+
   refreshConnection() {
     this.nicoliveCommentViewerService.refreshConnection();
   }

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -5,6 +5,7 @@ import { NicoliveCommentViewerService, WrappedChat } from 'services/nicolive-pro
 import CommentForm from './CommentForm.vue';
 import CommentFilter from './CommentFilter.vue';
 import CommentLocalFilter from './CommentLocalFilter.vue';
+import CommentSynthesizer from './CommentSynthesizer.vue';
 import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
 import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
 import { Menu } from 'util/menus/Menu';
@@ -37,6 +38,7 @@ const componentMap: { [type in ChatMessageType]: Vue.Component } = {
     CommentForm,
     CommentFilter,
     CommentLocalFilter,
+    CommentSynthesizer,
     CommonComment,
     NicoadComment,
     GiftComment,
@@ -60,10 +62,12 @@ export default class CommentViewer extends Vue {
   commentReloadTooltip = 'コメント再取得';
   filterTooltip = 'NG設定';
   localFilterTooltip = 'フィルター設定';
+  commentSynthesizerTooltip = 'コメント読み上げ設定';
 
   isFilterOpened = false;
 
   isLocalFilterOpened = false;
+  isCommentSynthesizerOpened = false;
   isLatestVisible = true;
 
   get pinnedComment(): WrappedChat | null {

--- a/app/components/nicolive-area/comment/CommentBase.ts
+++ b/app/components/nicolive-area/comment/CommentBase.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { WrappedChatWithComponent } from 'services/nicolive-program/nicolive-comment-viewer';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { WrappedChatWithComponent } from 'services/nicolive-program/WrappedChat';
+import { ChatMessage } from 'services/nicolive-program/ChatMessage';
 import { getDisplayText } from 'services/nicolive-program/ChatMessage/displaytext';
 
 @Component({})

--- a/app/components/nicolive-area/comment/CommentBase.ts
+++ b/app/components/nicolive-area/comment/CommentBase.ts
@@ -1,0 +1,20 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { WrappedChatWithComponent } from 'services/nicolive-program/nicolive-comment-viewer';
+import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { getDisplayText } from 'services/nicolive-program/ChatMessage/displaytext';
+
+@Component({})
+export class CommentBase extends Vue {
+  @Prop() chat: WrappedChatWithComponent;
+  @Prop() getFormattedLiveTime: (chat: ChatMessage) => string;
+
+  get computedContent() {
+    return getDisplayText(this.chat);
+  }
+
+  get computedTitle() {
+    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`;
+  }
+}
+

--- a/app/components/nicolive-area/comment/CommonComment.vue
+++ b/app/components/nicolive-area/comment/CommonComment.vue
@@ -1,7 +1,6 @@
 <template>
-  <div class="root" :class="[chat.type, { pseudoHover: commentMenuOpened }]" :title="computedTitle" @dblclick="$emit('pinned')">
+  <div class="root" :class="[chat.type, { pseudoHover: commentMenuOpened }]" :title="computedTitle" :speaking="speaking" @dblclick="$emit('pinned')">
     <div class="comment-number">{{ chat.value.no }}</div>
-    <div class="comment-speaking" v-if="speaking">▶</div>
     <div class="comment-body">{{ computedContent }}</div>
     <div class="comment-misc" @click.stop="$emit('commentMenu')"><i class="icon-btn icon-ellipsis-vertical"></i></div>
   </div>
@@ -23,25 +22,28 @@
       display: block;
     }
   }
-
-  &.operator > .comment-body {
-    color: @accent;
-  }
 }
 
 .comment-number {
   .common__comment-number();
   color: @grey;
-}
 
-.comment-speaking {
-  .common__comment-number();
-  color: @red;
+  [speaking=true] & {
+    color: @text-primary;
+  }
 }
 
 .comment-body {
   .common__comment-body();
   color: @white;
+
+  .operator & {
+    color: @accent;
+  }
+
+  [speaking=true] & {
+    color: @text-primary;
+  }
 }
 
 .comment-misc {

--- a/app/components/nicolive-area/comment/CommonComment.vue
+++ b/app/components/nicolive-area/comment/CommonComment.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="root" :class="[chat.type, { pseudoHover: commentMenuOpened }]" :title="computedTitle" @dblclick="$emit('pinned')">
     <div class="comment-number">{{ chat.value.no }}</div>
+    <div class="comment-speaking" v-if="speaking">▶</div>
     <div class="comment-body">{{ computedContent }}</div>
     <div class="comment-misc" @click.stop="$emit('commentMenu')"><i class="icon-btn icon-ellipsis-vertical"></i></div>
   </div>
@@ -31,6 +32,11 @@
 .comment-number {
   .common__comment-number();
   color: @grey;
+}
+
+.comment-speaking {
+  .common__comment-number();
+  color: @red;
 }
 
 .comment-body {

--- a/app/components/nicolive-area/comment/CommonComment.vue.ts
+++ b/app/components/nicolive-area/comment/CommonComment.vue.ts
@@ -1,30 +1,8 @@
-import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
-import { parseContent } from 'services/nicolive-program/ChatMessage/util';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
-import { getContentWithFilter } from 'services/nicolive-program/nicolive-comment-filter';
+import { CommentBase } from './CommentBase';
 
 @Component({})
-export default class CommonComment extends Vue {
-  @Prop()
-  chat: WrappedChat;
-  @Prop({ default: false })
-  commentMenuOpened: boolean;
-  @Prop()
-  getFormattedLiveTime: (chat: ChatMessage) => string;
-  @Prop()
-  speaking: boolean;
-
-  get computedContent() {
-    if (this.chat.type === 'normal') {
-      return getContentWithFilter(this.chat);
-    }
-    const parsed = parseContent(this.chat.value);
-    return parsed.values.join(' ');
-  }
-
-  get computedTitle() {
-    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`;
-  }
+export default class CommonComment extends CommentBase {
+  @Prop({ default: false }) commentMenuOpened: boolean;
+  @Prop() speaking: boolean;
 }

--- a/app/components/nicolive-area/comment/CommonComment.vue.ts
+++ b/app/components/nicolive-area/comment/CommonComment.vue.ts
@@ -13,6 +13,8 @@ export default class CommonComment extends Vue {
   commentMenuOpened: boolean;
   @Prop()
   getFormattedLiveTime: (chat: ChatMessage) => string;
+  @Prop()
+  speaking: boolean;
 
   get computedContent() {
     if (this.chat.type === 'normal') {

--- a/app/components/nicolive-area/comment/EmotionComment.vue
+++ b/app/components/nicolive-area/comment/EmotionComment.vue
@@ -26,5 +26,9 @@
 .comment-body {
   .common__comment-body();
   color: @light-grey;
+
+  [speaking=true] & {
+    color: @text-primary;
+  }
 }
 </style>

--- a/app/components/nicolive-area/comment/EmotionComment.vue.ts
+++ b/app/components/nicolive-area/comment/EmotionComment.vue.ts
@@ -1,19 +1,6 @@
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
-import { parseCommandArgument } from 'services/nicolive-program/ChatMessage/util';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { Component } from 'vue-property-decorator';
+import { CommentBase } from './CommentBase';
 
 @Component({})
-export default class CommonComment extends Vue {
-  @Prop() chat: WrappedChat;
-  @Prop() getFormattedLiveTime: (chat: ChatMessage) => string;
-
-  get computedContent() {
-    return parseCommandArgument(this.chat.value);
-  }
-
-  get computedTitle() {
-    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`
-  }
+export default class EmotionComment extends CommentBase {
 }

--- a/app/components/nicolive-area/comment/GiftComment.vue
+++ b/app/components/nicolive-area/comment/GiftComment.vue
@@ -25,5 +25,9 @@
 .comment-body {
   .common__comment-body();
   color: @light-grey;
+
+  [speaking=true] & {
+    color: @text-primary;
+  }
 }
 </style>

--- a/app/components/nicolive-area/comment/GiftComment.vue.ts
+++ b/app/components/nicolive-area/comment/GiftComment.vue.ts
@@ -1,22 +1,6 @@
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
-import { parseContent } from 'services/nicolive-program/ChatMessage/util';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { Component } from 'vue-property-decorator';
+import { CommentBase } from './CommentBase';
 
 @Component({})
-export default class GiftComment extends Vue {
-  @Prop() chat: WrappedChat;
-  @Prop() getFormattedLiveTime: (chat: ChatMessage) => string;
-
-  get computedContent() {
-    const parsed = parseContent(this.chat.value);
-    const [_itemId, _userId, advertiserName, point, _message, itemName, contributionRank] = parsed.values;
-    const contributionMessage = contributionRank ? `【ギフト貢献第${contributionRank}位】 ` : '';
-    return `${contributionMessage}${advertiserName}さんが「${itemName}（${point}pt）」を贈りました`;
-  }
-
-  get computedTitle() {
-    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`
-  }
+export default class GiftComment extends CommentBase {
 }

--- a/app/components/nicolive-area/comment/NicoadComment.vue
+++ b/app/components/nicolive-area/comment/NicoadComment.vue
@@ -28,5 +28,9 @@
 .comment-body {
   .common__comment-body();
   color: @light-grey;
+
+  [speaking=true] & {
+    color: @text-primary;
+  }
 }
 </style>

--- a/app/components/nicolive-area/comment/NicoadComment.vue.ts
+++ b/app/components/nicolive-area/comment/NicoadComment.vue.ts
@@ -1,20 +1,6 @@
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
-import { parseJsonContent } from 'services/nicolive-program/ChatMessage/util';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { Component } from 'vue-property-decorator';
+import { CommentBase } from './CommentBase';
 
 @Component({})
-export default class CommonComment extends Vue {
-  @Prop() chat: WrappedChat;
-  @Prop() getFormattedLiveTime: (chat: ChatMessage) => string;
-
-  get computedContent() {
-    const parsed = parseJsonContent(this.chat.value);
-    return parsed.value.message ?? '';
-  }
-
-  get computedTitle() {
-    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`
-  }
+export default class NicoadComment extends CommentBase {
 }

--- a/app/components/nicolive-area/comment/SystemMessage.vue
+++ b/app/components/nicolive-area/comment/SystemMessage.vue
@@ -18,5 +18,9 @@
 .comment-body {
   .common__comment-body();
   color: @light-grey;
+
+  [speaking=true] & {
+    color: @text-primary;
+  }
 }
 </style>

--- a/app/components/nicolive-area/comment/SystemMessage.vue.ts
+++ b/app/components/nicolive-area/comment/SystemMessage.vue.ts
@@ -1,27 +1,6 @@
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
-import { WrappedChat } from 'services/nicolive-program/nicolive-comment-viewer';
-import { parseContent } from 'services/nicolive-program/ChatMessage/util';
-import { ChatMessage } from 'services/nicolive-program/MessageServerClient';
+import { Component } from 'vue-property-decorator';
+import { CommentBase } from './CommentBase';
 
 @Component({})
-export default class CommonComment extends Vue {
-  @Prop() chat: WrappedChat;
-  @Prop() getFormattedLiveTime: (chat: ChatMessage) => string;
-
-  get computedContent() {
-    const parsed = parseContent(this.chat.value);
-    if (this.chat.type === 'unknown') {
-      return `${parsed.commandName} ${parsed.values.join(' ')}`;
-    }
-    if (this.chat.type === 'info') {
-      // info種別を除去
-      parsed.values.shift();
-    }
-    return parsed.values.join(' ');
-  }
-
-  get computedTitle() {
-    return `${this.computedContent} (${this.$props.getFormattedLiveTime(this.chat.value)})`
-  }
+export default class SystemMessage extends CommentBase {
 }

--- a/app/components/shared/Slider.vue
+++ b/app/components/shared/Slider.vue
@@ -54,12 +54,6 @@
   margin: 0;
   flex-grow: 1;
   height: auto;
-
-  &:hover {
-    .vue-slider-tooltip {
-      color: @navy !important;
-    }
-  }
 }
 
 .vue-slider {
@@ -93,7 +87,8 @@
 }
 
 .vue-slider-tooltip {
-  background-color: transparent !important;
+  background-color: @input-bg !important;
+  border-radius: 2px !important;
   border: none !important;
   color: @white !important;
   font-size: 13px !important;
@@ -102,6 +97,14 @@
 
   &:before {
     display: none;
+  }
+}
+
+.vue-slider-disabled {
+  opacity: 0.26 !important;
+
+  .vue-slider-tooltip-wrap {
+    display: none !important;
   }
 }
 

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -68,6 +68,7 @@ import { NicoliveProgramSelectorService } from 'services/nicolive-program/nicoli
 import { NicoliveCommentViewerService } from 'services/nicolive-program/nicolive-comment-viewer';
 import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
 import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
+import { NicoliveCommentSynthesizerService } from 'services/nicolive-program/nicolive-comment-synthesizer';
 
 const { ipcRenderer } = electron;
 
@@ -139,6 +140,7 @@ export class ServicesManager extends Service {
     NicoliveCommentViewerService,
     NicoliveCommentFilterService,
     NicoliveCommentLocalFilterService,
+    NicoliveCommentSynthesizerService,
   };
 
   private instances: Dictionary<Service> = {};

--- a/app/services/nicolive-program/ChatMessage.ts
+++ b/app/services/nicolive-program/ChatMessage.ts
@@ -1,0 +1,15 @@
+/** chatメッセージ（取得形のみ） */
+
+export type ChatMessage = {
+  content?: string;
+  date?: number;
+  date_usec?: number;
+  no?: number;
+  premium?: number;
+  thread?: number;
+  user_id?: string;
+  vpos?: number;
+  anonymity?: number;
+  mail?: string;
+  score?: number;
+};

--- a/app/services/nicolive-program/ChatMessage/ChatComponentType.ts
+++ b/app/services/nicolive-program/ChatMessage/ChatComponentType.ts
@@ -1,0 +1,28 @@
+import { ChatMessageType } from './classifier';
+
+export type ChatComponentType =
+  'common' |
+  'nicoad' |
+  'gift' |
+  'emotion' |
+  'system';
+
+export const chatComponentTypeMap: {
+  [type in ChatMessageType]: ChatComponentType;
+} = {
+  normal: 'common',
+  operator: 'common',
+  nicoad: 'nicoad',
+  gift: 'gift',
+  emotion: 'emotion',
+  system: 'system',
+  info: 'system',
+  unknown: 'system',
+  'n-air-emulated': 'system',
+  // コンポーネントに届く前にフィルタされて表示されないが念のため対応させておく
+  invisible: 'system',
+} as const;
+
+export function AddComponent<T extends { type: ChatMessageType }>(chat: T): T & { component: ChatComponentType } {
+  return { ...chat, component: chatComponentTypeMap[chat.type] };
+}

--- a/app/services/nicolive-program/ChatMessage/classifier.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from '../MessageServerClient';
+import { ChatMessage } from '../ChatMessage';
 import { isOperatorCommand, parseCommandName, isOperatorComment, parseContent } from './util';
 
 /**

--- a/app/services/nicolive-program/ChatMessage/displaytext.ts
+++ b/app/services/nicolive-program/ChatMessage/displaytext.ts
@@ -1,5 +1,5 @@
 import { getContentWithFilter } from '../getContentWithFilter';
-import { WrappedChat, WrappedChatWithComponent } from '../nicolive-comment-viewer';
+import { WrappedChat, WrappedChatWithComponent } from '../WrappedChat';
 import { ChatComponentType } from './ChatComponentType';
 import { parseCommandArgument, parseContent, parseJsonContent } from './util';
 

--- a/app/services/nicolive-program/ChatMessage/displaytext.ts
+++ b/app/services/nicolive-program/ChatMessage/displaytext.ts
@@ -1,0 +1,52 @@
+import { getContentWithFilter } from '../getContentWithFilter';
+import { WrappedChat, WrappedChatWithComponent } from '../nicolive-comment-viewer';
+import { ChatComponentType } from './ChatComponentType';
+import { parseCommandArgument, parseContent, parseJsonContent } from './util';
+
+function getCommonComment(chat: WrappedChat): string {
+    if (chat.type === 'normal') {
+        return getContentWithFilter(chat);
+    }
+    const parsed = parseContent(chat.value);
+    return parsed.values.join(' ');
+}
+
+function getNicoadComment(chat: WrappedChat): string {
+    const parsed = parseJsonContent(chat.value);
+    return parsed.value.message ?? '';
+}
+
+function getGiftComment(chat: WrappedChat): string {
+    const parsed = parseContent(chat.value);
+    const [_itemId, _userId, advertiserName, point, _message, itemName, contributionRank] = parsed.values;
+    const contributionMessage = contributionRank ? `【ギフト貢献第${contributionRank}位】 ` : '';
+    return `${contributionMessage}${advertiserName}さんが「${itemName}（${point}pt）」を贈りました`;
+}
+
+function getEmotionComment(chat: WrappedChat): string {
+    return parseCommandArgument(chat.value);
+}
+
+function getSystemMessage(chat: WrappedChat): string {
+    const parsed = parseContent(chat.value);
+    if (chat.type === 'unknown') {
+        return `${parsed.commandName} ${parsed.values.join(' ')}`;
+    }
+    if (chat.type === 'info') {
+        // info種別を除去
+        parsed.values.shift();
+    }
+    return parsed.values.join(' ');
+}
+
+const displayTextMap: { [type in ChatComponentType]: (chat: WrappedChat) => string } = {
+    common: getCommonComment,
+    nicoad: getNicoadComment,
+    gift: getGiftComment,
+    emotion: getEmotionComment,
+    system: getSystemMessage,
+}
+
+export function getDisplayText(chat: WrappedChatWithComponent): string {
+    return displayTextMap[chat.component](chat);
+}

--- a/app/services/nicolive-program/ChatMessage/util.test.ts
+++ b/app/services/nicolive-program/ChatMessage/util.test.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from '../MessageServerClient';
+import { ChatMessage } from '../ChatMessage';
 import {
   isPremium,
   isOperator,

--- a/app/services/nicolive-program/ChatMessage/util.ts
+++ b/app/services/nicolive-program/ChatMessage/util.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from '../MessageServerClient';
+import { ChatMessage } from '../ChatMessage';
 
 function checkPremiumBit(premiumBit: number | undefined, checkBit: number): boolean {
   return premiumBit !== undefined && Boolean(premiumBit & checkBit);

--- a/app/services/nicolive-program/MessageServerClient.ts
+++ b/app/services/nicolive-program/MessageServerClient.ts
@@ -1,23 +1,9 @@
 import { WebSocketSubject, webSocket } from 'rxjs/webSocket';
 import { Observable } from 'rxjs';
+import { ChatMessage } from './ChatMessage';
 
 export type MessageResponse = { chat: ChatMessage } | { leave_thread: LeaveThreadMessage } | { thread: ThreadMessage };
 export type Message = ChatMessage | LeaveThreadMessage | ThreadMessage;
-
-/** chatメッセージ（取得形のみ） */
-export type ChatMessage = {
-  content?: string;
-  date?: number;
-  date_usec?: number;
-  no?: number;
-  premium?: number;
-  thread?: number;
-  user_id?: string;
-  vpos?: number;
-  anonymity?: number;
-  mail?: string;
-  score?: number;
-};
 
 export function isChatMessage(msg: MessageResponse): msg is { chat: ChatMessage } {
   return msg.hasOwnProperty('chat');

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -18,7 +18,6 @@ import {
 } from './ResponseTypes';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import { handleErrors } from 'util/requests';
-import Util from 'services/utils';
 const { BrowserWindow } = remote;
 
 export enum CreateResult {
@@ -61,7 +60,7 @@ export function isOk<T>(result: WrappedResult<T>): result is SucceededResult<T> 
   return result.ok === true;
 }
 
-export class NotLoggedInError { }
+export class NotLoggedInError {}
 
 export class NicoliveClient {
   static live2BaseURL = 'https://live2.nicovideo.jp';
@@ -428,13 +427,13 @@ export class NicoliveClient {
   async fetchOnairChannelProgram(channelId: string): Promise<WrappedResult<OnairChannelProgramData>> {
     const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels/${channelId}`
     const headers = new Headers();
-    try {
+   try {
       const userSession = await this.fetchSession();
       headers.append('X-niconico-session', userSession);
       const request = new Request(url, { headers });
       const response = await fetch(request);
       return NicoliveClient.wrapResult<OnairChannelProgramData>(response);
-    } catch (error) {
+    } catch(error) {
       return NicoliveClient.wrapFetchError(error);
     }
   }
@@ -518,9 +517,6 @@ export class NicoliveClient {
       });
       ipcRenderer.send('window-preventLogout', win.id);
       ipcRenderer.send('window-preventNewWindow', win.id);
-      if (Util.isDevMode()) {
-        win.webContents.openDevTools({ mode: 'detach' });
-      }
       win.loadURL('https://live2.nicovideo.jp/create');
     });
   }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -18,6 +18,7 @@ import {
 } from './ResponseTypes';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import { handleErrors } from 'util/requests';
+import Util from 'services/utils';
 const { BrowserWindow } = remote;
 
 export enum CreateResult {
@@ -60,7 +61,7 @@ export function isOk<T>(result: WrappedResult<T>): result is SucceededResult<T> 
   return result.ok === true;
 }
 
-export class NotLoggedInError {}
+export class NotLoggedInError { }
 
 export class NicoliveClient {
   static live2BaseURL = 'https://live2.nicovideo.jp';
@@ -427,13 +428,13 @@ export class NicoliveClient {
   async fetchOnairChannelProgram(channelId: string): Promise<WrappedResult<OnairChannelProgramData>> {
     const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/channels/${channelId}`
     const headers = new Headers();
-   try {
+    try {
       const userSession = await this.fetchSession();
       headers.append('X-niconico-session', userSession);
       const request = new Request(url, { headers });
       const response = await fetch(request);
       return NicoliveClient.wrapResult<OnairChannelProgramData>(response);
-    } catch(error) {
+    } catch (error) {
       return NicoliveClient.wrapFetchError(error);
     }
   }
@@ -517,6 +518,9 @@ export class NicoliveClient {
       });
       ipcRenderer.send('window-preventLogout', win.id);
       ipcRenderer.send('window-preventNewWindow', win.id);
+      if (Util.isDevMode()) {
+        win.webContents.openDevTools({ mode: 'detach' });
+      }
       win.loadURL('https://live2.nicovideo.jp/create');
     });
   }

--- a/app/services/nicolive-program/ParaphraseDictionary.test.ts
+++ b/app/services/nicolive-program/ParaphraseDictionary.test.ts
@@ -1,0 +1,10 @@
+import { ParaphraseDictionary } from './ParaphraseDictionary';
+
+test('PhraseDictionary', async () => {
+  const dictionary = new ParaphraseDictionary();
+  expect(dictionary.process('https://www.nicovideo.jp')).toBe('URLショウリャク');
+  expect(dictionary.process('8888')).toBe('パチパチパチ');
+  expect(dictionary.process('ww')).toBe('ワラワラ');
+  expect(dictionary.process('テストw')).toBe('テスト、ワラ');
+  expect(dictionary.process('複数行は\nすべて無視')).toBe('');
+});

--- a/app/services/nicolive-program/ParaphraseDictionary.ts
+++ b/app/services/nicolive-program/ParaphraseDictionary.ts
@@ -1,0 +1,23 @@
+type replace_rules_type = {
+  elements: {
+    note?: string,
+    regularExpression: string,
+    replacement: string,
+  }[],
+}
+
+const replace_rules = require('./replace_rules.json') as replace_rules_type;
+
+export class ParaphraseDictionary {
+  dictionary = replace_rules.elements.map(e => ({
+    pattern: new RegExp(e.regularExpression, 'i'),
+    to: e.replacement
+  }));
+
+  process(input: string): string {
+    return this.dictionary.reduce<string>(
+      (acc, item) => acc.replace(item.pattern, item.to),
+      input
+    );
+  }
+}

--- a/app/services/nicolive-program/WrappedChat.ts
+++ b/app/services/nicolive-program/WrappedChat.ts
@@ -1,0 +1,14 @@
+import { ChatMessage } from './ChatMessage';
+import { ChatMessageType } from './ChatMessage/classifier';
+import { ChatComponentType } from './ChatMessage/ChatComponentType';
+
+
+export type WrappedChat = {
+  type: ChatMessageType;
+  value: ChatMessage;
+  seqId: number;
+  /** NG追加したときに手元でフィルタをかけた結果 */
+  filtered?: boolean;
+};
+
+export type WrappedChatWithComponent = WrappedChat & { component: ChatComponentType; };

--- a/app/services/nicolive-program/getContentWithFilter.ts
+++ b/app/services/nicolive-program/getContentWithFilter.ts
@@ -1,0 +1,8 @@
+import { WrappedChat } from './nicolive-comment-filter';
+
+export function getContentWithFilter(wrapped: WrappedChat): string {
+  if (wrapped.filtered) {
+    return '##このコメントは表示されません##';
+  }
+  return wrapped.value.content ?? '';
+}

--- a/app/services/nicolive-program/getContentWithFilter.ts
+++ b/app/services/nicolive-program/getContentWithFilter.ts
@@ -1,4 +1,4 @@
-import { WrappedChat } from './nicolive-comment-filter';
+import { WrappedChat } from './WrappedChat';
 
 export function getContentWithFilter(wrapped: WrappedChat): string {
   if (wrapped.filtered) {

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -1,5 +1,6 @@
 import { createSetupFunction } from 'util/test-setup';
 import { Subject } from 'rxjs';
+import { WrappedChat } from './nicolive-comment-viewer';
 type NicoliveCommentFilterService = import('./nicolive-comment-filter').NicoliveCommentFilterService;
 
 const setup = createSetupFunction({
@@ -198,7 +199,7 @@ test('applyFilter', async () => {
     { seqId: 4, type: 'operator', value: { user_id: 'user needle' } },
   ] as const;
 
-  const after = chats.map(c => instance.applyFilter(c));
+  const after = chats.map(c => instance.applyFilter<WrappedChat>(c));
 
   expect(after[0].filtered).toBe(true);
   expect(after[1].filtered).toBe(true);

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -1,6 +1,6 @@
 import { createSetupFunction } from 'util/test-setup';
 import { Subject } from 'rxjs';
-import { WrappedChat } from './nicolive-comment-viewer';
+import { WrappedChat } from './WrappedChat';
 type NicoliveCommentFilterService = import('./nicolive-comment-filter').NicoliveCommentFilterService;
 
 const setup = createSetupFunction({

--- a/app/services/nicolive-program/nicolive-comment-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.ts
@@ -5,7 +5,7 @@ import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import { map, distinctUntilChanged } from 'rxjs/operators';
 import { NicoliveFailure } from './NicoliveFailure';
-export type WrappedChat = import('./nicolive-comment-viewer').WrappedChat;
+import { WrappedChat } from './WrappedChat';
 import { Subject } from 'rxjs';
 
 interface INicoliveCommentFilterState {

--- a/app/services/nicolive-program/nicolive-comment-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.ts
@@ -5,13 +5,8 @@ import { Inject } from 'util/injector';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import { map, distinctUntilChanged } from 'rxjs/operators';
 import { NicoliveFailure } from './NicoliveFailure';
-type WrappedChat = import('./nicolive-comment-viewer').WrappedChat;
+export type WrappedChat = import('./nicolive-comment-viewer').WrappedChat;
 import { Subject } from 'rxjs';
-
-export function getContentWithFilter(wrapped: WrappedChat): string {
-  if (wrapped.filtered) return '##このコメントは表示されません##';
-  return wrapped.value.content ?? '';
-}
 
 interface INicoliveCommentFilterState {
   filters: FilterRecord[];
@@ -28,7 +23,7 @@ export class NicoliveCommentFilterService extends StatefulService<INicoliveComme
   private stateChangeSubject = new Subject<INicoliveCommentFilterState>();
   stateChange = this.stateChangeSubject.asObservable();
 
-  applyFilter(wrapped: WrappedChat) {
+  applyFilter<T extends WrappedChat>(wrapped: T) {
     if (wrapped.type === 'normal') {
       for (const record of this.state.filters) {
         if (

--- a/app/services/nicolive-program/nicolive-comment-local-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-local-filter.ts
@@ -1,7 +1,7 @@
 import { PersistentStatefulService } from 'services/persistent-stateful-service';
 import { mutation } from 'services/stateful-service';
 import { isAnonymous, getScore } from './ChatMessage/util';
-type WrappedChat = import('./nicolive-comment-viewer').WrappedChat;
+import { WrappedChat } from './WrappedChat';
 
 export type NGSharingLevel = 'none' | 'low' | 'mid' | 'high';
 

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
@@ -1,0 +1,82 @@
+import { createSetupFunction } from 'util/test-setup';
+import { WrappedChat } from './nicolive-comment-viewer';
+
+type NicoliveCommentSynthesizerService = import('./nicolive-comment-synthesizer').NicoliveCommentSynthesizerService;
+
+const setup = createSetupFunction({
+    injectee: {
+        NicoliveProgramStateService: {
+            updated: {
+                subscribe() { },
+            },
+        },
+    },
+});
+
+jest.mock('services/nicolive-program/state', () => ({ NicoliveProgramStateService: {} }));
+
+beforeEach(() => {
+    jest.doMock('services/stateful-service');
+    jest.doMock('util/injector');
+});
+
+afterEach(() => {
+    jest.resetModules();
+});
+
+test('makeSpeech', async () => {
+    setup();
+    const { NicoliveCommentSynthesizerService } = require('./nicolive-comment-synthesizer');
+    const instance = NicoliveCommentSynthesizerService.instance as NicoliveCommentSynthesizerService;
+
+    const testPitch = 0.2;
+    const testRate = 0.4;
+    const testVolume = 0.6;
+
+    jest.spyOn(instance as any, 'state', 'get').mockReturnValue(
+        {
+            enabled: true,
+            pitch: testPitch,
+            rate: testRate,
+            volume: testVolume,
+        }
+    );
+
+    // 辞書変換しない
+    jest.spyOn(instance.synth, 'makeSpeechText').mockImplementation(
+        (chat: WrappedChat) => chat.value.content
+    );
+
+    const makeChat = (s: string): WrappedChat => ({ type: 'normal', value: { content: s }, seqId: 1 });
+
+    // 空文字列を与えるとnullが返ってくる
+    expect(instance.makeSpeech(makeChat(''))).toBeNull();
+
+    // stateの設定値を反映している
+    expect(instance.makeSpeech(makeChat('test'))).toEqual({
+        text: 'test',
+        pitch: testPitch,
+        rate: testRate,
+        volume: testVolume,
+    });
+});
+
+test('NicoliveCommentSynthesizer', async () => {
+    setup();
+    const { NicoliveCommentSynthesizer } = require('./nicolive-comment-synthesizer');
+
+    jest.mock('./nicolive-comment-synthesizer', () => ({
+        ...jest.requireActual('./nicolive-comment-synthesizer'),
+        NicoliveProgramCommentSynthesizerService: {},
+    }));
+
+    const synth = new NicoliveCommentSynthesizer();
+
+    jest.spyOn(window, 'speechSynthesis', 'get').mockImplementation(undefined);
+    expect(synth.available).toBeFalsy();
+
+    jest.spyOn(window, 'speechSynthesis', 'get').mockImplementation(() => true as unknown as SpeechSynthesis);
+    expect(synth.available).toBeTruthy();
+
+    expect(synth.makeSpeechText((''))).toEqual('');
+});

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
@@ -1,5 +1,5 @@
 import { createSetupFunction } from 'util/test-setup';
-import { WrappedChat } from './nicolive-comment-viewer';
+import { WrappedChat } from './WrappedChat';
 
 type NicoliveCommentSynthesizerService = import('./nicolive-comment-synthesizer').NicoliveCommentSynthesizerService;
 

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -1,0 +1,108 @@
+import { mutation, StatefulService } from 'services/stateful-service';
+import { WrappedChat } from './nicolive-comment-viewer';
+import replace_rules from './replace_rules.json';
+
+export class ParaphraseDictionary {
+  dictionary = replace_rules.elements.map(e => ({
+    pattern: new RegExp(e.regularExpression, 'i'), 
+    to: e.replacement
+  }));
+
+  process(input: string): string {
+    return this.dictionary.reduce<string>(
+      (acc, item) => acc.replace(item.pattern, item.to),
+      input
+    );
+  }
+}
+
+export type Speech = {
+  text: string;
+  pitch?: number;
+  rate?: number;
+}
+
+interface ICommentSynthesizerState {
+  pitch: number; // SpeechSynthesisUtterance.pitch; 0(lowest) to 2(highest) (default: 1)
+  rate: number; // SpeechSynthesisUtterence.rate; 0.1(lowest) to 10(highest); default:1
+};
+
+export class NicoliveCommentSynthesizerService extends StatefulService<ICommentSynthesizerState> {
+  static initialState: ICommentSynthesizerState = {
+    pitch: 1,
+    rate: 1,
+  }
+
+  setPitch(pitch: number) {
+    this.setState({pitch});
+  }
+
+  setRate(rate: number) {
+    this.setState({rate});
+  }
+
+  private setState(partialState: Partial<ICommentSynthesizerState>) {
+    const nextState = { ...this.state, ...partialState };
+    this.SET_STATE(nextState);
+  }
+  
+  @mutation()
+  private SET_STATE(nextState: ICommentSynthesizerState): void {
+    this.state = nextState;
+  }
+
+  // delegate synth
+  synth = new NicoliveCommentSynthesizer();
+
+  makeSpeech(chat: WrappedChat): Speech | null {
+    console.log(`makeSpeech proxy: ${chat}`);
+    const r = this.synth.makeSpeech(chat);
+    if (r) {
+      return {
+        pitch: this.state.pitch,
+        rate: this.state.rate,
+        ...r,
+      };
+    }
+    return r;
+  }
+
+  speakText(speech: Speech,
+    onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any,
+    onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any
+  ) {
+    return this.synth.speakText(speech, onstart, onend);
+  }
+}
+
+export class NicoliveCommentSynthesizer {
+  dictionary = new ParaphraseDictionary();
+
+  makeSpeech(chat: WrappedChat): Speech | null {
+    if (!chat.value || !chat.value.content) {
+      return null;
+    }
+    console.log(`makeSpeech: ${chat.value.content} -> ${this.dictionary.process(chat.value.content)}`);
+
+    return {
+      text: this.dictionary.process(chat.value.content)
+    };
+  }
+
+  speakText(speech: Speech,
+    onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any,
+    onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any
+  ) {
+    if (!speech || speech.text == '') {
+      return;
+    }
+    console.log(`speechText: ${speech.text}`);
+
+    const uttr = new SpeechSynthesisUtterance(speech.text);
+    uttr.pitch = speech.pitch || 1;
+    uttr.rate = speech.rate || 1;
+    uttr.onstart = onstart;
+    uttr.onend = onend;
+    speechSynthesis.speak(uttr);
+  }
+}

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -39,7 +39,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     });
   }
 
-  setEnabled(enabled: boolean) {
+  private setEnabled(enabled: boolean) {
     this.setState({ enabled });
   }
   get enabled(): boolean {
@@ -93,7 +93,6 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
   synth = new NicoliveCommentSynthesizer();
 
   makeSpeech(chat: WrappedChat): Speech | null {
-    console.log(`makeSpeech proxy: ${chat}`);
     const r = this.synth.makeSpeechText(chat);
     if (r === '') {
       return null;
@@ -149,23 +148,17 @@ export class NicoliveCommentSynthesizer {
     const text = getDisplayText(AddComponent(chat));
 
     const converted = this.dictionary.process(text);
-    if (converted === text) {
-      console.log(`makeSpeech: ${text}`);
-    } else {
-      console.log(`makeSpeech: ${text} -> ${converted}`);
-    }
 
     return converted;
   }
 
   speakText(speech: Speech,
-    onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any,
-    onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any
+    onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => void,
+    onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => void
   ) {
     if (!speech || speech.text == '' || !this.available) {
       return;
     }
-    console.log(`speechText: ${speech.text}`);
 
     const uttr = new SpeechSynthesisUtterance(speech.text);
     uttr.pitch = speech.pitch || 1;

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -20,12 +20,14 @@ export type Speech = {
   text: string;
   pitch?: number;
   rate?: number;
+  volume?: number;
 }
 
 interface ICommentSynthesizerState {
   enabled: boolean;
   pitch: number; // SpeechSynthesisUtterance.pitch; 0(lowest) to 2(highest) (default: 1)
   rate: number; // SpeechSynthesisUtterence.rate; 0.1(lowest) to 10(highest); default:1
+  volume: number; // SpeechSynthesisUtterance.volume; 0(lowest) to 1(highest)
 };
 
 export class NicoliveCommentSynthesizerService extends StatefulService<ICommentSynthesizerState> {
@@ -33,6 +35,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     enabled: true,
     pitch: 1,
     rate: 1,
+    volume: 1,
   }
 
   setEnabled(enabled: boolean) {
@@ -65,6 +68,16 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     this.setRate(r);
   }
 
+  setVolume(volume: number) {
+    this.setState({ volume });
+  }
+  get volume(): number {
+    return this.state.volume;
+  }
+  set volume(r: number) {
+    this.setVolume(r);
+  }
+
   private setState(partialState: Partial<ICommentSynthesizerState>) {
     const nextState = { ...this.state, ...partialState };
     this.SET_STATE(nextState);
@@ -88,6 +101,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
       return {
         pitch: this.state.pitch,
         rate: this.state.rate,
+        volume: this.state.volume,
         ...r,
       };
     }
@@ -152,6 +166,7 @@ export class NicoliveCommentSynthesizer {
     const uttr = new SpeechSynthesisUtterance(speech.text);
     uttr.pitch = speech.pitch || 1;
     uttr.rate = speech.rate || 1;
+    uttr.volume = speech.volume || 1;
     uttr.onstart = onstart;
     uttr.onend = onend;
     speechSynthesis.speak(uttr);

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -3,6 +3,8 @@ import { Inject } from 'util/injector';
 import { NicoliveProgramStateService } from './state';
 import { ParaphraseDictionary } from './ParaphraseDictionary';
 import { WrappedChat } from './nicolive-comment-viewer';
+import { getDisplayText } from './ChatMessage/displaytext';
+import { AddComponent } from './ChatMessage/ChatComponentType';
 
 export type Speech = {
   text: string;
@@ -144,12 +146,13 @@ export class NicoliveCommentSynthesizer {
     if (!chat.value || !chat.value.content) {
       return '';
     }
+    const text = getDisplayText(AddComponent(chat));
 
-    const converted = this.dictionary.process(chat.value.content);
-    if (converted === chat.value.content) {
-      console.log(`makeSpeech: ${chat.value.content}`);
+    const converted = this.dictionary.process(text);
+    if (converted === text) {
+      console.log(`makeSpeech: ${text}`);
     } else {
-      console.log(`makeSpeech: ${chat.value.content} -> ${converted}`);
+      console.log(`makeSpeech: ${text} -> ${converted}`);
     }
 
     return converted;

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -2,7 +2,7 @@ import { mutation, StatefulService } from 'services/stateful-service';
 import { Inject } from 'util/injector';
 import { NicoliveProgramStateService } from './state';
 import { ParaphraseDictionary } from './ParaphraseDictionary';
-import { WrappedChat } from './nicolive-comment-viewer';
+import { WrappedChat } from './WrappedChat';
 import { getDisplayText } from './ChatMessage/displaytext';
 import { AddComponent } from './ChatMessage/ChatComponentType';
 

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -4,7 +4,7 @@ import replace_rules from './replace_rules.json';
 
 export class ParaphraseDictionary {
   dictionary = replace_rules.elements.map(e => ({
-    pattern: new RegExp(e.regularExpression, 'i'), 
+    pattern: new RegExp(e.regularExpression, 'i'),
     to: e.replacement
   }));
 
@@ -23,29 +23,53 @@ export type Speech = {
 }
 
 interface ICommentSynthesizerState {
+  enabled: boolean;
   pitch: number; // SpeechSynthesisUtterance.pitch; 0(lowest) to 2(highest) (default: 1)
   rate: number; // SpeechSynthesisUtterence.rate; 0.1(lowest) to 10(highest); default:1
 };
 
 export class NicoliveCommentSynthesizerService extends StatefulService<ICommentSynthesizerState> {
   static initialState: ICommentSynthesizerState = {
+    enabled: true,
     pitch: 1,
     rate: 1,
   }
 
+  setEnabled(enabled: boolean) {
+    this.setState({ enabled });
+  }
+  get enabled(): boolean {
+    return this.state.enabled;
+  }
+  set enabled(e: boolean) {
+    this.setEnabled(e);
+  }
+
   setPitch(pitch: number) {
-    this.setState({pitch});
+    this.setState({ pitch });
+  }
+  get pitch(): number {
+    return this.state.pitch;
+  }
+  set pitch(p: number) {
+    this.setPitch(p);
   }
 
   setRate(rate: number) {
-    this.setState({rate});
+    this.setState({ rate });
+  }
+  get rate(): number {
+    return this.state.rate;
+  }
+  set rate(r: number) {
+    this.setRate(r);
   }
 
   private setState(partialState: Partial<ICommentSynthesizerState>) {
     const nextState = { ...this.state, ...partialState };
     this.SET_STATE(nextState);
   }
-  
+
   @mutation()
   private SET_STATE(nextState: ICommentSynthesizerState): void {
     this.state = nextState;
@@ -55,6 +79,9 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
   synth = new NicoliveCommentSynthesizer();
 
   makeSpeech(chat: WrappedChat): Speech | null {
+    if (!this.enabled) {
+      return null;
+    }
     console.log(`makeSpeech proxy: ${chat}`);
     const r = this.synth.makeSpeech(chat);
     if (r) {
@@ -67,11 +94,29 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     return r;
   }
 
+  makeSimpleTextSpeech(text: string): Speech | null {
+    return this.makeSpeech({
+      type: 'normal',
+      value: {
+        content: text,
+      },
+      seqId: 1,
+    });
+  }
+
   speakText(speech: Speech,
     onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any,
     onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any
   ) {
     return this.synth.speakText(speech, onstart, onend);
+  }
+
+  get speaking(): boolean {
+    return this.synth.speaking;
+  }
+
+  cancelSpeak() {
+    this.synth.cancelSpeak();
   }
 }
 
@@ -82,10 +127,16 @@ export class NicoliveCommentSynthesizer {
     if (!chat.value || !chat.value.content) {
       return null;
     }
-    console.log(`makeSpeech: ${chat.value.content} -> ${this.dictionary.process(chat.value.content)}`);
+
+    const converted = this.dictionary.process(chat.value.content);
+    if (converted === chat.value.content) {
+      console.log(`makeSpeech: ${chat.value.content}`);
+    } else {
+      console.log(`makeSpeech: ${chat.value.content} -> ${converted}`);
+    }
 
     return {
-      text: this.dictionary.process(chat.value.content)
+      text: converted,
     };
   }
 
@@ -104,5 +155,13 @@ export class NicoliveCommentSynthesizer {
     uttr.onstart = onstart;
     uttr.onend = onend;
     speechSynthesis.speak(uttr);
+  }
+
+  get speaking(): boolean {
+    return speechSynthesis.speaking;
+  }
+
+  cancelSpeak() {
+    speechSynthesis.cancel();
   }
 }

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -137,6 +137,10 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
 export class NicoliveCommentSynthesizer {
   dictionary = new ParaphraseDictionary();
 
+  get available(): boolean {
+    return window.speechSynthesis !== undefined
+  }
+
   makeSpeech(chat: WrappedChat): Speech | null {
     if (!chat.value || !chat.value.content) {
       return null;
@@ -158,7 +162,7 @@ export class NicoliveCommentSynthesizer {
     onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any,
     onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any
   ) {
-    if (!speech || speech.text == '') {
+    if (!speech || speech.text == '' || !this.available) {
       return;
     }
     console.log(`speechText: ${speech.text}`);
@@ -173,10 +177,13 @@ export class NicoliveCommentSynthesizer {
   }
 
   get speaking(): boolean {
-    return speechSynthesis.speaking;
+    return this.available && speechSynthesis.speaking;
   }
 
   cancelSpeak() {
+    if (!this.available) {
+      return;
+    }
     speechSynthesis.cancel();
   }
 }

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -15,9 +15,9 @@ export type Speech = {
 
 interface ICommentSynthesizerState {
   enabled: boolean;
-  pitch: number; // SpeechSynthesisUtterance.pitch; 0(lowest) to 2(highest) (default: 1)
+  pitch: number; // SpeechSynthesisUtterance.pitch; 0.1(lowest) to 2(highest) (default: 1)
   rate: number; // SpeechSynthesisUtterence.rate; 0.1(lowest) to 10(highest); default:1
-  volume: number; // SpeechSynthesisUtterance.volume; 0(lowest) to 1(highest)
+  volume: number; // SpeechSynthesisUtterance.volume; 0.1(lowest) to 1(highest)
 };
 
 export class NicoliveCommentSynthesizerService extends StatefulService<ICommentSynthesizerState> {
@@ -49,7 +49,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     this.setEnabled(e);
   }
 
-  setPitch(pitch: number) {
+  private setPitch(pitch: number) {
     this.setState({ pitch });
   }
   get pitch(): number {
@@ -59,7 +59,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     this.setPitch(p);
   }
 
-  setRate(rate: number) {
+  private setRate(rate: number) {
     this.setState({ rate });
   }
   get rate(): number {
@@ -69,7 +69,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     this.setRate(r);
   }
 
-  setVolume(volume: number) {
+  private setVolume(volume: number) {
     this.setState({ volume });
   }
   get volume(): number {
@@ -116,8 +116,8 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
   }
 
   speakText(speech: Speech,
-    onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any,
-    onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any
+    onstart: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => void,
+    onend: (this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => void
   ) {
     if (!this.enabled) {
       return;

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -7,6 +7,9 @@ const setup = createSetupFunction({
     NicoliveCommentFilterService: {
       stateChange: new Subject(),
     },
+    NicoliveCommentLocalFilterService: {
+      filterFn: () => true,
+    },
     NicoliveCommentSynthesizerService: {
       stateChange: new Subject(),
       available: false,
@@ -16,6 +19,7 @@ const setup = createSetupFunction({
 
 jest.mock('services/nicolive-program/nicolive-program', () => ({ NicoliveProgramService: {} }));
 jest.mock('services/nicolive-program/nicolive-comment-filter', () => ({ NicoliveCommentFilterService: {} }));
+jest.mock('services/nicolive-program/nicolive-comment-local-filter', () => ({ NicoliveCommentLocalFilterService: {} }));
 jest.mock('services/nicolive-program/nicolive-comment-synthesizer', () => ({ NicoliveCommentSynthesizerService: {} }));
 
 beforeEach(() => {

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -156,6 +156,7 @@ test('chatメッセージはstateに保持する', () => {
   expect(instance.state.messages).toMatchInlineSnapshot(`
     Array [
       Object {
+        "component": "common",
         "seqId": 0,
         "type": "normal",
         "value": Object {
@@ -163,6 +164,7 @@ test('chatメッセージはstateに保持する', () => {
         },
       },
       Object {
+        "component": "common",
         "seqId": 1,
         "type": "normal",
         "value": Object {
@@ -170,6 +172,7 @@ test('chatメッセージはstateに保持する', () => {
         },
       },
       Object {
+        "component": "system",
         "seqId": 2,
         "type": "n-air-emulated",
         "value": Object {
@@ -226,6 +229,7 @@ test('接続エラー時にメッセージを表示する', () => {
   expect(instance.state.messages).toMatchInlineSnapshot(`
                           Array [
                             Object {
+                              "component": "system",
                               "seqId": 0,
                               "type": "n-air-emulated",
                               "value": Object {
@@ -234,6 +238,7 @@ test('接続エラー時にメッセージを表示する', () => {
                               },
                             },
                             Object {
+                              "component": "system",
                               "seqId": 1,
                               "type": "n-air-emulated",
                               "value": Object {
@@ -261,6 +266,7 @@ test('スレッドの参加失敗時にメッセージを表示する', () => {
   expect(instance.state.messages).toMatchInlineSnapshot(`
         Array [
           Object {
+            "component": "system",
             "seqId": 0,
             "type": "n-air-emulated",
             "value": Object {
@@ -269,6 +275,7 @@ test('スレッドの参加失敗時にメッセージを表示する', () => {
             },
           },
           Object {
+            "component": "system",
             "seqId": 1,
             "type": "n-air-emulated",
             "value": Object {
@@ -294,6 +301,7 @@ test('スレッドからの追い出し発生時にメッセージを表示す�
   expect(instance.state.messages).toMatchInlineSnapshot(`
         Array [
           Object {
+            "component": "system",
             "seqId": 0,
             "type": "n-air-emulated",
             "value": Object {
@@ -302,6 +310,7 @@ test('スレッドからの追い出し発生時にメッセージを表示す�
             },
           },
           Object {
+            "component": "system",
             "seqId": 1,
             "type": "n-air-emulated",
             "value": Object {

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -7,11 +7,16 @@ const setup = createSetupFunction({
     NicoliveCommentFilterService: {
       stateChange: new Subject(),
     },
+    NicoliveCommentSynthesizerService: {
+      stateChange: new Subject(),
+      available: false,
+    }
   },
 });
 
 jest.mock('services/nicolive-program/nicolive-program', () => ({ NicoliveProgramService: {} }));
 jest.mock('services/nicolive-program/nicolive-comment-filter', () => ({ NicoliveCommentFilterService: {} }));
+jest.mock('services/nicolive-program/nicolive-comment-synthesizer', () => ({ NicoliveCommentSynthesizerService: {} }));
 
 beforeEach(() => {
   jest.doMock('services/stateful-service');
@@ -145,6 +150,8 @@ test('chatメッセージはstateに保持する', () => {
 
   // bufferTime tweaks
   clientSubject.complete();
+  expect(clientSubject.hasError).toBeFalsy()
+  expect(clientSubject.thrownError).toBeNull()
 
   expect(instance.state.messages).toMatchInlineSnapshot(`
     Array [

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -77,6 +77,9 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
     return this.state.messages;
   }
 
+  get speakingEnabled(): boolean {
+    return this.nicoliveCommentSynthesizerService.enabled;
+  }
   get speakingSeqId() {
     return this.state.speakingSeqId;
   }

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -146,7 +146,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
               return group$
                 .pipe(
                   filter(isChatMessage),
-                  map(({ chat }) => AddComponent({
+                  map(({ chat }) => ({
                     type: classify(chat),
                     value: chat,
                   })),
@@ -181,7 +181,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
         map(({ type, value }, seqId) => ({ type, value, seqId })),
         bufferTime(1000),
         filter(arr => arr.length > 0),
-      ).subscribe(values => this.onMessage(values as any));
+      ).subscribe(values => this.onMessage(values.map(c => AddComponent(c))));
     this.client.requestLatestMessages();
   }
 

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -219,8 +219,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   }
 
   private onMessage(values: WrappedChatWithComponent[]) {
-    const maxQueueToSpeak = 3; // 直近3件つづ読み上げ対象にする...?
-    // TODO 開いたときは直近1分ぐらい読みたいが、コメントリロードボタンでは1秒ぐらいにしたい
+    const maxQueueToSpeak = 3; // 直近3件つづ読み上げ対象にする
     const recentSeconds = 60;
 
     const nowSeconds = Date.now() / 1000;

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -80,6 +80,9 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   get speakingEnabled(): boolean {
     return this.nicoliveCommentSynthesizerService.enabled;
   }
+  set speakingEnabled(e: boolean) {
+    this.nicoliveCommentSynthesizerService.enabled = e;
+  }
   get speakingSeqId() {
     return this.state.speakingSeqId;
   }

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -216,13 +216,6 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
     // TODO 開いたときは直近1分ぐらい読みたいが、コメントリロードボタンでは1秒ぐらいにしたい
     const recentSeconds = 60;
 
-    // TODO リロードするときは再生も中断したい
-    // TODO コメントごとに読み上げボタンを付けて任意で再生させたい
-    // TODO コメントアートを除外したい
-    // TODO 変換辞書を用意して /w+/ を ワラ, /8+/ をパチパチ とかにしたい
-    // TODO 読み上げ全体のスイッチを用意して、offにすると即座に止めたい
-    // TODO システムメッセージはon/offできるようにする(設定保存)
-
     const now = Date.now() / 1000;
     this.queueToSpeech(values.slice(-maxQueueToSpeak).filter(c => {
       if (!c.value || !c.value.date) {

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -25,6 +25,7 @@ import { ChatMessageType, classify } from './ChatMessage/classifier';
 import { isOperatorCommand } from './ChatMessage/util';
 import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
 import { NicoliveCommentSynthesizerService } from './nicolive-comment-synthesizer';
+import { AddComponent, ChatComponentType } from './ChatMessage/ChatComponentType';
 
 export type WrappedChat = {
   type: ChatMessageType;
@@ -33,6 +34,8 @@ export type WrappedChat = {
   /** NG追加したときに手元でフィルタをかけた結果 */
   filtered?: boolean;
 };
+
+export type WrappedChatWithComponent = WrappedChat & { component: ChatComponentType };
 
 function makeEmulatedChat(
   content: string,
@@ -49,13 +52,13 @@ function makeEmulatedChat(
 
 interface INicoliveCommentViewerState {
   /** 表示対象のコメント */
-  messages: WrappedChat[];
+  messages: WrappedChatWithComponent[];
   /**
    * 直前の更新で表示対象から押し出されたコメント
    * ローカルフィルターとスクロール位置維持のために実体を持っている
    */
-  popoutMessages: WrappedChat[];
-  pinnedMessage: WrappedChat | null;
+  popoutMessages: WrappedChatWithComponent[];
+  pinnedMessage: WrappedChatWithComponent | null;
   speakingSeqId: number | null;
 }
 
@@ -153,7 +156,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
               return group$
                 .pipe(
                   filter(isChatMessage),
-                  map(({ chat }) => ({
+                  map(({ chat }) => AddComponent({
                     type: classify(chat),
                     value: chat,
                   })),
@@ -218,7 +221,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
     }
   }
 
-  private onMessage(values: WrappedChat[]) {
+  private onMessage(values: WrappedChatWithComponent[]) {
     const maxQueueToSpeak = 3; // 直近3件つづ読み上げ対象にする...?
     // TODO 開いたときは直近1分ぐらい読みたいが、コメントリロードボタンでは1秒ぐらいにしたい
     const recentSeconds = 60;
@@ -253,7 +256,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
     this.SET_STATE({ messages: [], popoutMessages: [] });
   }
 
-  pinComment(pinnedMessage: WrappedChat | null) {
+  pinComment(pinnedMessage: WrappedChatWithComponent | null) {
     this.SET_STATE({ pinnedMessage });
   }
 

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -18,24 +18,14 @@ import {
   MessageServerClient,
   MessageServerConfig,
   isChatMessage,
-  ChatMessage,
   isThreadMessage,
 } from './MessageServerClient';
-import { ChatMessageType, classify } from './ChatMessage/classifier';
+import { classify } from './ChatMessage/classifier';
 import { isOperatorCommand } from './ChatMessage/util';
 import { NicoliveCommentFilterService } from 'services/nicolive-program/nicolive-comment-filter';
 import { NicoliveCommentSynthesizerService } from './nicolive-comment-synthesizer';
-import { AddComponent, ChatComponentType } from './ChatMessage/ChatComponentType';
-
-export type WrappedChat = {
-  type: ChatMessageType;
-  value: ChatMessage;
-  seqId: number;
-  /** NG追加したときに手元でフィルタをかけた結果 */
-  filtered?: boolean;
-};
-
-export type WrappedChatWithComponent = WrappedChat & { component: ChatComponentType };
+import { AddComponent } from './ChatMessage/ChatComponentType';
+import { WrappedChat, WrappedChatWithComponent } from './WrappedChat';
 
 function makeEmulatedChat(
   content: string,

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -187,6 +187,9 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   }
 
   private queueToSpeech(values: WrappedChat[]) {
+    if (!this.nicoliveCommentSynthesizerService.enabled) {
+      return;
+    }
     for (const chat of values) {
       const speech = this.nicoliveCommentSynthesizerService.makeSpeech(chat);
       if (speech) {

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -203,13 +203,11 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
       if (speech) {
         this.nicoliveCommentSynthesizerService.speakText(speech,
           () => {
-            console.log(`#${chat.seqId}: ${chat.value.content}: onstart`);
             this.SET_STATE({
               speakingSeqId: chat.seqId
             });
           },
           () => {
-            console.log(`#${chat.seqId}: ${chat.value.content}: onend`);
             if (this.state.speakingSeqId == chat.seqId) {
               this.SET_STATE({
                 speakingSeqId: null
@@ -225,7 +223,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
     // TODO 開いたときは直近1分ぐらい読みたいが、コメントリロードボタンでは1秒ぐらいにしたい
     const recentSeconds = 60;
 
-    const now = Date.now() / 1000;
+    const nowSeconds = Date.now() / 1000;
     this.queueToSpeech(values.filter(c => {
       if (!this.filterFn(c)) {
         return false;
@@ -233,7 +231,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
       if (!c.value || !c.value.date) {
         return false;
       }
-      if (c.value.date < (now - recentSeconds)) {
+      if (c.value.date < (nowSeconds - recentSeconds)) {
         return false;
       }
       return true;

--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -1,0 +1,110 @@
+{
+  "elements": [
+    {
+      "note": "最初に改行あるかどうかを優先してチェック",
+      "regularExpression": ".*[\n\r].*",
+      "replacement": ""
+    },
+    {
+      "regularExpression": "HTTPS?://[\\w/:%#\\$&\\?\\(\\)~\\.=\\+\\-]+",
+      "replacement": "URLショウリャク"
+    },
+    {
+      "regularExpression": "[8８]{4,}",
+      "replacement": "パチパチパチ"
+    },
+    {
+      "regularExpression": "[WＷ]{2,}",
+      "replacement": "ワラワラ"
+    },
+    {
+      "regularExpression": "([^A-Z])[WＷ]$",
+      "replacement": "$1、ワラ"
+    },
+    {
+      "regularExpression": "([^A-Z\\s])[WＷ]([！。\\s].*)",
+      "replacement": "$1、ワラ$2"
+    },
+    {
+      "regularExpression": "㌧",
+      "replacement": "トン"
+    },
+    {
+      "regularExpression": "(\\(RY|（ＲＹ)",
+      "replacement": "リャク"
+    },
+    {
+      "regularExpression": "う[PＰ]",
+      "replacement": "ウプ"
+    },
+    {
+      "regularExpression": "厨",
+      "replacement": "チュウ"
+    },
+    {
+      "regularExpression": "CH",
+      "replacement": "チャンネル"
+    },
+    {
+      "regularExpression": "行って",
+      "replacement": "イッテ"
+    },
+    {
+      "regularExpression": "行った",
+      "replacement": "イッタ"
+    },
+    {
+      "regularExpression": "ニコ生",
+      "replacement": "ニコナマ"
+    },
+    {
+      "regularExpression": "〜",
+      "replacement": "ー"
+    },
+    {
+      "regularExpression": "~",
+      "replacement": "ー"
+    },
+    {
+      "regularExpression": "━",
+      "replacement": "ー"
+    },
+    {
+      "regularExpression": "&(APOS|LT|GT|QUOT);",
+      "replacement": ""
+    },
+    {
+      "regularExpression": "[＾Ω∞☠♭〇㈲＃#＄$＊\\*＾≧≦･＞＜．.×\"'<>^°]+",
+      "replacement": ""
+    },
+    {
+      "regularExpression": "♥",
+      "replacement": "ハート"
+    },
+    {
+      "regularExpression": "★",
+      "replacement": "ほし"
+    },
+    {
+      "regularExpression": "^[WＷ]$",
+      "replacement": "ワラ"
+    },
+    {
+      "regularExpression": "^[!！]$",
+      "replacement": "びっくり"
+    },
+    {
+      "regularExpression": "^[\\?？]$",
+      "replacement": "はてな"
+    },
+    {
+      "regularExpression": "^(!\\?|！？|⁉)$",
+      "replacement": "びっくりはてな"
+    },
+    {
+      "note": "最後に長さチェック40文字を超える場合は41文字以降をリャク",
+      "regularExpression": "(.{40,40}).+",
+      "replacement": "$1リャク"
+    }
+  ]
+}

--- a/app/services/nicolive-program/state.ts
+++ b/app/services/nicolive-program/state.ts
@@ -2,9 +2,17 @@ import { PersistentStatefulService } from 'services/persistent-stateful-service'
 import { mutation } from '../stateful-service';
 import { Subject, BehaviorSubject, Observable } from 'rxjs';
 
+type SpeechSynthesizerSettingsState = {
+  enabled: boolean;
+  pitch: number;
+  rate: number;
+  volume: number;
+}
+
 interface IState {
   autoExtensionEnabled: boolean;
   panelOpened: boolean;
+  speechSynthesizerSettings?: SpeechSynthesizerSettingsState; 
 }
 
 /**
@@ -25,6 +33,10 @@ export class NicoliveProgramStateService extends PersistentStatefulService<IStat
 
   togglePanelOpened(): void {
     this.setState({ panelOpened: !this.state.panelOpened });
+  }
+
+  updateSpeechSynthesizerSettings(newState: SpeechSynthesizerSettingsState): void {
+    this.setState({ speechSynthesizerSettings: newState });
   }
 
   private setState(nextState: Partial<IState>): void {

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -189,9 +189,19 @@ button,
 }
 
 .button--default {
-  background: rgba(255, 255, 255, .1);
-  border-color: transparent;
-  color: @white;
+  background: rgba(255, 255, 255, .1) !important;
+  border-color: transparent !important;
+  color: @white !important;
+
+  &:hover {
+    background: rgba(255, 255, 255, .2) !important;
+ }
+
+ &:disabled {
+   &:hover {
+    background: rgba(255, 255, 255, .1) !important;
+   }
+ }
 }
 
 .button--create-program {
@@ -229,4 +239,24 @@ button,
       background-color: transparent;
     }
   }
+}
+
+.button-nicolive--action {
+  color: @white;
+  background-color: @nicolive-button;
+
+  &:hover {
+    background-color: @nicolive-button-hover;
+ }
+
+ &:disabled {
+   &:hover {
+     background-color: @nicolive-button;
+   }
+ }
+}
+
+.button-nicolive--default {
+  color: @white;
+  background-color: @grey;
 }

--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -153,7 +153,7 @@ textarea {
   &:after {
     width: 20px;
     height: 20px;
-    background-color: @grey;
+    background-color: @light-grey;
     border-radius: 100%;
   }
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,6 +12,7 @@
     "allowJs": true,
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "experimentalDecorators": true,
     "noImplicitThis": true,
     "removeComments": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "removeComments": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
 
     "outDir": "bundles/ts",
     "sourceMap": true,


### PR DESCRIPTION
# このpull requestが解決する内容
コメント読み上げ機能(初期リリース用)。

* [x] 設定画面
    * [x] 有効/無効
    * [x] 声の高さ
    * [x] 読み上げ速度
    * [x] 音量
    * [x] テスト再生
* コメント一覧 
    * [x] 再生中のコメントに印をつける
* [x] 設定を永続化する
* [x] testを書く
* [x] デザインを当てる

# 動作確認手順
番組を作成して、コメントをしたり、コメント一覧の右上の設定を開いたりする

# 関連するIssue（あれば）
