### PR TITLE
修正: bin ディレクトリ以下のjsファイルがbabel-loaderに巻き込まれないようにした

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,7 +109,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        exclude: /node_modules/,
+        exclude: [/node_modules/, path.join(__dirname, 'bin')],
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
# このpull requestが解決する内容
- webpackバンドルに bin ディレクトリ以下のリリーススクリプトなどの js ファイルが巻き込まれていたので、含めないようにしました。

# 動作確認手順
- yarn start で起動できる

# 関連するIssue（あれば）
