### PR TITLE
修正: ニコニコミュニティの情報取得方法を更新

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -52,7 +52,7 @@ export type FailedResult = {
  * if (isOk(result)) result.value; // number
  * else result.value // CommonErrorResponse
  */
-type WrappedResult<T> = SucceededResult<T> | FailedResult;
+export type WrappedResult<T> = SucceededResult<T> | FailedResult;
 
 export function isOk<T>(result: WrappedResult<T>): result is SucceededResult<T> {
   return result.ok === true;

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -64,6 +64,7 @@ export class NicoliveClient {
   static live2BaseURL = 'https://live2.nicovideo.jp';
   static publicBaseURL = 'https://public.api.nicovideo.jp';
   static nicoadBaseURL = 'https://api.nicoad.nicovideo.jp';
+  static communityBaseURL = 'https://com.nicovideo.jp';
   private static frontendID = 134;
 
   static isProgramPage(url: string): boolean {
@@ -372,9 +373,10 @@ export class NicoliveClient {
     communityId: string,
     headers?: HeaderSeed,
   ): Promise<WrappedResult<Community>> {
-    const url = new URL(`${NicoliveClient.publicBaseURL}/v1/communities.json`);
+    const url = new URL(`${NicoliveClient.communityBaseURL}/api/v2/communities.json`);
+    const communityNo = communityId.replace(/^co/, '');
     const params = {
-      communityIds: communityId,
+      ids: communityNo,
     };
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.append(key, value);
@@ -409,24 +411,26 @@ export class NicoliveClient {
 
     if (res.ok) {
       const data = obj.data as Communities['data'];
-      const communities = data.communities || [];
-      const errors = data.errors || [];
+      const communities = data.communities?.communities || [];
 
-      const community = communities.find(c => c.id === communityId);
+      const community = communities.find(c => c.global_id === communityId);
       if (community) {
         // 正常成功
         return {
           ok: true,
           value: community,
         };
-      }
-
-      const error = errors.find(e => e.id === communityId);
-      if (error) {
-        // 正常失敗
+      } else {
+        // community not found
         return {
           ok: false,
-          value: errors[0] as CommonErrorResponse,
+          value: {
+            meta: {
+              status: 404,
+              errorCode: 'NOT_FOUND',
+              errorMessage: `community ${communityId} not found`,
+            },
+          } as CommonErrorResponse,
         };
       }
     }

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -161,20 +161,17 @@ export interface NicoadStatistics {
 
 export interface Community {
   // 使用しそうなものだけ雑に抜粋
-  id: string;
+  id: string; // eg. '1'
+  global_id: string; // eg. 'co123'
   name: string;
   description: 'string';
-  status: 'open' | 'closed';
-  thumbnailUrl: {
-    normal: string;
-    small: string;
-  };
-  thumbnails: {
-    '1024x1024': string;
-    '512x512': string;
-    '256x256': string;
-    '128x128': string;
-    '64x64': string;
+  public: 'open' | 'closed';
+  icon: {
+    id: number;
+    url: {
+      size_128x128: string;
+      size_64x64: string;
+    };
   };
 }
 
@@ -183,15 +180,10 @@ export interface Communities {
     status: 200;
   };
   data: {
-    communities: Community[];
-    errors: {
-      id: string;
-      meta: {
-        status: number;
-        errorCode: string;
-        errorMessage: string;
-      };
-    }[];
+    communities: {
+      total: number;
+      communities: Community[];
+    };
   };
 }
 

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -164,7 +164,7 @@ export interface Community {
   id: string; // eg. '1'
   global_id: string; // eg. 'co123'
   name: string;
-  description: 'string';
+  description: string;
   public: 'open' | 'closed';
   icon: {
     id: number;

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -1,4 +1,6 @@
 import { createSetupFunction } from 'util/test-setup';
+import { WrappedResult } from './NicoliveClient';
+import { Community } from './ResponseTypes';
 
 type NicoliveProgramService = import('./nicolive-program').NicoliveProgramService;
 
@@ -240,8 +242,8 @@ test('fetchProgram:成功', async () => {
   instance.client.fetchProgram = jest.fn().mockResolvedValue({ ok: true, value: programs.onAir });
   instance.client.fetchCommunity = jest.fn().mockResolvedValue({
     ok: true,
-    value: { name: 'comunity.name', thumbnailUrl: { small: 'symbol url' } },
-  });
+    value: { name: 'community.name', icon: { url: { size_64x64: 'symbol url' } } },
+  } as WrappedResult<Community>);
 
   // TODO: StatefulServiceのモックをVue非依存にする
   (instance as any).setState = jest.fn();
@@ -260,7 +262,7 @@ test('fetchProgram:成功', async () => {
       Array [
         Object {
           "communityID": "co1",
-          "communityName": "comunity.name",
+          "communityName": "community.name",
           "communitySymbol": "symbol url",
           "description": "番組詳細情報",
           "endTime": 150,
@@ -298,7 +300,7 @@ test('fetchProgramで番組があったが取りに行ったらエラー', async
   });
   instance.client.fetchCommunity = jest.fn().mockResolvedValue({
     ok: true,
-    value: { name: 'comunity.name', thumbnailUrl: { small: 'symbol url' } },
+    value: { name: 'community.name', thumbnailUrl: { small: 'symbol url' } },
   });
 
   (instance as any).setState = jest.fn();

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -5,7 +5,7 @@ import { mutation, StatefulService } from 'services/core/stateful-service';
 import { UserService } from 'services/user';
 import { CreateResult, EditResult, isOk, NicoliveClient } from './NicoliveClient';
 import { NicoliveFailure, openErrorDialogFromFailure } from './NicoliveFailure';
-import { ProgramSchedules } from './ResponseTypes';
+import { Community, ProgramSchedules } from './ResponseTypes';
 import { NicoliveProgramStateService } from './state';
 
 type Schedules = ProgramSchedules['data'];
@@ -30,6 +30,14 @@ type ProgramState = {
   adPoint: number;
   giftPoint: number;
 };
+
+function getCommunityIconUrl(community: Community): string {
+  const urls = community.icon.url;
+  if (urls.size_64x64) {
+    return urls.size_64x64;
+  }
+  return urls[Object.keys(urls)[0]] || '';
+}
 
 interface INicoliveProgramState extends ProgramState {
   /**
@@ -244,7 +252,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
         isMemberOnly: program.isMemberOnly,
         communityID: socialGroupId,
         communityName: community ? community.name : '(コミュニティの取得に失敗しました)',
-        communitySymbol: community ? community.thumbnailUrl.small : '',
+        communitySymbol: community ? getCommunityIconUrl(community) : '',
         roomURL: room ? room.webSocketUri : '',
         roomThreadID: room ? room.threadId : '',
       });

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -36,7 +36,7 @@ function getCommunityIconUrl(community: Community): string {
   if (urls.size_64x64) {
     return urls.size_64x64;
   }
-   // 目的のサイズが存在しなかった場合、フォールバックとして存在する一つを返す
+  // 目的のサイズが存在しなかった場合、フォールバックとして存在する一つを返す
   return urls[Object.keys(urls)[0]] || '';
 }
 

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -36,6 +36,7 @@ function getCommunityIconUrl(community: Community): string {
   if (urls.size_64x64) {
     return urls.size_64x64;
   }
+   // 目的のサイズが存在しなかった場合、フォールバックとして存在する一つを返す
   return urls[Object.keys(urls)[0]] || '';
 }
 


### PR DESCRIPTION
* [x] code
* [x] test

# このpull requestが解決する内容
利用しているニコニコミュ二ティのAPIが古いので現行のAPIに更新します。

# 動作確認手順
番組を作成し、取得した番組情報のアイコンとコミュニティ名が正しく表示されること

# 関連するIssue（あれば）
