### PR TITLE
改善:配信開始時にニコ生ログイン状態なら番組情報取得も行う

### DIFF
--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -92,7 +92,8 @@ const createInjectee = ({
   NicoliveProgramService: {
     state: {
       programID: '',
-    }
+    },
+    fetchProgram: noop,
   },
 });
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -218,6 +218,10 @@ export class StreamingService
         if (streamKey === '') {
           return this.showNotBroadcastingMessageBox();
         }
+
+        // [番組情報を取得]してニコ生パネルを更新する
+        await this.nicoliveProgramService.fetchProgram();
+
         if (this.customizationService.optimizeForNiconico) {
           return this.optimizeForNiconicoAndStartStreaming(
             setting,


### PR DESCRIPTION
# このpull requestが解決する内容
N Air起動後、ニコ生ログイン状態で、すでにN Airの外で番組が作成済みの状態で、番組情報取得を押さずに配信開始を押した場合、N Airが番組状態を把握していないのでコメントパネルなどが出ていませんでした。

この修正では、配信開始時に自動的に番組情報取得を行うため、番組情報のパネルが更新されるので、意識しなくてもコメント一覧や読み上げが行われるようになります。

# 動作確認手順
1. ニコ生の番組を作成する。N Airで行っても良いが、作成後一旦終了すること
2. N Airを起動する。ニコニコログインしていなければする。番組情報の取得はしない。
3. 配信開始を押す
4. ニコ生パネルの番組情報が自動的に更新される。

# 関連するIssue（あれば）
#530