### PR TITLE
開発:Sentryに送信するsourceMap情報を修正する

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -125,14 +125,12 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
 
       if (event.exception && event.exception.values[0].stacktrace) {
         event.exception.values[0].stacktrace.frames.forEach(frame => {
-          console.log('frame before', frame); // DEBUG
           if (frame.abs_path) {
             frame.abs_path = normalize(frame.abs_path);
           }
           if (frame.filename) {
             frame.filename = normalize(frame.filename);
           }
-          console.log('frame', frame); // DEBUG
         });
       }
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -119,14 +119,20 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
       // isn't that great, so we do this hack.
       // Some discussion here: https://github.com/getsentry/sentry/issues/2708
       const normalize = (filename: string) => {
-        const splitArray = filename.split('/');
-        return splitArray[splitArray.length - 1];
+        const splitArray = filename.split(/[/\\]/);
+        return '~/' + splitArray[splitArray.length - 1];
       };
 
       if (event.exception && event.exception.values[0].stacktrace) {
         event.exception.values[0].stacktrace.frames.forEach(frame => {
-          frame.abs_path = '~/' + normalize(frame.abs_path);
-          frame.filename = normalize(frame.filename);
+          console.log('frame before', frame); // DEBUG
+          if (frame.abs_path) {
+            frame.abs_path = normalize(frame.abs_path);
+          }
+          if (frame.filename) {
+            frame.filename = normalize(frame.filename);
+          }
+          console.log('frame', frame); // DEBUG
         });
       }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = {
     },
   },
 
-  devtool: 'cheap-module-source-map', // source-map',
+  devtool: 'source-map',
 
   target: 'electron-renderer',
 
@@ -76,12 +76,12 @@ module.exports = {
     // Not actually a native addons, but for one reason or another
     // we don't want them compiled in our webpack bundle.
     'aws-sdk': 'require("aws-sdk")',
-    'asar': 'require("asar")',
+    asar: 'require("asar")',
     'backtrace-node': 'require("backtrace-node")',
     'node-fontinfo': 'require("node-fontinfo")',
     'socket.io-client': 'require("socket.io-client")',
-    'rimraf': 'require("rimraf")',
-    'request': 'require("request")',
+    rimraf: 'require("rimraf")',
+    request: 'require("request")',
   },
 
   module: {


### PR DESCRIPTION
# このpull requestが解決する内容
現在Sentryに来ているissueのstackTraceが壊れているので直したい

* [x] stackTraceのnormalize()で送信パスの区切りがWindowsになってなくてちゃんと正規化できていなかった -> 対応
* [x] Webpackのsourcemapの指定が productionだと生成しないものになっていた -> 出すものに変更
* [ ] 来てるstackTraceの途中にsourceMapが引けないものが混じっている