### PR TITLE
改善:ニコ生の番組情報のビットレートなどの設定値の将来変更に対応

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -1,7 +1,7 @@
 import * as fetchMock from 'fetch-mock';
 import { WrappedResult } from './NicoliveClient';
 import { Communities, Community } from './ResponseTypes';
-const { NicoliveClient } = require('./NicoliveClient');
+const { NicoliveClient, parseMaxQuality } = require('./NicoliveClient');
 
 jest.mock('services/i18n', () => ({
   $t: (x: any) => x,
@@ -10,6 +10,26 @@ jest.mock('util/menus/Menu', () => ({}));
 
 afterEach(() => {
   fetchMock.reset();
+});
+
+describe('parseMaxQuality', () => {
+  const fallback = { bitrate: 192, height: 288, fps: 30 };
+  test.each([
+    ['6Mbps720p', 6000, 720, 30],
+    ['2Mbps450p', 2000, 450, 30],
+    ['1Mbps450p', 1000, 450, 30],
+    ['384kbps288p', 384, 288, 30],
+    ['192kbps288p', 192, 288, 30],
+    ['8Mbps1080p60fps', 8000, 1080, 60],
+    ['invalid', fallback.bitrate, fallback.height, fallback.fps],
+  ])(`%s => %d kbps, %d x %d`, (maxQuality, bitrate, height, fps) => {
+    expect(parseMaxQuality(maxQuality, fallback)).toEqual({
+      bitrate,
+      height,
+      fps,
+    });
+  }
+  );
 });
 
 test('constructor', () => {
@@ -231,7 +251,7 @@ function setupMock() {
     loadURL(url: string) {
       this.url = url;
       for (const cb of this.webContentsCallbacks) {
-        cb({ preventDefault() {} }, url);
+        cb({ preventDefault() { } }, url);
       }
     }
     close = jest.fn().mockImplementation(() => {
@@ -263,7 +283,7 @@ function setupMock() {
       },
     },
     ipcRenderer: {
-      send() {},
+      send() { },
     },
   }));
 

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -3,7 +3,11 @@ import { NiconicoService } from './niconico';
 export type IStreamingSetting = {
   url: string;
   key: string;
-  bitrate: number | undefined;
+  quality: {
+    bitrate: number;
+    height: number;
+    fps: number;
+  } | undefined;
 };
 
 // All platform services should implement

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -7,7 +7,7 @@ const setup = createSetupFunction({
     UserService: {},
     StreamingService: {
       streamingStatusChange: {
-        subscribe() {},
+        subscribe() { },
       },
     },
     WindowsService: {},
@@ -82,12 +82,23 @@ test('setupStreamSettingsでストリーム情報がとれた場合', async () =
       name: 'key1',
     }),
   );
-  instance.client.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
+  instance.client.fetchMaxQuality = jest.fn((programId: string) => Promise.resolve({
+    bitrate: 6000,
+    height: 720,
+    fps: 30,
+  }));
 
   const result = await instance.setupStreamSettings('lv12345');
-  expect(result.url).toBe('url1');
-  expect(result.key).toBe('key1');
-  expect(result.bitrate).toBe(6000);
+  expect(result).toEqual({
+    url: 'url1',
+    key: 'key1',
+    quality: {
+      bitrate: 6000,
+      height: 720,
+      fps: 30,
+    },
+  })
+
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();
 });
@@ -123,13 +134,21 @@ test('setupStreamSettingsで番組取得にリトライで成功する場合', a
       name: 'key1',
     }),
   );
-  instance.client.fetchMaxBitrate = jest.fn((programId: string) => Promise.resolve(6000));
+  instance.client.fetchMaxQuality = jest.fn((programId: string) => Promise.resolve({
+    bitrate: 6000,
+    height: 720,
+    fps: 30,
+  }));
 
   const result = await instance.setupStreamSettings();
   expect(result).toEqual({
     url: 'url1',
     key: 'key1',
-    bitrate: 6000,
+    quality: {
+      bitrate: 6000,
+      height: 720,
+      fps: 30,
+    },
   });
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -174,9 +174,9 @@ export class NiconicoService extends Service implements IPlatformService {
   }
 
   private async _setupStreamSettings(programId: string): Promise<IStreamingSetting> {
-    const [stream, bitrate] = await Promise.all([
+    const [stream, quality] = await Promise.all([
       this.client.fetchBroadcastStream(programId),
-      this.client.fetchMaxBitrate(programId),
+      this.client.fetchMaxQuality(programId),
     ]);
     const url = stream.url;
     const key = stream.name;
@@ -201,7 +201,7 @@ export class NiconicoService extends Service implements IPlatformService {
     this.settingsService.setSettings('Stream', settings);
 
     // 有効な番組が選択されているので stream keyを返す
-    return NiconicoService.createStreamingSetting(url, key, bitrate);
+    return NiconicoService.createStreamingSetting(url, key, quality);
   }
 
   private static emptyStreamingSetting(): IStreamingSetting {
@@ -211,9 +211,13 @@ export class NiconicoService extends Service implements IPlatformService {
   private static createStreamingSetting(
     url: string,
     key: string,
-    bitrate?: number,
+    quality?: {
+      bitrate: number,
+      height: number,
+      fps: number
+    } | undefined,
   ): IStreamingSetting {
-    return { url, key, bitrate };
+    return { url, key, quality };
   }
 
   // TODO ニコニコOAuthのtoken更新に使う

--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -6,6 +6,8 @@ import { OptimizeSettings, SettingsKeyAccessor, OptimizationKey, EncoderType } f
 export function getBestSettingsForNiconico(
   options: {
     bitrate: number;
+    height: number;
+    fps: number;
     useHardwareEncoder?: boolean;
   },
   settings: SettingsKeyAccessor,
@@ -14,20 +16,29 @@ export function getBestSettingsForNiconico(
   let resolution: string;
   if (options.bitrate >= 6000) {
     audioBitrate = 192;
-    resolution = '1280x720';
   } else if (options.bitrate >= 2000) {
     audioBitrate = 192;
-    resolution = '800x450';
   } else if (options.bitrate >= 1000) {
     audioBitrate = 96;
-    resolution = '800x450';
   } else if (options.bitrate >= 384) {
     audioBitrate = 48;
-    resolution = '512x288';
   } else {
     audioBitrate = 48;
-    resolution = '512x288';
   }
+
+  switch (options.height) {
+    case 720:
+      resolution = '1280x720';
+      break;
+    case 450:
+      resolution = '800x450';
+      break;
+    case 288:
+    default:
+      resolution = '512x288';
+      break;
+  }
+
 
   let encoderSettings: OptimizeSettings = {
     encoder: EncoderType.x264,
@@ -68,7 +79,7 @@ export function getBestSettingsForNiconico(
     audioBitrate: audioBitrate.toString(10),
     quality: resolution,
     fpsType: 'Common FPS Values',
-    fpsCommon: '30',
+    fpsCommon: `${options.fps || 30}`,
     audioSampleRate: 48000,
   };
 

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -548,6 +548,8 @@ export class SettingsService
 
   diffOptimizedSettings(options: {
     bitrate: number;
+    height: number;
+    fps: number;
     useHardwareEncoder?: boolean;
   }): OptimizedSettings {
     const accessor = new SettingsKeyAccessor(this);

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -349,7 +349,7 @@ export class StreamingService
     streamingSetting: IStreamingSetting,
     mustShowDialog: boolean,
   ) {
-    if (streamingSetting.bitrate === undefined) {
+    if (streamingSetting.quality === undefined) {
       return new Promise(resolve => {
         electron.remote.dialog
           .showMessageBox(electron.remote.getCurrentWindow(), {
@@ -363,7 +363,9 @@ export class StreamingService
       });
     }
     const settings = this.settingsService.diffOptimizedSettings({
-      bitrate: streamingSetting.bitrate,
+      bitrate: streamingSetting.quality.bitrate,
+      height: streamingSetting.quality.height,
+      fps: streamingSetting.quality.fps,
       useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
     });
     if (Object.keys(settings.delta).length > 0 || mustShowDialog) {


### PR DESCRIPTION
# このpull requestが解決する内容
現在はmaxQuality値が既知の値のどれかに一致していたら、という分岐をしていますが、ちゃんと中身をパースして使うようにします。

# 動作確認手順

# 関連するIssue（あれば）
