### PR TITLE
改善:読み上げ辞書に「穣崇」の読み(しげたか)を追加

### DIFF
--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -194,6 +194,10 @@
       "replacement": "あいかわらず"
     },
     {
+      "text": "栗田穣崇",
+      "replacement": "くりたしげたか"
+    },
+    {
       "regularExpression": "（生放送クルーズさんの番組）$",
       "replacement": ""
     },

--- a/app/services/nicolive-program/replace_rules.json
+++ b/app/services/nicolive-program/replace_rules.json
@@ -194,8 +194,8 @@
       "replacement": "あいかわらず"
     },
     {
-      "text": "栗田穣崇",
-      "replacement": "くりたしげたか"
+      "text": "穣崇",
+      "replacement": "しげたか"
     },
     {
       "regularExpression": "（生放送クルーズさんの番組）$",


### PR DESCRIPTION
# このpull requestが解決する内容
`栗田穣崇` を `くりたしげたか` と読み上げるようにします

# 動作確認手順
ニコ生コメント読み上げ状態で `栗田穣崇` とコメントして読み上げ音声を確認する

# 関連するIssue（あれば）
fix #567