### PR TITLE
修正: リリーススクリプトが生成するpatch note ts に対して eslint --fix を適用する(コミット時チェック対策)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "cdup",
+    "toplevel"
+  ]
+}

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -22,6 +22,15 @@ const { uploadS3File, uploadToGithub, uploadToSentry } = require('./scripts/uplo
 const pjson = JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8'));
 
 /**
+ * @param {string} filename
+ */
+function eslintFix(filename) {
+  const gitRootDir = executeCmd('git rev-parse --show-toplevel', { silent: true }).stdout.trim();
+  const eslint = path.resolve(gitRootDir, 'node_modules/.bin/eslint');
+  executeCmd(`${eslint} --fix ${filename}`);
+}
+
+/**
  * This is the main function of the script
  * @param {object} param0
  * @param {'public' | 'internal'} param0.releaseEnvironment
@@ -142,6 +151,7 @@ async function runScript({
     title: newVersion,
     ...patchNote,
   });
+  eslintFix(noteFilename);
   info(`generated patch-note file: ${noteFilename}.`);
 
   // update package.json with newVersion and git tag

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -9,28 +9,15 @@ const OctoKit = require('@octokit/rest');
 const sh = require('shelljs');
 const colors = require('colors/safe');
 const yaml = require('js-yaml');
-const {
-  log,
-  info,
-  error,
-  executeCmd,
-  confirm,
-} = require('./scripts/prompt');
-const {
-  checkEnv,
-  getTagCommitId,
-} = require('./scripts/util');
+const { log, info, error, executeCmd, confirm } = require('./scripts/prompt');
+const { checkEnv, getTagCommitId } = require('./scripts/util');
 const {
   getVersionContext,
   isSameVersionContext,
   updateNotesTs,
   readPatchNote,
 } = require('./scripts/patchNote');
-const {
-  uploadS3File,
-  uploadToGithub,
-  uploadToSentry,
-} = require('./scripts/uploadArtifacts');
+const { uploadS3File, uploadToGithub, uploadToSentry } = require('./scripts/uploadArtifacts');
 
 const pjson = JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8'));
 
@@ -81,7 +68,10 @@ async function runScript({
 
   info('Release summary:');
   log('version:', colors.cyan(patchNote.version));
-  log('environment: ', (releaseEnvironment === 'public' ? colors.red : colors.cyan)(releaseEnvironment));
+  log(
+    'environment: ',
+    (releaseEnvironment === 'public' ? colors.red : colors.cyan)(releaseEnvironment),
+  );
   log('channel: ', (releaseChannel === 'stable' ? colors.red : colors.cyan)(releaseChannel));
   log('---- ---- ---- ----');
   log('notes:', colors.cyan(patchNote.notes));
@@ -103,7 +93,10 @@ async function runScript({
   log('---- ---- ---- ----');
   info('repeat again');
   log('version:', colors.cyan(patchNote.version));
-  log('environment: ', (releaseEnvironment === 'public' ? colors.red : colors.cyan)(releaseEnvironment));
+  log(
+    'environment: ',
+    (releaseEnvironment === 'public' ? colors.red : colors.cyan)(releaseEnvironment),
+  );
   log('channel: ', (releaseChannel === 'stable' ? colors.red : colors.cyan)(releaseChannel));
   log('---- ---- ---- ----\n');
 
@@ -114,12 +107,17 @@ async function runScript({
       throw new Error(`branch mismatch: '${currentBranch}' is not '${target.branch}'`);
     }
 
-    if (!(await confirm(`current branch '${currentBranch}' is not '${target.branch}'. continue?`, false))) {
+    if (
+      !(await confirm(
+        `current branch '${currentBranch}' is not '${target.branch}'. continue?`,
+        false,
+      ))
+    ) {
       sh.exit(1);
     }
   }
 
-  if (!await confirm('Are you sure to release with these configs?', false)) {
+  if (!(await confirm('Are you sure to release with these configs?', false))) {
     sh.exit(1);
   }
 
@@ -331,7 +329,9 @@ async function releaseRoutine() {
       await confirm(`${msg} Are you sure?`, false);
     } else {
       error(msg);
-      log('if you wish to release the first release of a new channel or environment, set "NAIR_IGNORE_VERSION_CONTEXT_CHECK".');
+      log(
+        'if you wish to release the first release of a new channel or environment, set "NAIR_IGNORE_VERSION_CONTEXT_CHECK".',
+      );
       throw new Error(msg);
     }
   }


### PR DESCRIPTION
# このpull requestが解決する内容
* リリース時に patch-note が短いと eslint が1行にまとめないとcommit を阻止してしまうので、fixを自動でかけるようにします。

ついでに mini-release.js自体も eslint -fixをかけたので差分が少し多いです

# 動作確認手順
短いpatch-note でreleaseしてみる
