### PR TITLE
コメント読み上げ辞書更新(初見追加)

### DIFF
--- a/app/services/nicolive-program/ParaphraseDictionary.test.ts
+++ b/app/services/nicolive-program/ParaphraseDictionary.test.ts
@@ -7,4 +7,5 @@ test('PhraseDictionary', async () => {
   expect(dictionary.process('ww')).toBe('ワラワラ');
   expect(dictionary.process('テストw')).toBe('テスト、ワラ');
   expect(dictionary.process('複数行は\nすべて無視')).toBe('');
+  expect(dictionary.process('初見')).toBe('しょけん');
 });

--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -105,6 +105,10 @@
       "note": "最後に長さチェック40文字を超える場合は41文字以降をリャク",
       "regularExpression": "(.{40,40}).+",
       "replacement": "$1リャク"
+    },
+    {
+      "regularExpression": "初見",
+      "replacement": "しょけん"
     }
   ]
 }


### PR DESCRIPTION
# このpull requestが解決する内容
初見が「はつみ」と読まれているのを修正する

# 動作確認手順
放送で「初見」とコメントすると「しょけん」と読まれる

# 関連するIssue（あれば）
#502 