### PR TITLE
修正:ストリーミングURLが無効なときに配信開始・終了するとActionログの送信ができていなかった

### DIFF
--- a/app/services/streaming/extractPlatform.test.ts
+++ b/app/services/streaming/extractPlatform.test.ts
@@ -1,0 +1,12 @@
+import { extractPlatform } from "./extractPlatform";
+
+
+describe('extractPlatform', () => {
+  test.each([
+    ['rtmp://a.b.c.d/', 'c'], // second level domain
+    ['rtmp://1.2.3.4/', '1.2'], // first 2 numbers
+    ['invalid', 'invalid'], // invalid URL: return original string
+  ])(`%s -> %s`, (url, expected) => {
+    expect(extractPlatform(url)).toBe(expected);
+  });
+});

--- a/app/services/streaming/extractPlatform.ts
+++ b/app/services/streaming/extractPlatform.ts
@@ -20,7 +20,7 @@ export function extractPlatform(streamingURL: string): string {
 
     return streamingURL;
   } catch (e) {
-    console.warn(`extractPlatform(${JSON.stringify(streamingURL)}): URL failed`, e);
+    console.warn(`extractPlatform(${JSON.stringify(streamingURL)}): URL() failed`, e);
     return streamingURL;
   }
 }

--- a/app/services/streaming/extractPlatform.ts
+++ b/app/services/streaming/extractPlatform.ts
@@ -5,17 +5,22 @@ function isOnlyNumberOrDot(str: string): boolean {
 // streaming URLから domain の一部を抽出する
 // eg. "rtmp://kliveorigin.dmc.nico/named_input" -> "dmc"
 export function extractPlatform(streamingURL: string): string {
-  // URL は rtmp: だとhostnameを抽出してくれないためhttpに置換する
-  const u = new URL(streamingURL.replace('rtmp://', 'http://'));
-  if (isOnlyNumberOrDot(u.hostname)) {
-    // IPアドレスは 先頭の2つの値までを返す
-    return u.hostname.split('.').slice(0, 2).join('.');
-  }
+  try {
+    // URL は rtmp: だとhostnameを抽出してくれないためhttpに置換する
+    const u = new URL(streamingURL.replace('rtmp://', 'http://'));
+    if (isOnlyNumberOrDot(u.hostname)) {
+      // IPアドレスは 先頭の2つの値までを返す
+      return u.hostname.split('.').slice(0, 2).join('.');
+    }
 
-  const components = u.hostname.split('.');
-  if (components.length >= 2) {
-    return components[components.length - 2]; // second level domain
-  }
+    const components = u.hostname.split('.');
+    if (components.length >= 2) {
+      return components[components.length - 2]; // second level domain
+    }
 
-  return streamingURL;
+    return streamingURL;
+  } catch (e) {
+    console.warn(`extractPlatform(${JSON.stringify(streamingURL)}): URL failed`, e);
+    return streamingURL;
+  }
 }


### PR DESCRIPTION
# このpull requestが解決する内容
Sentryに来ていた: https://n-air-app.sentry.io/issues/4045267465/events/b55dc51f8eae4d268c437da271ab2163/

配信URLが正しくないとき、配信開始・終了でAction Logを送信できていなかった
