### PR TITLE
修正: リンクを中ボタン(ホイール)クリックしても操作できないウィンドウが開かないようにする

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -116,6 +116,7 @@ Vue.use(VModal);
 document.addEventListener('dragover', event => event.preventDefault());
 document.addEventListener('dragenter', event => event.preventDefault());
 document.addEventListener('drop', event => event.preventDefault());
+document.addEventListener('auxclick', event => event.preventDefault());
 
 document.addEventListener('DOMContentLoaded', () => {
   createStore().then(async store => {


### PR DESCRIPTION
# このpull requestが解決する内容
番組情報のツイッターアイコンなどを中クリックするとElectronのブラウザウィンドウが開いてしまうが、初期化していないのでまともに使えないため、単純に押しても何も起きないようにします。

# 動作確認手順
1. 番組を作成する
2. 番組情報のツイッターアイコンを中クリックする
3. 真っ白とかのウィンドウが開くのではなく、押しても何も起きないこと

# 関連するIssue（あれば）
#412