### PR TITLE
開発: mini-release.js: コード署名証明書ファイルパス環境変数チェックを削除

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -404,8 +404,6 @@ async function releaseRoutine() {
   info(colors.magenta('| N Air Interactive Release Script |'));
   info(colors.magenta('|----------------------------------|'));
 
-  checkEnv('CSC_LINK');
-  checkEnv('CSC_KEY_PASSWORD');
   checkEnv('NAIR_LICENSE_API_KEY');
   checkEnv('SENTRY_AUTH_TOKEN');
   checkEnv('AWS_ACCESS_KEY_ID');


### PR DESCRIPTION
# このpull requestが解決する内容
コート署名証明書をトークンに切り替えたので `CSC_LINK`, `CSC_KEY_PASSWORD` 環境変数を使わなくなったので、残っていた存在チェックを削除します
