### PR TITLE
修正:「最適化して配信」ボタンの連打対策

### DIFF
--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -1,61 +1,69 @@
 <template>
-<modal-layout
-  :show-controls="false"
-  :customControls="true">
-  <div slot="content">
-    <p class="optimize-title">{{ $t('streaming.optimizationForNiconico.description') }}</p>
-    <ul class="optimize-category-list">
-      <li class="optimize-category-list-item" v-for="category in settings.info" :key="category[0]">
-        <p class="optimize-category-name">{{ $t(`settings.${category[0]}.name`, { fallback: category[0] }) }}</p>
-        <ul class="optimize-setting-list">
-          <li class="optimize-setting-list-item" v-for="o in category[1]" :key="o.key">
-            <span class="item-name">{{ o.name }}: </span><span class="item-value">{{ o.currentValue }}
-            <span class="item-new-value" v-if="o.newValue"> -&gt; {{ o.newValue }}</span></span>
-          </li>
-        </ul>
-      </li>
-    </ul>
-    <BoolInput :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
-    <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
-  </div>
-  <div slot="controls">
-    <button
-      class="button button--secondary"
-      @click="skip">
-      {{ $t('streaming.skipOptimization') }}
-    </button>
-    <button
-      class="button button--primary"
-      @click="optimizeAndGoLive">
-      {{ $t('streaming.optimizeAndGoLive') }}
-    </button>
-  </div>
-</modal-layout>
+  <modal-layout :show-controls="false" :customControls="true">
+    <div slot="content">
+      <p class="optimize-title">{{ $t('streaming.optimizationForNiconico.description') }}</p>
+      <ul class="optimize-category-list">
+        <li
+          class="optimize-category-list-item"
+          v-for="category in settings.info"
+          :key="category[0]"
+        >
+          <p class="optimize-category-name">
+            {{ $t(`settings.${category[0]}.name`, { fallback: category[0] }) }}
+          </p>
+          <ul class="optimize-setting-list">
+            <li class="optimize-setting-list-item" v-for="o in category[1]" :key="o.key">
+              <span class="item-name">{{ o.name }}: </span
+              ><span class="item-value"
+                >{{ o.currentValue }}
+                <span class="item-new-value" v-if="o.newValue"> -&gt; {{ o.newValue }}</span></span
+              >
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <BoolInput :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
+      <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
+    </div>
+    <div slot="controls">
+      <button class="button button--secondary" :disabled="isStarting" @click="skip">
+        {{ $t('streaming.skipOptimization') }}
+      </button>
+      <button class="button button--primary" :disabled="isStarting" @click="optimizeAndGoLive">
+        {{ $t('streaming.optimizeAndGoLive') }}
+      </button>
+    </div>
+  </modal-layout>
 </template>
 
 <script lang="ts" src="./OptimizeForNiconico.vue.ts"></script>
 
 <style lang="less" scoped>
-@import "../../styles/index";
+@import url('../../styles/index');
 
 .input-container {
   flex-direction: column;
 }
+
 .optimize-title {
   color: var(--color-text-light);
 }
+
 .optimize-category-list {
-  list-style: none;
   margin: 0;
+  list-style: none;
 }
+
 .optimize-category-list-item {
   .radius;
-  color: var(--color-text);
-  margin-bottom: 16px;
+
   padding: 16px;
+  margin-bottom: 16px;
+  color: var(--color-text);
   list-style: none;
   background: var(--color-bg-secondary);
 }
+
 .optimize-category-name {
   display: flex;
   align-items: center;
@@ -66,8 +74,9 @@
     margin-right: 8px;
   }
 }
+
 .optimize-setting-list {
-  list-style: none;
   margin: 0;
+  list-style: none;
 }
 </style>

--- a/app/components/windows/OptimizeForNiconico.vue.ts
+++ b/app/components/windows/OptimizeForNiconico.vue.ts
@@ -56,13 +56,17 @@ export default class OptimizeNiconico extends Vue {
     this.streamingService.toggleStreamingAsync({ mustShowOptimizationDialog: true });
   }
 
+  isStarting = false;
+
   optimizeAndGoLive() {
+    this.isStarting = true;
     this.settingsService.optimizeForNiconico(this.settings.best);
     this.streamingService.toggleStreaming();
     this.windowsService.closeChildWindow();
   }
 
   skip() {
+    this.isStarting = true;
     if (this.doNotShowAgain.value) {
       this.customizationService.setOptimizeForNiconico(false);
     }


### PR DESCRIPTION
# このpull requestが解決する内容
ニコニコ生放送で配信開始をするときに、最適化で設定変更が必要な場合に出る最適化確認ダイアログの「最適化して配信」ボタンを連打すると内部的に配信トグルが2回実行されるがアプリの状態管理と不整合を起こして配信ボタンがグレーになってしまうことがあったのを、2回押せないようにします。

# 動作確認手順
1. ニコ生出番組を作成
2. 設定から出力の項目を適当に変更して最適化が必要な状態にする
3. 配信開始ボタンを押すと最適化確認ダイアログが出る
4. 「最適化して配信」ボタンを素早く連打する
5. うまく発生できた場合、配信開始ボタンがグレーになる

# 関連するIssue（あれば）
