### PR TITLE
追加:コメント読み上げ:振り分け設定のエンジン選択に「読み上げない」を追加

### DIFF
--- a/app/components/CommentSettings.vue.ts
+++ b/app/components/CommentSettings.vue.ts
@@ -1,8 +1,7 @@
 import { Inject } from 'services/core/injector';
 import { NicoliveCommentLocalFilterService } from 'services/nicolive-program/nicolive-comment-local-filter';
 import { NicoliveCommentSynthesizerService } from 'services/nicolive-program/nicolive-comment-synthesizer';
-import { SynthesizerId, SynthesizerIds } from 'services/nicolive-program/state';
-import { sleep } from 'util/sleep';
+import { SynthesizerId, SynthesizerSelector, SynthesizerSelectors } from 'services/nicolive-program/state';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import VueSlider from 'vue-slider-component';
@@ -77,37 +76,37 @@ export default class CommentSettings extends Vue {
     this.resetVolume();
   }
 
-  get synthIds(): readonly SynthesizerId[] {
-    return SynthesizerIds;
+  get synthIds(): readonly SynthesizerSelector[] {
+    return SynthesizerSelectors;
   }
   synthName(id: SynthesizerId): string {
     return this.$t(`settings.synthId.${id}`) as string;
   }
-  get normal(): SynthesizerId {
+  get normal(): SynthesizerSelector {
     return this.nicoliveCommentSynthesizerService.normal;
   }
-  set normal(s: SynthesizerId) {
+  set normal(s: SynthesizerSelector) {
     this.nicoliveCommentSynthesizerService.normal = s;
   }
-  get normalDefault(): SynthesizerId {
+  get normalDefault(): SynthesizerSelector {
     return NicoliveCommentSynthesizerService.initialState.selector.normal;
   }
-  get operator(): SynthesizerId {
+  get operator(): SynthesizerSelector {
     return this.nicoliveCommentSynthesizerService.operator;
   }
-  set operator(s: SynthesizerId) {
+  set operator(s: SynthesizerSelector) {
     this.nicoliveCommentSynthesizerService.operator = s;
   }
-  get operatorDefault(): SynthesizerId {
+  get operatorDefault(): SynthesizerSelector {
     return NicoliveCommentSynthesizerService.initialState.selector.operator;
   }
-  get system(): SynthesizerId {
+  get system(): SynthesizerSelector {
     return this.nicoliveCommentSynthesizerService.system;
   }
-  set system(s: SynthesizerId) {
+  set system(s: SynthesizerSelector) {
     this.nicoliveCommentSynthesizerService.system = s;
   }
-  get systemDefault(): SynthesizerId {
+  get systemDefault(): SynthesizerSelector {
     return NicoliveCommentSynthesizerService.initialState.selector.system;
   }
 

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -657,6 +657,7 @@
   },
   "synthId": {
     "webSpeech": "Windows SpeechSynthesizer",
-    "nVoice": "N Voice / KOTOYOMI Near"
+    "nVoice": "N Voice / KOTOYOMI Near",
+    "ignore": "ignore"
   }
 }

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -657,6 +657,7 @@
   },
   "synthId": {
     "webSpeech": "Windowsの音声合成",
-    "nVoice": "N Voice 琴詠ニア"
+    "nVoice": "N Voice 琴詠ニア",
+    "ignore": "読み上げない"
   }
 }

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
@@ -75,6 +75,9 @@ test('makeSpeech', async () => {
   // 空文字列を与えるとnullが返ってくる
   expect(instance.makeSpeech(makeChat(''))).toBeNull();
 
+  // ignore 設定の時はnullが返ってくる
+  expect(instance.makeSpeech(makeChat('test'), 'ignore')).toBeNull();
+
   // stateの設定値を反映している
   expect(instance.makeSpeech(makeChat('test'))).toEqual({
     text: 'test',

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -9,7 +9,7 @@ import { PhonemeServer } from './PhonemeServer';
 import { ISpeechSynthesizer } from './speech/ISpeechSynthesizer';
 import { NVoiceSynthesizer } from './speech/NVoiceSynthesizer';
 import { WebSpeechSynthesizer } from './speech/WebSpeechSynthesizer';
-import { NicoliveProgramStateService, SynthesizerId } from './state';
+import { NicoliveProgramStateService, SynthesizerId, SynthesizerSelector } from './state';
 import { WrappedChat } from './WrappedChat';
 
 export type Speech = {
@@ -32,9 +32,9 @@ interface ICommentSynthesizerState {
   volume: number; // SpeechSynthesisUtterance.volume; 0.1(lowest) to 1(highest)
   maxTime: number; // nVoice max time in seconds
   selector: {
-    normal: SynthesizerId;
-    operator: SynthesizerId;
-    system: SynthesizerId;
+    normal: SynthesizerSelector;
+    operator: SynthesizerSelector;
+    system: SynthesizerSelector;
   };
 }
 
@@ -117,7 +117,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     return converted;
   }
 
-  private selectSpeechSynthesizer(chat: WrappedChat): SynthesizerId {
+  private selectSpeechSynthesizer(chat: WrappedChat): SynthesizerSelector {
     switch (chat.type) {
       case 'normal':
         return this.state.selector.normal;
@@ -128,8 +128,11 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     }
   }
 
-  makeSpeech(chat: WrappedChat, synthId?: SynthesizerId): Speech | null {
+  makeSpeech(chat: WrappedChat, synthId?: SynthesizerSelector): Speech | null {
     const synthesizer = synthId || this.selectSpeechSynthesizer(chat);
+    if (synthesizer === 'ignore') {
+      return null;
+    }
 
     const r = this.makeSpeechText(chat, synthesizer);
     if (r === '') {
@@ -271,22 +274,22 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
   }
 
   // selector accessor
-  get normal(): SynthesizerId {
+  get normal(): SynthesizerSelector {
     return this.state.selector.normal;
   }
-  set normal(s: SynthesizerId) {
+  set normal(s: SynthesizerSelector) {
     this.setState({ selector: { ...this.state.selector, normal: s } });
   }
-  get operator(): SynthesizerId {
+  get operator(): SynthesizerSelector {
     return this.state.selector.operator;
   }
-  set operator(s: SynthesizerId) {
+  set operator(s: SynthesizerSelector) {
     this.setState({ selector: { ...this.state.selector, operator: s } });
   }
-  get system(): SynthesizerId {
+  get system(): SynthesizerSelector {
     return this.state.selector.system;
   }
-  set system(s: SynthesizerId) {
+  set system(s: SynthesizerSelector) {
     this.setState({ selector: { ...this.state.selector, system: s } });
   }
 

--- a/app/services/nicolive-program/state.ts
+++ b/app/services/nicolive-program/state.ts
@@ -5,6 +5,8 @@ import { $t } from 'services/i18n';
 
 export const SynthesizerIds = ['webSpeech', 'nVoice'] as const;
 export type SynthesizerId = typeof SynthesizerIds[number];
+export const SynthesizerSelectors = [...SynthesizerIds, 'ignore'] as const;
+export type SynthesizerSelector = typeof SynthesizerSelectors[number];
 
 type SpeechSynthesizerSettingsState = {
   enabled: boolean;
@@ -13,9 +15,9 @@ type SpeechSynthesizerSettingsState = {
   volume: number;
   maxTime?: number;
   selector: {
-    normal: SynthesizerId;
-    operator: SynthesizerId;
-    system: SynthesizerId;
+    normal: SynthesizerSelector;
+    operator: SynthesizerSelector;
+    system: SynthesizerSelector;
   };
 };
 

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { Inject } from './core/injector';
 import { Service } from './core/service';
 import { HostsService } from './hosts';
-import { SynthesizerId } from './nicolive-program/state';
+import { SynthesizerId, SynthesizerSelector } from './nicolive-program/state';
 import { QuestionaireService } from './questionaire';
 import { EncoderType } from './settings/optimizer';
 import { UserService } from './user';
@@ -56,9 +56,9 @@ export type TUsageEvent =
       volume: number;
       max_seconds: number;
       engine: {
-        normal: SynthesizerId;
-        operator: SynthesizerId;
-        system: SynthesizerId;
+        normal: SynthesizerSelector;
+        operator: SynthesizerSelector;
+        system: SynthesizerSelector;
       };
     };
     compact_mode: {


### PR DESCRIPTION
* [x] デザイン確認
* [x] 文言確認

# このpull requestが解決する内容
読み上げの振り分け設定の選択肢に「読み上げない」を追加します。
下記画像はそれぞれひとつずつ設定してみた例です(規定値ではない)。

![image](https://user-images.githubusercontent.com/864587/218676858-1eacb79e-a2c5-4e1f-9a90-2cc3448ccb3d.png)

# 動作確認手順

# 関連するIssue（あれば）
resolve #589