### PR TITLE
修正: コメント読み上げ「生主」「放送主」

### DIFF
--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -102,17 +102,25 @@
       "replacement": "びっくりはてな"
     },
     {
-      "note": "最後に長さチェック40文字を超える場合は41文字以降をリャク",
-      "regularExpression": "(.{40,40}).+",
-      "replacement": "$1リャク"
-    },
-    {
       "regularExpression": "初見",
       "replacement": "しょけん"
     },
     {
       "regularExpression": "古参",
       "replacement": "こさん"
+    },
+    {
+      "regularExpression": "生主",
+      "replacement": "なまぬし"
+    },
+    {
+      "regularExpression": "放送主",
+      "replacement": "ほうそうぬし"
+    },
+    {
+      "note": "最後に長さチェック40文字を超える場合は41文字以降をリャク",
+      "regularExpression": "(.{40,40}).+",
+      "replacement": "$1リャク"
     }
   ]
 }


### PR DESCRIPTION
# このpull requestが解決する内容
`生主` が `ナマオモ` 、 `放送主` が `ホウソウオモ` と読み上げられてしまっているのを `ナマヌシ` 、 `ホウソウヌシ` に修正します。
あと、40文字チェックが最後でないといけなかったので並べ替えました。

# 動作確認手順
番組で「生主」や「放送主」を読み上げてみる

# 関連するIssue（あれば）
#522 #523