### PR TITLE
修正:幾つかの実行時エラーを修正

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -296,9 +296,11 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
   }
 
   private removeAudioSource(sourceId: string) {
-    this.sourceData[sourceId].volmeter.removeCallback(this.sourceData[sourceId].callbackInfo);
-    delete this.sourceData[sourceId];
-    this.REMOVE_AUDIO_SOURCE(sourceId);
+    if (this.sourceData[sourceId]) {
+      this.sourceData[sourceId].volmeter.removeCallback(this.sourceData[sourceId].callbackInfo);
+      delete this.sourceData[sourceId];
+      this.REMOVE_AUDIO_SOURCE(sourceId);
+    }
   }
 
   @mutation()

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -94,7 +94,9 @@ export class SelectionService extends StatefulService<ISelectionState> {
 
   @shortcut('Delete')
   remove() {
-    const name = this.getLastSelected().name;
+    const last = this.getLastSelected();
+    if (!last) return;
+    const name = last.name;
     electron.remote.dialog
       .showMessageBox(electron.remote.getCurrentWindow(), {
         type: 'warning',

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -766,15 +766,13 @@ export class SettingsService
     settingsData[0].parameters.forEach((deviceForm, ind) => {
       const channel = ind + 1;
       const isOutput = [E_AUDIO_CHANNELS.OUTPUT_1, E_AUDIO_CHANNELS.OUTPUT_2].includes(channel);
+      const device = audioDevices.find(device => device.id === deviceForm.value);
       const source = this.sourcesService.getSources().find(source => source.channel === channel);
 
       if (source && deviceForm.value === null) {
-        if (deviceForm.value === null) {
-          this.sourcesService.removeSource(source.sourceId);
-          return;
-        }
-      } else if (deviceForm.value !== null) {
-        const device = audioDevices.find(device => device.id === deviceForm.value);
+        this.sourcesService.removeSource(source.sourceId);
+        return;
+      } else if (device && deviceForm.value !== null) {
         const displayName = device.id === 'default' ? deviceForm.name : device.description;
 
         if (!source) {
@@ -785,9 +783,10 @@ export class SettingsService
             { channel },
           );
         } else {
-          source.setName(displayName);
           source.updateSettings({ device_id: deviceForm.value, name: displayName });
         }
+
+        source.setName(displayName);
       }
     });
   }


### PR DESCRIPTION
# このpull requestが解決する内容
1. audio.ts removeAudioSource
    * アプリ終了時に発生していた。ユーザーには見えないがSentryに飛んでいた
2. selection.ts remove
    * シーン選択がない状態でシーン削除しようとすると発生してSentryに飛んでいた。主にアプリ終了時に起きていた?
3. settings.ts setAudioSettings
   * 音声デバイス構成が前回と変わり、以前あったデバイスがなくなっていたときに起動時に発生し、起動自体できなくなっていた問題と思われる
   * 修正をstreamlabsからbackport
