### PR TITLE
修正: ニコ生番組作成後、作成ウィンドウが閉じなくなっていた

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -251,7 +251,7 @@ describe('webviews', () => {
 
     // don't await
     const result = expect(client.createProgram()).resolves.toBe('CREATED');
-    mock.browserWindow.loadURL(`https://live2.nicovideo.jp/watch/${programID}`);
+    mock.browserWindow.loadURL(`https://live.nicovideo.jp/watch/${programID}`);
 
     await result;
     expect(mock.browserWindow.close).toHaveBeenCalled();

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -69,7 +69,7 @@ export class NicoliveClient {
   private static frontendID = 134;
 
   static isProgramPage(url: string): boolean {
-    return /^https?:\/\/live2\.nicovideo\.jp\/watch\/lv\d+/.test(url);
+    return /^https?:\/\/live2?\.nicovideo\.jp\/watch\/lv\d+/.test(url);
   }
 
   static isMyPage(url: string): boolean {


### PR DESCRIPTION
# このpull requestが解決する内容
ニコ生の番組ページアドレスが `live2.nicovideo.jp/watch` から `live.nicovideo.jp/watch` に変わったため、判定が失敗してウィンドウが開きっぱなしのまま再生ページが見えていたので、新しいアドレスを認識するように修正します

# 動作確認手順
N Airから番組を作成すると作成ウィンドウが閉じる
(unit testあり)
