### PR TITLE
追加: どのような設定で配信されているのかの統計用データを送信する

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,8 @@
     "keylistener",
     "libuiohook",
     "linebreak",
+    "llhp",
+    "llhq",
     "Maximizable",
     "minimizable",
     "multiselect",
@@ -54,14 +56,17 @@
     "spectron",
     "ssng",
     "statusarea",
+    "superfast",
     "systeminformation",
     "toplevel",
     "typedoc",
+    "ultrafast",
     "unama",
     "undocked",
     "unmaximize",
     "urijs",
     "userkey",
+    "veryfast",
     "Volmeter",
     "vpos",
     "vuedraggable",
@@ -69,7 +74,9 @@
     "vuex",
     "webdriverio",
     "webfont",
-    "xkeshi"
+    "xkeshi",
+    "yomiage"
   ],
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "typescript.format.enable": true
 }

--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -50,8 +50,7 @@ const TCP_PORT = 28194;
  */
 export class TcpServerService
   extends PersistentStatefulService<ITcpServersSettings>
-  implements ITcpServerServiceApi
-{
+  implements ITcpServerServiceApi {
   static defaultState: ITcpServersSettings = {
     token: '',
     namedPipe: {
@@ -348,7 +347,6 @@ export class TcpServerService
       if (!requestString) return;
       try {
         const request: IJsonRpcRequest = JSON.parse(requestString);
-        this.usageStatisticsService.recordAnalyticsEvent('TCP_API_REQUEST', request);
 
         const errorMessage = this.validateRequest(request);
 

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -74,7 +74,7 @@ export class AppService extends StatefulService<IAppState> {
 
   private pid = require('process').pid;
 
-  @track('app_start')
+  @track({ event: 'app_start' })
   @RunInLoadingMode()
   async load() {
     if (Utils.isDevMode()) {
@@ -162,7 +162,7 @@ export class AppService extends StatefulService<IAppState> {
     this.protocolLinksService.start(this.state.argv);
   }
 
-  @track('app_close')
+  @track({ event: 'app_close' })
   private shutdownHandler() {
     this.START_LOADING();
     obs.NodeObs.StopCrashHandler();

--- a/app/services/crash-reporter.ts
+++ b/app/services/crash-reporter.ts
@@ -47,9 +47,7 @@ export class CrashReporterService extends Service {
 
     // Report any crash that happened last time
     if (this.appState !== EAppState.CleanExit) {
-      this.usageStatisticsService.recordEvent('crash', {
-        crashType: this.appState,
-      });
+      this.usageStatisticsService.recordEvent({ event: 'crash' });
     }
 
     this.setState(EAppState.Starting);

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -1,5 +1,5 @@
 import { Service } from './core/service';
-import Util from 'services/utils';
+import Utils from 'services/utils';
 
 // Hands out hostnames to the rest of the app. Eventually
 // we should allow overriding this value. But for now we
@@ -48,6 +48,13 @@ export class HostsService extends Service {
   }
   get niconicoNAirInformationsFeed() {
     return this.replaceHost('https://blog.nicovideo.jp/niconews/category/se_n-air/feed/index.xml');
+  }
+  get statistics() {
+    if (Utils.isDevMode()) {
+      return 'https://n-air-app.dev.nicovideo.jp/statistics';
+    } else {
+      return 'https://n-air-app.nicovideo.jp/statistics';
+    }
   }
 
   getWatchPageURL(programID: string): string {

--- a/app/services/settings/optimizer.test.ts
+++ b/app/services/settings/optimizer.test.ts
@@ -93,7 +93,7 @@ test('SettingsKeyAccessor#traverseKeyDescriptions', () => {
 
   // 分岐の選択されている側のみの値が得られること
   outputMode = 'Simple';
-  const simpleResult = [...a.travarseKeyDescriptions(simpleDescriptions, d => [d.key, d.setting])];
+  const simpleResult = [...a.traverseKeyDescriptions(simpleDescriptions, d => [d.key, d.setting])];
 
   expect(accessor.findSettingValue).toHaveBeenCalledTimes(1);
   expect(accessor.findSettingValue).toHaveBeenLastCalledWith(undefined, 'Untitled', 'Mode');
@@ -105,7 +105,7 @@ test('SettingsKeyAccessor#traverseKeyDescriptions', () => {
 
   outputMode = 'Advanced';
   const advancedResult = [
-    ...a.travarseKeyDescriptions(advancedDescriptions, d => [d.key, d.setting]),
+    ...a.traverseKeyDescriptions(advancedDescriptions, d => [d.key, d.setting]),
   ];
   expect(advancedResult).toEqual([
     [OptimizationKey.outputMode, 'Mode'],

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -52,7 +52,7 @@ export type OptimizeSettings = {
   | 'medium'
   | 'slow'
   | 'slower'; // for x264
-  NVENCPreset?: 'default' | 'mq' | 'hq' | 'hp' | 'll' | 'llhp' | 'llhq' | 'llhp'; // for NVENC
+  NVENCPreset?: 'default' | 'mq' | 'hq' | 'hp' | 'll' | 'llhp' | 'llhq'; // for NVENC
   advRateControl?: 'CBR' | 'VBR' | 'ABR' | 'CRF';
   videoBitrate?: number;
   advKeyframeInterval?: number;
@@ -60,7 +60,7 @@ export type OptimizeSettings = {
   advX264Tune?: string;
   audioBitrate?: string;
   advAudioTrackIndex?: string;
-  audioSampleRate?: 441000 | 48000;
+  audioSampleRate?: 44100 | 48000;
 };
 
 export enum CategoryName {
@@ -592,10 +592,11 @@ function isDependOnItems(values: OptimizeSettings, items: KeyDescription[]): boo
  * @param keysNeeded
  */
 export function filterKeyDescriptions(
-  keysNeeded: OptimizeSettings,
+  keysNeeded: Set<OptimizationKey> | OptimizeSettings,
   source: KeyDescription[],
 ): KeyDescription[] {
   const result: KeyDescription[] = [];
+  const keys = keysNeeded instanceof Set ? keysNeeded : new Set(Object.keys(keysNeeded));
 
   for (const item of source) {
     const key = item.key;
@@ -615,11 +616,11 @@ export function filterKeyDescriptions(
       if (newDependents.length > 0) {
         newItem.dependents = newDependents;
       }
-      if (newDependents.length > 0 || keysNeeded.hasOwnProperty(key)) {
+      if (newDependents.length > 0 || keys.has(key)) {
         result.push(newItem);
       }
     } else {
-      if (keysNeeded.hasOwnProperty(key)) {
+      if (keys.has(key)) {
         result.push(item);
       }
     }
@@ -858,7 +859,7 @@ export class SettingsKeyAccessor {
     value: any,
     keyDescriptions: KeyDescription[] = AllKeyDescriptions,
   ): boolean {
-    const descriptions = filterKeyDescriptions({ [key]: 'dummy' }, keyDescriptions);
+    const descriptions = filterKeyDescriptions(new Set([key]), keyDescriptions);
     const setting = this.getSetting(key, descriptions);
     if (setting && setting.hasOwnProperty('options') && Array.isArray(setting.options)) {
       const options: { value: any }[] = setting.options;
@@ -872,7 +873,7 @@ export class Optimizer {
   private accessor: SettingsKeyAccessor;
   private keyDescriptions: KeyDescription[];
 
-  constructor(accessor: SettingsKeyAccessor, keysNeeded: OptimizeSettings) {
+  constructor(accessor: SettingsKeyAccessor, keysNeeded: Set<OptimizationKey> | OptimizeSettings) {
     this.accessor = accessor;
     this.keyDescriptions = filterKeyDescriptions(keysNeeded, AllKeyDescriptions);
   }

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -44,14 +44,14 @@ export type OptimizeSettings = {
   simpleUseAdvanced?: boolean;
   targetUsage?: 'quality' | 'balanced' | 'speed'; // for QSV
   encoderPreset?:
-    | 'ultrafast'
-    | 'superfast'
-    | 'veryfast'
-    | 'faster'
-    | 'fast'
-    | 'medium'
-    | 'slow'
-    | 'slower'; // for x264
+  | 'ultrafast'
+  | 'superfast'
+  | 'veryfast'
+  | 'faster'
+  | 'fast'
+  | 'medium'
+  | 'slow'
+  | 'slower'; // for x264
   NVENCPreset?: 'default' | 'mq' | 'hq' | 'hp' | 'll' | 'llhp' | 'llhq' | 'llhp'; // for NVENC
   advRateControl?: 'CBR' | 'VBR' | 'ABR' | 'CRF';
   videoBitrate?: number;
@@ -769,7 +769,7 @@ export class SettingsKeyAccessor {
    * @param keyDescriptions
    * @param f
    */
-  *travarseKeyDescriptions<T>(
+  *traverseKeyDescriptions<T>(
     keyDescriptions: KeyDescription[],
     f: (d: KeyDescription) => T,
   ): IterableIterator<T> {
@@ -780,7 +780,7 @@ export class SettingsKeyAccessor {
         if (value) {
           for (const dependent of item.dependents) {
             if (dependent.values.includes(value)) {
-              yield* this.travarseKeyDescriptions(dependent.params, f);
+              yield* this.traverseKeyDescriptions(dependent.params, f);
             }
           }
         }
@@ -789,7 +789,7 @@ export class SettingsKeyAccessor {
   }
 
   *getValues(keyDescriptions: KeyDescription[]): IterableIterator<OptimizeSettings> {
-    yield* this.travarseKeyDescriptions(
+    yield* this.traverseKeyDescriptions(
       keyDescriptions,
       (item: KeyDescription): OptimizeSettings => {
         /* DEBUG
@@ -807,7 +807,7 @@ export class SettingsKeyAccessor {
   }
 
   *getSettings(keyDescriptions: KeyDescription[]): IterableIterator<[OptimizationKey, any]> {
-    yield* this.travarseKeyDescriptions(
+    yield* this.traverseKeyDescriptions(
       keyDescriptions,
       (item: KeyDescription): [OptimizationKey, any] => {
         const setting = this.findSetting(item);

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -422,9 +422,6 @@ export class SettingsService
     const audio = this.getSettingsFormData('Audio');
     const stream = this.getSettingsFormData('Stream');
 
-    console.log('output', output); // DEBUG
-    console.log('video', video); // DEBUG
-
     const outputMode = this.findSettingValue(output, 'Untitled', 'Mode') as 'Simple' | 'Advanced';
     const isSimple = outputMode === 'Simple';
     const streamingURL = this.findSettingValue(stream, 'Untitled', 'server') as string;

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -93,8 +93,7 @@ type RecordingSettings = {
 
 export class SettingsService
   extends StatefulService<ISettingsState>
-  implements ISettingsServiceApi, ISettingsAccessor
-{
+  implements ISettingsServiceApi, ISettingsAccessor {
   static initialState = {};
 
   static convertFormDataToState(settingsFormData: TSettingsFormData): ISettingsState {
@@ -420,10 +419,20 @@ export class SettingsService
   getStreamEncoderSettings() {
     const output = this.getSettingsFormData('Output');
     const video = this.getSettingsFormData('Video');
+    const audio = this.getSettingsFormData('Audio');
+    const stream = this.getSettingsFormData('Stream');
 
-    const encoder =
-      (this.findSettingValue(output, 'Streaming', 'Encoder') as string) ||
-      (this.findSettingValue(output, 'Streaming', 'StreamEncoder') as string);
+    console.log('output', output); // DEBUG
+    console.log('video', video); // DEBUG
+
+    const outputMode = this.findSettingValue(output, 'Untitled', 'Mode') as 'Simple' | 'Advanced';
+    const isSimple = outputMode === 'Simple';
+    const streamingURL = this.findSettingValue(stream, 'Untitled', 'server') as string;
+
+    const encoder = isSimple ?
+      (this.findSettingValue(output, 'Streaming', 'StreamEncoder') as string)
+      :
+      (this.findSettingValue(output, 'Streaming', 'Encoder') as string);
     const preset =
       (this.findSettingValue(output, 'Streaming', 'preset') as string) ||
       (this.findSettingValue(output, 'Streaming', 'Preset') as string) ||
@@ -432,18 +441,65 @@ export class SettingsService
       (this.findSettingValue(output, 'Streaming', 'target_usage') as string) ||
       (this.findSettingValue(output, 'Streaming', 'QualityPreset') as string) ||
       (this.findSettingValue(output, 'Streaming', 'AMDPreset') as string);
-    const bitrate =
-      (this.findSettingValue(output, 'Streaming', 'bitrate') as string) ||
-      (this.findSettingValue(output, 'Streaming', 'VBitrate') as string);
+    const bitrate = isSimple ?
+      (this.findSettingValue(output, 'Streaming', 'VBitrate') as number)
+      :
+      (this.findSettingValue(output, 'Streaming', 'bitrate') as number);
     const baseResolution = this.findSettingValue(video, 'Untitled', 'Base') as string;
     const outputResolution = this.findSettingValue(video, 'Untitled', 'Output') as string;
 
+    const fpsType = this.findSettingValue(video, 'Untitled', 'FPSType') as 'Fractional FPS Value' | 'Integer FPS Value' | 'Common FPS Values';
+    let fps = '';
+    switch (fpsType) {
+      case 'Fractional FPS Value':
+        {
+          const fpsNum = this.findSettingValue(video, 'Untitled', 'FPSNum') as number;
+          const fpsDen = this.findSettingValue(video, 'Untitled', 'FPSDen') as number;
+          fps = `${fpsNum}/${fpsDen}`;
+        }
+        break;
+      case 'Integer FPS Value':
+        {
+          const fpsInt = this.findSettingValue(video, 'Untitled', 'FPSInt') as number;
+          fps = `${fpsInt}`;
+        }
+        break;
+      case 'Common FPS Values':
+        {
+          const fpsCommon = this.findSettingValue(video, 'Untitled', 'FPSCommon') as string;
+          fps = fpsCommon;
+        }
+        break;
+    }
+
+    const audio_bitrate = isSimple ?
+      this.findSettingValue(output, 'Streaming', 'ABitrate') as string
+      :
+      this.findSettingValue(output, 'Audio - Track 1', 'Track1Bitrate') as string;
+    const rate_control = !isSimple ?
+      this.findSettingValue(output, 'Streaming', 'rate_control') as 'CBR' | 'VBR' | 'ABR' | 'CRF'
+      : null;
+    const profile = !isSimple ?
+      this.findSettingValue(output, 'Streaming', 'profile') as 'high' | 'main' | 'baseline'
+      : null;
+
+    const sample_rate = this.findSettingValue(audio, 'Untitled', 'SampleRate') as 44100 | 48000;
+
     return {
+      streamingURL,
+      outputMode,
       encoder,
       preset,
+      profile,
       bitrate,
       baseResolution,
       outputResolution,
+      fps,
+      audio: {
+        bitrate: audio_bitrate,
+        sampleRate: sample_rate,
+        rateControl: rate_control,
+      }
     };
   }
 

--- a/app/services/streaming/extractPlatform.ts
+++ b/app/services/streaming/extractPlatform.ts
@@ -1,0 +1,21 @@
+function isOnlyNumberOrDot(str: string): boolean {
+  return /^[\d.]+$/.test(str);
+}
+
+// streaming URLから domain の一部を抽出する
+// eg. "rtmp://kliveorigin.dmc.nico/named_input" -> "dmc"
+export function extractPlatform(streamingURL: string): string {
+  // URL は rtmp: だとhostnameを抽出してくれないためhttpに置換する
+  const u = new URL(streamingURL.replace('rtmp://', 'http://'));
+  if (isOnlyNumberOrDot(u.hostname)) {
+    // IPアドレスは 先頭の2つの値までを返す
+    return u.hostname.split('.').slice(0, 2).join('.');
+  }
+
+  const components = u.hostname.split('.');
+  if (components.length >= 2) {
+    return components[components.length - 2]; // second level domain
+  }
+
+  return streamingURL;
+}

--- a/app/services/streaming/streaming-api.ts
+++ b/app/services/streaming/streaming-api.ts
@@ -29,6 +29,7 @@ export interface IStreamingServiceState {
   recordingStatusTime: string;
   replayBufferStatus: EReplayBufferState;
   replayBufferStatusTime: string;
+  streamingTrackId: string;
 }
 
 export interface IStreamingServiceApi {

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -3,7 +3,7 @@ import { EStreamingState, ERecordingState } from './streaming-api';
 
 import { createSetupFunction } from 'util/test-setup';
 
-function noop(..._args: any[]) {}
+function noop(..._args: any[]) { }
 
 jest.mock('services/core/stateful-service');
 jest.mock('services/core/injector');
@@ -24,10 +24,28 @@ jest.mock('services/customization', () => ({}));
 jest.mock('services/user', () => ({}));
 jest.mock('util/menus/Menu', () => ({}));
 jest.mock('services/notifications', () => ({}));
+jest.mock('services/nicolive-program/nicolive-program', () => ({}));
+jest.mock('services/nicolive-program/nicolive-comment-synthesizer', () => ({}));
 const showWindow = jest.fn();
 
 const createInjectee = ({
   recordEvent = noop,
+  generateStreamingTrackID = noop,
+  getStreamEncoderSettings = () => ({
+    streamingURL: 'rtmp://service.domain/path',
+    encoder: '',
+    preset: '',
+    profile: '',
+    bitrate: '',
+    baseResolution: '',
+    outputResolution: '',
+    fps: '',
+    audio: {
+      bitrate: '',
+      sampleRate: 48000,
+      rateControl: null,
+    }
+  }),
   WarnBeforeStartingStream = false,
   WarnBeforeStoppingStream = false,
   RecordWhenStreaming = false,
@@ -45,21 +63,36 @@ const createInjectee = ({
         KeepRecordingWhenStreamStops,
       },
     },
+    getStreamEncoderSettings,
   },
   UserService: {
     isNiconicoLoggedIn() {
       return isNiconicoLoggedIn;
     },
     updateStreamSettings,
+    isLoggedIn() {
+      return isNiconicoLoggedIn;
+    },
   },
   UsageStatisticsService: {
     recordEvent,
+    generateStreamingTrackID,
   },
   CustomizationService: {
+    state: {
+      autoCompactMode: false,
+    },
     optimizeForNiconico,
   },
   WindowsService: {
     showWindow,
+  },
+  NicoliveCommentSynthesizerService: {
+  },
+  NicoliveProgramService: {
+    state: {
+      programID: '',
+    }
   },
 });
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1,26 +1,32 @@
-import { StatefulService, mutation } from 'services/core/stateful-service';
-import * as obs from '../../../obs-api';
-import { Inject } from 'services/core/injector';
-import moment from 'moment';
-import { SettingsService } from 'services/settings';
-import { WindowsService } from 'services/windows';
-import { Subject } from 'rxjs';
 import * as electron from 'electron';
+import moment from 'moment';
+import { Subject } from 'rxjs';
+import { Inject } from 'services/core/injector';
+import { mutation, StatefulService } from 'services/core/stateful-service';
+import { CustomizationService } from 'services/customization';
+import { $t } from 'services/i18n';
+import { NicoliveCommentSynthesizerService } from 'services/nicolive-program/nicolive-comment-synthesizer';
+import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { isOk, NicoliveClient } from 'services/nicolive-program/NicoliveClient';
+import { ENotificationType, INotification, NotificationsService } from 'services/notifications';
+import { SettingsService } from 'services/settings';
 import {
-  IStreamingServiceApi,
-  IStreamingServiceState,
-  EStreamingState,
+  EncoderType,
+  OptimizedSettings,
+} from 'services/settings/optimizer';
+import { TUsageEvent, UsageStatisticsService } from 'services/usage-statistics';
+import { UserService } from 'services/user';
+import { WindowsService } from 'services/windows';
+import * as obs from '../../../obs-api';
+import { IStreamingSetting } from '../platforms';
+import { extractPlatform } from './extractPlatform';
+import {
   ERecordingState,
   EReplayBufferState,
+  EStreamingState,
+  IStreamingServiceApi,
+  IStreamingServiceState,
 } from './streaming-api';
-import { UsageStatisticsService } from 'services/usage-statistics';
-import { $t } from 'services/i18n';
-import { CustomizationService } from 'services/customization';
-import { UserService } from 'services/user';
-import { IStreamingSetting } from '../platforms';
-import { OptimizedSettings } from 'services/settings/optimizer';
-import { NicoliveClient, isOk } from 'services/nicolive-program/NicoliveClient';
-import { NotificationsService, ENotificationType, INotification } from 'services/notifications';
 
 enum EOBSOutputType {
   Streaming = 'streaming',
@@ -48,14 +54,15 @@ interface IOBSOutputSignalInfo {
 
 export class StreamingService
   extends StatefulService<IStreamingServiceState>
-  implements IStreamingServiceApi
-{
+  implements IStreamingServiceApi {
   @Inject() settingsService: SettingsService;
   @Inject() userService: UserService;
   @Inject() windowsService: WindowsService;
   @Inject() usageStatisticsService: UsageStatisticsService;
   @Inject() customizationService: CustomizationService;
   @Inject() notificationsService: NotificationsService;
+  @Inject() private nicoliveCommentSynthesizerService: NicoliveCommentSynthesizerService;
+  @Inject() private nicoliveProgramService: NicoliveProgramService;
 
   streamingStatusChange = new Subject<EStreamingState>();
   recordingStatusChange = new Subject<ERecordingState>();
@@ -69,7 +76,7 @@ export class StreamingService
 
   powerSaveId: number;
 
-  static initialState = {
+  static initialState: IStreamingServiceState = {
     programFetching: false,
     streamingStatus: EStreamingState.Offline,
     streamingStatusTime: new Date().toISOString(),
@@ -77,6 +84,7 @@ export class StreamingService
     recordingStatusTime: new Date().toISOString(),
     replayBufferStatus: EReplayBufferState.Offline,
     replayBufferStatusTime: new Date().toISOString(),
+    streamingTrackId: '',
   };
 
   init() {
@@ -196,8 +204,8 @@ export class StreamingService
         // ユーザー番組については、即時番組があればそれを優先し、なければ予約番組の番組IDを採用する。
         const programId =
           opts.nicoliveProgramSelectorResult &&
-          opts.nicoliveProgramSelectorResult.providerType === 'channel' &&
-          opts.nicoliveProgramSelectorResult.channelProgramId
+            opts.nicoliveProgramSelectorResult.providerType === 'channel' &&
+            opts.nicoliveProgramSelectorResult.channelProgramId
             ? opts.nicoliveProgramSelectorResult.channelProgramId
             : broadcastableUserProgram.programId || broadcastableUserProgram.nextProgramId;
 
@@ -207,8 +215,8 @@ export class StreamingService
         }
 
         const setting = await this.userService.updateStreamSettings(programId);
-        const streamkey = setting.key;
-        if (streamkey === '') {
+        const streamKey = setting.key;
+        if (streamKey === '') {
           return this.showNotBroadcastingMessageBox();
         }
         if (this.customizationService.optimizeForNiconico) {
@@ -350,7 +358,7 @@ export class StreamingService
           queryParams: settings,
           size: {
             width: 600,
-            height: 594,
+            height: 594, // なぜ {@link this.calculateOptimizeWindowSize()} を使っていない?
           },
         });
       } else {
@@ -490,6 +498,62 @@ export class StreamingService
     return `${hours}:${minutes}:${seconds}`;
   }
 
+  private actionLog(eventType: 'stream_start' | 'stream_end') {
+    if (eventType === 'stream_start') {
+      const streaming_track_id = this.usageStatisticsService.generateStreamingTrackID();
+      this.SET_STREAMING_TRACK_ID(streaming_track_id);
+    }
+    const streamingTrackId = this.state.streamingTrackId;
+    if (eventType === 'stream_end') {
+      this.SET_STREAMING_TRACK_ID('');
+    }
+
+    const settings = this.settingsService.getStreamEncoderSettings();
+
+    const event: TUsageEvent = {
+      event: eventType,
+      user_id: this.userService.isLoggedIn() ? this.userService.platformId : null,
+      platform: extractPlatform(settings.streamingURL),
+      stream_track_id: streamingTrackId,
+      content_id: this.nicoliveProgramService.state.programID || null,
+      output_mode: settings.outputMode,
+      video: {
+        base_resolution: settings.baseResolution,
+        output_resolution: settings.outputResolution,
+        bitrate: settings.bitrate,
+        fps: settings.fps,
+      },
+      audio: {
+        bitrate: Number(settings.audio.bitrate),
+        sample_rate: settings.audio.sampleRate,
+      },
+      advanced: settings.outputMode === 'Advanced' ? {
+        rate_control: settings.audio.rateControl,
+        profile: settings.profile,
+      } : undefined,
+      encoder: {
+        encoder_type: settings.encoder as unknown as EncoderType,
+        preset: settings.preset,
+      },
+      auto_optimize: {
+        enabled: this.customizationService.optimizeForNiconico,
+        use_hardware_encoder: this.customizationService.optimizeWithHardwareEncoder,
+      },
+      yomiage: {
+        enabled: this.nicoliveCommentSynthesizerService.enabled,
+        pitch: this.nicoliveCommentSynthesizerService.pitch,
+        rate: this.nicoliveCommentSynthesizerService.rate,
+        volume: this.nicoliveCommentSynthesizerService.volume,
+      },
+      compact_mode: {
+        auto_compact_mode: this.customizationService.state.autoCompactMode,
+        current: this.customizationService.state.compactMode,
+      },
+    };
+
+    this.usageStatisticsService.recordEvent(event);
+  }
+
   private handleOBSOutputSignal(info: IOBSOutputSignalInfo) {
     console.debug('OBS Output signal: ', info);
 
@@ -502,14 +566,6 @@ export class StreamingService
         this.SET_STREAMING_STATUS(EStreamingState.Live, time);
         this.streamingStatusChange.next(EStreamingState.Live);
 
-        let streamEncoderInfo: Dictionary<string> = {};
-
-        try {
-          streamEncoderInfo = this.settingsService.getStreamEncoderSettings();
-        } catch (e) {
-          console.error('Error fetching stream encoder info: ', e);
-        }
-
         const recordWhenStreaming = this.settingsService.state.General.RecordWhenStreaming;
         if (recordWhenStreaming && this.state.recordingStatus === ERecordingState.Offline) {
           this.toggleRecording();
@@ -521,7 +577,7 @@ export class StreamingService
           this.startReplayBuffer();
         }
 
-        this.usageStatisticsService.recordEvent('stream_start', streamEncoderInfo);
+        this.actionLog('stream_start');
       } else if (info.signal === EOBSOutputSignal.Starting) {
         this.SET_STREAMING_STATUS(EStreamingState.Starting, time);
         this.streamingStatusChange.next(EStreamingState.Starting);
@@ -531,7 +587,7 @@ export class StreamingService
       } else if (info.signal === EOBSOutputSignal.Stopping) {
         this.SET_STREAMING_STATUS(EStreamingState.Ending, time);
         this.streamingStatusChange.next(EStreamingState.Ending);
-        this.usageStatisticsService.recordEvent('stream_end');
+        this.actionLog('stream_end');
       } else if (info.signal === EOBSOutputSignal.Reconnect) {
         this.SET_STREAMING_STATUS(EStreamingState.Reconnecting);
         this.streamingStatusChange.next(EStreamingState.Reconnecting);
@@ -616,5 +672,10 @@ export class StreamingService
   private SET_REPLAY_BUFFER_STATUS(status: EReplayBufferState, time?: string) {
     this.state.replayBufferStatus = status;
     if (time) this.state.replayBufferStatusTime = time;
+  }
+
+  @mutation()
+  private SET_STREAMING_TRACK_ID(id: string) {
+    this.state.streamingTrackId = id;
   }
 }

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -498,16 +498,19 @@ export class StreamingService
     return `${hours}:${minutes}:${seconds}`;
   }
 
-  private actionLog(eventType: 'stream_start' | 'stream_end') {
-    if (eventType === 'stream_start') {
-      const streaming_track_id = this.usageStatisticsService.generateStreamingTrackID();
-      this.SET_STREAMING_TRACK_ID(streaming_track_id);
-    }
-    const streamingTrackId = this.state.streamingTrackId;
-    if (eventType === 'stream_end') {
-      this.SET_STREAMING_TRACK_ID('');
-    }
+  private logStreamStart() {
+    const streamingTrackId = this.usageStatisticsService.generateStreamingTrackID();
+    this.SET_STREAMING_TRACK_ID(streamingTrackId);
+    this.actionLog('stream_start', streamingTrackId);
+  }
 
+  private logStreamEnd() {
+    const streamingTrackId = this.state.streamingTrackId;
+    this.SET_STREAMING_TRACK_ID('');
+    this.actionLog('stream_end', streamingTrackId);
+  }
+
+  private actionLog(eventType: 'stream_start' | 'stream_end', streamingTrackId: string) {
     const settings = this.settingsService.getStreamEncoderSettings();
 
     const event: TUsageEvent = {
@@ -577,7 +580,7 @@ export class StreamingService
           this.startReplayBuffer();
         }
 
-        this.actionLog('stream_start');
+        this.logStreamStart();
       } else if (info.signal === EOBSOutputSignal.Starting) {
         this.SET_STREAMING_STATUS(EStreamingState.Starting, time);
         this.streamingStatusChange.next(EStreamingState.Starting);
@@ -587,7 +590,7 @@ export class StreamingService
       } else if (info.signal === EOBSOutputSignal.Stopping) {
         this.SET_STREAMING_STATUS(EStreamingState.Ending, time);
         this.streamingStatusChange.next(EStreamingState.Ending);
-        this.actionLog('stream_end');
+        this.logStreamEnd();
       } else if (info.signal === EOBSOutputSignal.Reconnect) {
         this.SET_STREAMING_STATUS(EStreamingState.Reconnecting);
         this.streamingStatusChange.next(EStreamingState.Reconnecting);

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -4,19 +4,65 @@ import { HostsService } from './hosts';
 import fs from 'fs';
 import path from 'path';
 import electron from 'electron';
-import { authorizedHeaders } from 'util/requests';
-import throttle from 'lodash/throttle';
 import { Service } from './core/service';
+import { randomBytes } from 'crypto';
+import { EncoderType } from './settings/optimizer';
 
-export type TUsageEvent = 'stream_start' | 'stream_end' | 'app_start' | 'app_close' | 'crash';
-
-interface IUsageApiData {
-  installer_id?: string;
-  version: string;
-  slobs_user_id: string;
-  event: TUsageEvent;
-  data: string;
+function randomCharacters(len: number): string {
+  const buf = randomBytes(len);
+  const characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  return Array.from(buf)
+    .map(b => characters[Math.floor((b / 256) * characters.length)])
+    .join('');
 }
+
+export type TUsageEvent =
+  | {
+    event: 'stream_start' | 'stream_end';
+    user_id: string | null;
+    platform: string;
+    stream_track_id: string;
+    content_id: string | null;
+    output_mode: 'Simple' | 'Advanced';
+    video: {
+      base_resolution: string; // eg. '1920x1080'
+      output_resolution: string; // eg. '1280x720'
+      fps: string; // "30", "29.97", "24 NTSC", ... 
+      bitrate: number;
+    };
+    audio: {
+      bitrate: number;
+      sample_rate: 44100 | 48000;
+    };
+    encoder: {
+      encoder_type: EncoderType;
+      preset: string;
+    };
+    auto_optimize: {
+      enabled: boolean;
+      use_hardware_encoder: boolean;
+    };
+    advanced?: {
+      rate_control: 'CBR' | 'VBR' | 'ABR' | 'CRF';
+      profile: 'high' | 'main' | 'baseline';
+    };
+    yomiage: {
+      enabled: boolean;
+      pitch: number;
+      rate: number;
+      volume: number;
+    };
+    compact_mode: {
+      auto_compact_mode: boolean;
+      current: boolean;
+    }
+  }
+  | {
+    event: 'app_start' | 'app_close';
+  }
+  | {
+    event: 'crash';
+  };
 
 type TAnalyticsEvent = 'TCP_API_REQUEST' | 'FacebookLogin'; // add more types if you need
 
@@ -50,11 +96,8 @@ export class UsageStatisticsService extends Service {
   installerId: string;
   version = electron.remote.process.env.NAIR_VERSION;
 
-  private anaiticsEvents: IAnalyticsEvent[] = [];
-
   init() {
     this.loadInstallerId();
-    this.sendAnalytics = throttle(this.sendAnalytics, 2 * 60 * 1000);
   }
 
   loadInstallerId() {
@@ -84,8 +127,9 @@ export class UsageStatisticsService extends Service {
     this.installerId = installerId;
   }
 
-  get isProduction() {
-    return process.env.NODE_ENV === 'production';
+  generateStreamingTrackID(): string {
+    const id = randomCharacters(10);
+    return id;
   }
 
   /**
@@ -93,69 +137,20 @@ export class UsageStatisticsService extends Service {
    * @param event the event type to record
    * @param metadata arbitrary data to store with the event (must be serializable)
    */
-  recordEvent(event: TUsageEvent, metadata: object = {}) {
-    /* TODO
-    if (!this.isProduction) return;
+  recordEvent(event: TUsageEvent) {
+    console.log('recordEvent', event);
 
-    let headers = new Headers();
-    headers.append('Content-Type', 'application/json');
+    if (event.event === 'stream_start' || event.event === 'stream_end') {
+      const headers = new Headers();
+      headers.append('Content-Type', 'application/json');
 
-    const bodyData: IUsageApiData = {
-      event,
-      slobs_user_id: this.userService.getLocalUserId(),
-      version: this.version,
-      data: JSON.stringify(metadata),
-    };
+      const request = new Request(`${this.hostsService.statistics}/action`, {
+        headers,
+        method: 'POST',
+        body: JSON.stringify(event),
+      });
 
-    if (this.userService.isLoggedIn()) {
-      headers = authorizedHeaders(this.userService.apiToken, headers);
+      return fetch(request);
     }
-
-    if (this.installerId) {
-      bodyData.installer_id = this.installerId;
-    }
-
-    const request = new Request(`https://${this.hostsService.streamlabs}/api/v5/slobs/log`, {
-      headers,
-      method: 'POST',
-      body: JSON.stringify(bodyData),
-    });
-
-    return fetch(request);
-    */
-  }
-
-  /**
-   * Record event for the analytics DB
-   */
-  recordAnalyticsEvent(event: TAnalyticsEvent, value: any) {
-    if (!this.isProduction) return;
-
-    this.anaiticsEvents.push({
-      event,
-      value,
-      product: 'NAIR',
-      version: this.version,
-      count: 1,
-      uuid: this.userService.getLocalUserId(),
-    });
-    this.sendAnalytics();
-  }
-
-  private sendAnalytics() {
-    /* TODO
-    const data = { analyticsTokens: [...this.anaiticsEvents] };
-    const headers = authorizedHeaders(this.userService.apiToken);
-    headers.append('Content-Type', 'application/json');
-
-    this.anaiticsEvents.length = 0;
-
-    const request = new Request(`https://${this.hostsService.analitycs}/slobs/data/ping`, {
-      headers,
-      method: 'post',
-      body: JSON.stringify(data || {}),
-    });
-    fetch(request).then(handleResponse);
-    */
   }
 }

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -128,6 +128,7 @@ export class UsageStatisticsService extends Service {
   }
 
   generateStreamingTrackID(): string {
+    // 配信の開始と終了を対応付ける一時的な識別子はランダムな文字列で生成する
     const id = randomCharacters(10);
     return id;
   }


### PR DESCRIPTION
# このpull requestが解決する内容
配信開始・終了時の配信設定などを集計することで、利用状況から機能改善の資料にできるようにします。

# 動作確認手順
配信開始・終了をすると設定が送信されること。

# 関連するIssue（あれば）
fix #448
