### PR TITLE
修正: Sentryにたまに来ている RecRB of undefined エラーを修正

### DIFF
--- a/app/components/StreamingController.vue.ts
+++ b/app/components/StreamingController.vue.ts
@@ -39,7 +39,7 @@ export default class StudioFooterComponent extends Vue {
   }
 
   get replayBufferEnabled() {
-    return this.settingsService.state.Output.RecRB;
+    return this.settingsService.state.Output?.RecRB;
   }
 
   get replayBufferOffline() {


### PR DESCRIPTION
# このpull requestが解決する内容
SettingsService.state のメンバーは `{}` で初期化されているため、初期状態だとその中の `Output` の中身を見ようとしても `Output` 自体がまだないときがある
ないときは参照をスルーして良い

# 関連するIssue（あれば）
fix #675