### PR TITLE
vue-draggable の obsolete property 'options'を使わなくする

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
     'generator-star-spacing': OFF,
     indent: OFF,
 
+    'vue/multi-word-component-names': OFF,
+
     // "variable-name": [ERROR, "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"], // We do imports where our files are suffixed .vue and this rule would expect we import as e.g. MainVue
     'import-name': OFF,
     // TODO: fix instances instead

--- a/app/components/Selector.vue
+++ b/app/components/Selector.vue
@@ -1,77 +1,75 @@
 <template>
-<ul class="selector-list" @contextmenu="handleContextMenu()" data-test="Selector">
-  <draggable
-    :list="normalizedItems"
-    :options="{draggable: draggableSelector}"
-    @change="handleChange">
-    <li
-      v-for="(item, index) in normalizedItems"
-      :key="item.value"
-      class="selector-item"
-      :class="{ 'selector-item--active': activeItems.includes(item.value) }"
-      @contextmenu.stop="(ev) => handleContextMenu(ev, index)"
-      @click="(ev) => handleSelect(ev, index)"
-      @dblclick="(ev) => handleDoubleClick(ev, index)">
-      <div class="selector-item-text" :data-test="item.name">
-        <span class="layer-icon"><i class="icon-studio-mode"/></span>
-        <span class="item-title">{{item.name}}</span>
-      </div>
-      <div class="selector-actions">
-        <slot name="actions" :item="item"/>
-      </div>
-    </li>
-  </draggable>
-</ul>
+  <ul class="selector-list" @contextmenu="handleContextMenu()" data-test="Selector">
+    <draggable :list="normalizedItems" :draggable="draggableSelector" @change="handleChange">
+      <li
+        v-for="(item, index) in normalizedItems"
+        :key="item.value"
+        class="selector-item"
+        :class="{ 'selector-item--active': activeItems.includes(item.value) }"
+        @contextmenu.stop="ev => handleContextMenu(ev, index)"
+        @click="ev => handleSelect(ev, index)"
+        @dblclick="ev => handleDoubleClick(ev, index)"
+      >
+        <div class="selector-item-text" :data-test="item.name">
+          <span class="layer-icon"><i class="icon-studio-mode" /></span>
+          <span class="item-title">{{ item.name }}</span>
+        </div>
+        <div class="selector-actions">
+          <slot name="actions" :item="item" />
+        </div>
+      </li>
+    </draggable>
+  </ul>
 </template>
 
 <script lang="ts" src="./Selector.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../styles/index";
+@import url('../styles/index');
 
 .sortable-ghost {
-  opacity: .7;
-  background-image: none;
   background-color: var(--color-bg-active);
+  background-image: none;
+  opacity: 0.7;
 }
 
 .sortable-chosen {
-  opacity: .7;
+  background-color: var(--color-bg-active);
   background-image: none;
-  background-color: var(--color-bg-active);
+  opacity: 0.7;
 }
+
 .sortable-drag {
-  border: 1px solid var(--color-border-light);
   background-color: var(--color-bg-active);
+  border: 1px solid var(--color-border-light);
 }
 
 .selector-list {
-  list-style-type: none;
   margin: 0;
   overflow: auto;
+  list-style-type: none;
 }
 
 .selector-item {
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   min-height: @item-generic-size;
   padding: 0 12px;
   cursor: pointer;
-  justify-content: space-between;
 
   .text-ellipsis;
   .transition;
 
-  &:hover {
-    color: var(--color-text-light);
-  }
   &.selector-item--active {
-    background-color: var(--color-bg-active);
     color: var(--color-text-light);
+    background-color: var(--color-bg-active);
   }
 
   &:hover {
+    color: var(--color-text-light);
+
     .selector-actions {
       opacity: 1;
     }
@@ -86,8 +84,10 @@
     font-size: @font-size2;
   }
 }
+
 .selector-item-text {
   .text-ellipsis;
+
   display: flex;
   align-items: center;
 }
@@ -96,12 +96,11 @@
   display: flex;
   flex-direction: row;
   font-size: 13px;
-  opacity: .2;
+  opacity: 0.2;
 }
 
 .selector-drag-handle {
   cursor: move;
   .icon-hover;
 }
-
 </style>


### PR DESCRIPTION
# このpull requestが解決する内容
* 起動するとこのエラーが console やSentryに送信されていたのを解決します。
```
Options props is deprecated, add sortable options directly as vue.draggable item, or use v-bind. See https://github.com/SortableJS/Vue.Draggable/blob/master/documentation/migrate.md#options-props
```
* eslintルールで Selector.vue がそのままだとcommitできなくなっていたので eslintrc に Selector という1単語のコンポーネントを許容させる設定変更もしています。

# 動作確認手順
dev起動してconsoleに上記メッセージが出なくなっている

# 関連するIssue（あれば）
