### PR TITLE
開発:Sentryを更新し、送信内容も改善する

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -125,7 +125,8 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
 
       if (event.exception && event.exception.values[0].stacktrace) {
         event.exception.values[0].stacktrace.frames.forEach(frame => {
-          frame.filename = /* 'app:///' + */ normalize(frame.filename);
+          frame.abs_path = '~/' + normalize(frame.abs_path);
+          frame.filename = normalize(frame.filename);
         });
       }
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -47,10 +47,9 @@ function getSentryCrashReportUrl(p: SentryParams): string {
 
 // This is the development DSN
 let sentryParam: SentryParams = {
-  // Akihiko Koizuka n-air-dev
-  organization: 'o159526',
-  project: '1222027',
-  key: '9264887647bb4b108355c6bef3a9bb5d',
+  organization: sentryOrg,
+  project: '1262580',
+  key: '1cb5cdf6a93c466dad570861b8c82b61',
 };
 
 if (isProduction) {

--- a/app/app.ts
+++ b/app/app.ts
@@ -181,16 +181,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (Utils.isChildWindow()) {
         ipcRenderer.on('closeWindow', () => windowsService.closeChildWindow());
       }
-
-      /* TODO
-      if (usingSentry) {
-        const userService = getResource<UserService>('UserService');
-
-        const ctx = userService.getSentryContext();
-        if (ctx) setSentryContext(ctx);
-        userService.sentryContext.subscribe(setSentryContext);
-      }
-      */
     }
 
     // setup VueI18n plugin

--- a/app/app.ts
+++ b/app/app.ts
@@ -13,8 +13,7 @@ import { WindowsService } from './services/windows';
 import { AppService } from './services/app';
 import Utils from './services/utils';
 import electron from 'electron';
-import * as Sentry from '@sentry/browser';
-import * as Integrations from '@sentry/integrations';
+import * as Sentry from '@sentry/vue';
 import VTooltip from 'v-tooltip';
 import Toasted from 'vue-toasted';
 import VueI18n from 'vue-i18n';
@@ -109,6 +108,7 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
   const sentryDsn = getSentryDsn(sentryParam);
   console.log(`Sentry DSN: ${sentryDsn}`);
   Sentry.init({
+    Vue,
     dsn: sentryDsn,
     release: nAirVersion,
     sampleRate: /* isPreview ? */ 1.0 /* : 0.1 */,
@@ -135,7 +135,6 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
 
       return event;
     },
-    integrations: [new Integrations.Vue({ Vue })],
   });
 
   const oldConsoleError = console.error;
@@ -149,7 +148,7 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
       }
 
       scope.setExtra('console-args', JSON.stringify(params, null, 2));
-      Sentry.captureMessage(msg, Sentry.Severity.Error);
+      Sentry.captureMessage(msg, 'error');
     });
   };
 }

--- a/app/app.ts
+++ b/app/app.ts
@@ -47,9 +47,10 @@ function getSentryCrashReportUrl(p: SentryParams): string {
 
 // This is the development DSN
 let sentryParam: SentryParams = {
-  organization: sentryOrg,
-  project: '1262580',
-  key: '1cb5cdf6a93c466dad570861b8c82b61',
+  // Akihiko Koizuka n-air-dev
+  organization: 'o159526',
+  project: '1222027',
+  key: '9264887647bb4b108355c6bef3a9bb5d',
 };
 
 if (isProduction) {

--- a/app/components/CommentSettings.vue.ts
+++ b/app/components/CommentSettings.vue.ts
@@ -26,7 +26,7 @@ export default class CommentSettings extends Vue {
   async testSpeechPlay(synthId: SynthesizerId) {
     const service = this.nicoliveCommentSynthesizerService;
 
-    await service.startTestSpeech('これは読み上げ設定のテスト音声です', synthId);
+    service.startTestSpeech('これは読み上げ設定のテスト音声です', synthId);
   }
 
   get enabled(): boolean {

--- a/app/services/file-manager.ts
+++ b/app/services/file-manager.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import { Service } from 'services/core/service';
 import path from 'path';
 import fs from 'fs';
@@ -155,7 +156,16 @@ export class FileManagerService extends Service {
         file.locked = false;
         await this.flush(filePath, tries - 1);
       } else {
-        console.error(`Ran out of retries writing ${filePath}`);
+        Sentry.withScope(scope => {
+          scope.setLevel('error');
+          scope.setTag('service', 'FileManagerService');
+          scope.setTag('method', 'flush');
+          scope.setTag('tries', tries);
+          scope.setExtra('filePath', filePath);
+          scope.setExtra('fileVersion', version);
+          scope.setFingerprint(['FileManagerService', 'flush', 'RunOutOfRetries']);
+          Sentry.captureMessage('Ran out of retries writing file');
+        });
       }
     }
   }

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.test.ts
@@ -141,7 +141,7 @@ test.each([
     Object.defineProperty(queue, 'length', { get: () => filled ? instance.NUM_COMMENTS_TO_SKIP : 0 });
     expect(queue.cancel).toBeCalledTimes(0);
     expect(queue.add).toBeCalledTimes(0);
-    await instance.queueToSpeech(speech, onstart, onend, cancelBeforeSpeaking);
+    instance.queueToSpeech(speech, onstart, onend, cancelBeforeSpeaking);
     expect(queue.cancel).toBeCalledTimes(numCancel);
     expect(queue.cancelQueue).toBeCalledTimes(numCancelQueue);
     expect(queue.add).toBeCalledTimes(numAdd);

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -163,19 +163,19 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     }, synthId);
   }
 
-  async startSpeakingSimple(speech: Speech) {
+  startSpeakingSimple(speech: Speech) {
     // empty anonymous functions must be created in this service
-    await this.queueToSpeech(speech, () => { }, () => { }, true);
+    this.queueToSpeech(speech, () => { }, () => { }, true);
   }
 
-  async startTestSpeech(text: string, synthId: SynthesizerId) {
+  startTestSpeech(text: string, synthId: SynthesizerId) {
     const speech = this.makeSimpleTextSpeech(text, synthId);
     if (speech) {
-      await this.startSpeakingSimple(speech);
+      this.startSpeakingSimple(speech);
     }
   }
 
-  async queueToSpeech(
+  queueToSpeech(
     speech: Speech,
     onstart: () => void,
     onend: () => void,

--- a/app/services/nicolive-program/speech/NVoiceSynthesizer.ts
+++ b/app/services/nicolive-program/speech/NVoiceSynthesizer.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import { Speech } from '../nicolive-comment-synthesizer';
 import { ISpeechSynthesizer } from './ISpeechSynthesizer';
 
@@ -58,7 +59,15 @@ export class NVoiceSynthesizer implements ISpeechSynthesizer {
           };
         }
       } catch (error) {
-        console.error(`NVoiceSynthesizer: text:${JSON.stringify(speech.text)} -> ${error}`);
+        Sentry.withScope(scope => {
+          scope.setLevel('error');
+          scope.setTag('in', 'NVoiceSynthesizer:speakText')
+          scope.setExtra('speech', speech);
+          scope.setExtra('error', error);
+          scope.setFingerprint(['NVoiceSynthesizer', 'speakText', 'error']);
+          Sentry.captureException(error);
+        });
+        console.info(`NVoiceSynthesizer: text:${JSON.stringify(speech.text)} -> ${error}`);
       }
     };
   }

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import { IObsInput, IObsListInput, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { $t } from 'services/i18n';
 import { ISettingsSubCategory } from './settings-api';
@@ -506,9 +507,15 @@ class OptKeyProperty {
 
   value(v: any): string {
     if (v === undefined) {
-      console.error(
-        `value(undefined): ${i18nPath('settings', this.category, this.subCategory, this.setting)}`,
-      );
+      Sentry.withScope(scope => {
+        scope.setLevel('info');
+        scope.setTag('key', this.key);
+        scope.setExtra('category', this.category);
+        scope.setExtra('subCategory', this.subCategory);
+        scope.setExtra('setting', this.setting);
+        scope.setFingerprint(['OptKeyProperty', 'value(undefined)', this.key, this.category, this.subCategory, this.setting]);
+        Sentry.captureMessage(`OptKeyProperty: value(undefined): ${i18nPath('settings', this.category, this.subCategory, this.setting)}`);
+      });
       return;
     }
     if (this.lookupValueName) {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import * as electron from 'electron';
 import moment from 'moment';
 import { Subject } from 'rxjs';
@@ -224,7 +225,13 @@ export class StreamingService
           );
         }
       } catch (e) {
-        console.error('StreamingService.toggleStreamAsync niconico', JSON.stringify(e));
+        Sentry.withScope(scope => {
+          scope.setLevel('error');
+          scope.setTag('service', 'StreamingService');
+          scope.setTag('method', 'toggleStreamingAsync');
+          scope.setFingerprint(['StreamingService', 'toggleStreamingAsync', 'niconico', 'exception']);
+          Sentry.captureException(e);
+        });
         let message: string;
         if (e instanceof Response) {
           if (e.status === 401) {
@@ -405,8 +412,13 @@ export class StreamingService
         const recordingSettings = this.settingsService.getRecordingSettings();
         if (recordingSettings) {
           // send Recording type to Sentry (どれぐらいURL出力が使われているかの比率を調査する)
-          console.error('Recording / recType:' + recordingSettings.recType);
-          console.log('Recording / path:' + JSON.stringify(recordingSettings.path));
+          Sentry.withScope(scope => {
+            scope.setLevel('info');
+            scope.setExtra('recType', recordingSettings.recType);
+            scope.setExtra('path', recordingSettings.path);
+            scope.setFingerprint(['recording', 'recType', recordingSettings.recType]);
+            Sentry.captureMessage('Recording / recType:' + recordingSettings.recType);
+          });
         }
       }
 

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -13,7 +13,7 @@ import {
   IPlatformService,
   IStreamingSetting,
 } from './platforms';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/vue';
 import { AppService } from 'services/app';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { Subject, Observable, merge } from 'rxjs';

--- a/bin/package.json
+++ b/bin/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "dependencies": {
     "@octokit/rest": "^16.28.1",
-    "@sentry/cli": "^1.35.4"
+    "@sentry/cli": "^2.14.3"
   },
   "devDependencies": {
     "7zip-bin": "^2.2.7",
@@ -19,7 +19,6 @@
     "moment": "^2.17.1",
     "progress": "^2.0.0",
     "semver": "^5.4.1",
-    "sentry-cli-binary": "^1.24.1",
     "shelljs": "^0.8.4",
     "webfont": "^11.2.26"
   }

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -287,7 +287,9 @@ async function runScript({
 
   if (enableUploadToSentry) {
     info('uploading to sentry...');
-    uploadToSentry(sentry.organization, sentry.project, newVersion, path.resolve('.', 'bundles'));
+    uploadToSentry(sentry.organization, sentry.project, newVersion,
+      [path.resolve('.', 'bundles'), path.resolve('.', 'main.js')].join(' '),
+    );
   } else {
     info('uploading to sentry: SKIP');
   }

--- a/bin/upload-to-sentry.sh
+++ b/bin/upload-to-sentry.sh
@@ -8,6 +8,6 @@ export SENTRY_PROJECT=$(jq -r .name < ${BASEDIR}package.json)
 RELEASE=$(jq -r .version < ${BASEDIR}package.json)
 echo Release: $RELEASE
 
-$SENTRY_CLI releases files $RELEASE upload-sourcemaps ${BASEDIR}bundles/ || exit 1
+$SENTRY_CLI releases files $RELEASE upload-sourcemaps ${BASEDIR}bundles/ ${BASEDIR}main.js || exit 1
 $SENTRY_CLI releases new $RELEASE || exit 1
 

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -118,15 +118,16 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@sentry/cli@^1.35.4":
-  version "1.35.4"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.35.4.tgz#d89bc26a62baa33a8bf4991af04247bfd5093849"
-  integrity sha512-Rg9czbl/z9+ZPR1tOv/uFS0ShvnRxmEOgIHd4s8zZYzYWsihBe46drfWyOpvjgcSrMGxQPNdDZ3daEzb3u5vYA==
+"@sentry/cli@^2.14.3":
+  version "2.14.3"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.14.3.tgz#4b7f386c8dc5484992cac0f64a02f1b6c65f4911"
+  integrity sha512-/u8SKYohSDbg/Tf180qAJY+wgxIwwpZwH0uV/xn9t7/Rdb6x/YyD4AbFcPlBORnEZq4goVazWBLjJEkepO95YA==
   dependencies:
-    https-proxy-agent "^2.2.1"
-    node-fetch "^2.1.2"
-    progress "2.0.0"
-    proxy-from-env "^1.0.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -148,12 +149,12 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-agent-base@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
-    es6-promisify "^5.0.0"
+    debug "4"
 
 ajv@^5.1.0:
   version "5.5.0"
@@ -597,19 +598,19 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+debug@4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^2.1.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -681,18 +682,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1011,13 +1000,13 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
-  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
-    agent-base "^4.1.0"
-    debug "^3.1.0"
+    agent-base "6"
+    debug "4"
 
 iconv-lite@^0.4.23:
   version "0.4.23"
@@ -1512,7 +1501,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -1539,15 +1528,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
-  integrity sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
-
 node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^2.6.7:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 nopt@~3.0.1:
   version "3.0.6"
@@ -1790,11 +1781,7 @@ process-nextick-args@~1.0.6:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
   integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
 
-progress@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -1804,10 +1791,10 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-proxy-from-env@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
-  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 "pullstream@>= 0.4.1 < 1":
   version "0.4.1"
@@ -2084,13 +2071,6 @@ semver@^7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
-sentry-cli-binary@^1.24.1:
-  version "1.24.1"
-  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.24.1.tgz#1ba26f49e7d2a0906b9879e6da87804f01517969"
-  integrity sha1-G6JvSefSoJBrmHnm2oeATwFReWk=
-  dependencies:
-    progress "2.0.0"
-
 "setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
@@ -2353,6 +2333,11 @@ tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 traceur@0.0.x:
   version "0.0.111"
   resolved "https://registry.yarnpkg.com/traceur/-/traceur-0.0.111.tgz#c04de74d14696c3373427de4fc08ecaf913fc3a1"
@@ -2531,6 +2516,19 @@ webfont@^11.2.26:
     wawoff2 "^2.0.0"
     xml2js "^0.4.23"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which@^1.0.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
@@ -2542,6 +2540,13 @@ which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 

--- a/main.js
+++ b/main.js
@@ -264,9 +264,7 @@ if (!gotTheLock) {
   }
 
   if (pjson.env === 'production' || process.env.NAIR_REPORT_TO_SENTRY) {
-    const params = process.env.NAIR_UNSTABLE
-      ? { organization: 'o170115', project: '5372801', key: '819e76e51864453aafd28c6d0473881f' } // crash-reporter-unstable
-      : { organization: 'o170115', project: '1520076', key: 'd965eea4b2254c2b9f38d2346fb8a472' }; // crash-reporter
+    const params = { organization: 'o159526', project: '1222027', key: '9264887647bb4b108355c6bef3a9bb5d', }; // koizuka
 
     process.on('uncaughtException', (error) => {
       console.log('uncaughtException', error);

--- a/main.js
+++ b/main.js
@@ -259,7 +259,7 @@ if (!gotTheLock) {
     );
     crashHandler.registerProcess(pid, false);
 
-    const Raven = require('raven');
+    const SentryElectron = require('@sentry/electron');
 
     function handleFinishedReport() {
       dialog.showErrorBox(
@@ -276,11 +276,13 @@ if (!gotTheLock) {
         ? { project: '5372801', key: '819e76e51864453aafd28c6d0473881f' } // crash-reporter-unstable
         : { project: '1520076', key: 'd965eea4b2254c2b9f38d2346fb8a472' }; // crash-reporter
 
-      Raven.config(`https://${params.key}@o170115.ingest.sentry.io/${params.project}`, {
+      SentryElectron.init({
+        dsn: `https://${params.key}@o170115.ingest.sentry.io/${params.project}`,
         release: process.env.NAIR_VERSION,
-      }).install(function (err, initialErr, eventId) {
-        handleFinishedReport();
       });
+
+      // TODO
+      // handleFinishedReport();
 
       crashReporter.start({
         productName: 'n-air-app',

--- a/main.js
+++ b/main.js
@@ -243,6 +243,42 @@ if (!gotTheLock) {
     mainWindow.webContents.openDevTools({ mode: 'undocked' });
   }
 
+  const SentryElectron = require('@sentry/electron/main');
+
+  function handleFinishedReport() {
+    // 先にsentryへの送信flushを開始する
+    const flush = SentryElectron.flush(3000).catch(error => {
+      console.error(error);
+    });
+
+    dialog.showErrorBox(
+      '予期せぬエラー',
+      '予期しないエラーが発生したため、アプリケーションをシャットダウンします。ご不便をおかけして申し訳ありません。\n' +
+      'この件に関する情報はデバッグ目的で送信されました。不具合を解決するためにご協力いただきありがとうございます。',
+    );
+
+    // ダイアログが閉じたら終了
+    flush.finally(() => {
+      app.exit();
+    });
+  }
+
+  if (pjson.env === 'production' || process.env.NAIR_REPORT_TO_SENTRY) {
+    const params = process.env.NAIR_UNSTABLE
+      ? { organization: 'o170115', project: '5372801', key: '819e76e51864453aafd28c6d0473881f' } // crash-reporter-unstable
+      : { organization: 'o170115', project: '1520076', key: 'd965eea4b2254c2b9f38d2346fb8a472' }; // crash-reporter
+
+    process.on('uncaughtException', (error) => {
+      console.log('uncaughtException', error);
+      handleFinishedReport();
+    });
+
+    SentryElectron.init({
+      dsn: `https://${params.key}@${params.organization}.ingest.sentry.io/${params.project}`,
+      release: process.env.NAIR_VERSION,
+    });
+  }
+
   // eslint-disable-next-line no-inner-declarations
   function startApp() {
     const isDevMode = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
@@ -258,44 +294,6 @@ if (!gotTheLock) {
       crashHandlerLogPath,
     );
     crashHandler.registerProcess(pid, false);
-
-    const SentryElectron = require('@sentry/electron');
-
-    function handleFinishedReport() {
-      dialog.showErrorBox(
-        '予期せぬエラー',
-        '予期しないエラーが発生したため、アプリケーションをシャットダウンします。ご不便をおかけして申し訳ありません。\n' +
-        'この件に関する情報はデバッグ目的で送信されました。不具合を解決するためにご協力いただきありがとうございます。',
-      );
-
-      app.exit();
-    }
-
-    if (pjson.env === 'production') {
-      const params = process.env.NAIR_UNSTABLE
-        ? { project: '5372801', key: '819e76e51864453aafd28c6d0473881f' } // crash-reporter-unstable
-        : { project: '1520076', key: 'd965eea4b2254c2b9f38d2346fb8a472' }; // crash-reporter
-
-      SentryElectron.init({
-        dsn: `https://${params.key}@o170115.ingest.sentry.io/${params.project}`,
-        release: process.env.NAIR_VERSION,
-      });
-
-      // TODO
-      // handleFinishedReport();
-
-      crashReporter.start({
-        productName: 'n-air-app',
-        companyName: 'n-air-app',
-        submitURL:
-          `https://o170115.ingest.sentry.io/api/${params.project}/minidump/` +
-          `?sentry_key=${params.key}`,
-        extra: {
-          'sentry[release]': pjson.version,
-          processType: 'main',
-        },
-      });
-    }
 
     const mainWindowState = windowStateKeeper({
       defaultWidth: 1600,

--- a/main.js
+++ b/main.js
@@ -264,7 +264,9 @@ if (!gotTheLock) {
   }
 
   if (pjson.env === 'production' || process.env.NAIR_REPORT_TO_SENTRY) {
-    const params = { organization: 'o159526', project: '1222027', key: '9264887647bb4b108355c6bef3a9bb5d', }; // koizuka
+    const params = process.env.NAIR_UNSTABLE
+      ? { organization: 'o170115', project: '5372801', key: '819e76e51864453aafd28c6d0473881f' } // crash-reporter-unstable
+      : { organization: 'o170115', project: '1520076', key: 'd965eea4b2254c2b9f38d2346fb8a472' }; // crash-reporter
 
     process.on('uncaughtException', (error) => {
       console.log('uncaughtException', error);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "n-air-app",
+  "name": "n-air-dev",
   "description": "Streaming application for niconico",
   "author": "DWANGO Co.,Ltd.",
   "license": "GPL-3.0",
   "//": {
     "version": "0.11.2"
   },
-  "version": "1.1.20210826-unstable.1",
+  "version": "1.1.20230306-unstable.1",
   "main": "main.js",
   "engines": {
     "npm": "please-use-yarn"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "n-air-dev",
+  "name": "n-air-app",
   "description": "Streaming application for niconico",
   "author": "DWANGO Co.,Ltd.",
   "license": "GPL-3.0",
   "//": {
     "version": "0.11.2"
   },
-  "version": "1.1.20230306-unstable.1",
+  "version": "1.1.20210826-unstable.1",
   "main": "main.js",
   "engines": {
     "npm": "please-use-yarn"

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   },
   "dependencies": {
     "@n-air-app/n-voice-package": "^1.0.1",
-    "@sentry/browser": "^6.11.0",
-    "@sentry/integrations": "^6.11.0",
+    "@sentry/electron": "^4.3.0",
+    "@sentry/vue": "^7.40.0",
     "archiver": "^3.0.0",
     "aws-sdk": "^2.344.0",
     "base64-js": "^1.3.0",
@@ -95,7 +95,6 @@
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
     "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.36-iojs-v6.0.3-release.tar.gz",
     "progress": "^2.0.0",
-    "raven": "2.6.4",
     "recursive-readdir": "^2.2.2",
     "reflect-metadata": "^0.1.13",
     "request": "^2.85.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,66 +2153,125 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/browser@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.11.0.tgz#9e90bbc0488ebcdd1e67937d8d5b4f13c3f6dee0"
-  integrity sha512-Qr2QRA0t5/S9QQqxzYKvM9W8prvmiWuldfwRX4hubovXzcXLgUi4WK0/H612wSbYZ4dNAEcQbtlxFWJNN4wxdg==
+"@sentry/browser@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.37.1.tgz#d452ebed7f974f20872d34744e67d856ab54a41b"
+  integrity sha512-MfVbKzEVHKVH6ZyMCKLtPXvMtRCvxqQzrnK735sYW6EyMpcMYhukBU0pq7ws1E/KaCZjAJi1wDx2nqf2yPIVdQ==
   dependencies:
-    "@sentry/core" "6.11.0"
-    "@sentry/types" "6.11.0"
-    "@sentry/utils" "6.11.0"
+    "@sentry/core" "7.37.1"
+    "@sentry/replay" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/core@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.11.0.tgz#40e94043afcf6407a109be26655c77832c64e740"
-  integrity sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==
+"@sentry/browser@7.40.0":
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.40.0.tgz#e088154b4d104dfb33f7ca19bfd1276c60010b2d"
+  integrity sha512-07rZ+cTcpmYB1r84/oZtmSPJJvLCxW8yIh/5s4MdKRyZpqIDKhOz6cCS/4j+l1V+MeLcNLZBjFtNdKA2eocTpg==
   dependencies:
-    "@sentry/hub" "6.11.0"
-    "@sentry/minimal" "6.11.0"
-    "@sentry/types" "6.11.0"
-    "@sentry/utils" "6.11.0"
+    "@sentry/core" "7.40.0"
+    "@sentry/replay" "7.40.0"
+    "@sentry/types" "7.40.0"
+    "@sentry/utils" "7.40.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
-  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
+"@sentry/core@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.37.1.tgz#6d8d151b3d6ae0d6f81c7f4da92cd2e7cb5bf1fa"
+  integrity sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==
   dependencies:
-    "@sentry/types" "6.11.0"
-    "@sentry/utils" "6.11.0"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/integrations@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.11.0.tgz#da0706306b5ff13eaae5771095d7fc82c9f4c68b"
-  integrity sha512-CtSMW+PJlw+EunDJ+9LCWxRcXQIsUDlcUZOhFyAdmM5YIbg2V0IqHtnYg8X2sSGRO3aTEc7lOG5nF4lqr3R0yg==
+"@sentry/core@7.40.0":
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.40.0.tgz#1013ddf576ed3a4be9abf2b8e8b0c95ab7e3d7bb"
+  integrity sha512-OPAobQG0GTY++r5LWUcOA1lS+2TY2Lmw/i5s4kL9WbY+f08dbLNEGNBObY7/V98OL4f7OG+nWaPFybgM7kqUTQ==
   dependencies:
-    "@sentry/types" "6.11.0"
-    "@sentry/utils" "6.11.0"
-    localforage "^1.8.1"
+    "@sentry/types" "7.40.0"
+    "@sentry/utils" "7.40.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
-  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
+"@sentry/electron@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/electron/-/electron-4.3.0.tgz#c38eefe5fad32122e55f7bde0147d3f9e625e3aa"
+  integrity sha512-LqFMvgycMd+Mcs4Km9S8YBtaHISHSiIUVUz6mgAr2khKY6SNhkW9A4GcoOKtzRJreqYLVeBSbaUVttQfQ4Ot7g==
   dependencies:
-    "@sentry/hub" "6.11.0"
-    "@sentry/types" "6.11.0"
+    "@sentry/browser" "7.37.1"
+    "@sentry/core" "7.37.1"
+    "@sentry/node" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
+    deepmerge "4.3.0"
+    tslib "^2.5.0"
+
+"@sentry/node@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.37.1.tgz#c234e8711090b7532358bb1d6ab3fcca75356e98"
+  integrity sha512-nGerngIo5JwinJgl7m0SaL/xI+YRBlhb53gbkuLSAAcnoitBFzbp7LjywsqYFTWuWDIyk7O2t124GNxtolBAgA==
+  dependencies:
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/types@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
-  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
-
-"@sentry/utils@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
-  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
+"@sentry/replay@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.37.1.tgz#8ab4588b28baa07e35c417d3ffc6aaf934c58c45"
+  integrity sha512-3sHOE/oPirdvJbOn0IA/wpds12Sm2WaEtiAeC0+5Gg5mxQzFBLRrsA1Mz/ifzPGwr+ETn3sCyPCnd9b3PWaWMQ==
   dependencies:
-    "@sentry/types" "6.11.0"
+    "@sentry/core" "7.37.1"
+    "@sentry/types" "7.37.1"
+    "@sentry/utils" "7.37.1"
+
+"@sentry/replay@7.40.0":
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.40.0.tgz#cf78b5bf92b9a3c045022e7cc4fede7ef4ffe874"
+  integrity sha512-Y9Kvo9jKouUdrHQhHVv5SmWZClF5o7BFI6oVpLlv4zXORPQlyoZONM/9sxiMvvH73alDSpxzCoxyhlypAOH4ww==
+  dependencies:
+    "@sentry/core" "7.40.0"
+    "@sentry/types" "7.40.0"
+    "@sentry/utils" "7.40.0"
+
+"@sentry/types@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.37.1.tgz#269da7da39c1a5243bf5f9a35370291b5cc205bb"
+  integrity sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==
+
+"@sentry/types@7.40.0":
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.40.0.tgz#27b012b59d593132e413018773f0a045d68075d7"
+  integrity sha512-dIbqBenbmDx1F8pvfC11C88J83ecwumUhV+YOIxcmVd1fmlPF2hXWZ01+NTkTDkCu341sJx4wPQogByFy8FwGA==
+
+"@sentry/utils@7.37.1":
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.37.1.tgz#7695d6e30d6178723f3fa446a9553893bca85e96"
+  integrity sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==
+  dependencies:
+    "@sentry/types" "7.37.1"
+    tslib "^1.9.3"
+
+"@sentry/utils@7.40.0":
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.40.0.tgz#0986f2e93b1d42b1e1aeb077941226e3d76419c4"
+  integrity sha512-ZdCbTpAXPiVVfvNJVftnDhsctOui71MDUhVIdLkgg4Cuic+WHGPRmmZ+H6uZdp7vRaeB+Uvnn5+t2iSAVo/mAA==
+  dependencies:
+    "@sentry/types" "7.40.0"
+    tslib "^1.9.3"
+
+"@sentry/vue@^7.40.0":
+  version "7.40.0"
+  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-7.40.0.tgz#994420acf94cd983e4395e00033ed7050199eaba"
+  integrity sha512-aMOFe3xPIi4VLcf35Qpb087sDi9ESRZytBX2HYQUVaYjZ2hZxoOaYESiw699jlHmGkypfTfLHxiYCHMN8ZC9Kg==
+  dependencies:
+    "@sentry/browser" "7.40.0"
+    "@sentry/core" "7.40.0"
+    "@sentry/types" "7.40.0"
+    "@sentry/utils" "7.40.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":
@@ -4832,11 +4891,6 @@ chardet@^0.4.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
-
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -5424,17 +5478,12 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
-
 cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cookie@~0.4.1:
+cookie@^0.4.1, cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -5597,11 +5646,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -5904,6 +5948,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.0.tgz#65491893ec47756d44719ae520e0e2609233b59b"
+  integrity sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -9005,7 +9054,7 @@ is-buffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
   integrity sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=
 
-is-buffer@^1.1.5, is-buffer@~1.1.6:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -10687,13 +10736,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lie@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
-  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
-  dependencies:
-    immediate "~3.0.5"
-
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -10853,13 +10895,6 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
-
-localforage@^1.8.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.9.0.tgz#f3e4d32a8300b362b4634cc4e066d9d00d2f09d1"
-  integrity sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==
-  dependencies:
-    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -11082,6 +11117,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
 make-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
@@ -11177,15 +11217,6 @@ md5-hex@^3.0.1:
   integrity sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==
   dependencies:
     blueimp-md5 "^2.10.0"
-
-md5@^2.2.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
 
 mdn-data@~1.1.0:
   version "1.1.4"
@@ -13078,17 +13109,6 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raven@2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-2.6.4.tgz#458d4a380c8fbb59e0150c655625aaf60c167ea3"
-  integrity sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==
-  dependencies:
-    cookie "0.3.1"
-    md5 "^2.2.1"
-    stack-trace "0.0.10"
-    timed-out "4.0.1"
-    uuid "3.3.2"
-
 raw-body@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
@@ -14700,11 +14720,6 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
-stack-trace@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
-
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -15380,11 +15395,6 @@ time-zone@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=
 
-timed-out@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
-  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
 timers-browserify@^2.0.4:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
@@ -15623,6 +15633,11 @@ tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
* [x] sourceMap修正
* [x] electron側のエラー送信確認
* [x] app/services/nicolive-program/NicoliveClient.test.ts のテストが失敗するのを直す
* [x] mergeする前に koizukaのDSNにしてるのをrevertする

# このpull requestが解決する内容
* ElectronのSentryがRavenで古いので@sentry/electronに更新する
    * 初期化は app.on('ready') より前にやらないといけないので移動
    * 初期化方法を新バージョンに合わせた
    * crashReporterは sentryがやってくれるので明示的な初期化を削除
* sentry-cliも最新に更新
* Sentryへのuploadに main.js も追加(main process ソース追跡用)
* @sentry/browser なども @sentry/vue にして最新に更新
* Sentryへの情報送信を Sentryのtagとかfingerprintを使うようにする
    * 番組作成・編集ウィンドウのloadURLの結果
    * シーンファイル書き込みのリトライオーバー
    * NVoice.talk
    * 配信最適化の情報
* コメント読み上げServiceの queueToSpeachのasyncを外した(Vueのハンドラからserviceのメソッドを呼び、中で例外が飛んだときにIPC Proxyがうまく例外を伝えてくれてないようで、Sentryにうまく送れていないため workaround)

# 関連するIssue（あれば）
#175 