### PR TITLE
修正: ニコ生の番組を終了したら即座に配信を終了する

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -9,6 +9,7 @@ import {
   NicoliveFailure,
   openErrorDialogFromFailure,
 } from 'services/nicolive-program/NicoliveFailure';
+import { Subscription } from 'rxjs';
 
 @Component({})
 export default class ProgramInfo extends Vue {
@@ -18,6 +19,25 @@ export default class ProgramInfo extends Vue {
 
   // TODO: 後でまとめる
   programIsMemberOnlyTooltip = 'コミュニティ限定放送';
+
+  private subscription: Subscription = null;
+
+  mounted() {
+    this.subscription = this.nicoliveProgramService.stateChange.subscribe(state => {
+      if (state.status === 'end') {
+        if (this.streamingService.isStreaming) {
+          this.streamingService.toggleStreamingAsync();
+        }
+      }
+    });
+  }
+
+  destroyed() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+  }
 
   isCreating: boolean = false;
   async createProgram() {


### PR DESCRIPTION
# このpull requestが解決する内容
従来はOBSのstreamingの再接続のタイミングで番組が続いているかをチェックしてトリガーしていましたが、どうやら今は番組が終了してもOBSが再接続をすぐにしないため、これが発動するのに35秒ほどかかるようになってしまっていました。

それでは不便なので、番組状態を把握している部分が終了状態になったときにトリガーして止めるようにしました。
N Air内から番組終了を押すか、N Airの外で番組を終了した場合はN Airで番組情報を更新することで終了状態を認識し、即座にストリーミングを停止します。

# 動作確認手順
## N Airの終了ボタンを押すケース
1. 番組を作成し、番組を開始する(ストリーミングをする)
2. N Airの番組終了ボタンを押す
3. ストリーミングもすぐに止まる

## N Air以外で番組を終了するケース
1. 番組を作成し、番組を開始する(ストリーミングをする)
2. ブラウザで番組ページを開き、番組を終了する
3. N Airで番組情報の更新ボタンをクリックする
4. N Airが放送が終わっていることを認識し、ストリーミングが止まる

# 関連するIssue（あれば）
#507 