### PR TITLE
Sentry:「配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。」の原因調査

### DIFF
--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import { BehaviorSubject } from 'rxjs';
 import { Inject } from 'services/core/injector';
 import { mutation, StatefulService } from 'services/core/stateful-service';
@@ -236,6 +237,11 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
       if (!programSchedule) {
         this.setState({ status: 'end' });
+        Sentry.addBreadcrumb({
+          category: 'program',
+          message: 'suitable program not found',
+          data: { schedulesResponse: schedulesResponse.value },
+        });
         throw NicoliveFailure.fromConditionalError('fetchProgram', 'no_suitable_program');
       }
       const { nicoliveProgramId, socialGroupId } = programSchedule;


### PR DESCRIPTION
# このpull requestが解決する内容
番組を作って配信しようとしたら `配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。`  が出ているケースの調査用に、配信中番組APIの応答をSentryに送信するようにします。
