### PR TITLE
修正: スイッチのスタイルが壊れていたので autoprefixerを追加

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -72,7 +72,7 @@
 <script lang="ts" src="./ExtraSettings.vue.ts"></script>
 
 <style lang="less">
-@import '../styles/index';
+@import url('../styles/index');
 
 .optional-item {
   margin-left: 24px;
@@ -80,27 +80,27 @@
 
 .cacheid-view {
   display: flex;
-  justify-content: start;
   align-items: center;
+  justify-content: flex-start;
   font-size: @font-size4;
 
   label {
-    cursor: pointer;
     display: flex;
-    height: @item-generic-size;
-    margin: 0;
-    padding: 0;
-    justify-content: start;
     align-items: center;
+    justify-content: flex-start;
+    height: @item-generic-size;
+    padding: 0;
+    margin: 0;
+    margin-bottom: 16px;
     color: var(--color-text-active);
+    cursor: pointer;
     border: 1px solid var(--color-input);
     border-radius: 4px;
-    margin-bottom: 16px;
 
     input[type='password'] {
-      font-family: 'Verdana', sans-serif;
-      font-size: 0;
       width: 332px;
+      font-family: Verdana, sans-serif;
+      font-size: 0;
       color: var(--color-text-light);
     }
 
@@ -109,13 +109,14 @@
 
       & ~ .view-button {
         .transition;
-        width: 36px;
-        cursor: pointer;
-        display: inline-block;
+
         position: relative;
-        text-align: center;
-        font-size: @font-size5;
+        display: inline-block;
+        width: 36px;
         padding: 0 8px;
+        font-size: @font-size5;
+        text-align: center;
+        cursor: pointer;
 
         &:hover {
           color: @white;
@@ -124,14 +125,17 @@
         .on {
           display: inline-block;
         }
+
         .off {
           display: none;
         }
       }
+
       &:checked ~ .view-button {
         .on {
           display: none;
         }
+
         .off {
           display: inline-block;
           color: var(--color-text-active);
@@ -139,23 +143,21 @@
       }
 
       & ~ input {
+        box-sizing: border-box;
+        width: 320px;
+        padding: 0 8px;
+        margin: 0;
+        font-family: Verdana, sans-serif;
+        font-size: @font-size4;
+        color: @text-primary;
+        color: var(--color-text-light);
+        text-align: center;
         cursor: default;
-        font-family: 'Verdana', sans-serif;
         background: none;
         border: none;
         border-radius: 0;
         outline: none;
-        -webkit-appearance: none;
-        -moz-appearance: none;
         appearance: none;
-        color: @text-primary;
-        text-align: center;
-        padding: 0 8px;
-        margin: 0;
-        box-sizing: border-box;
-        width: 320px;
-        color: var(--color-text-light);
-        font-size: @font-size4;
       }
 
       &:checked ~ input {
@@ -177,23 +179,24 @@
       background-color: var(--color-button-secondary-hover);
     }
 
-    &:before {
+    &::before {
       position: absolute;
       top: -8px;
       left: 16px;
-      transition: all 0s;
-      opacity: 0;
+      padding: 4px 8px;
+      color: @bg-secondary;
       content: 'Copied!';
       background-color: @text-primary;
-      color: @bg-secondary;
-      padding: 4px 8px;
       border-radius: 3px;
+      opacity: 0;
+      transition: all 0s;
     }
+
     &:active {
-      &:before {
-        transform: scale(1.2) translateY(-8px);
-        transition: all 0.3s;
+      &::before {
         opacity: 1;
+        transition: all 0.3s;
+        transform: scale(1.2) translateY(-8px);
       }
     }
   }

--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -215,7 +215,7 @@ textarea {
   margin: 0;
   cursor: pointer;
   outline: none;
-  appearance: inherit;
+  appearance: none;
 
   &::before,
   &::after {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "engines": {
     "npm": "please-use-yarn"
   },
+  "browserslist": [
+    "chrome >= 76"
+  ],
   "scripts": {
     "compile": "yarn clear && webpack-cli --progress --mode development",
     "compile:ci": "yarn clear && webpack-cli --mode development",
@@ -83,6 +86,7 @@
     "@sentry/electron": "4.6.0",
     "@sentry/vue": "7.50.0",
     "archiver": "^5.3.1",
+    "autoprefixer": "^10.4.14",
     "aws-sdk": "^2.344.0",
     "base64-js": "^1.5.1",
     "crash-handler": "https://github.com/stream-labs/crash-handler/releases/download/v0.1.2/iojs-v6.0.3-crash-handler.tar.gz",
@@ -100,6 +104,7 @@
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
     "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.36-iojs-v6.0.3-release.tar.gz",
+    "postcss-loader": "4.3.0",
     "progress": "^2.0.3",
     "recursive-readdir": "^2.2.3",
     "reflect-metadata": "^0.1.13",
@@ -191,7 +196,7 @@
     "npm-run-all": "^4.1.5",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.4.0",
-    "postcss": "^8.4.21",
+    "postcss": "^8.4.24",
     "postcss-html": "^1.5.0",
     "postcss-less": "^6.0.0",
     "prettier": "^2.8.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,6 +115,14 @@ module.exports = {
               importLoaders: 1,
             },
           },
+          {
+            loader: 'postcss-loader',
+            options: {
+              postcssOptions: {
+                plugins: [require('autoprefixer')({ grid: true })],
+              },
+            },
+          },
         ],
       },
       {
@@ -125,6 +133,14 @@ module.exports = {
             loader: 'css-loader',
             options: {
               importLoaders: 1,
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              postcssOptions: {
+                plugins: [require('autoprefixer')({ grid: true })],
+              },
             },
           },
           'less-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4306,6 +4306,18 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
   integrity sha1-ri1acpR38onWDdf5amMUoi3Wwio=
 
+autoprefixer@^10.4.14:
+  version "10.4.14"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.14.tgz#e28d49902f8e759dd25b153264e862df2705f79d"
+  integrity sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==
+  dependencies:
+    browserslist "^4.21.5"
+    caniuse-lite "^1.0.30001464"
+    fraction.js "^4.2.0"
+    normalize-range "^0.1.2"
+    picocolors "^1.0.0"
+    postcss-value-parser "^4.2.0"
+
 ava@^3.0.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/ava/-/ava-3.15.0.tgz#a239658ab1de8a29a243cc902e6b42e4574de2f0"
@@ -5325,6 +5337,11 @@ caniuse-lite@^1.0.30001449:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz#b2e801e37536d453731286857c8520d3dcee15fe"
   integrity sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==
 
+caniuse-lite@^1.0.30001464:
+  version "1.0.30001492"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz#4a06861788a52b4c81fd3344573b68cc87fe062b"
+  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
+
 capture-exit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
@@ -6090,7 +6107,7 @@ cosmiconfig@^5.2.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cosmiconfig@^7.1.0:
+cosmiconfig@^7.0.0, cosmiconfig@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
   integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
@@ -8394,6 +8411,11 @@ forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fraction.js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
+  integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -11354,6 +11376,11 @@ kleur@^3.0.2:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+klona@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
+  integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
+
 known-css-properties@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.26.0.tgz#008295115abddc045a9f4ed7e2a84dc8b3a77649"
@@ -12407,6 +12434,11 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+
 nanomatch@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
@@ -12641,6 +12673,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
 normalize-url@^4.1.0:
   version "4.5.0"
@@ -13513,6 +13550,17 @@ postcss-less@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-6.0.0.tgz#463b34c60f53b648c237f569aeb2e09149d85af4"
   integrity sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==
 
+postcss-loader@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.3.0.tgz#2c4de9657cd4f07af5ab42bd60a673004da1b8cc"
+  integrity sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==
+  dependencies:
+    cosmiconfig "^7.0.0"
+    klona "^2.0.4"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+    semver "^7.3.4"
+
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
@@ -13622,12 +13670,21 @@ postcss@^7.0.36:
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.3.11, postcss@^8.4.0, postcss@^8.4.14, postcss@^8.4.19, postcss@^8.4.21:
+postcss@^8.3.11, postcss@^8.4.0, postcss@^8.4.14, postcss@^8.4.19:
   version "8.4.21"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
   integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
   dependencies:
     nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.24:
+  version "8.4.24"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
+  integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
+  dependencies:
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 


### PR DESCRIPTION
# このpull requestが解決する内容
(#660 で発生した問題を修正)

chrome 76に合わせて一部プロパティにプレフィックスを付与する必要があるため、autoprefixerを導入

例）トグルボタンに指定している `appearance: none;` はchrome 76では `-webkit-` が必要
https://caniuse.com/?search=apperance

### 修正前
stylelintがプレフィックスを削除したことでデフォルトのチェックボックスが表示されていた

![rog_2023-05-31_16-36-04_480](https://github.com/n-air-app/n-air-app/assets/43235200/e0ef84bc-4d08-42a3-8b2a-7cd6fc5d12cd)

### 修正後

プレフィックスを付与したことでチェックボックスが非表示になっている

![キャプチャ](https://github.com/n-air-app/n-air-app/assets/43235200/8ae1a4b7-7cc7-4ad6-ae23-518313c55a85)


