### PR TITLE
修正: 開発時以外はvue devtoolsをinstallしないようにする

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,7 +96,7 @@ if (!gotTheLock) {
 
   // workaround for  https://github.com/electron/electron/issues/19468, https://github.com/electron/electron/issues/19978
   // (Electron 6 to 8 does not launch in Win10 dark mode with DevTool extensions installed)
-  rimraf.sync(path.join(app.getPath('userData'), 'extensions'));
+  rimraf.sync(path.join(app.getPath('userData'), 'DevTools Extensions'));
 
   const util = require('util');
   const logFile = path.join(app.getPath('userData'), 'app.log');
@@ -401,10 +401,13 @@ if (!gotTheLock) {
       }
     });
 
-    const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
-    installExtension(VUEJS_DEVTOOLS)
-      .then(name => console.log(name))
-      .catch(err => console.log(err));
+    if (isDevMode || process.env.NAIR_PRODUCTION_DEBUG) {
+      console.log('installing vue devtools extension...');
+      const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
+      installExtension(VUEJS_DEVTOOLS)
+        .then(name => console.log(name))
+        .catch(err => console.log(err));
+    }
 
     // if (process.env.NAIR_PRODUCTION_DEBUG || process.env.DEV_SERVER) openDevTools();
 


### PR DESCRIPTION
# このpull requestが解決する内容
devtoolを開かない実行ではvue devtoolsを入れる意味がないのと、 #580 で毎回消しているために無駄に入れているので省略します
あと前回インストールを捨てる方法(消す内容)を変更しました。 `extensions` ディレクトリではなく、 `DevTools extension` ファイルを消すだけにします。 `extensions` だけを消す方法だと後者のファイルをもとに実態を探して見つからないという実行時エラーが出ていて、後者のファイルを消すとそもそも探さなくなります。

# 動作確認手順
開発ビルドではconsole出力の中に `installing vue extension...` が含まれるが、パッケージビルドの( `yarn package` で作成したインストーラを実行してインストールしたアプリをコマンドラインで起動することで) console出力を見るとそれがないこと
また、ダークモードで起動できること

# 関連するIssue（あれば）
#578