### PR TITLE
修正:ユーザーインターフェイスのテキストを選択すると赤くなっていた

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -13,9 +13,9 @@ body {
   color: var(--color-text);
 }
 
-:not(input, textarea),
-:not(input, textarea)::after,
-:not(input, textarea)::before {
+:not(input):not(textarea),
+:not(input):not(textarea)::after,
+:not(input):not(textarea)::before {
   user-select: none;
 }
 

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
     // ルールは随時追加する
     'selector-class-pattern': null,
     'no-descending-specificity': null,
+    'selector-not-notation': 'simple',
   },
   overrides: [
     {


### PR DESCRIPTION
# このpull requestが解決する内容

画面上の文字列が選択できないよう戻す修正

cssにて :notが使用されているが、引数がカンマ区切りに変更されていた
https://github.com/n-air-app/n-air-app/commit/c38933d3eb45dc75a8623725a159e6aacbe3b9d1

現在N-Airで使用されているelectronは6.1.11のため
node 12.4.0
chrome 76.0.3809.146
となっている
https://github.com/electron/releases

だが:not()における引数のカンマ区切り対応はchrome88からのため使用できない
https://developer.mozilla.org/ja/docs/Web/CSS/:not


そのため:not()が指定されているにも関わらず無効になり、選択が可能になっていた

またstylelintによりcommit時にカンマ区切りが自動適用されるためこちらもルールを修正
'selector-not-notation': 'simple',

# 動作確認手順

- [x] 画面上の文字列が選択できない
- [x] devtoolsにて文字列のCSSを確認し:not()要素が追加されていることを確認


# 関連するIssue（あれば）
