### PR TITLE
修正: インストーラで実行に必要なVisual C++再頒布可能パッケージを自動インストール / 起動時に足りないときもダウンロードを案内する

### DIFF
--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -29,6 +29,7 @@ const config = {
     // eslint-disable-next-line no-template-curly-in-string
     artifactName: 'n-air-app-setup.${version}.${ext}',
     include: 'installer.nsh',
+    warningsAsErrors: false,
   },
   win: {
     publisherName: ['DWANGO Co.,Ltd.'],

--- a/installer.nsh
+++ b/installer.nsh
@@ -19,9 +19,9 @@ LangString require_restart 1033 "You must restart your computer to complete the 
 LangString failed_download 1033 "WARNING: N Air was unable to download the latest Visual C++ Redistributable package from Microsoft."
 
 # Japanese
-LangString failed_install 1041 "警告: Microsoft の最新の Visual C++再頒布可能パッケージのインストールができませんでした。"	
+LangString failed_install 1041 "警告: Microsoft の最新の Visual C++ 再頒布可能パッケージのインストールができませんでした。"	
 LangString require_restart 1041 "インストールを完了するには、コンピューターを再起動してください。"	
-LangString failed_download 1041 "警告: Microsoftから最新の Visual C++ 再頒布可能パッケージをダウンロードできませんでした。"	
+LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ 再頒布可能パッケージをダウンロードできませんでした。"	
 
 !macro customInstall
   NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  

--- a/installer.nsh
+++ b/installer.nsh
@@ -13,7 +13,36 @@
 	DeleteRegKey HKCU "Software\Classes\${Protocol}"
 !macroend
 
+# English
+LangString failed_install 1033 "WARNING: N Air was unable to install the latest Visual C++ Redistributable package from Microsoft."
+LangString require_restart 1033 "You must restart your computer to complete the installation."
+LangString failed_download 1033 "WARNING: N Air was unable to download the latest Visual C++ Redistributable package from Microsoft."
+
+# Japanese
+LangString failed_install 1041 "警告: Microsoft の最新の Visual C++再頒布可能パッケージのインストールができませんでした。"	
+LangString require_restart 1041 "インストールを完了するには、コンピューターを再起動してください。"	
+LangString failed_download 1041 "警告: Microsoftから最新の Visual C++ 再頒布可能パッケージをダウンロードできませんでした。"	
+
 !macro customInstall
+  NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  
+
+  ${If} ${FileExists} `$INSTDIR\vc_redist.x64.exe`
+    ExecWait '$INSTDIR\vc_redist.x64.exe /passive /norestart' $1
+
+    ${If} $1 != '0' 
+      ${If} $1 != '3010'
+        MessageBox MB_OK|MB_ICONEXCLAMATION "$(failed_install)"
+      ${EndIf}
+    ${EndIf}
+
+    # ${If} $1 == '3010'
+    #     MessageBox MB_OK|MB_ICONEXCLAMATION "$(require_restart)"
+    # ${EndIf}
+
+  ${Else}
+    MessageBox MB_OK|MB_ICONEXCLAMATION "$(failed_download)"
+  ${EndIf}
+
   FileOpen $0 "$INSTDIR\installername" w
   FileWrite $0 $EXEFILE
   FileClose $0

--- a/main.js
+++ b/main.js
@@ -706,12 +706,6 @@ if (!gotTheLock) {
     mainWindow.close();
   });
 
-  ipcMain.on('requestSourceAttributes', (e, names) => {
-    const sizes = require('obs-studio-node').getSourcesSize(names);
-
-    e.sender.send('notifySourceAttributes', sizes);
-  });
-
   /* The following 2 methods need to live in the main process
      because events bound using the remote module are not
      executed synchronously and therefore default actions

--- a/main.js
+++ b/main.js
@@ -86,19 +86,17 @@ if (!gotTheLock) {
   app.quit();
 }
 
-let crashHandler;
-
 try {
-  crashHandler = require('crash-handler');
+  const crashHandler = require('crash-handler');
+  initialize(crashHandler);
 } catch (e) {
+  console.error('require crash-handler failed: ', e);
   app.on('ready', () => {
     showRequiredSystemComponentInstallGuideDialog();
   });
 }
 
-if (crashHandler) initialize();
-
-function initialize() {
+function initialize(crashHandler) {
   const fs = require('fs');
   const { Updater } = require('./updater/Updater.js');
   const NoWorkResult = require('postcss/lib/no-work-result');

--- a/main.js
+++ b/main.js
@@ -99,7 +99,6 @@ try {
 function initialize(crashHandler) {
   const fs = require('fs');
   const { Updater } = require('./updater/Updater.js');
-  const NoWorkResult = require('postcss/lib/no-work-result');
   //const uuid = require('uuid/v4');
   const windowStateKeeper = require('electron-window-state');
   const { URL } = require('url');

--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ async function showRequiredSystemComponentInstallGuideDialog() {
   });
   switch (result.response) {
     case 0:
-      await shell.openExternal('https://aka.ms/vs/16/release/vc_redist.x64.exe');
+      await shell.openExternal('https://aka.ms/vs/17/release/vc_redist.x64.exe');
       break;
     case 1:
       await shell.openExternal(

--- a/main.js
+++ b/main.js
@@ -33,16 +33,7 @@ console.log(`pjson.name = ${pjson.name}`); // DEBUG
 // Modules and other Requires
 ////////////////////////////////////////////////////////////////////////////////
 const electron = require('electron');
-const {
-  app,
-  BrowserWindow,
-  ipcMain,
-  session,
-  crashReporter,
-  dialog,
-  webContents,
-  shell,
-} = require('electron');
+const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell } = electron;
 const path = require('path');
 const rimraf = require('rimraf');
 
@@ -75,10 +66,10 @@ async function showRequiredSystemComponentInstallGuideDialog() {
   });
   switch (result.response) {
     case 0:
-      await electron.shell.openExternal('https://aka.ms/vs/16/release/vc_redist.x64.exe');
+      await shell.openExternal('https://aka.ms/vs/16/release/vc_redist.x64.exe');
       break;
     case 1:
-      await electron.shell.openExternal(
+      await shell.openExternal(
         'https://support.microsoft.com/ja-jp/help/2977003/the-latest-supported-visual-c-downloads',
       );
       break;

--- a/main.js
+++ b/main.js
@@ -285,7 +285,7 @@ if (!gotTheLock) {
   async function showRequiredSystemComponentInstallGuideDialog() {
     const result = await dialog.showMessageBox({
       type: 'error',
-      title: '実行に必要なシステムコンポーネントが不足しています',
+      title: `${pjson.buildProductName} の実行に必要なシステムコンポーネントが不足しています`,
       message:
         'Microsoftのウェブサイトから Visual C++ 再頒布可能パッケージ(x64)をインストールしてから再度起動してください。',
       buttons: ['ブラウザでダウンロードする', 'ダウンロードページを開く', '何もせず終了'],

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -4,6 +4,7 @@
 const { autoUpdater } = require('electron-updater');
 const { app, BrowserWindow, ipcMain } = require('electron');
 const semver = require('semver');
+const path = require('path');
 
 class Updater {
   // startApp is a callback that will start the app.  Ideally this
@@ -34,8 +35,8 @@ class Updater {
     });
   }
 
-  skipUpdateAndContinue() {
-    this.startApp();
+  async skipUpdateAndContinue() {
+    await this.startApp();
     this.finished = true;
     this.browserWindow.close();
   }
@@ -48,17 +49,17 @@ class Updater {
     if (!currentVer || !newVer) {
       return true;
     }
-    if (currentVer.major != newVer.major) {
+    if (currentVer.major !== newVer.major) {
       return true;
     }
-    if (currentVer.minor != newVer.minor) {
+    if (currentVer.minor !== newVer.minor) {
       return true;
     }
     return false;
   }
 
   textToLines(text) {
-    return text.split('\n')
+    return text.split('\n');
   }
 
   bindListeners() {
@@ -69,7 +70,10 @@ class Updater {
       this.updateState.fileSize = info.files[0].size;
       this.updateState.version = info.version;
       this.updateState.percent = 0;
-      this.updateState.isUnskippable = this.isUnskippableUpdate(process.env.NAIR_VERSION, info.version);
+      this.updateState.isUnskippable = this.isUnskippableUpdate(
+        process.env.NAIR_VERSION,
+        info.version,
+      );
       console.log(`oldVersion: ${process.env.NAIR_VERSION}
 newVersion: ${info.version}
 isUnskippable: ${this.updateState.isUnskippable}`);
@@ -159,7 +163,7 @@ isUnskippable: ${this.updateState.isUnskippable}`);
       browserWindow.webContents.openDevTools({ mode: 'undocked' });
     }
 
-    browserWindow.loadURL('file://' + __dirname + '/index.html');
+    browserWindow.loadURL('file://' + path.join(__dirname, 'index.html'));
 
     return browserWindow;
   }


### PR DESCRIPTION
# このpull requestが解決する内容

## アプリ起動時のDLL不足エラー時
![image](https://github.com/n-air-app/n-air-app/assets/864587/c24c10c4-7263-4d50-bcd1-86c22b5864f2)

## インストーラ
![image](https://github.com/n-air-app/n-air-app/assets/864587/7bd1136f-3a1d-4585-9381-ff7ffa3c585d)


# 動作確認手順

## アプリ起動時の問題
1. windows\system32\msvcp140.dll のファイル名を変更し(特権が必要)
2. 起動すると上記エラーダイアログが出る
3. ダウンロード・インストールをしてから再度起動すると起動できる(またはインストールせずファイル名を元に戻す)
4. 後始末: リネームしたものは元に戻すか、インストールして重複したなら消す

## インストール時の動作
1. インストーラをビルドする(`yarn compile:production ; yarn package`)
2. start dist/*.exe などで作ったインストーラを起動
3. インストールの流れの中で vc_redist.x64.exe がダウンロードされる過程が表示される
4. その後、vc_redist.x64.exeが起動し、まだインストールされていなければインストールが行われる


# 関連するIssue（あれば）
#676 