### PR TITLE
開発:PRタイトルに引用符が含まれているときにpatch-noteが生成失敗していたのを修正

### DIFF
--- a/bin/release/scripts/patchNote.test.js
+++ b/bin/release/scripts/patchNote.test.js
@@ -1,4 +1,10 @@
-const { parseVersion, getVersionContext, validateVersionContext, generateNewVersion } = require('./patchNote');
+const {
+  parseVersion,
+  getVersionContext,
+  validateVersionContext,
+  generateNewVersion,
+  generateNotesTsContent,
+} = require('./patchNote');
 
 const fixtures = {
   public: {
@@ -153,43 +159,56 @@ test('ふたつのVersionContextが同じか否か判定できる', () => {
 });
 
 test('次のバージョンを生成する(当日、publicでstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.public.stable, now: TODAY })).toMatchInlineSnapshot(
-    `"1.0.20190826-3"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.public.stable, now: TODAY }),
+  ).toMatchInlineSnapshot(`"1.0.20190826-3"`);
 });
 test('次のバージョンを生成する(当日、publicでunstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.public.unstable, now: TODAY })).toMatchInlineSnapshot(
-    `"1.0.20190826-unstable.3"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.public.unstable, now: TODAY }),
+  ).toMatchInlineSnapshot(`"1.0.20190826-unstable.3"`);
 });
 test('次のバージョンを生成する(当日、internalでstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.internal.stable, now: TODAY })).toMatchInlineSnapshot(
-    `"1.0.20190826-3d"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.internal.stable, now: TODAY }),
+  ).toMatchInlineSnapshot(`"1.0.20190826-3d"`);
 });
 test('次のバージョンを生成する(当日、internalでunstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.internal.unstable, now: TODAY })).toMatchInlineSnapshot(
-    `"1.0.20190826-unstable.3d"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.internal.unstable, now: TODAY }),
+  ).toMatchInlineSnapshot(`"1.0.20190826-unstable.3d"`);
 });
 
 test('次のバージョンを生成する(別日、publicでstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.public.stable, now: TOMORROW })).toMatchInlineSnapshot(
-    `"1.0.20190827-1"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.public.stable, now: TOMORROW }),
+  ).toMatchInlineSnapshot(`"1.0.20190827-1"`);
 });
 test('次のバージョンを生成する(別日、publicでunstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.public.unstable, now: TOMORROW })).toMatchInlineSnapshot(
-    `"1.0.20190827-unstable.1"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.public.unstable, now: TOMORROW }),
+  ).toMatchInlineSnapshot(`"1.0.20190827-unstable.1"`);
 });
 test('次のバージョンを生成する(別日、internalでstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.internal.stable, now: TOMORROW })).toMatchInlineSnapshot(
-    `"1.0.20190827-1d"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.internal.stable, now: TOMORROW }),
+  ).toMatchInlineSnapshot(`"1.0.20190827-1d"`);
 });
 test('次のバージョンを生成する(別日、internalでunstable)', () => {
-  expect(generateNewVersion({ previousVersion: fixtures.internal.unstable, now: TOMORROW })).toMatchInlineSnapshot(
-    `"1.0.20190827-unstable.1d"`
-  );
+  expect(
+    generateNewVersion({ previousVersion: fixtures.internal.unstable, now: TOMORROW }),
+  ).toMatchInlineSnapshot(`"1.0.20190827-unstable.1d"`);
+});
+
+test('patch-noteに引用符があったらエスケープされる', () => {
+  expect(generateNotesTsContent('version', 'title', 'a"b"c')).toBe(`import { IPatchNotes } from '.';
+
+export const notes: IPatchNotes = {
+  version: 'version',
+  title: 'title',
+  notes: [
+    "a\\"b\\"c",
+  ]
+};
+`);
 });


### PR DESCRIPTION
# このpull requestが解決する内容
リリースをするときの `yarn patch-note` で GitHubからPRタイトルを集めた patch-notesに引用符が含まれているときに、 `yarn release` で生成するコードで引用符をエスケープできていなかったためコンパイルエラーで止まってしまうのを、エスケープをかけて回避します。

※prettierがかかったのでスタイル変更が多いけど、テストは末尾にひとつテストケースを追加しただけです