### PR TITLE
修正:設定やミキサーのスライダーを操作しても設定値が変化しなくなっていた

### DIFF
--- a/app/components/MixerItem.vue
+++ b/app/components/MixerItem.vue
@@ -24,7 +24,7 @@
         :max="1"
         :interval="0.01"
         @input="onSliderChangeHandler"
-        tooltip="none"
+        tooltip="false"
       />
       <div class="controls">
         <i

--- a/app/components/shared/Slider.vue.ts
+++ b/app/components/shared/Slider.vue.ts
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import VueSlider from 'vue-slider-component';
 import { Component, Prop } from 'vue-property-decorator';
+import ResizeSensor from 'css-element-queries/src/ResizeSensor';
+import { debounce } from 'lodash-decorators';
 
 @Component({
   components: { VueSlider },
@@ -16,6 +18,20 @@ export default class SliderInput extends Vue {
   @Prop() dotSize: number;
   @Prop() sliderStyle: object;
   @Prop() usePercentages: boolean;
+
+  $refs: { slider: any };
+
+  mounted() {
+    // Hack to prevent transitions from messing up slider width
+    setTimeout(() => {
+      this.onResizeHandler();
+    }, 500);
+
+    // eslint-disable-next-line no-new
+    new ResizeSensor(this.$el, () => {
+      this.onResizeHandler();
+    });
+  }
 
   updateValue(value: number) {
     this.$emit('input', this.roundNumber(value));
@@ -35,5 +51,10 @@ export default class SliderInput extends Vue {
     let formattedValue = String(value);
     if (this.usePercentages) formattedValue = Math.round(value * 100) + '%';
     return formattedValue;
+  }
+
+  @debounce(500)
+  private onResizeHandler() {
+    if (this.$refs.slider) this.$refs.slider.refresh();
   }
 }

--- a/app/components/shared/inputs/SliderInput.vue.ts
+++ b/app/components/shared/inputs/SliderInput.vue.ts
@@ -17,15 +17,25 @@ export default class SliderInput extends BaseInput<number, ISliderMetadata> {
 
   usePercentages: boolean;
   interval: number;
+  isFullyMounted = false;
+
+  $refs: { slider: any };
 
   mounted() {
     // setup defaults
     this.interval = this.options.interval || 1;
     this.usePercentages = this.options.usePercentages || false;
+
+    // Hack to prevent transitions from messing up slider width
+    setTimeout(() => {
+      if (this.$refs.slider) this.$refs.slider.refresh();
+      this.isFullyMounted = true;
+    }, 500);
   }
 
   @throttle(500)
   updateValue(value: number) {
+    if (!this.isFullyMounted) return;
     this.emitInput(this.roundNumber(value));
   }
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "vue-multiselect": "https://github.com/stream-labs/vue-multiselect.git",
     "vue-popperjs": "^2.3.0",
     "vue-property-decorator": "^7.0.0",
-    "vue-slider-component": "^3.2.24",
+    "vue-slider-component": "^2.7.7",
     "vue-spinner": "^1.0.4",
     "vue-toasted": "^1.1.24",
     "vuedraggable": "^2.24.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,7 +6103,7 @@ core-js@^2.5.7:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@^3.0.0, core-js@^3.6.5:
+core-js@^3.0.0:
   version "3.29.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.29.1.tgz#40ff3b41588b091aaed19ca1aa5cb111803fa9a6"
   integrity sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==
@@ -17268,11 +17268,6 @@ vue-class-component@^6.2.0:
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-6.3.2.tgz#e6037e84d1df2af3bde4f455e50ca1b9eec02be6"
   integrity sha512-cH208IoM+jgZyEf/g7mnFyofwPDJTM/QvBNhYMjqGB8fCsRyTf68rH2ISw/G20tJv+5mIThQ3upKwoL4jLTr1A==
 
-vue-class-component@^7.1.0:
-  version "7.2.6"
-  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.2.6.tgz#8471e037b8e4762f5a464686e19e5afc708502e4"
-  integrity sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==
-
 vue-codemirror@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/vue-codemirror/-/vue-codemirror-4.0.6.tgz#b786bb80d8d762a93aab8e46f79a81006f0437c4"
@@ -17361,13 +17356,6 @@ vue-property-decorator@^7.0.0:
   dependencies:
     vue-class-component "^6.2.0"
 
-vue-property-decorator@^8.0.0:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz#571a91cf8d2b507f537d79bf8275af3184572fff"
-  integrity sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==
-  dependencies:
-    vue-class-component "^7.1.0"
-
 vue-resize@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-1.0.1.tgz#c120bed4e09938771d622614f57dbcf58a5147ee"
@@ -17375,13 +17363,10 @@ vue-resize@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-vue-slider-component@^3.2.24:
-  version "3.2.24"
-  resolved "https://registry.yarnpkg.com/vue-slider-component/-/vue-slider-component-3.2.24.tgz#9c931da3d10d0efde361138626a76d21c4359fd5"
-  integrity sha512-28hfotAL/CPXPwqHgVFyUwUEV0zweoc2wW0bgraGkoIcRZGlFjk8caYJLE8+Luug5t3b9tJm/NyDXpyIdmcYZg==
-  dependencies:
-    core-js "^3.6.5"
-    vue-property-decorator "^8.0.0"
+vue-slider-component@^2.7.7:
+  version "2.8.16"
+  resolved "https://registry.yarnpkg.com/vue-slider-component/-/vue-slider-component-2.8.16.tgz#b2036f816ed64fa4fcd6741219b80c5063b4fd60"
+  integrity sha512-06gDoheKMU8TdqjoofIJaYfXw3uuWOXF2I14d/F5yW/8iOxnoI4Ks9WSXy8RWY+gs62GBE6tQXHDSX/H6IOaAw==
 
 vue-spinner@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
* 発生原因
  * vue-slider-componentをアップデートしたときに変更が必要な部分がまだあったことに気づいていなかった
* 対処
  * 一旦 vue-slider-componentを 3.2.24 から以前のバージョン 2.7.7 に戻す (revert commit 870b8de808d7eb3cc739270a82ea5e8fe2447be0)

# 動作確認手順
#644 記載の手順

# 関連するIssue（あれば）
fix #643 #644 