### PR TITLE
改善:読み上げ待ちが5コメント溜まって飛ばすときに今読んでいるものは止めない

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
@@ -99,11 +99,17 @@ test('makeSpeech', async () => {
 
 
 test.each([
-  ['normal', false, false, 0, 1],
-  ['cancelBeforeSpeaking', true, false, 1, 1],
-  ['NUM_COMMENTS_TO_SKIP', false, true, 1, 1],
+  ['normal', false, false, 0, 0, 1],
+  ['cancelBeforeSpeaking', true, false, 1, 0, 1],
+  ['NUM_COMMENTS_TO_SKIP', false, true, 0, 1, 1],
 ])('queueToSpeech %s cancelBeforeSpeaking:%s filled:%s cancel:%d add:%d',
-  async (name: string, cancelBeforeSpeaking: boolean, filled: boolean, numCancel: number, numAdd: number) => {
+  async (name: string,
+    cancelBeforeSpeaking: boolean,
+    filled: boolean,
+    numCancel: number,
+    numCancelQueue: number,
+    numAdd: number,
+  ) => {
     setup();
     const { NicoliveCommentSynthesizerService } = require('./nicolive-comment-synthesizer');
     const instance = NicoliveCommentSynthesizerService.instance as NicoliveCommentSynthesizerService;
@@ -137,6 +143,7 @@ test.each([
     expect(queue.add).toBeCalledTimes(0);
     await instance.queueToSpeech(speech, onstart, onend, cancelBeforeSpeaking);
     expect(queue.cancel).toBeCalledTimes(numCancel);
+    expect(queue.cancelQueue).toBeCalledTimes(numCancelQueue);
     expect(queue.add).toBeCalledTimes(numAdd);
     if (numAdd) {
       expect(queue.add).toBeCalledWith(expect.anything(), speech.text);

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -193,7 +193,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     } else if (this.queue.length >= this.NUM_COMMENTS_TO_SKIP) {
       // コメント溜まりすぎスキップ
       // TODO 飛ばした発言
-      this.queue.cancel();
+      this.queue.cancelQueue();
     }
 
     this.queue.add(

--- a/app/util/QueueRunner.test.ts
+++ b/app/util/QueueRunner.test.ts
@@ -159,4 +159,24 @@ describe('QueueRunner', () => {
     await queue.waitUntilFinished();
     expect(results).toEqual([1, 2, 3]);
   });
+
+  test('cancelQueue', async () => {
+    const queue = new QueueRunner();
+    const task = new Task();
+    queue.add(task.prepare, 'one');
+    task.completePrepare(false);
+    const task2 = new Task();
+    queue.add(task2.prepare, 'two');
+    expect(queue.length).toBe(2);
+    queue.runNext();
+    await sleep(0);
+    expect(task.state).toBe('running');
+    expect(queue.isRunning).toBe(true);
+    queue.cancelQueue();
+    expect(task.state).toBe('running');
+    expect(queue.length).toBe(0);
+    task.completeRun();
+    await queue.waitUntilFinished();
+    expect(queue.isRunning).toBe(false);
+  });
 });

--- a/app/util/QueueRunner.ts
+++ b/app/util/QueueRunner.ts
@@ -120,12 +120,17 @@ export class QueueRunner {
     }
   }
 
-  async cancel() {
-    // 実行中のものはキャンセルし、キューに残っているものは削除する
+  async cancelQueue() {
+    // 実行中のものはキャンセルしない
     this.queue = [];
     if (this.preparing) {
       this.preparing = null;
     }
+  }
+
+  async cancel() {
+    // 実行中のものはキャンセルし、キューに残っているものは削除する
+    this.cancelQueue();
     if (this.runningState) {
       await this.runningState.cancel();
     }


### PR DESCRIPTION
# このpull requestが解決する内容
resolve #594 

# 動作確認手順
読み上げ前のコメントが5個溜まったときに、今読んでいるコメントが中断せずに最後まで読み上げられる

# 関連するIssue（あれば）
#594 