### PR TITLE
修正: シーンフォルダの無限ループ対策

### DIFF
--- a/app/services/scenes/scene-node.ts
+++ b/app/services/scenes/scene-node.ts
@@ -45,7 +45,7 @@ export abstract class SceneItemNode implements ISceneItemNode {
   get childrenIds(): string[] {
     return this.getScene()
       .getModel()
-      .nodes.filter(node => node.parentId === this.id)
+      .nodes.filter(node => node.parentId === this.id && node.id !== this.id)
       .map(node => node.id);
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容
sentryにシーンフォルダの無限ループがちらほら上がってきてるので、対策をStreamlabsからポートしてみます
https://github.com/stream-labs/desktop/pull/3035/files

手元で再現できてるわけではないので本当に効くかは不明...