### PR TITLE
修正:パフォーマンス優先モードでスタジオモードにすると内部的にエラーが送信され続けていた

### DIFF
--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -34,7 +34,7 @@ export default class Studio extends Vue {
 
   mounted() {
     this.sizeCheckInterval = window.setInterval(() => {
-      if (this.studioMode) {
+      if (this.studioMode && this.$refs.studioModeContainer) {
         const rect = this.$refs.studioModeContainer.getBoundingClientRect();
 
         if (rect.width / rect.height > 16 / 9) {


### PR DESCRIPTION
# このpull requestが解決する内容
#638 Sentryに出ている getBoundingClientRect of undefined 対策
setIntervalで1秒ボーリングしているが、Studioが存在しない条件のときもノーチェックで参照していたため、チェックしてスキップします

# 関連するIssue（あれば）
fix #638