### PR TITLE
開発:Sentryに来ている "Error in callback for watcher "value": cannot read property call of undefined"回避

### DIFF
--- a/app/components/obs/inputs/ObsBitMaskInput.vue.ts
+++ b/app/components/obs/inputs/ObsBitMaskInput.vue.ts
@@ -14,9 +14,13 @@ class ObsBitMaskInput extends ObsInput<IObsBitmaskInput> {
 
   mounted() {
     this.updateFlags();
+    // workaround: avoid using @Watch decorator, use $watch instead
+    // see:
+    //   https://github.com/kaorun343/vue-property-decorator/issues/247,
+    //   https://github.com/kaorun343/vue-property-decorator/issues/228
+    this.$watch('value', this.updateFlags);
   }
 
-  @Watch('value')
   updateFlags() {
     this.flags = Utils.numberToBinnaryArray(this.value.value, this.value.size).reverse();
   }


### PR DESCRIPTION
# このpull requestが解決する内容
Sentryに来ている `Error in callback for watcher "value": cannot read property 'call' of undefined` というエラーの原因が
vue-property-decorator が同じabstract classを派生しているクラス間で混信するというものだったため、
設定のObsInput派生の ObsBitMaskInput に付けられている `@Watch('value')` が他のクラスにも登録されてしまい、callbackが undefinedであるという例外が起きていた。

decoratorではなく、Vueの this.$watchで登録することで回避する。

# 動作確認手順
例えば設定の映像の解像度を変更するときに発生していた。(consoleにも例外が表示された)
これが出なくなる。
