### PR TITLE
修正: ダークモードでも起動できるようにする

### DIFF
--- a/main.js
+++ b/main.js
@@ -94,6 +94,10 @@ if (!gotTheLock) {
   // Main Program
   ////////////////////////////////////////////////////////////////////////////////
 
+  // workaround for  https://github.com/electron/electron/issues/19468, https://github.com/electron/electron/issues/19978
+  // (Electron 6 to 8 does not launch in Win10 dark mode with DevTool extensions installed)
+  rimraf.sync(path.join(app.getPath('userData'), 'extensions'));
+
   const util = require('util');
   const logFile = path.join(app.getPath('userData'), 'app.log');
   const maxLogBytes = 131072;


### PR DESCRIPTION
# このpull requestが解決する内容
バージョン v1.1.20221003-unstable.2, v1.1.20221005-1 で発生していた「ダークモード起動するとクラッシュする問題」を回避し、ダークモードでも起動できるようにします。

(Electron 6 to 8 は、前回 dev tools extensionをインストールした状態で起動するときに、Win10 が dark modeだとフリーズする問題があるため、その初期化の前に前回インストール分を削除してしまうことで回避する)

# 動作確認手順
スタートメニュー - 設定 - 個人用設定 - 色 を開き、`色を選択する` をダークモードにしてから起動しても正常に起動すること

# 関連するIssue（あれば）
fix #578