### PR TITLE
修正: 起動時のニコニコログインチェックを強化

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -29,9 +29,6 @@ export class HostsService extends Service {
   get niconicoFlapi() {
     return 'http://flapi.nicovideo.jp/api';
   }
-  get niconicolive() {
-    return 'http://live.nicovideo.jp';
-  }
   get nAirLogin() {
     if (process.env.NAIR_LOGIN_URL) {
       return process.env.NAIR_LOGIN_URL;

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -66,7 +66,10 @@ export class NiconicoService extends Service implements IPlatformService {
     const request = new Request(url, { credentials: 'same-origin' });
 
     const response = await fetch(request);
-    const response_1 = await handleErrors(response);
+    if (response.status === 401) {
+      return '';
+    }
+    const response_1 = await handleErrors(response); // !response.ok を例外にする
     const json = await response_1.json();
     if (json.data && json.data.userId) {
       return json.data.userId;

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -45,10 +45,8 @@ interface IUserServiceState {
 export class UserService extends PersistentStatefulService<IUserServiceState> {
   @Inject() private appService: AppService;
   @Inject() private sceneCollectionsService: SceneCollectionsService;
-  @Inject() private windowsService: WindowsService;
   @Inject() private onboardingService: OnboardingService;
   @Inject() private incrementalRolloutService: IncrementalRolloutService;
-  @Inject() private hostsService: HostsService;
   @Inject() private questionaireService: QuestionaireService;
 
   @mutation()
@@ -78,7 +76,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   init() {
     super.init();
     this.setRavenContext();
-    this.validateLogin();
+    setTimeout(() => this.validateLogin(), 0); // validateLogin is async
     this.incrementalRolloutService.fetchAvailableFeatures();
   }
 
@@ -276,8 +274,8 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
 
     this.startAuth({
       platform: this.platform.type,
-      onAuthFinish: () => {},
-      onAuthClose: () => {},
+      onAuthFinish: () => { },
+      onAuthClose: () => { },
     });
   }
 


### PR DESCRIPTION
TODO
* [x] 起動時ログアウト化が発動すると、ウィンドウサイズがおかしくなる(ニコニコパネルがあるサイズでパネル無しになる)現象が起きているので、これも直したい

# このpull requestが解決する内容
前回終了時にniconicoがログイン状態だったか、そのセッションが次に起動したときに無効だった場合、ログイン状態を解除されないことがあったのを修正します。

# 動作確認手順
1. ニコニコログイン状態でN Airを終了し
2. そのセッションが無効になることをする(ニコニコアカウントでの[アカウントログイン状況](https://account.nicovideo.jp/my/history/login) から該当セッションの `アクセスを切る`)
3. N Airを起動すると、ログアウト状態になっていること。また、ウィンドウサイズが正しくニコニコパネルがなくなったぶん縮小していること


# 関連するIssue（あれば）
#564