### PR TITLE
修正: NG登録してもコメント一覧に反映されなかった

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -20,7 +20,8 @@ import {
   Statistics,
   UserFollowStatus,
   UserFollow,
-  AddFilterRecord
+  AddFilterRecord,
+  AddFilterResult
 } from './ResponseTypes';
 const { BrowserWindow } = remote;
 
@@ -386,7 +387,7 @@ export class NicoliveClient {
   async addFilters(
     programID: string,
     records: AddFilterRecord[],
-  ): Promise<WrappedResult<Filters['data']>> {
+  ): Promise<WrappedResult<AddFilterResult['data']>> {
     const session = await this.fetchSession();
     if (records.length !== 1) {
       throw new Error('addFilters: records.length must be 1');
@@ -403,7 +404,7 @@ export class NicoliveClient {
         `${NicoliveClient.live2BaseURL}/unama/tool/v2/programs/${programID}/ssng/create`,
         requestInit,
       );
-      return NicoliveClient.wrapResult<Filters['data']>(resp);
+      return NicoliveClient.wrapResult<AddFilterResult['data']>(resp);
     } catch (err) {
       return NicoliveClient.wrapFetchError(err as Error);
     }

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -207,6 +207,15 @@ export interface Filters {
   data: FilterRecord[];
 }
 
+export interface AddFilterResult {
+  meta: {
+    status: 200;
+  };
+  data: {
+    id: number;
+  };
+}
+
 export type OnairUserProgramData = {
   programId?: string;
   nextProgramId?: string;

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -85,7 +85,7 @@ test('addFilters/通常成功', async () => {
 
   const addFilters = jest
     .fn()
-    .mockResolvedValue({ ok: true, value: [{ type: 'word', body: '810', id: 114514 }] });
+    .mockResolvedValue({ ok: true, value: { id: 114514 } });
   (instance as any).client.addFilters = addFilters;
 
   const UPDATE_FILTERS = jest.fn();

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -87,6 +87,10 @@ test('addFilters/通常成功', async () => {
     .fn()
     .mockResolvedValue({ ok: true, value: { id: 114514 } });
   (instance as any).client.addFilters = addFilters;
+  const fetchFilters = jest
+    .fn()
+    .mockResolvedValue({ ok: true, value: [{ type: 'word', body: '810', id: 114514 }] });
+  (instance as any).client.fetchFilters = fetchFilters;
 
   const UPDATE_FILTERS = jest.fn();
   (instance as any).UPDATE_FILTERS = UPDATE_FILTERS;

--- a/app/services/nicolive-program/nicolive-comment-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.ts
@@ -83,17 +83,7 @@ export class NicoliveCommentFilterService extends StatefulService<INicoliveComme
     if (!isOk(result)) {
       throw NicoliveFailure.fromClientError('addFilters', result);
     }
-
-    const resultRecord = result.value.find(
-      (rec: FilterRecord) => rec.type === record.type && rec.body === record.body,
-    );
-
-    if (!resultRecord) {
-      // conflictしているので再取得しないとIDがわからない
-      return this.fetchFilters();
-    }
-    const filters = this.state.filters.concat(resultRecord);
-    this.updateFilters(filters);
+    return this.fetchFilters();
   }
 
   async deleteFilters(ids: number[]) {


### PR DESCRIPTION
# このpull requestが解決する内容
#692 によって、コメント一覧からNG追加したときに、コメント一覧が反映しない、というか、NG登録が一旦解消したかのような動作をしていたのを修正します。

# 詳細
`AddFilters` の戻り値が旧APIでは新しいフィルタ一覧だったのに対し、新しいAPIは一覧が返ってこないように変わっていたのに対応が漏れていたため、一覧が空になったような挙動になってしまった。
成功したときに一覧を取得しなおすことで修正。

# 関連するIssue（あれば）
fix #717