### PR TITLE
修正: patchnote ts生成コードをeslintルールに合わせる(開発)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
 plugins/obs-browser.7z filter=lfs diff=lfs merge=lfs -text
 plugins/obs-facemask-plugin.7z filter=lfs diff=lfs merge=lfs -text
 *.7z filter=lfs diff=lfs merge=lfs -text
-* text eol=lf
+.* text eol=lf
+*.{js,ts,json} text eol=lf
 
 *.mp3 binary
 *.wav binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@ plugins/obs-browser.7z filter=lfs diff=lfs merge=lfs -text
 plugins/obs-facemask-plugin.7z filter=lfs diff=lfs merge=lfs -text
 *.7z filter=lfs diff=lfs merge=lfs -text
 * text eol=lf
+
+*.mp3 binary
+*.wav binary
+*.png binary

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -184,8 +184,8 @@ export const notes: IPatchNotes = {
 ${notes
       .trim()
       .split('\n')
-      .map(s => `    '${s}'`)
-      .join(',\n')}
+      .map(s => `    '${s}',`)
+      .join('\n')}
   ]
 };
 `;


### PR DESCRIPTION
# このpull requestが解決する内容
release script実行中に生成される note.ts のスタイルが現在の eslint ruleにひっかかってリリースが止まるので、そうならないように修正します。
あとリリース中にバイナリファイルがgitに警告されるのを回避する .gitattributesも追加します。

# 動作確認手順
リリーススクリプトを実行して成功すること

# 関連するIssue（あれば）
