### PR TITLE
開発:リリース時にトークンのコード署名証明書で署名する

### DIFF
--- a/electron-builder/local.config.js
+++ b/electron-builder/local.config.js
@@ -1,0 +1,8 @@
+const config = require('./stable.config.js');
+
+config.productName += '(Local)';
+delete config.publish;
+delete config.upload;
+config.extraMetadata.buildProductName = config.productName;
+
+module.exports = config;

--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -33,7 +33,6 @@ const config = {
   },
   win: {
     publisherName: ['DWANGO Co.,Ltd.'],
-    certificateSubjectName: 'DWANGO Co.,Ltd.',
     rfc3161TimeStampServer: 'http://timestamp.digicert.com',
     timeStampServer: 'http://timestamp.digicert.com',
   },
@@ -44,6 +43,9 @@ const config = {
 
 if (process.env.NAIR_LICENSE_API_KEY) {
   config.extraMetadata.getlicensenair_key = process.env.NAIR_LICENSE_API_KEY;
+}
+if (process.env.CERTIFICATE_SUBJECT_NAME) {
+  config.win.certificateSubjectName = process.env.CERTIFICATE_SUBJECT_NAME;
 }
 
 module.exports = config;

--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -33,7 +33,8 @@ const config = {
   },
   win: {
     publisherName: ['DWANGO Co.,Ltd.'],
-    rfc3161TimeStampServer: 'http://timestamp.digicert.com/?alg=sha1',
+    certificateSubjectName: 'DWANGO Co.,Ltd.',
+    rfc3161TimeStampServer: 'http://timestamp.digicert.com',
     timeStampServer: 'http://timestamp.digicert.com',
   },
   extraMetadata: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "package:public-unstable": "shx rm -rf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && electron-builder build -w --x64 --config electron-builder/unstable.config.js",
     "package:internal-stable": "shx rm -rf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && electron-builder build -w --x64 --config electron-builder/internal-stable.config.js",
     "package:internal-unstable": "shx rm -rf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && electron-builder build -w --x64 --config electron-builder/internal-unstable.config.js",
+    "package:local": "shx rm -rf dist && yarn install --cwd bin && node bin/convert-to-shiftjis.js AGREEMENT && electron-builder build -w --x64 --config electron-builder/local.config.js",
     "release": "yarn install --cwd bin && node bin/release/mini-release.js",
     "patch-note": "yarn install --cwd bin && node bin/release/generatePatchNote.js",
     "webfont": "yarn install --cwd bin && node bin/generate-webfont.js",


### PR DESCRIPTION
# このpull requestが解決する内容
[2023年6月以降に発行されるDigiCertのコード署名証明書はハードウェアトークンが必要になった](https://knowledge.digicert.com/ja/jp/alerts/ALERT2807.html)ため、署名方法をそれにあわせて変更します。
参考: [Electron Builderのコード署名のドキュメント](https://www.electron.build/code-signing.html)

アップロードせずにパッケージ作成だけを試す `yarn package:local` を新設したので、これで試せます。
ただし手元にトークンが必要...
トークンの証明書は環境変数 `CERTIFICATE_SUBJECT_NAME` で指定するようにしました。これがないとトークンを使いません。

- [x] 環境変数 `CERTIFICATE_SUBJECT_NAME` をセットせずに `CSC_LINK` などを使う事で古い証明書ファイルで署名ができ、ファイルの証明書で署名されたファイルができる
- [x] 環境変数 `CERTIFICATE_SUBJECT_NAME` をセットして、トークンをつけないと署名がエラーで終了する
- [x] 環境変数 `CERTIFICATE_SUBJECT_NAME` をセットして、トークンをつけると署名が成功し、トークンの証明書で署名がされたファイルができる
 
現在使用中のコード署名証明書は2023年9月9日まで有効なので、それ以後に必要となります。