### PR TITLE
変更: 初回インストール時にシーンプリセットの前に空のシーンを作り、そちらをデフォルトとする

### DIFF
--- a/scene-presets/basic.json
+++ b/scene-presets/basic.json
@@ -234,6 +234,26 @@
     "nodeType": "ScenesNode",
     "items": [
       {
+        "id": "scene_72e390cb-66d6-47ae-9b6d-e0deda2be1ec",
+        "name": "シーン",
+        "sceneItems": {
+          "schemaVersion": 1,
+          "nodeType": "SceneItemsNode",
+          "items": []
+        },
+        "hotkeys": {
+          "schemaVersion": 2,
+          "nodeType": "HotkeysNode",
+          "items": []
+        },
+        "filters": {
+          "schemaVersion": 1,
+          "nodeType": "SceneFiltersNode",
+          "items": []
+        },
+        "active": true
+      },
+      {
         "id": "scene_d8929ac0-3632-4225-b0ba-59a67227b388",
         "name": "プリセット",
         "sceneItems": {
@@ -429,8 +449,7 @@
           "schemaVersion": 1,
           "nodeType": "SceneFiltersNode",
           "items": []
-        },
-        "active": true
+        }
       }
     ]
   },

--- a/test/api/audio.ts
+++ b/test/api/audio.ts
@@ -11,10 +11,11 @@ test('The default sources exists', async t => {
   const audioService = client.getResource<IAudioServiceApi>('AudioService');
   const audioSources = audioService.getSourcesForCurrentScene();
 
-  t.deepEqual(audioSources.map(i => i.getModel().name), ['デスクトップ音声', 'マイク', 'Webカメラ']);
-
+  t.deepEqual(
+    audioSources.map(i => i.getModel().name),
+    ['デスクトップ音声', 'マイク'],
+  );
 });
-
 
 test('The sources with audio have to be appeared in AudioService', async t => {
   const client = await getClient();
@@ -25,15 +26,18 @@ test('The sources with audio have to be appeared in AudioService', async t => {
   scene.createAndAddSource('MyAudio', 'wasapi_output_capture');
   const audioSources = audioService.getSourcesForCurrentScene();
 
-  t.deepEqual(audioSources.map(i => i.getModel().name), ['デスクトップ音声', 'マイク', 'MyAudio', 'Webカメラ']);
+  t.deepEqual(
+    audioSources.map(i => i.getModel().name),
+    ['デスクトップ音声', 'マイク', 'MyAudio'],
+  );
 });
-
 
 test('The audio sources have to keep settings after application restart', async t => {
   const client = await getClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');
   const audioService = client.getResource<IAudioServiceApi>('AudioService');
-  const sceneCollectionsService = client.getResource<ISceneCollectionsServiceApi>('SceneCollectionsService');
+  const sceneCollectionsService =
+    client.getResource<ISceneCollectionsServiceApi>('SceneCollectionsService');
 
   const scene = scenesService.activeScene;
   const source = scene.createAndAddSource('MyMic', 'wasapi_input_capture');
@@ -44,7 +48,7 @@ test('The audio sources have to keep settings after application restart', async 
     monitoringType: 1,
     forceMono: true,
     syncOffset: 10,
-    muted: true
+    muted: true,
   });
 
   const audioSourceModel = audioSource.getModel();
@@ -55,7 +59,6 @@ test('The audio sources have to keep settings after application restart', async 
   const loadedAudioSourceModel = audioService.getSource(source.sourceId).getModel();
 
   t.deepEqual(audioSourceModel, loadedAudioSourceModel);
-
 });
 
 test('Events are emitted when the audio source is updated', async t => {

--- a/test/api/scenes.ts
+++ b/test/api/scenes.ts
@@ -13,41 +13,45 @@ test('The default scene exists', async t => {
   const scenesService = client.getResource<ScenesService>('ScenesService');
   const scenes = scenesService.getScenes();
 
-  t.true(scenes.length === 1);
+  t.true(scenes.length === 2);
 });
 
 test('Creating, fetching and removing scenes', async t => {
   const client = await getClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');
-  t.is(scenesService.getScenes().length, 1);
-  const scene1name = scenesService.getScenes()[0].name;
+  t.is(scenesService.getScenes().length, 2);
+  const scenesBefore = scenesService.getScenes().map(s => s.name);
 
   const scene2 = scenesService.createScene('Scene2');
 
   t.is(scene2.name, 'Scene2');
 
-  let scenes = scenesService.getScenes().filter(scene => [scene1name, 'Scene2'].includes(scene.name));
+  let scenes = scenesService
+    .getScenes()
+    .filter(scene => [...scenesBefore, 'Scene2'].includes(scene.name));
   let scenesNames = scenes.map(scene => scene.name);
 
-  t.deepEqual(scenesNames, [scene1name, 'Scene2']);
+  t.deepEqual(scenesNames, [...scenesBefore, 'Scene2']);
 
-  scenesService.removeScene(scenes[1].id);
-  scenes = scenesService.getScenes().filter(scene => [scene1name, 'Scene2'].includes(scene.name));
+  scenesService.removeScene(scenes[scenes.length - 1].id);
+  scenes = scenesService
+    .getScenes()
+    .filter(scene => [...scenesBefore, 'Scene2'].includes(scene.name));
   scenesNames = scenes.map(scene => scene.name);
 
-  t.deepEqual(scenesNames, [scene1name]);
+  t.deepEqual(scenesNames, scenesBefore);
 });
 
 test('Switching between scenes', async t => {
   const client = await getClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');
-  t.is(scenesService.getScenes().length, 1);
-  const scene1name = scenesService.getScenes()[0].name;
+  t.is(scenesService.getScenes().length, 2);
 
-  const scene = scenesService.getSceneByName(scene1name);
+  const beforeActiveSceneId = scenesService.activeSceneId;
+
   const scene2 = scenesService.createScene('Scene2');
 
-  t.is(scene.id, scenesService.activeSceneId);
+  t.is(beforeActiveSceneId, scenesService.activeSceneId);
 
   scenesService.makeSceneActive(scene2.id);
 
@@ -55,8 +59,7 @@ test('Switching between scenes', async t => {
 
   scene2.remove();
 
-  t.is(scene.id, scenesService.activeSceneId);
-
+  t.is(beforeActiveSceneId, scenesService.activeSceneId);
 });
 
 test('Creating, fetching and removing scene-items', async t => {
@@ -169,7 +172,7 @@ test('SceneItem.setSettings()', async t => {
       bottom: 5.6,
       left: 7.1,
       right: 10,
-    }
+    },
   });
 
   // crop values must be rounded
@@ -216,7 +219,8 @@ test('SceneItem.addFile()', async t => {
   scene.clear();
   scene.addFile(dataDir);
 
-  t.true(sceneBuilder.isEqualTo(`
+  t.true(
+    sceneBuilder.isEqualTo(`
     sources-files
       html
         hello.html: browser_source
@@ -228,5 +232,6 @@ test('SceneItem.addFile()', async t => {
         chatbox.mp4: ffmpeg_source
       text
         hello.txt: text_gdiplus
-  `));
+  `),
+  );
 });

--- a/test/helpers/spectron/scenes.js
+++ b/test/helpers/spectron/scenes.js
@@ -3,7 +3,8 @@ import { focusMain, focusChild } from '.';
 import { contextMenuClick } from './context-menu';
 import { dialogDismiss } from './dialog';
 
-export const DefaultSceneName = 'プリセット';
+export const DefaultSceneName = 'シーン';
+export const PresetSceneName = 'プリセット';
 
 async function clickSceneAction(t, selector) {
   await t.context.app.client


### PR DESCRIPTION
* [x] code
* [x] test

# このpull requestが解決する内容
resolve #547 

# 動作確認手順
キャッシュをクリアするかシーンを全部消してから起動すると:
* シーンコレクションが `シーン` と `プリセット` の二つあり、`シーン` が選択されていること
* `シーン` は空、 `プリセット` がプリセット設定になること

![image](https://user-images.githubusercontent.com/864587/163099818-ccf66aa1-dbdf-4cec-9236-d38a80fb99eb.png)

# 関連するIssue（あれば）
#547