### PR TITLE
開発: AppVeyor: node version 16 -> 18

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_commits:
     - README.md
 
 install:
-  - ps: Install-Product node 16 x64
+  - ps: Install-Product node 18 x64
   - ps: Add-Content -Path "$env:userprofile\.npmrc" -Value "//npm.pkg.github.com/:_authToken=$env:github_token"
   - yarn install --frozen-lockfile --check-files
   - yarn compile:ci
@@ -28,7 +28,7 @@ test_script:
 
 notifications:
   - provider: GitHubPullRequest
-    template: "{{#failed}}:x: build failed{{/failed}} {{#jobs}} {{#messages}} {{message}} {{/messages}} {{/jobs}}"
+    template: '{{#failed}}:x: build failed{{/failed}} {{#jobs}} {{#messages}} {{message}} {{/messages}} {{/jobs}}'
 
 cache:
   - plugins


### PR DESCRIPTION
# このpull requestが解決する内容
[Node.js 16 がEnd of life を迎えた](https://nodejs.org/en/blog/announcements/nodejs16-eol?utm_content=263954443&utm_medium=social&utm_source=twitter&hss_channel=tw-91985735)ので、まだ16だったAppVeyorの設定をNode 18に上げます

# 動作確認手順
CIが通ればok
