### PR TITLE
修正: OBS初期化タイミングを修正し、初期化エラーダイアログの文言も正しく出るように修正

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -205,6 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         crashHandler.unregisterProcess(appService.pid);
 
+        obs.NodeObs.InitShutdownSequence();
         obs.IPC.disconnect();
 
         electron.ipcRenderer.send('shutdownComplete');

--- a/app/app.ts
+++ b/app/app.ts
@@ -1,4 +1,4 @@
-import { I18nService, $t } from 'services/i18n';
+import { I18nService } from 'services/i18n';
 
 // eslint-disable-next-line
 window['eval'] = global.eval = () => {

--- a/app/app.ts
+++ b/app/app.ts
@@ -10,7 +10,7 @@ import Vue from 'vue';
 
 import { createStore } from './store';
 import { WindowsService } from './services/windows';
-import { AppService } from './services/app';
+import { AppService, setAppServiceSentryBackendUrl } from './services/app';
 import Utils from './services/utils';
 import electron from 'electron';
 import * as Sentry from '@sentry/electron/renderer';
@@ -64,7 +64,10 @@ if (isProduction) {
       processType: 'renderer',
     },
   });
+
 }
+
+setAppServiceSentryBackendUrl(getSentryCrashReportUrl(sentryParam));
 
 const windowId = Utils.getWindowId();
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -36,6 +36,8 @@ const { ipcRenderer, remote } = electron;
 const nAirVersion = remote.process.env.NAIR_VERSION;
 const isProduction = process.env.NODE_ENV === 'production';
 
+const FakeObsInitializeError = true; // DEBUG
+
 type SentryParams = {
   organization: string;
   key: string;
@@ -204,12 +206,16 @@ document.addEventListener('DOMContentLoaded', () => {
       // await this.obsUserPluginsService.initialize();
 
       // Initialize OBS API
-      const apiResult = obs.NodeObs.OBS_API_initAPI(
+      let apiResult = obs.NodeObs.OBS_API_initAPI(
         'en-US',
         appService.appDataDirectory,
         electron.remote.process.env.NAIR_VERSION,
         SENTRY_SERVER_URL,
       );
+
+      if (FakeObsInitializeError) {
+        apiResult = obs.EVideoCodes.NotSupported;
+      }
 
       if (apiResult !== obs.EVideoCodes.Success) {
         const message = apiInitErrorResultToMessage(apiResult);

--- a/app/app.ts
+++ b/app/app.ts
@@ -147,27 +147,35 @@ document.addEventListener('dragenter', event => event.preventDefault());
 document.addEventListener('drop', event => event.preventDefault());
 document.addEventListener('auxclick', event => event.preventDefault());
 
+const locale = electron.remote.app.getLocale();
 
 export const apiInitErrorResultToMessage = (resultCode: obs.EVideoCodes) => {
   switch (resultCode) {
     case obs.EVideoCodes.NotSupported: {
-      // "Failed to initialize OBS. Your video drivers may be out of date, or N Air may not be supported on your system.",
-      return 'OBSの初期化に失敗しました。ビデオドライバーが古い、もしくはN Airがサポートしないシステムの可能性があります。';
+      if (locale === 'ja') {
+        return 'OBSの初期化に失敗しました。ビデオドライバーが古い、もしくはN Airがサポートしないシステムの可能性があります。';
+      }
+      return 'Failed to initialize OBS. Your video drivers may be out of date, or N Air may not be supported on your system.';
     }
     case obs.EVideoCodes.ModuleNotFound: {
-      // "DirectX could not be found on your system. Please install the latest version of DirectX for your machine here <https://www.microsoft.com/en-us/download/details.aspx?id=35?> and try again.",
-      return 'DirectXが見つかりませんでした。最新のDirectXをこちら<https://www.microsoft.com/en-us/download/details.aspx?id=35?> からインストールしてから、再度お試しください。';
+      if (locale === 'ja') {
+        return 'DirectXが見つかりませんでした。最新のDirectXをこちら<https://www.microsoft.com/en-us/download/details.aspx?id=35?> からインストールしてから、再度お試しください。';
+      }
+      return 'DirectX could not be found on your system. Please install the latest version of DirectX for your machine here <https://www.microsoft.com/en-us/download/details.aspx?id=35?> and try again.';
     }
     default: {
-      // "An unknown error was encountered while initializing OBS.",
-      return 'OBSの初期化中に不明なエラーが発生しました';
+      if (locale === 'ja') {
+        return 'OBSの初期化中に不明なエラーが発生しました';
+      }
+      return 'An unknown error was encountered while initializing OBS.';
     }
   }
 };
 
 const showDialog = (message: string): void => {
-  // "OBSInit.ErrorTitle": "Initialization Error",
-  electron.remote.dialog.showErrorBox('初期化エラー', message);
+  electron.remote.dialog.showErrorBox(
+    locale === 'ja' ? '初期化エラー' : 'Initialization Error',
+    message);
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/app.ts
+++ b/app/app.ts
@@ -151,19 +151,23 @@ document.addEventListener('auxclick', event => event.preventDefault());
 export const apiInitErrorResultToMessage = (resultCode: obs.EVideoCodes) => {
   switch (resultCode) {
     case obs.EVideoCodes.NotSupported: {
-      return $t('OBSInit.NotSupportedError');
+      // "Failed to initialize OBS. Your video drivers may be out of date, or N Air may not be supported on your system.",
+      return 'OBSの初期化に失敗しました。ビデオドライバーが古い、もしくはN Airがサポートしないシステムの可能性があります。';
     }
     case obs.EVideoCodes.ModuleNotFound: {
-      return $t('OBSInit.ModuleNotFoundError');
+      // "DirectX could not be found on your system. Please install the latest version of DirectX for your machine here <https://www.microsoft.com/en-us/download/details.aspx?id=35?> and try again.",
+      return 'DirectXが見つかりませんでした。最新のDirectXをこちら<https://www.microsoft.com/en-us/download/details.aspx?id=35?> からインストールしてから、再度お試しください。';
     }
     default: {
-      return $t('OBSInit.UnknownError');
+      // "An unknown error was encountered while initializing OBS.",
+      return 'OBSの初期化中に不明なエラーが発生しました';
     }
   }
 };
 
 const showDialog = (message: string): void => {
-  electron.remote.dialog.showErrorBox($t('OBSInit.ErrorTitle'), message);
+  // "OBSInit.ErrorTitle": "Initialization Error",
+  electron.remote.dialog.showErrorBox('初期化エラー', message);
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/app.ts
+++ b/app/app.ts
@@ -36,8 +36,6 @@ const { ipcRenderer, remote } = electron;
 const nAirVersion = remote.process.env.NAIR_VERSION;
 const isProduction = process.env.NODE_ENV === 'production';
 
-const FakeObsInitializeError = true; // DEBUG
-
 type SentryParams = {
   organization: string;
   key: string;
@@ -206,16 +204,12 @@ document.addEventListener('DOMContentLoaded', () => {
       // await this.obsUserPluginsService.initialize();
 
       // Initialize OBS API
-      let apiResult = obs.NodeObs.OBS_API_initAPI(
+      const apiResult = obs.NodeObs.OBS_API_initAPI(
         'en-US',
         appService.appDataDirectory,
         electron.remote.process.env.NAIR_VERSION,
         SENTRY_SERVER_URL,
       );
-
-      if (FakeObsInitializeError) {
-        apiResult = obs.EVideoCodes.NotSupported;
-      }
 
       if (apiResult !== obs.EVideoCodes.Success) {
         const message = apiInitErrorResultToMessage(apiResult);

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -43,7 +43,7 @@ export declare type TObsValue = number | string | boolean | IObsFont | TObsStrin
  * common interface for OBS objects properties
  */
 export interface IObsInput<TValueType> {
-  value: TValueType;
+  value?: TValueType;
   name: string;
   description: string;
   showDescription?: boolean;

--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -77,9 +77,5 @@
   "fieldMustBeLess": "The field value must be %{value} or less",
   "dateFieldFormat": "The date must be in %{format} format",
   "fieldAlphaNumeric": "This field may only contain alphabetic characters or numbers",
-  "OBSInit.ErrorTitle": "Initialization Error",
-  "OBSInit.UnknownError": "An unknown error was encountered while initializing OBS.",
-  "OBSInit.ModuleNotFoundError": "DirectX could not be found on your system. Please install the latest version of DirectX for your machine here <https://www.microsoft.com/en-us/download/details.aspx?id=35?> and try again.",
-  "OBSInit.NotSupportedError": "Failed to initialize OBS. Your video drivers may be out of date, or N Air may not be supported on your system.",
   "Interact": "Interact"
 }

--- a/app/i18n/ja-JP/common.json
+++ b/app/i18n/ja-JP/common.json
@@ -77,9 +77,5 @@
   "fieldMustBeLess": "%{value} 以上を指定してください",
   "dateFieldFormat": "日付は %{format} の書式に従ってください",
   "fieldAlphaNumeric": "半角英数以外は使用しないでください",
-  "OBSInit.ErrorTitle": "初期化エラー",
-  "OBSInit.UnknownError": "OBSの初期化中に不明なエラーが発生しました",
-  "OBSInit.ModuleNotFoundError": "DirectXが見つかりませんでした。最新のDirectXをこちら<https://www.microsoft.com/en-us/download/details.aspx?id=35?> からインストールしてから、再度お試しください。",
-  "OBSInit.NotSupportedError": "OBSの初期化に失敗しました。ビデオドライバーが古い、もしくはN Airがサポートしないシステムの可能性があります。",
   "Interact": "インタラクション(WEB操作)"
 }

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -23,19 +23,9 @@ import { QuestionaireService } from 'services/questionaire';
 import { InformationsService } from 'services/informations';
 import { CrashReporterService } from 'services/crash-reporter';
 import * as obs from '../../../obs-api';
-import { EVideoCodes } from 'obs-studio-node/module';
-import { $t } from '../i18n';
 import { RunInLoadingMode } from './app-decorators';
-import path from 'path';
 import Utils from 'services/utils';
 
-const crashHandler = window['require']('crash-handler');
-
-let SENTRY_SERVER_URL: string;
-
-export function setAppServiceSentryBackendUrl(url: string) {
-  SENTRY_SERVER_URL = url;
-};
 
 interface IAppState {
   loading: boolean;
@@ -78,7 +68,7 @@ export class AppService extends StatefulService<IAppState> {
   @Inject() private crashReporterService: CrashReporterService;
   private loadingPromises: Dictionary<Promise<any>> = {};
 
-  private pid = require('process').pid;
+  readonly pid = require('process').pid;
 
   @track({ event: 'boot' })
   @RunInLoadingMode()
@@ -87,43 +77,6 @@ export class AppService extends StatefulService<IAppState> {
       electron.ipcRenderer.on('showErrorAlert', () => {
         this.SET_ERROR_ALERT(true);
       });
-    }
-
-    // This is used for debugging
-    window['obs'] = obs;
-
-    // Host a new OBS server instance
-    obs.IPC.host(`nair-${uuid()}`);
-    obs.NodeObs.SetWorkingDirectory(
-      path.join(
-        electron.remote.app.getAppPath().replace('app.asar', 'app.asar.unpacked'),
-        'node_modules',
-        'obs-studio-node',
-      ),
-    );
-
-    crashHandler.registerProcess(this.pid, false);
-
-    // await this.obsUserPluginsService.initialize();
-
-    // Initialize OBS API
-    const apiResult = obs.NodeObs.OBS_API_initAPI(
-      'en-US',
-      this.appDataDirectory,
-      electron.remote.process.env.NAIR_VERSION,
-      SENTRY_SERVER_URL,
-    );
-
-    if (apiResult !== EVideoCodes.Success) {
-      const message = apiInitErrorResultToMessage(apiResult);
-      showDialog(message);
-
-      crashHandler.unregisterProcess(this.pid);
-
-      obs.IPC.disconnect();
-
-      electron.ipcRenderer.send('shutdownComplete');
-      return;
     }
 
     // We want to start this as early as possible so that any
@@ -305,21 +258,3 @@ export class AppService extends StatefulService<IAppState> {
     this.state.argv = argv;
   }
 }
-
-export const apiInitErrorResultToMessage = (resultCode: EVideoCodes) => {
-  switch (resultCode) {
-    case EVideoCodes.NotSupported: {
-      return $t('OBSInit.NotSupportedError');
-    }
-    case EVideoCodes.ModuleNotFound: {
-      return $t('OBSInit.ModuleNotFoundError');
-    }
-    default: {
-      return $t('OBSInit.UnknownError');
-    }
-  }
-};
-
-const showDialog = (message: string): void => {
-  electron.remote.dialog.showErrorBox($t('OBSInit.ErrorTitle'), message);
-};

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -31,6 +31,12 @@ import Utils from 'services/utils';
 
 const crashHandler = window['require']('crash-handler');
 
+let SENTRY_SERVER_URL: string;
+
+export function setAppServiceSentryBackendUrl(url: string) {
+  SENTRY_SERVER_URL = url;
+};
+
 interface IAppState {
   loading: boolean;
   argv: string[];
@@ -105,6 +111,7 @@ export class AppService extends StatefulService<IAppState> {
       'en-US',
       this.appDataDirectory,
       electron.remote.process.env.NAIR_VERSION,
+      SENTRY_SERVER_URL,
     );
 
     if (apiResult !== EVideoCodes.Success) {

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -771,14 +771,22 @@ export class SettingsService
   setSettings(categoryName: string, settingsData: ISettingsSubCategory[]) {
     if (categoryName === 'Audio') this.setAudioSettings([settingsData.pop()]);
 
-    const dataToSave = [];
+    const dataToSave: {
+      nameSubCategory: string;
+      parameters: {
+        name: string;
+        type: string;
+        subType: string;
+        currentValue: number | string | boolean;
+      }[];
+    }[] = [];
 
     for (const subGroup of settingsData) {
       dataToSave.push({
         ...subGroup,
         parameters: inputValuesToObsValues(subGroup.parameters, {
           valueToCurrentValue: true,
-        }),
+        }) as any, // TODO fix type
       });
     }
 

--- a/obs-api/obs-api.d.ts
+++ b/obs-api/obs-api.d.ts
@@ -1,1 +1,156 @@
-export * from 'obs-studio-node/module'
+// export * from 'obs-studio-node/module'
+export {
+  EBlendingMethod,
+  EBlendingMode,
+  EDeinterlaceFieldOrder,
+  EDeinterlaceMode,
+  EMonitoringType,
+  EFaderType,
+  EFontStyle,
+  EInteractionFlags,
+  EMouseButtonType,
+  ENumberType,
+  EOutputCode,
+  EPathType,
+  EPropertyType,
+  ERenderingMode,
+  EScaleType,
+  ESceneDupType,
+  ESourceFlags,
+  ESourceOutputFlags,
+  ETextType,
+  EVideoCodes,
+  Global,
+  IBooleanProperty,
+  IButtonProperty,
+  ICallbackData,
+  IColorProperty,
+  IEditableListProperty,
+  IFader,
+  IFilter,
+  IFontProperty,
+  IInput,
+  IListProperty,
+  INumberProperty,
+  IPathProperty,
+  IProperty,
+  IScene,
+  ISceneItem,
+  ISceneItemInfo,
+  ISettings,
+  ISource,
+  ITextProperty,
+  ITimeSpec,
+  ITransition,
+  IVolmeter,
+  FaderFactory,
+  FilterFactory,
+  IPC,
+  InputFactory,
+  SceneFactory,
+  TransitionFactory,
+  VideoFactory,
+  VolmeterFactory,
+  addItems,
+  createSources,
+  getSourcesSize,
+} from 'obs-studio-node/module';
+import { EVideoCodes } from 'obs-studio-node/module';
+
+export const NodeObs: {
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_api.hpp
+  OBS_API_initAPI(locale: string, directory: string, version: string, sentryUrl: string): EVideoCodes;
+  // OBS_API_destroyOBS_API
+  OBS_API_getPerformanceStatistics(): any;
+  SetWorkingDirectory(path: string): void;
+  InitShutdownSequence(): void;
+  // OBS_API_QueryHotkeys
+  // OBS_API_ProcessHotkeyStatus
+  // SetUsername
+  // GetPermissionsStatus
+  // RequestPermissions
+  // GetBrowserAcceleration
+  // SetBrowserAcceleration
+  // GetBrowserAccelerationLegacy
+  // GetMediaFileCaching
+  // SetMediaFileCaching
+  // GetMediaFileCachingLegacy
+  // GetProcessPriority
+  // SetProcessPriority
+  // GetProcessPriorityLegacy
+  // OBS_API_forceCrash
+  // GetForceGPURendering
+  // SetForceGPURendering
+  // GetForceGPURenderingLegacy
+
+  // GetSdrWhiteLevel
+  // SetSdrWhiteLevel
+  // GetSdrWhiteLevelLegacy
+  // GetHdrNominalPeakLevel
+  // SetHdrNominalPeakLevel
+  // GetHdrNominalPeakLevelLegacy
+  // GetLowLatencyAudioBuffering
+  // SetLowLatencyAudioBuffering
+  // GetLowLatencyAudioBufferingLegacy
+
+
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/callback-manager.cpp
+  RegisterSourceCallback(callback: (objs: any[]) => void): void;
+  RemoveSourceCallback(): void;
+
+
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_service.hpp
+  OBS_service_resetVideoContext(): void;
+  OBS_service_resetAudioContext(): void;
+
+  OBS_service_startStreaming(): void;
+  OBS_service_startRecording(): void;
+  OBS_service_startReplayBuffer(): void;
+  OBS_service_stopStreaming(flag: boolean): void;
+  OBS_service_stopRecording(): void;
+  OBS_service_stopReplayBuffer(flag: boolean): void;
+
+  OBS_service_connectOutputSignals(callback: (info: any) => void): void;
+  OBS_service_removeCallback(): void;
+  OBS_service_processReplayBufferHotkey(): void;
+  OBS_service_getLastReplay(): string;
+  // OBS_service_getLastRecording
+  // OBS_service_splitFile
+
+  // OBS_service_createVirtualWebcam
+  // OBS_service_removeVirtualWebcam
+  // OBS_service_startVirtualWebcam
+  // OBS_service_stopVirtualWebcam
+  // OBS_service_installVirtualCamPlugin
+  // OBS_service_uninstallVirtualCamPlugin
+  // OBS_service_isVirtualCamPluginInstalled
+
+
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_display.hpp
+  // OBS_content_setDayTheme
+  OBS_content_createDisplay(window: Buffer, name: string, renderingMode: number): void;
+  OBS_content_destroyDisplay(name: string): void;
+  OBS_content_getDisplayPreviewOffset(name: string): IVec2;
+  OBS_content_getDisplayPreviewSize(name: string): { width: number; height: number };
+  OBS_content_createSourcePreviewDisplay(window: Buffer, sourceId: string, name: string): void;
+  OBS_content_resizeDisplay(name: string, width: number, height: number): void;
+  OBS_content_moveDisplay(name: string, x: number, y: number): void;
+  OBS_content_setPaddingSize(name: string, size: number): void;
+  OBS_content_setPaddingColor(name: string, r: number, g: number, b: number): void;
+  // OBS_content_setOutlineColor
+  // OBS_content_setCropOutlineColor
+  OBS_content_setShouldDrawUI(name: string, drawUI: boolean): void;
+  OBS_content_setDrawGuideLines(name: string, drawGuideLines: boolean): void;
+  // OBS_content_setDrawRotationHandle
+  // OBS_content_createIOSurface
+
+
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_settings.hpp
+  OBS_settings_getSettings(categoryName: string): { data: {}[] };
+  OBS_settings_saveSettings(categoryName: string, dataToSave: {}[]): void;
+  OBS_settings_getListCategories(): string[];
+  // OBS_settings_getInputAudioDevices
+  // OBS_settings_getOutputAudioDevices
+  // OBS_settings_getVideoDevices
+};
+

--- a/obs-api/obs-api.d.ts
+++ b/obs-api/obs-api.d.ts
@@ -55,102 +55,167 @@ export {
   createSources,
   getSourcesSize,
 } from 'obs-studio-node/module';
-import { EVideoCodes } from 'obs-studio-node/module';
+import { EOutputCode, EVideoCodes } from 'obs-studio-node/module';
+
+export interface IGetSettingsData {
+  nameSubCategory: string;
+  parameters: {
+    name: string;
+    type: string; // 'OBS_PROPERTY_EDIT_TEXT', ...
+    description: string;
+    subType: string; // 'OBS_COMBO_FORMAT_INT', ...
+    currentValue: number | string | boolean;
+    minVal?: number;
+    maxVal?: number;
+    stepVal?: number;
+
+    values: { [name: string]: number | string }[];
+    visible: boolean;
+    enabled: boolean;
+    masked: boolean;
+  }[];
+}
+
+export interface ISaveSettingsData {
+  nameSubCategory: string;
+  parameters: {
+    name: string;
+    type: string;
+    subType: string;
+    currentValue: number | string | boolean;
+  }[];
+}
 
 export const NodeObs: {
   // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_api.hpp
   OBS_API_initAPI(locale: string, directory: string, version: string, sentryUrl: string): EVideoCodes;
-  // OBS_API_destroyOBS_API
-  OBS_API_getPerformanceStatistics(): any;
+  // OBS_API_destroyOBS_API(): void;
+  OBS_API_getPerformanceStatistics(): {
+    CPU: number;
+    numberDroppedFrames: number;
+    percentageDroppedFrames: number;
+    streamingBandwidth: number;
+    streamingDataOutput: number;
+    recordingBandwidth: number;
+    recordingDataOutput: number;
+    frameRate: number;
+    averageTimeToRenderFrame: number;
+    memoryUsage: number;
+    diskSpaceAvailable: string;
+  } | undefined;
   SetWorkingDirectory(path: string): void;
   InitShutdownSequence(): void;
-  // OBS_API_QueryHotkeys
-  // OBS_API_ProcessHotkeyStatus
-  // SetUsername
-  // GetPermissionsStatus
-  // RequestPermissions
-  // GetBrowserAcceleration
-  // SetBrowserAcceleration
-  // GetBrowserAccelerationLegacy
-  // GetMediaFileCaching
-  // SetMediaFileCaching
-  // GetMediaFileCachingLegacy
-  // GetProcessPriority
-  // SetProcessPriority
-  // GetProcessPriorityLegacy
-  // OBS_API_forceCrash
-  // GetForceGPURendering
-  // SetForceGPURendering
-  // GetForceGPURenderingLegacy
+  /* OBS_API_QueryHotkeys(): {
+      ObjectName: string;
+      ObjectType: number;
+      HotkeyName: string;
+      HotkeyDesc: string;
+      HotkeyId: number;
+     }[];
+  */
+  // OBS_API_ProcessHotkeyStatus(hotkeyId: string; press: any): void;
+  // SetUsername(username: string): void;
+  /* GetPermissionsStatus(): {
+        webcamPermission: boolean;
+        micPermission: boolean;
+    } | undefined;
+  */
+  // RequestPermissions(callback: ({webcamPermission: boolean; micPermission: boolean}) => void): void;
+  // GetBrowserAcceleration(): boolean | undefined;
+  // SetBrowserAcceleration(browserAccel: boolean): void;
+  // GetBrowserAccelerationLegacy(): boolean | undefined;
+  // GetMediaFileCaching(): boolean | undefined;
+  // SetMediaFileCaching(mediaFileCaching: boolean): void;
+  // GetMediaFileCachingLegacy(): boolean | undefined;
+  // GetProcessPriority(): string | undefined;
+  // SetProcessPriority(processPriority: string): void;
+  // GetProcessPriorityLegacy(): string | undefined;
+  // OBS_API_forceCrash(backendCrash: boolean): void;
+  // GetForceGPURendering(): boolean | undefined;
+  // SetForceGPURendering(forceGPURendering: boolean): void;
+  // GetForceGPURenderingLegacy(): boolean | undefined;
 
-  // GetSdrWhiteLevel
-  // SetSdrWhiteLevel
-  // GetSdrWhiteLevelLegacy
-  // GetHdrNominalPeakLevel
-  // SetHdrNominalPeakLevel
-  // GetHdrNominalPeakLevelLegacy
-  // GetLowLatencyAudioBuffering
-  // SetLowLatencyAudioBuffering
-  // GetLowLatencyAudioBufferingLegacy
+  // GetSdrWhiteLevel(): number | undefined;
+  // SetSdrWhiteLevel(sdrWhiteLevel: number): void;
+  // GetSdrWhiteLevelLegacy(): number | undefined;
+  // GetHdrNominalPeakLevel(): number | undefined;
+  // SetHdrNominalPeakLevel(hdrNominalPeakLevel: number): void;
+  // GetHdrNominalPeakLevelLegacy(): number | undefined;
+  // GetLowLatencyAudioBuffering(): boolean | undefined;
+  // SetLowLatencyAudioBuffering(lowLatencyAudioBuffering: boolean): void;
+  // GetLowLatencyAudioBufferingLegacy(): boolean | undefined;
 
 
   // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/callback-manager.cpp
-  RegisterSourceCallback(callback: (objs: any[]) => void): void;
+  RegisterSourceCallback(callback: (objs: {
+    name: string;
+    width: number;
+    height: number;
+    flags: number;
+  }[]) => void): void;
   RemoveSourceCallback(): void;
 
 
   // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_service.hpp
-  OBS_service_resetVideoContext(): void;
   OBS_service_resetAudioContext(): void;
+  OBS_service_resetVideoContext(): void;
 
   OBS_service_startStreaming(): void;
   OBS_service_startRecording(): void;
   OBS_service_startReplayBuffer(): void;
-  OBS_service_stopStreaming(flag: boolean): void;
+  OBS_service_stopStreaming(forceStop: boolean): void;
   OBS_service_stopRecording(): void;
-  OBS_service_stopReplayBuffer(flag: boolean): void;
+  OBS_service_stopReplayBuffer(forceStop: boolean): void;
 
-  OBS_service_connectOutputSignals(callback: (info: any) => void): void;
+  OBS_service_connectOutputSignals(callback: (info: {
+    type: any; // 'streaming' | 'recording' | 'replay-buffer';
+    signal: any; // 'starting' | 'start' | 'stopping' | 'stop' | 'reconnect' | 'reconnect_success' | 'wrote' | 'writing_error';
+    code: EOutputCode;
+    error: string;
+  }) => void): boolean;
   OBS_service_removeCallback(): void;
   OBS_service_processReplayBufferHotkey(): void;
   OBS_service_getLastReplay(): string;
-  // OBS_service_getLastRecording
-  // OBS_service_splitFile
+  // OBS_service_getLastRecording(): string;
+  // OBS_service_splitFile(): void;
 
-  // OBS_service_createVirtualWebcam
-  // OBS_service_removeVirtualWebcam
-  // OBS_service_startVirtualWebcam
-  // OBS_service_stopVirtualWebcam
-  // OBS_service_installVirtualCamPlugin
-  // OBS_service_uninstallVirtualCamPlugin
-  // OBS_service_isVirtualCamPluginInstalled
+  // OBS_service_createVirtualWebcam(name: string): void;
+  // OBS_service_removeVirtualWebcam(): void;
+  // OBS_service_startVirtualWebcam(): void;
+  // OBS_service_stopVirtualWebcam(): void;
+  // OBS_service_installVirtualCamPlugin(): void;
+  // OBS_service_uninstallVirtualCamPlugin(): void;
+  // OBS_service_isVirtualCamPluginInstalled(): number; // VcamInstalledStatus
 
 
   // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_display.hpp
-  // OBS_content_setDayTheme
-  OBS_content_createDisplay(window: Buffer, name: string, renderingMode: number): void;
-  OBS_content_destroyDisplay(name: string): void;
-  OBS_content_getDisplayPreviewOffset(name: string): IVec2;
-  OBS_content_getDisplayPreviewSize(name: string): { width: number; height: number };
-  OBS_content_createSourcePreviewDisplay(window: Buffer, sourceId: string, name: string): void;
-  OBS_content_resizeDisplay(name: string, width: number, height: number): void;
-  OBS_content_moveDisplay(name: string, x: number, y: number): void;
-  OBS_content_setPaddingSize(name: string, size: number): void;
-  OBS_content_setPaddingColor(name: string, r: number, g: number, b: number): void;
-  // OBS_content_setOutlineColor
-  // OBS_content_setCropOutlineColor
-  OBS_content_setShouldDrawUI(name: string, drawUI: boolean): void;
-  OBS_content_setDrawGuideLines(name: string, drawGuideLines: boolean): void;
-  // OBS_content_setDrawRotationHandle
-  // OBS_content_createIOSurface
+  // OBS_content_setDayTheme(dayTheme: boolean): void;
+  OBS_content_createDisplay(window: Buffer, key: string, mode: number, renderAtBottom?: boolean): void;
+  OBS_content_destroyDisplay(key: string): void;
+  OBS_content_getDisplayPreviewOffset(key: string): IVec2 | undefined;
+  OBS_content_getDisplayPreviewSize(key: string): { width: number; height: number } | undefined;
+  OBS_content_createSourcePreviewDisplay(window: Buffer, sourceName: string, key: string, renderAtBottom?: boolean): void;
+  OBS_content_resizeDisplay(key: string, width: number, height: number): void;
+  OBS_content_moveDisplay(key: string, x: number, y: number): void;
+  OBS_content_setPaddingSize(key: string, paddingSize: number): void;
+  OBS_content_setPaddingColor(key: string, r: number, g: number, b: number, a?: number): void;
+  // OBS_content_setOutlineColor(key: string, r: number, g: number, b: number, a?: number): void;
+  // OBS_content_setCropOutlineColor(key: string, r: number, g: number, b: number, a?: number): void;
+  OBS_content_setShouldDrawUI(key: string, drawUI: boolean): void;
+  OBS_content_setDrawGuideLines(key: string, drawGuideLines: boolean): void;
+  // OBS_content_setDrawRotationHandle(key: string, drawRotationHandle: boolean): void;
+  // OBS_content_createIOSurface(key: string): number | undefined;
 
 
   // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_settings.hpp
-  OBS_settings_getSettings(categoryName: string): { data: {}[] };
-  OBS_settings_saveSettings(categoryName: string, dataToSave: {}[]): void;
+  OBS_settings_getSettings(category: string): {
+    data: IGetSettingsData[];
+    type: number;
+  };
+  OBS_settings_saveSettings(category: string, settings: ISaveSettingsData[]): void;
   OBS_settings_getListCategories(): string[];
-  // OBS_settings_getInputAudioDevices
-  // OBS_settings_getOutputAudioDevices
-  // OBS_settings_getVideoDevices
+  // OBS_settings_getInputAudioDevices(): { description: string; id: string; }[];
+  // OBS_settings_getOutputAudioDevices(): { description: string; id: string; }[];
+  // OBS_settings_getVideoDevices(): { description: string; id: string; }[];
 };
 

--- a/obs-api/obs-api.d.ts
+++ b/obs-api/obs-api.d.ts
@@ -87,7 +87,7 @@ export interface ISaveSettingsData {
 }
 
 export const NodeObs: {
-  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_api.hpp
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.59/obs-studio-client/source/nodeobs_api.hpp
   OBS_API_initAPI(locale: string, directory: string, version: string, sentryUrl: string): EVideoCodes;
   // OBS_API_destroyOBS_API(): void;
   OBS_API_getPerformanceStatistics(): {
@@ -146,7 +146,7 @@ export const NodeObs: {
   // GetLowLatencyAudioBufferingLegacy(): boolean | undefined;
 
 
-  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/callback-manager.cpp
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.59/obs-studio-client/source/callback-manager.cpp
   RegisterSourceCallback(callback: (objs: {
     name: string;
     width: number;
@@ -156,7 +156,7 @@ export const NodeObs: {
   RemoveSourceCallback(): void;
 
 
-  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_service.hpp
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.59/obs-studio-client/source/nodeobs_service.hpp
   OBS_service_resetAudioContext(): void;
   OBS_service_resetVideoContext(): void;
 
@@ -188,7 +188,7 @@ export const NodeObs: {
   // OBS_service_isVirtualCamPluginInstalled(): number; // VcamInstalledStatus
 
 
-  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_display.hpp
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.59/obs-studio-client/source/nodeobs_display.hpp
   // OBS_content_setDayTheme(dayTheme: boolean): void;
   OBS_content_createDisplay(window: Buffer, key: string, mode: number, renderAtBottom?: boolean): void;
   OBS_content_destroyDisplay(key: string): void;
@@ -207,7 +207,7 @@ export const NodeObs: {
   // OBS_content_createIOSurface(key: string): number | undefined;
 
 
-  // https://github.com/stream-labs/obs-studio-node/blob/0.23.71/obs-studio-client/source/nodeobs_settings.hpp
+  // https://github.com/stream-labs/obs-studio-node/blob/0.23.59/obs-studio-client/source/nodeobs_settings.hpp
   OBS_settings_getSettings(category: string): {
     data: IGetSettingsData[];
     type: number;


### PR DESCRIPTION
# このpull requestが解決する内容
obs-studio-node APIの変更追従漏れを探したい

* Streamlabs `obs-studio-node` は OBS APIの関数宣言がなく `any` となっていてノーチェックだったので、`obs-studio-node` 
*  0.23.59 のソースを解読してN Air側で宣言を当て直した
    * 呼んでいるAPIは有効にし、呼んでいないAPIは宣言は定義した上でコメントアウトした
    * `OBS_API_initAPI()` にSentry URLの引数が追加されていて、これを省略するとStreamlabsに送信されていたのでN Airに向き先を付け替える
    * 他の呼んでいるAPIについては `obs-studi-node` 0.23.59 の段階では引数の変更は見あたらなかった
* OBSの初期化コードの修正
    * `app/services/app` にあったOBS初期化処理を `app/app` に移動し、Vue初期化前に実行するように変更(Streamlabsからのbackport)
    * OBS初期化エラーの文言がvue/i18nを使うようになっていたが実際に機能していなかった問題を修正(vue/i18nを使わず、ハードコードに変更)(Streamlabsに追従した上で日本語と英語に対応)
