### PR TITLE
開発: stable releaseのpatch-noteから authorを削除

### DIFF
--- a/bin/release/generatePatchNote.js
+++ b/bin/release/generatePatchNote.js
@@ -121,7 +121,10 @@ async function generateRoutine({ githubTokenForReadPullRequest }) {
       owner: 'n-air-app',
       repo: 'n-air-app',
     },
-    previousVersion
+    previousVersion,
+    {
+      addAuthor: !(environment === 'public' && channel === 'stable'),
+    }
   );
 
   const directCommits = executeCmd(`git log --no-merges --first-parent --pretty=format:"%s (%t)" v${previousVersion}..`, {

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -148,11 +148,11 @@ async function collectPullRequestMerges({ octokit, owner, repo }, previousVersio
     for (const result of results) {
       const { data } = result;
       if ('title' in data) {
-        const lines = [`${data.title} (#${data.number})`];
+        const elements = [data.title, `(#${data.number})`];
         if (addAuthor) {
-          lines.push(`by ${data.user.login}\n`);
+          elements.push(`by ${data.user.login}`);
         }
-        summary.push(lines.join(' '));
+        summary.push(elements.join(' ') + '\n');
       }
     }
 

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -108,8 +108,12 @@ function writePatchNoteFile(patchNoteFileName, version, contents) {
   fs.writeFileSync(patchNoteFileName, body);
 }
 
-async function collectPullRequestMerges({ octokit, owner, repo }, previousVersion) {
-  const merges = executeCmd(`git log --oneline --merges v${previousVersion}..`, { silent: true }).stdout;
+function gitLog(previousVersion) {
+  return executeCmd(`git log --oneline --merges v${previousVersion}..`, { silent: true }).stdout;
+}
+
+async function collectPullRequestMerges({ octokit, owner, repo }, previousVersion, { addAuthor } ) {
+  const merges = gitLog(previousVersion);
 
   const promises = [];
   for (const line of merges.split(/\r?\n/)) {
@@ -144,7 +148,11 @@ async function collectPullRequestMerges({ octokit, owner, repo }, previousVersio
     for (const result of results) {
       const { data } = result;
       if ('title' in data) {
-        summary.push(`${data.title} (#${data.number}) by ${data.user.login}\n`);
+        const lines = [`${data.title} (#${data.number})`];
+        if (addAuthor) {
+          lines.push(`by ${data.user.login}\n`);
+        }
+        summary.push(lines.join(' '));
       }
     }
 
@@ -174,10 +182,10 @@ export const notes: IPatchNotes = {
   title: '${title}',
   notes: [
 ${notes
-    .trim()
-    .split('\n')
-    .map(s => `    '${s}'`)
-    .join(',\n')}
+      .trim()
+      .split('\n')
+      .map(s => `    '${s}'`)
+      .join(',\n')}
   ]
 };
 `;


### PR DESCRIPTION
# このpull requestが解決する内容
release scriptで、public stable release (通常版) のときには `yarn patch-note` で `by koizuka`  みたいな author 表示を省略するようにします

# 動作確認手順
* n-air_stable にmerge して `yarn patch-note` すると author が付かない
* n-air_unstable にmerge して `yarn patch-note` すると author が付く

