### PR TITLE
修正: コメント読み上げ「古参」

### DIFF
--- a/app/services/nicolive-program/ParaphraseDictionary.test.ts
+++ b/app/services/nicolive-program/ParaphraseDictionary.test.ts
@@ -8,4 +8,5 @@ test('PhraseDictionary', async () => {
   expect(dictionary.process('テストw')).toBe('テスト、ワラ');
   expect(dictionary.process('複数行は\nすべて無視')).toBe('');
   expect(dictionary.process('初見')).toBe('しょけん');
+  expect(dictionary.process('古参')).toBe('こさん');
 });

--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -109,6 +109,10 @@
     {
       "regularExpression": "初見",
       "replacement": "しょけん"
+    },
+    {
+      "regularExpression": "古参",
+      "replacement": "こさん"
     }
   ]
 }


### PR DESCRIPTION
# このpull requestが解決する内容
コメント読み上げで｢古参」を「ふるさん」と読んでいたので「こさん」に修正する

# 動作確認手順
コメント読み上げを有効にして｢古参」とコメントする

# 関連するIssue（あれば）
#509 