### PR TITLE
修正: 番組予約時刻30分以上前から開いていた場合、開始時刻に番組開始に切り替わらなかった

### DIFF
--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -713,6 +713,24 @@ describe('refreshProgramStatusTimer', () => {
       result: 'REFRESH',
     },
     {
+      name: '予約状態なら毎回タイマーを更新する(30分前境界超え対策)',
+      prev: {
+        status: 'reserved',
+        programID: 'lv1',
+        testStartTime: 100,
+        startTime: 30 * 60 - 1,
+        endTime: 300,
+      },
+      next: {
+        status: 'reserved',
+        programID: 'lv1',
+        testStartTime: 100,
+        startTime: 30 * 60 - 1,
+        endTime: 300,
+      },
+      result: 'REFRESH',
+    },
+    {
       name: '予約状態から放送中状態になったらタイマーを更新する',
       prev: {
         status: 'reserved',

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -400,7 +400,14 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     const prev = prevState.status !== 'end';
     const next = nextState.status !== 'end';
 
-    if (next && (!prev || programUpdated || statusUpdated || targetTimeUpdated)) {
+    if (
+      next &&
+      (!prev ||
+        programUpdated ||
+        statusUpdated ||
+        targetTimeUpdated ||
+        nextState.status === 'reserved') // 予約中は30分前境界を越えたときにタイマーを再設定できていなかったので雑に予約中なら毎回設定する
+    ) {
       const now = Date.now();
       const waitTime = (nextTargetTime + NicoliveProgramService.TIMER_PADDING_SECONDS) * 1000 - now;
 

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -406,7 +406,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
         programUpdated ||
         statusUpdated ||
         targetTimeUpdated ||
-        nextState.status === 'reserved') // 予約中は30分前境界を越えたときにタイマーを再設定できていなかったので雑に予約中なら毎回設定する
+        nextState.status === 'reserved') // 予約中は30分前境界を越えたときに status が 'reserved' のまま変わらないためタイマーを再設定できていなかったので雑に予約中なら毎回設定する
     ) {
       const now = Date.now();
       const waitTime = (nextTargetTime + NicoliveProgramService.TIMER_PADDING_SECONDS) * 1000 - now;


### PR DESCRIPTION
# このpull requestが解決する内容
予約番組の開始時刻30分以上前から待機していると、番組開始時刻に自動更新されていなかったのを修正します。

# 動作確認手順
番組作成時に予約を利用をチェック(プレミアム会員)し、現在時刻より30分以上未来で予約する。
30分以上前の段階でN Airで番組の予約状態表示にして、そこから放置して番組開始時刻に自動的に状態が変わること。

# 関連するIssue（あれば）
#519 