### PR TITLE
改善:ログインボタン案内ヘルプチップを閉じても次にログインするとまた表示されるようにする

### DIFF
--- a/app/components/Login.vue
+++ b/app/components/Login.vue
@@ -8,7 +8,12 @@
     </a>
   </div>
   <div v-else>
-    <a v-if="!isCompactMode" class="link help_tip_content" @click="login" :title="$t('common.login')">
+    <a
+      v-if="!isCompactMode"
+      class="link help_tip_content"
+      @click="login"
+      :title="$t('common.login')"
+    >
       <i class="icon-log-in"></i>
       <help-tip :dismissable-key="loginHelpTipDismissable" mode="login">
         <div slot="title">
@@ -25,29 +30,29 @@
 <script lang="ts" src="./Login.vue.ts"></script>
 
 <style lang="less" scoped>
-@import '../styles/index';
+@import url('../styles/index');
 
 .login__status {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
 }
 
 .user__profile {
-  height: 40px;
-  width: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 48px;
+  height: 40px;
 
   .user__thumbnail {
     display: flex;
     align-items: center;
     width: 24px;
     height: 24px;
-    border-radius: 50%;
     background-color: @text-secondary;
+    border-radius: 50%;
   }
 }
 

--- a/app/components/Login.vue.ts
+++ b/app/components/Login.vue.ts
@@ -1,7 +1,7 @@
 import electron from 'electron';
 import { CompactModeService } from 'services/compact-mode';
 import { Inject } from 'services/core/injector';
-import { EDismissable } from 'services/dismissables';
+import { DismissablesService, EDismissable } from 'services/dismissables';
 import { $t } from 'services/i18n';
 import { UserService } from 'services/user';
 import Vue from 'vue';
@@ -12,6 +12,17 @@ import HelpTip from './shared/HelpTip.vue';
 export default class Login extends Vue {
   @Inject() userService: UserService;
   @Inject() compactModeService: CompactModeService;
+
+  @Inject() dismissablesService: DismissablesService;
+
+  mounted() {
+    if (this.loggedIn) {
+      if (!this.dismissablesService.shouldShow(EDismissable.LoginHelpTip)) {
+        console.log('reset login tooltip');
+        this.dismissablesService.reset(EDismissable.LoginHelpTip);
+      }
+    }
+  }
 
   get loggedIn() {
     return this.userService.isLoggedIn();

--- a/app/components/Login.vue.ts
+++ b/app/components/Login.vue.ts
@@ -18,7 +18,6 @@ export default class Login extends Vue {
   mounted() {
     if (this.loggedIn) {
       if (!this.dismissablesService.shouldShow(EDismissable.LoginHelpTip)) {
-        console.log('reset login tooltip');
         this.dismissablesService.reset(EDismissable.LoginHelpTip);
       }
     }

--- a/app/components/shared/HelpTip.vue
+++ b/app/components/shared/HelpTip.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="help-tip" v-if="shouldShow && !isCompactMode" :data-mode="mode">
     <div class="help-tip__arrow"></div>
-    <i @click="closeHelpTip" class="help-tip__close icon-close" />
+    <i @click.stop="closeHelpTip" class="help-tip__close icon-close" />
     <div class="help-tip__title">
       <i class="icon-notification" />
       <slot name="title"></slot>
@@ -13,44 +13,44 @@
 <script lang="ts" src="./HelpTip.vue.ts"></script>
 
 <style lang="less" scoped>
-@import '../../styles/index';
+@import url('../../styles/index');
 
 .help-tip {
   position: absolute;
-  background: @text-primary;
-  .radius;
-  color: @hover;
+  z-index: 100000;
   width: 240px;
   padding: 8px;
   font-size: 14px;
-  z-index: 100000;
+  color: @hover;
   white-space: initial;
+  background: @text-primary;
+  .radius;
 
-  &[data-mode="scene-selector"] {
+  &[data-mode='scene-selector'] {
     top: -8px;
     left: 90px;
   }
 
-  &[data-mode="login"] {
+  &[data-mode='login'] {
     bottom: 2px;
     left: 44px;
   }
 }
 
 .help-tip__arrow {
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 8px 8px 8px 0;
-  border-color: transparent @text-primary transparent transparent;
   position: absolute;
   left: -8px;
+  width: 0;
+  height: 0;
+  border-color: transparent @text-primary transparent transparent;
+  border-style: solid;
+  border-width: 8px 8px 8px 0;
 
-  .help-tip[data-mode="scene-selector"] & {
+  .help-tip[data-mode='scene-selector'] & {
     top: 8px;
   }
 
-  .help-tip[data-mode="login"] & {
+  .help-tip[data-mode='login'] & {
     bottom: 8px;
   }
 }
@@ -70,11 +70,12 @@
 
 .help-tip__title {
   .semibold;
-  font-size: 16px;
+
   display: flex;
   align-items: center;
-  margin-bottom: 4px;
   padding-bottom: 4px;
+  margin-bottom: 4px;
+  font-size: 16px;
   border-bottom: 1px solid @hover;
 
   i {


### PR DESCRIPTION
# このpull requestが解決する内容
ログイン状態のつもりが意図せずログアウトしていたときに、なぜコメント欄が出ないのかが分からず困っているユーザーがいたため、その状態でログイン案内ヘルプチップがあれば気づけるだろう、という仮説を立てた。

ログインボタン案内ヘルプチップの [x] を押すと閉じるが、次にログインに成功すると、次にログアウトしたときにまた表示されるようにします。
![image](https://user-images.githubusercontent.com/864587/234781133-4b5c8ae0-e97b-4624-a425-d6babd4cf606.png)

また、[x] を押した時にツールチップを閉じるだけでなくログインボタン遷移までしてしまっていたので、これは止めて非表示にだけします。(これを押したときはログインしないという選択なので、意図に反する挙動をしていた)

# 動作確認手順
1. ログアウトし、ログインツールチップを閉じる
    * ログイン画面に遷移せず、ツールチップだけが消える
1. ログインする
1. もう一度ログアウトすると、ログインツールチップが表示されること
