### PR TITLE
追加: 番組の開始/終了のショートカットキー

### DIFF
--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -6,6 +6,7 @@ import { KeyListenerService } from 'services/key-listener';
 import { StatefulService, mutation, ServiceHelper, Inject } from './core';
 import { defer, mapValues } from 'lodash';
 import { $t } from 'services/i18n';
+import { NicoliveProgramService } from './nicolive-program/nicolive-program';
 
 function getScenesService(): ScenesService {
   return ScenesService.instance;
@@ -17,6 +18,10 @@ function getSourcesService(): SourcesService {
 
 function getStreamingService(): StreamingService {
   return StreamingService.instance;
+}
+
+function getNicoliveProgramService(): NicoliveProgramService {
+  return NicoliveProgramService.instance;
 }
 
 function getTransitionsService(): TransitionsService {
@@ -119,6 +124,24 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
       name: 'SAVE_REPLAY',
       description: () => $t('hotkeys.saveReplay'),
       down: () => getStreamingService().saveReplay(),
+    },
+    {
+      name: 'START_PROGRAM',
+      description: () => '番組開始',
+      down: () => getNicoliveProgramService().startProgram(),
+      isActive: () => {
+        const nicolive = getNicoliveProgramService();
+        return nicolive.state.isStarting || nicolive.state.status !== 'test';
+      },
+    },
+    {
+      name: 'END_PROGRAM',
+      description: () => '番組終了',
+      down: () => getNicoliveProgramService().endProgram(),
+      isActive: () => {
+        const nicolive = getNicoliveProgramService();
+        return nicolive.state.isEnding || nicolive.state.status !== 'onAir';
+      }
     },
   ],
 


### PR DESCRIPTION
# このpull requestが解決する内容
設定のショートカットキーに以下の項目を追加します
![image](https://github.com/n-air-app/n-air-app/assets/864587/019b76db-fe31-4a1c-8174-c4273e0b49c7)

* [x] 従来の配信開始ボタンを押した時には配信開始をしていないと確認がでるが、このショートカットキーだと確認は出ない(実装が楽だったため)。それでいいか確認

# 動作確認手順

# 関連するIssue（あれば）
