### PR TITLE
開発:Sentry送信を細々と追加 & scene関係のnullチェックなど

### DIFF
--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import electron from 'electron';
 import { AppService } from 'services/app';
 import { CompactModeService } from 'services/compact-mode';
@@ -98,6 +99,13 @@ export default class Main extends Vue {
 
   onDropHandler(event: DragEvent) {
     const files = event.dataTransfer.files;
+    if (!this.scenesService.activeScene) {
+      Sentry.captureMessage(
+        'Attempted to add files to a scene when no scene was active',
+        'warning',
+      );
+      return;
+    }
 
     let fi = files.length;
     while (fi--) {

--- a/app/services/nicolive-program/speech/NVoiceClient.test.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.test.ts
@@ -1,10 +1,15 @@
-import { getNVoicePath } from "@n-air-app/n-voice-package";
-import { join } from "path";
-import { NVoiceClient } from "./NVoiceClient";
+import { getNVoicePath } from '@n-air-app/n-voice-package';
+import { join } from 'path';
+import { NVoiceClient } from './NVoiceClient';
 
 describe('NVoiceClient', () => {
   const dir = getNVoicePath();
-  const client = new NVoiceClient({ baseDir: dir, onError: (err: Error) => { console.error(err) } });
+  const client = new NVoiceClient({
+    baseDir: dir,
+    onError: (err: Error) => {
+      console.error(err);
+    },
+  });
   const filename = join(dir, 'test.wav');
 
   test('empty', async () => {
@@ -15,5 +20,5 @@ describe('NVoiceClient', () => {
     const { wave, labels } = await client.talk(1.0, 'テスト', filename);
     expect(wave).not.toBeNull();
     expect(labels.map(l => l.phoneme)).toEqual(['silB', 't', 'e', 's', 'U', 't', 'o', 'silE']);
-  });
+  }, 10000 /* longer timeout */);
 });

--- a/app/services/nicolive-program/speech/NVoiceClient.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.ts
@@ -1,7 +1,8 @@
-import { ChildProcess, spawn } from "child_process";
-import { existsSync, readdirSync, readFileSync, unlinkSync } from "fs";
-import { basename, join } from "path";
-import { createInterface } from "readline";
+import * as Sentry from '@sentry/vue';
+import { ChildProcess, spawn } from 'child_process';
+import { existsSync, readdirSync, readFileSync, unlinkSync } from 'fs';
+import { basename, join } from 'path';
+import { createInterface } from 'readline';
 
 export function getNVoicePath(): string {
   // import/require構文を使うとビルド時に展開してしまうが、
@@ -70,24 +71,28 @@ class CommandLineClient {
     this.stdout = this.subprocess.stdout;
     this.stderr = this.subprocess.stderr;
 
-    this.terminateResolve = () => { /* do nothing */ };
-    this.terminateReject = () => { /* do nothing */ };
+    this.terminateResolve = () => {
+      /* do nothing */
+    };
+    this.terminateReject = () => {
+      /* do nothing */
+    };
     this.terminated = new Promise<number>((resolve, reject) => {
       this.terminateResolve = resolve;
       this.terminateReject = reject;
     }).finally(() => {
-      this.terminateCallbacks.forEach((callback) => callback());
+      this.terminateCallbacks.forEach(callback => callback());
     });
   }
 
   /**
-  * register callback to be called on terminated
-  * @returns cancel function
-  */
-  onTerminate(callback: () => void): (() => void) {
+   * register callback to be called on terminated
+   * @returns cancel function
+   */
+  onTerminate(callback: () => void): () => void {
     this.terminateCallbacks.push(callback);
     return () => {
-      this.terminateCallbacks = this.terminateCallbacks.filter((c) => c !== callback);
+      this.terminateCallbacks = this.terminateCallbacks.filter(c => c !== callback);
     };
   }
 
@@ -127,12 +132,12 @@ class CommandLineClient {
       };
       rl.on('line', onLine);
 
-      this.subprocess.on('error', (err) => {
+      this.subprocess.on('error', err => {
         console.log('subprocess.error', err);
         reject(err);
         this.terminateReject(err);
       });
-      this.subprocess.on('close', (code) => {
+      this.subprocess.on('close', code => {
         this.log(`${label} terminated: ${code}`);
         this.terminateResolve(code || -1);
       });
@@ -142,7 +147,7 @@ class CommandLineClient {
   }
 
   async send(line: string): Promise<void> {
-    await new Promise((resolve) => {
+    await new Promise(resolve => {
       this.log(`<- ${line}`);
       this.subprocess.stdin.write(line + '\n', resolve);
     });
@@ -162,11 +167,23 @@ class CommandLineClient {
 
 // API document https://github.com/n-air-app/n-voice-package/tree/main/n-voice/doc
 
-async function StartNVoice(enginePath: string, dictionaryPath: string, userDictionary: string, modelPath: string, extraVoicesPath: string, cwd: string): Promise<CommandLineClient> {
-  const log = ((...args: unknown[]) => { console.log(...args); });
+async function StartNVoice(
+  enginePath: string,
+  dictionaryPath: string,
+  userDictionary: string,
+  modelPath: string,
+  extraVoicesPath: string,
+  cwd: string,
+): Promise<CommandLineClient> {
+  const log = (...args: unknown[]) => {
+    console.log(...args);
+  };
 
   const client = new CommandLineClient(
-    spawn(enginePath, [dictionaryPath, userDictionary, modelPath, extraVoicesPath], { stdio: 'pipe', cwd }),
+    spawn(enginePath, [dictionaryPath, userDictionary, modelPath, extraVoicesPath], {
+      stdio: 'pipe',
+      cwd,
+    }),
     log,
     true, // options.showStdout,
   );
@@ -189,7 +206,7 @@ type Command =
   | 'annotated_talk'
   | 'max_time'
   | 'set_max_time'
-  | 'test'
+  | 'test';
 
 const ErrorCodes: { [code: number]: string } = {
   1: 'invalid argument',
@@ -223,14 +240,26 @@ function loadLabelFile(filename: string): Label[] {
   return result;
 }
 
+class NVoiceEngineError extends Error {
+  constructor(public code: string) {
+    const title = ErrorCodes[code];
+    super(`${code}: ${title}`);
+
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 const supportedProtocolVersion = '1.0.0';
 export class NVoiceClient {
   private commandLineClient: CommandLineClient | undefined;
 
-  constructor(readonly options: {
-    baseDir: string;
-    onError: (err: Error) => void;
-  }) {
+  constructor(
+    readonly options: {
+      baseDir: string;
+      onError: (err: Error) => void;
+    },
+  ) {
     console.log(`NVoiceClient: baseDir: ${this.options.baseDir}`);
   }
 
@@ -247,13 +276,20 @@ export class NVoiceClient {
       const dictionaryPath = 'open_jtalk_dic_shift_jis-1.11';
       const userDictionary = 'user.dic';
 
-      const models = readdirSync(baseDir).filter(s => /.*\.pt$/.test(s))
+      const models = readdirSync(baseDir).filter(s => /.*\.pt$/.test(s));
       if (models.length !== 1) {
         throw new Error('model file found: ' + models.join(', '));
       }
       const cwd = baseDir;
-      const extraVoicesPath = 'n-voice_extra-voices'
-      const client = await StartNVoice(enginePath, dictionaryPath, userDictionary, models[0], extraVoicesPath, cwd);
+      const extraVoicesPath = 'n-voice_extra-voices';
+      const client = await StartNVoice(
+        enginePath,
+        dictionaryPath,
+        userDictionary,
+        models[0],
+        extraVoicesPath,
+        cwd,
+      );
       let started = false;
       client.waitExit().then(code => {
         if (!started) {
@@ -290,14 +326,12 @@ export class NVoiceClient {
             resolve(rest);
             return true;
 
-          case 'ng':
-            {
-              const code = rest[0];
-              const title = ErrorCodes[code];
-              cancelWatchingTerminate();
-              reject(new Error(`code ${code}: ${title}`));
-              return true;
-            }
+          case 'ng': {
+            const code = rest[0];
+            cancelWatchingTerminate();
+            reject(new NVoiceEngineError(code));
+            return true;
+          }
 
           default:
             return false;
@@ -306,13 +340,45 @@ export class NVoiceClient {
     });
   }
 
-  async _command(command: Command, ...args: string[]): Promise<string[]> {
+  async _command(
+    command: Command,
+    ...args: { label: string; value: string; encoder?: (value: string) => string }[]
+  ): Promise<string[]> {
     await this.startNVoice();
     try {
-      await this.commandLineClient.send([command, ...args].join(' '));
+      await this.commandLineClient.send(
+        [
+          command,
+          ...args.map(a => {
+            if (a.encoder) {
+              return a.encoder(a.value);
+            } else {
+              return a.value;
+            }
+          }),
+        ].join(' '),
+      );
       return await this.waitOkNg(this.commandLineClient);
     } catch (err) {
-      throw new Error(`${err}: ${command} ${args.join(' ')}`);
+      Sentry.withScope(scope => {
+        scope.setLevel('error');
+        if (err instanceof NVoiceEngineError) {
+          scope.setTag('NVoiceEngineError.code', err.code);
+          for (const a of args) {
+            scope.setTag(`${command}.${a.label}`, a.value);
+          }
+          switch (err.code) {
+            case '401': // テキスト解析失敗
+              scope.setLevel('warning');
+              break;
+          }
+          scope.setFingerprint([command, 'NVoiceEngineError', err.code]);
+        } else {
+          scope.setFingerprint([command]);
+        }
+        Sentry.captureException(err);
+        throw err;
+      });
     }
   }
 
@@ -321,16 +387,35 @@ export class NVoiceClient {
     return r[0];
   }
 
-  async talk(speed: number, text: string, filename: string): Promise<{ wave: Buffer | null, labels: Label[] }> {
-    const sjis = toShiftJisBase64(text);
-    if (sjis === '') {
+  async talk(
+    speed: number,
+    text: string,
+    filename: string,
+  ): Promise<{ wave: Buffer | null; labels: Label[] }> {
+    if (text === '') {
       // ignore empty text
       return { wave: null, labels: [] };
     }
     try {
-      await this._command('talk', speed.toString(), sjis, toShiftJisBase64(filename));
-    } catch (e) {
-      console.error('talk exception', e);
+      await this._command(
+        'talk',
+        {
+          label: 'speed',
+          value: speed.toString(),
+        },
+        {
+          label: 'text',
+          value: text,
+          encoder: toShiftJisBase64,
+        },
+        {
+          label: 'filename',
+          value: filename,
+          encoder: toShiftJisBase64,
+        },
+      );
+    } catch (err) {
+      // TODO エラー内容によってはユーザーに伝えるか?
       return { wave: null, labels: [] };
     }
 
@@ -348,7 +433,10 @@ export class NVoiceClient {
   }
 
   async set_max_time(seconds: number): Promise<void> {
-    await this._command('set_max_time', seconds.toString());
+    await this._command('set_max_time', {
+      label: 'seconds',
+      value: seconds.toString(),
+    });
   }
 
   loaded(): boolean {

--- a/app/services/nicolive-program/speech/NVoiceClient.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.ts
@@ -346,6 +346,10 @@ export class NVoiceClient {
   ): Promise<string[]> {
     await this.startNVoice();
     try {
+      Sentry.addBreadcrumb({
+        category: 'n-voice-engine',
+        message: `${command} ${args.map(a => a.value).join(' ')}`,
+      });
       await this.commandLineClient.send(
         [
           command,

--- a/app/services/scenes/scene-folder.ts
+++ b/app/services/scenes/scene-folder.ts
@@ -9,6 +9,7 @@ import { TSceneNodeType } from './scenes';
 
 import { SceneItemNode } from './scene-node';
 import { ISceneItemFolder } from '.';
+import { assertIsDefined } from 'util/properties-type-guards';
 
 @ServiceHelper()
 export class SceneItemFolder extends SceneItemNode {
@@ -28,7 +29,7 @@ export class SceneItemFolder extends SceneItemNode {
     const state = this.scenesService.state.scenes[sceneId].nodes.find(item => {
       return item.id === id;
     });
-
+    assertIsDefined(state);
     Utils.applyProxy(this, state);
     this.state = state as ISceneItemFolder;
   }
@@ -64,7 +65,9 @@ export class SceneItemFolder extends SceneItemNode {
   }
 
   getScene(): Scene {
-    return this.scenesService.getScene(this.sceneId);
+    const scene = this.scenesService.getScene(this.sceneId);
+    assertIsDefined(scene);
+    return scene;
   }
 
   /**

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -19,6 +19,7 @@ import {
 } from './index';
 import { SceneItemNode } from './scene-node';
 import { TSceneNodeType } from './scenes';
+import { assertIsDefined } from 'util/properties-type-guards';
 /**
  * A SceneItem is a source that contains
  * all of the information about that source, and
@@ -76,6 +77,7 @@ export class SceneItem extends SceneItemNode {
     const sceneItemState = this.scenesService.state.scenes[sceneId].nodes.find(item => {
       return item.id === sceneItemId;
     }) as ISceneItem;
+    assertIsDefined(sceneItemState);
     const sourceState = this.sourcesService.state.sources[sourceId];
     this.state = sceneItemState;
     Utils.applyProxy(this, sourceState);
@@ -87,11 +89,15 @@ export class SceneItem extends SceneItemNode {
   }
 
   getScene(): Scene {
-    return this.scenesService.getScene(this.sceneId);
+    const scene = this.scenesService.getScene(this.sceneId);
+    assertIsDefined(scene);
+    return scene;
   }
 
   get source() {
-    return this.sourcesService.getSource(this.sourceId);
+    const source = this.sourcesService.getSource(this.sourceId);
+    assertIsDefined(source);
+    return source;
   }
 
   getSource() {

--- a/app/services/scenes/scene-node.ts
+++ b/app/services/scenes/scene-node.ts
@@ -13,6 +13,7 @@ import {
   TSceneNode,
 } from './index';
 import { SelectionService } from 'services/selection';
+import { assertIsDefined } from 'util/properties-type-guards';
 
 export function isFolder(node: SceneItemNode): node is SceneItemFolder {
   return node.sceneNodeType === 'folder';
@@ -36,7 +37,9 @@ export abstract class SceneItemNode implements ISceneItemNode {
   @Inject() protected selectionService: SelectionService;
 
   getScene(): Scene {
-    return this.scenesService.getScene(this.sceneId);
+    const scene = this.scenesService.getScene(this.sceneId);
+    assertIsDefined(scene);
+    return scene;
   }
 
   get childrenIds(): string[] {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -19,6 +19,7 @@ import { uniqBy } from 'lodash';
 import { TSceneNodeInfo } from 'services/scene-collections/nodes/scene-items';
 import * as fs from 'fs';
 import uuid from 'uuid/v4';
+import { assertIsDefined } from 'util/properties-type-guards';
 
 export type TSceneNode = SceneItem | SceneItemFolder;
 
@@ -42,7 +43,9 @@ export class Scene {
   private readonly state: IScene;
 
   constructor(sceneId: string) {
+    if (!sceneId) console.trace('undefined sceneId');
     this.state = this.scenesService.state.scenes[sceneId];
+    assertIsDefined(this.state);
     Utils.applyProxy(this, this.state);
   }
 
@@ -317,7 +320,9 @@ export class Scene {
     if (newDestNode) {
       this.placeAfter(sourceNodeId, newDestNode.id);
     } else if (destNode.parentId) {
-      this.getNode(sourceNodeId).setParent(destNode.parentId); // place to the top of folder
+      const sourceNode = this.getNode(sourceNodeId);
+      assertIsDefined(sourceNode);
+      sourceNode.setParent(destNode.parentId); // place to the top of folder
     } else {
       this.placeAfter(sourceNodeId); // place to the top of scene
     }
@@ -447,7 +452,10 @@ export class Scene {
    * returns the source linked to scene
    */
   getSource(): Source {
-    return this.sourcesService.getSource(this.id);
+    // scene must always have a linked source
+    const source = this.sourcesService.getSource(this.id);
+    assertIsDefined(source);
+    return source;
   }
 
   getResourceId() {

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -13,6 +13,7 @@ import { TObsFormData } from 'components/obs/inputs/ObsInput';
 import Utils from 'services/utils';
 import * as obs from '../../../obs-api';
 import { cloneDeep, isEqual } from 'lodash';
+import { assertIsDefined } from 'util/properties-type-guards';
 
 @ServiceHelper()
 export class Source implements ISourceApi {
@@ -175,14 +176,12 @@ export class Source implements ISourceApi {
     // is always up-to-date, and essentially acts
     // as a view into the store.  It also enforces
     // the read-only nature of this data
-    const isTemporarySource = !!this.sourcesService.state.temporarySources[sourceId];
-    if (isTemporarySource) {
-      this.state = this.sourcesService.state.temporarySources[sourceId];
-      Utils.applyProxy(this, this.sourcesService.state.temporarySources[sourceId]);
-    } else {
-      this.state = this.sourcesService.state.sources[sourceId];
-      Utils.applyProxy(this, this.sourcesService.state.sources[sourceId]);
-    }
+    const state =
+      this.sourcesService.state.sources[sourceId] ||
+      this.sourcesService.state.temporarySources[sourceId];
+    assertIsDefined(state);
+    Utils.applyProxy(this, state);
+    this.state = state;
   }
 
   @mutation()

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -2,8 +2,9 @@ import * as electron from 'electron';
 import { EStreamingState, ERecordingState } from './streaming-api';
 
 import { createSetupFunction } from 'util/test-setup';
+import { RequestError } from 'util/RequestError';
 
-function noop(..._args: any[]) { }
+function noop(..._args: any[]) {}
 
 jest.mock('services/core/stateful-service');
 jest.mock('services/core/injector');
@@ -44,7 +45,7 @@ const createInjectee = ({
       bitrate: '',
       sampleRate: 48000,
       rateControl: null,
-    }
+    },
   }),
   WarnBeforeStartingStream = false,
   WarnBeforeStoppingStream = false,
@@ -87,8 +88,7 @@ const createInjectee = ({
   WindowsService: {
     showWindow,
   },
-  NicoliveCommentSynthesizerService: {
-  },
+  NicoliveCommentSynthesizerService: {},
   NicoliveProgramService: {
     state: {
       programID: '',
@@ -739,10 +739,7 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
     injectee: createInjectee({
       isNiconicoLoggedIn: true,
       updateStreamSettings: () => {
-        throw new Response('HTTPError', {
-          statusText: 'Internal Server Error(stub)',
-          status: 500,
-        });
+        throw new RequestError(500, 'updateStreamSettings dummy URL');
       },
     }),
     state: {

--- a/app/util/RequestError.ts
+++ b/app/util/RequestError.ts
@@ -1,0 +1,9 @@
+// Sentry.captureException で内容が見えるようにするために Response ではなく Error にする
+export class RequestError extends Error {
+  constructor(public status: number, public url: string) {
+    super(`${status}`);
+
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/app/util/properties-type-guards.ts
+++ b/app/util/properties-type-guards.ts
@@ -55,3 +55,10 @@ export function isEmptyProperty(property: obs.IProperty): boolean {
 
   return false;
 }
+
+export function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
+  if (val === undefined || val === null) {
+    throw new Error(`Expected 'val' to be defined, but received ${val}`);
+  }
+  return null;
+}

--- a/app/util/requests.ts
+++ b/app/util/requests.ts
@@ -1,6 +1,7 @@
 // Helper methods for making HTTP requests
 
 import fs from 'fs';
+import { RequestError } from './RequestError';
 
 /**
  * Passing this function as your first "then" handler when making
@@ -11,7 +12,7 @@ import fs from 'fs';
  */
 export function handleErrors(response: Response): Promise<Response> {
   if (response.ok) return Promise.resolve(response);
-  return Promise.reject(response);
+  return Promise.reject(new RequestError(response.status, response.url));
 }
 
 export function requiresToken() {
@@ -20,7 +21,7 @@ export function requiresToken() {
     return {
       ...descriptor,
       value(...args: any[]) {
-        return original.apply(target.constructor.instance, args).catch((error: Response) => {
+        return original.apply(target.constructor.instance, args).catch((error: RequestError) => {
           if (error.status === 401) {
             return target.fetchNewToken().then(() => {
               return original.apply(target.constructor.instance, args);

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@n-air-app/n-voice-package": "^1.0.2",
     "@sentry/electron": "^4.3.0",
-    "@sentry/vue": "^7.40.0",
+    "@sentry/vue": "^7.42.0",
     "archiver": "^3.0.0",
     "aws-sdk": "^2.344.0",
     "base64-js": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,15 +2640,15 @@
     "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/browser@7.40.0":
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.40.0.tgz#e088154b4d104dfb33f7ca19bfd1276c60010b2d"
-  integrity sha512-07rZ+cTcpmYB1r84/oZtmSPJJvLCxW8yIh/5s4MdKRyZpqIDKhOz6cCS/4j+l1V+MeLcNLZBjFtNdKA2eocTpg==
+"@sentry/browser@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.42.0.tgz#357731e5ab65a226c98370f9e487fe48cadab765"
+  integrity sha512-xTwfvrQPmYTkAvGivoJFadPLKLDS2N57D/18NA1gcrnF8NwR+I28x3I9ziVUiMCYX+6nJuqBNlMALAEPbb2G5A==
   dependencies:
-    "@sentry/core" "7.40.0"
-    "@sentry/replay" "7.40.0"
-    "@sentry/types" "7.40.0"
-    "@sentry/utils" "7.40.0"
+    "@sentry/core" "7.42.0"
+    "@sentry/replay" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     tslib "^1.9.3"
 
 "@sentry/core@7.37.1":
@@ -2660,13 +2660,13 @@
     "@sentry/utils" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/core@7.40.0":
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.40.0.tgz#1013ddf576ed3a4be9abf2b8e8b0c95ab7e3d7bb"
-  integrity sha512-OPAobQG0GTY++r5LWUcOA1lS+2TY2Lmw/i5s4kL9WbY+f08dbLNEGNBObY7/V98OL4f7OG+nWaPFybgM7kqUTQ==
+"@sentry/core@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.42.0.tgz#3333a1b868e8e69b6fbc8e5a9e9281be49321ac7"
+  integrity sha512-vNcTyoQz5kUXo5vMGDyc5BJMO0UugPvMfYMQVxqt/BuDNR30LVhY+DL2tW1DFZDvRvyn5At+H7kSTj6GFrANXQ==
   dependencies:
-    "@sentry/types" "7.40.0"
-    "@sentry/utils" "7.40.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     tslib "^1.9.3"
 
 "@sentry/electron@^4.3.0":
@@ -2704,24 +2704,24 @@
     "@sentry/types" "7.37.1"
     "@sentry/utils" "7.37.1"
 
-"@sentry/replay@7.40.0":
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.40.0.tgz#cf78b5bf92b9a3c045022e7cc4fede7ef4ffe874"
-  integrity sha512-Y9Kvo9jKouUdrHQhHVv5SmWZClF5o7BFI6oVpLlv4zXORPQlyoZONM/9sxiMvvH73alDSpxzCoxyhlypAOH4ww==
+"@sentry/replay@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.42.0.tgz#03be2bdab35e0f2d4e415a770c23d50dba8d73b5"
+  integrity sha512-81HQm20hrW0+0eZ5sZf8KsSekkAlI0/u/M+9ZmOn2bHpGihqAM/O/lrXhTzaRXdpX/9NSwSCGY9k7LIRNMKaEQ==
   dependencies:
-    "@sentry/core" "7.40.0"
-    "@sentry/types" "7.40.0"
-    "@sentry/utils" "7.40.0"
+    "@sentry/core" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
 
 "@sentry/types@7.37.1":
   version "7.37.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.37.1.tgz#269da7da39c1a5243bf5f9a35370291b5cc205bb"
   integrity sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==
 
-"@sentry/types@7.40.0":
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.40.0.tgz#27b012b59d593132e413018773f0a045d68075d7"
-  integrity sha512-dIbqBenbmDx1F8pvfC11C88J83ecwumUhV+YOIxcmVd1fmlPF2hXWZ01+NTkTDkCu341sJx4wPQogByFy8FwGA==
+"@sentry/types@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.42.0.tgz#e5019cd41a8c4a98c296e2ff28d6adab4b2eb14e"
+  integrity sha512-Ga0xaBIR/peuXQ88hI9a5TNY3GLNoH8jpsgPaAjAtRHkLsTx0y3AR+PrD7pUysza9QjvG+Qux01DRvLgaNKOHA==
 
 "@sentry/utils@7.37.1":
   version "7.37.1"
@@ -2731,23 +2731,23 @@
     "@sentry/types" "7.37.1"
     tslib "^1.9.3"
 
-"@sentry/utils@7.40.0":
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.40.0.tgz#0986f2e93b1d42b1e1aeb077941226e3d76419c4"
-  integrity sha512-ZdCbTpAXPiVVfvNJVftnDhsctOui71MDUhVIdLkgg4Cuic+WHGPRmmZ+H6uZdp7vRaeB+Uvnn5+t2iSAVo/mAA==
+"@sentry/utils@7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.42.0.tgz#fcffd0404836cb56975fbef9e889a42cc55de596"
+  integrity sha512-cBiDZVipC+is+IVgsTQLJyZWUZQxlLZ9GarNT+XZOZ5BFh0acFtz88hO6+S7vGmhcx2aCvsdC9yb2Yf+BphK6Q==
   dependencies:
-    "@sentry/types" "7.40.0"
+    "@sentry/types" "7.42.0"
     tslib "^1.9.3"
 
-"@sentry/vue@^7.40.0":
-  version "7.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-7.40.0.tgz#994420acf94cd983e4395e00033ed7050199eaba"
-  integrity sha512-aMOFe3xPIi4VLcf35Qpb087sDi9ESRZytBX2HYQUVaYjZ2hZxoOaYESiw699jlHmGkypfTfLHxiYCHMN8ZC9Kg==
+"@sentry/vue@^7.42.0":
+  version "7.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-7.42.0.tgz#6c95ef1c57cdd7d0c0f3d361683e4246386ed0d1"
+  integrity sha512-Q9LWTyMD1vCaYQc1XjXkItMosJ4SINKSBnt3Ha0PP1DCe2aooLDb4L5Gxwg9LQp/AF949sd4v6BBUOh4p69X4g==
   dependencies:
-    "@sentry/browser" "7.40.0"
-    "@sentry/core" "7.40.0"
-    "@sentry/types" "7.40.0"
-    "@sentry/utils" "7.40.0"
+    "@sentry/browser" "7.42.0"
+    "@sentry/core" "7.42.0"
+    "@sentry/types" "7.42.0"
+    "@sentry/utils" "7.42.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":


### PR DESCRIPTION
# このpull requestが解決する内容
* NVoiceClient: Sentry送信を整備
* NVoice playAudio: 前の再生のキャンセルのタイミングが早すぎて例外が出ていたのを修正
* fetch responseのエラー処理をSentryで見えるようにResponse自体ではなく `Error` 派生にした `RequestError` でthrow(reject)する
* onDropHandler で aceiveScene がnullのときに例外を記録
* scene関係のnullチェック `assertIsDefined` とその使用箇所をslobsからbackport (原因解消ではない)
* @sentry/vue を更新
* ついでに NVoiceClientのunit testがよくtimeoutするのでtimeoutを5秒から10秒に伸ばした

触ったファイルはprettierを適用したため差分が余計に多いのが注意
