### PR TITLE
修正:ニコ生の番組作成と番組編集ウィンドウから英語のメニューバーを削除

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -260,6 +260,7 @@ function setupMock() {
         cb(null);
       }
     });
+    removeMenu = jest.fn();
     options: any;
     constructor(options: any) {
       this.options = options;
@@ -293,6 +294,19 @@ function setupMock() {
 describe('webviews', () => {
   beforeEach(() => {
     jest.resetModules();
+  });
+
+  test('createProgramで removeMenuが呼ばれる', async () => {
+    const mock = setupMock();
+
+    const { NicoliveClient } = require('./NicoliveClient');
+    const client = new NicoliveClient();
+
+    // don't await
+    const result = expect(client.createProgram()).resolves.toBe('CREATED');
+    mock.browserWindow.loadURL(`https://live.nicovideo.jp/watch/${programID}`);
+    await result;
+    expect(mock.browserWindow.removeMenu).toHaveBeenCalled();
   });
 
   test('createProgramで番組ページへ遷移すると番組を作成したことになる', async () => {
@@ -351,6 +365,18 @@ describe('webviews', () => {
 
     await result;
     expect(mock.browserWindow.close).toHaveBeenCalled();
+  });
+
+  test('editProgramでremoveMenuが呼ばれる', async () => {
+    const mock = setupMock();
+
+    const { NicoliveClient } = require('./NicoliveClient');
+    const client = new NicoliveClient();
+
+    const result = expect(client.editProgram(programID)).resolves.toBe('EDITED');
+    mock.browserWindow.loadURL(`https://live.nicovideo.jp/watch/${programID}`);
+    await result;
+    expect(mock.browserWindow.removeMenu).toHaveBeenCalled();
   });
 
   test('editProgramで番組ページへ遷移すると番組を作成したことになる', async () => {

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -552,6 +552,7 @@ export class NicoliveClient {
         nativeWindowOpen: true,
       },
     });
+    win.removeMenu();
     Sentry.addBreadcrumb({
       category: 'createProgram.open',
     });
@@ -627,6 +628,7 @@ export class NicoliveClient {
         nativeWindowOpen: true,
       },
     });
+    win.removeMenu();
     this.editProgramWindow = win;
     this.editProgramId = programID;
     Sentry.addBreadcrumb({


### PR DESCRIPTION
# このpull requestが解決する内容
#668 番組作成および番組編集ウィンドウに意図せず英語のメニューバーが出ていたのを消します。

# 動作確認手順
1. 番組作成で現れるウィンドウを確認する
![image](https://github.com/n-air-app/n-air-app/assets/864587/adf6389b-c12d-48d7-afcc-121c16732c08)

2. 作成した番組を番組編集したときのウィンドウも確認する

# 関連するIssue（あれば）
fix #668