### PR TITLE
修正:シーンの名前変更で (1) が付加されないようにする

### DIFF
--- a/app/components/windows/NameScene.vue.ts
+++ b/app/components/windows/NameScene.vue.ts
@@ -38,6 +38,7 @@ export default class NameScene extends Vue {
 
     if (this.options.rename) {
       name = this.scenesService.getScene(this.options.rename).name;
+      this.name = name;
     } else if (this.options.sceneToDuplicate) {
       name = this.scenesService.getScene(this.options.sceneToDuplicate).name;
     } else if (this.options.itemsToGroup) {
@@ -47,8 +48,7 @@ export default class NameScene extends Vue {
     } else {
       name = $t('scenes.newSceneName');
     }
-
-    this.name = this.sourcesService.suggestName(name);
+    if (!this.options.rename) this.name = this.sourcesService.suggestName(name);
   }
 
   submit() {


### PR DESCRIPTION
# このpull requestが解決する内容
シーンの「名前を変更」で出るダイアログの名前欄の初期値として現在の名前の後ろに (1) のような数値が追加されてしまう問題を修正します。

# 動作確認手順
シーンから名前の変更を開くと、入力欄が現在の名前のままになっていること

# 関連するIssue（あれば）
#376