### PR TITLE
修正: コメントからのNG追加時のAPIエラーハンドリングが抜けていた/APIパラメータのミス修正

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -209,7 +209,6 @@ export default class CommentViewer extends Vue {
           this.nicoliveCommentFilterService.addFilter({ type: 'user', body: item.value.user_id, messageId: `${item.value.no}`, memo: item.value.content })
             .catch(e => {
               if (e instanceof NicoliveFailure) {
-                console.log('failed to add filter', e); // DEBUG
                 openErrorDialogFromFailure(e);
               }
             });

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -22,6 +22,7 @@ import GiftComment from './comment/GiftComment.vue';
 import NicoadComment from './comment/NicoadComment.vue';
 import SystemMessage from './comment/SystemMessage.vue';
 import { getDisplayName } from 'services/nicolive-program/ChatMessage/getDisplayName';
+import { NicoliveFailure, openErrorDialogFromFailure } from 'services/nicolive-program/NicoliveFailure';
 
 const componentMap: { [type in ChatComponentType]: Vue.Component } = {
   common: CommonComment,
@@ -193,14 +194,25 @@ export default class CommentViewer extends Vue {
         id: 'Ban comment content',
         label: 'コメントをNGに追加',
         click: () => {
-          this.nicoliveCommentFilterService.addFilter({ type: 'word', body: item.value.content });
+          this.nicoliveCommentFilterService.addFilter({ type: 'word', body: item.value.content })
+            .catch(e => {
+              if (e instanceof NicoliveFailure) {
+                openErrorDialogFromFailure(e);
+              }
+            });
         },
       });
       menu.append({
         id: 'Ban comment owner',
         label: 'ユーザーIDをNGに追加',
         click: () => {
-          this.nicoliveCommentFilterService.addFilter({ type: 'user', body: item.value.user_id, messageId: `${item.value.no}` });
+          this.nicoliveCommentFilterService.addFilter({ type: 'user', body: item.value.user_id, messageId: `${item.value.no}`, memo: item.value.content })
+            .catch(e => {
+              if (e instanceof NicoliveFailure) {
+                console.log('failed to add filter', e); // DEBUG
+                openErrorDialogFromFailure(e);
+              }
+            });
         },
       });
     }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -388,8 +388,11 @@ export class NicoliveClient {
     records: AddFilterRecord[],
   ): Promise<WrappedResult<Filters['data']>> {
     const session = await this.fetchSession();
+    if (records.length !== 1) {
+      throw new Error('addFilters: records.length must be 1');
+    }
     const requestInit = NicoliveClient.createRequest('POST', {
-      body: JSON.stringify(records),
+      body: JSON.stringify(records[0]),
       headers: {
         'X-Niconico-Session': session,
         'Content-Type': 'application/json',


### PR DESCRIPTION
# このpull requestが解決する内容
* NG追加API失敗時にエラーダイアログを出す
![image](https://github.com/n-air-app/n-air-app/assets/864587/cf72d3e9-7b88-4f28-8270-fe29471cfb36)

* あと、NGユーザー時のmemoもAPIリクエストに追加
* NG登録APIを配列ではなく1個に修正