### PR TITLE
Bump webpack from 5.88.1 to 5.88.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "postcss-less": "^6.0.0",
     "prettier": "^2.8.7",
     "prettier-eslint": "^13.0.0",
+    "shelljs": "^0.8.5",
     "shx": "^0.3.4",
     "spectron": "^8.0.0",
     "style-loader": "^0.23.1",
@@ -225,16 +226,11 @@
     "vue-loader": "^15.10.1",
     "vue-svg-loader": "^0.12.0",
     "vue-template-compiler": "^2.7.10",
-    "webpack": "^5.88.1",
+    "webpack": "^5.88.2",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.13.1",
     "webpack-manifest-plugin": "^4.0.2",
-    "webpack-merge": "^5.8.0",
-    "@vue/babel-preset-jsx": "1.2.4",
-    "babel-helper-vue-jsx-merge-props": "2.0.3",
-    "babel-plugin-syntax-jsx": "6.18.0",
-    "babel-plugin-transform-vue-jsx": "3.7.0",
-    "shelljs": "^0.8.5"
+    "webpack-merge": "^5.8.0"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16751,10 +16751,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.88.1:
-  version "5.88.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.88.1.tgz#21eba01e81bd5edff1968aea726e2fbfd557d3f8"
-  integrity sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==
+webpack@^5.88.2:
+  version "5.88.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.88.2.tgz#f62b4b842f1c6ff580f3fcb2ed4f0b579f4c210e"
+  integrity sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.0"


### PR DESCRIPTION
# このpull requestが解決する内容
webpackを5.88.1 から[5.88.2](https://github.com/webpack/webpack/releases/tag/v5.88.2) に上げて、package.jsonのdevDependenciesをソート・重複除去(yarn addによって自動的に行われた)します。
