### PR TITLE
開発: リリーススクリプトがGitHub Releaseを作ったときにSlackに報告する

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -6,7 +6,8 @@
   "version": "0.0.1",
   "dependencies": {
     "@octokit/rest": "^16.28.1",
-    "@sentry/cli": "^2.20.3"
+    "@sentry/cli": "^2.20.3",
+    "node-fetch": "2"
   },
   "devDependencies": {
     "7zip-bin": "^2.2.7",

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -1528,6 +1528,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"


### PR DESCRIPTION
# このpull requestが解決する内容

GitHub Releaseを作成したときに、こんなふうにSlackに出します
![image](https://github.com/n-air-app/n-air-app/assets/864587/bbe2d11c-eea9-4153-814d-0b2671da8c6d)

# 動作確認手順
環境変数 `NAIR_SLACK_WEBHOOK_URL` にwebhook URLを入れた状態で
`SLACK_TEST` をtrueに書き換えて `yarn release` を実行するとテストデータが投稿される
