### PR TITLE
修正:（生放送クルーズさんの番組）を読み上げないように

### DIFF
--- a/app/services/nicolive-program/ParaphraseDictionary.test.ts
+++ b/app/services/nicolive-program/ParaphraseDictionary.test.ts
@@ -9,6 +9,16 @@ describe('ParaphraseDictionary', async () => {
   expect(dictionary.process('ww')).toBe('ワラワラ');
   expect(dictionary.process('テストw')).toBe('テスト、ワラ');
 
+  test('末尾の（生放送クルーズさんの番組）を除去', () => {
+    expect(dictionary.process('A（生放送クルーズさんの番組）')).toBe('A');
+    expect(dictionary.process('A（生放送クルーズさんの番組）B')).toBe(
+      'A（生放送クルーズさんの番組）B',
+    );
+    expect(dictionary.process('（生放送クルーズさんの番組）B')).toBe(
+      '（生放送クルーズさんの番組）B',
+    );
+  });
+
   test('remove multiple lines comments', () => {
     expect(dictionary.process('複数行は\nすべて無視')).toBe('');
     expect(dictionary.process('今\n北\n産\n業')).toBe('');

--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -194,6 +194,10 @@
       "replacement": "あいかわらず"
     },
     {
+      "regularExpression": "（生放送クルーズさんの番組）$",
+      "replacement": ""
+    },
+    {
       "regularExpression": "[＾Ω∞☠♭〇㈲＃#＄$＊\\*＾≧≦･＞＜．.×\"'<>^°]+",
       "replacement": ""
     },


### PR DESCRIPTION
# このpull requestが解決する内容
コメント末尾についた  `（生放送クルーズさんの番組）` は読み上げないようにします。　

# 動作確認手順
本番確認をする場合、読み上げonで番組を作り、その番組がクルーズで紹介され、コメントされる(厳しい)

# 関連するIssue（あれば）
#543 