### PR TITLE
修正:画像スライドソースの歯車アイコンで画像を変更できるようにする

### DIFF
--- a/app/components/obs/inputs/ObsEditableListInput.vue.ts
+++ b/app/components/obs/inputs/ObsEditableListInput.vue.ts
@@ -58,8 +58,8 @@ class ObsEditableListProperty extends ObsInput<IObsEditableListInputValue> {
     this.showReplaceFileDialog();
   }
 
-  showReplaceFileDialog() {
-    const files = electron.remote.dialog.showOpenDialog({
+  async showReplaceFileDialog() {
+    const files = await electron.remote.dialog.showOpenDialog({
       defaultPath: this.value.defaultPath,
       filters: this.value.filters,
       properties: ['openFile'],
@@ -68,10 +68,10 @@ class ObsEditableListProperty extends ObsInput<IObsEditableListInputValue> {
     if (files) {
       const activeIndex = _.indexOf(this.list, this.activeItem);
 
-      this.list[activeIndex] = files[0];
+      this.list[activeIndex] = files.filePaths[0];
 
       // Preserve this item as active
-      this.activeItem = files[0];
+      this.activeItem = files.filePaths[0];
       this.setList(this.list);
     }
   }


### PR DESCRIPTION
# このpull requestが解決する内容
fix #665.
ObsEditableListInputの画像ファイル置き替え用ダイアログの結果受け取りをPromiseに修正し忘れていました。

# 動作確認手順
#665 参照

# 関連するIssue（あれば）
#665