### PR TITLE
修正:ログイン状態確認に失敗したときにログアウトに移行できていないケースがあった

### DIFF
--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -66,7 +66,7 @@ export class NiconicoService extends Service implements IPlatformService {
     const request = new Request(url, { credentials: 'same-origin' });
 
     const response = await fetch(request);
-    if (response.status === 401) {
+    if (response.status === 400 || response.status === 401) {
       return '';
     }
     const response_1 = await handleErrors(response); // !response.ok を例外にする

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -100,6 +100,9 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
           this.LOGOUT();
           this.userLogout.next();
         }
+      }).catch((e) => {
+        // offline や Internal Server Error などのときなので記録するだけ
+        console.warn('validateLogin: error=' + JSON.stringify(e));
       });
     }
 


### PR DESCRIPTION
# このpull requestが解決する内容
起動時に、前回から引き継いだログインセッションが無効(401 Unauthorizedではなく400 Bad Request応答をするケースがある)になっていたときに自動でログアウトしそこねていたケースをリカバーします。

# 動作確認手順
確認は難しい。アカウント設定でセッション無効化をした場合は今回に当てはまらない。

# 関連するIssue（あれば）
#573