### PR TITLE
修正:ビットレートが0になっていた

### DIFF
--- a/app/components/PerformanceMetrics.vue.ts
+++ b/app/components/PerformanceMetrics.vue.ts
@@ -79,11 +79,11 @@ export default class PerformanceMetrics extends Vue {
 
   get bandwidth() {
     if (!this.customizationService.pollingPerformanceStatistics) return '--';
-    return this.performanceService.state.bandwidth.toFixed(0);
+    return this.performanceService.state.streamingBandwidth.toFixed(0);
   }
 
   get bandwidthAlert(): boolean {
     if (!this.customizationService.pollingPerformanceStatistics) return false;
-    return this.isStreaming && this.performanceService.state.bandwidth === 0;
+    return this.isStreaming && this.performanceService.state.streamingBandwidth === 0;
   }
 }

--- a/app/components/PerformanceMetricsStream.vue.ts
+++ b/app/components/PerformanceMetricsStream.vue.ts
@@ -21,6 +21,6 @@ export default class PerformanceMetrics extends Vue {
   }
 
   get bandwidth() {
-    return this.performanceService.state.bandwidth.toFixed(0);
+    return this.performanceService.state.streamingBandwidth.toFixed(0);
   }
 }

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -11,7 +11,7 @@ interface IPerformanceState {
   CPU: number;
   numberDroppedFrames: number;
   percentageDroppedFrames: number;
-  bandwidth: number;
+  streamingBandwidth: number;
   frameRate: number;
 }
 
@@ -28,7 +28,7 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
     CPU: 0,
     numberDroppedFrames: 0,
     percentageDroppedFrames: 0,
-    bandwidth: 0,
+    streamingBandwidth: 0,
     frameRate: 0,
   };
 


### PR DESCRIPTION
# このpull requestが解決する内容
配信開始をしてもビットレート表示が0だったのを修正します
![image](https://user-images.githubusercontent.com/864587/193503592-48d4c18b-545a-4d60-9667-08fb77bf0084.png)
↓
![image](https://user-images.githubusercontent.com/864587/193503734-cd855388-db5e-4f7b-b928-16f4ffcb6c80.png)

OBSのperformanstStats APIの戻り構造体のフィールド名が変更になっていました

# 動作確認手順
配信を開始して、下端のステータスを見る
