### PR TITLE
修正: ニコニコ生放送の最大放送時間を6時間から24時間に変更

### DIFF
--- a/app/services/nicolive-program/nicolive-constants.ts
+++ b/app/services/nicolive-program/nicolive-constants.ts
@@ -1,0 +1,3 @@
+
+export const MAX_PROGRAM_DURATION_SECONDS = 24 * 60 * 60; // 番組の最大放送時間(秒)
+

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -1,6 +1,7 @@
 import { createSetupFunction } from 'util/test-setup';
 import { WrappedResult } from './NicoliveClient';
 import { Community } from './ResponseTypes';
+import { MAX_PROGRAM_DURATION_SECONDS } from './nicolive-constants';
 
 type NicoliveProgramService = import('./nicolive-program').NicoliveProgramService;
 
@@ -140,13 +141,14 @@ test('isProgramExtendable', () => {
   const { NicoliveProgramService } = require('./nicolive-program');
   const { isProgramExtendable } = NicoliveProgramService;
 
-  expect(isProgramExtendable({ status: 'reserved', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(
+  const SAFE_TIME = MAX_PROGRAM_DURATION_SECONDS - 30 * 60;
+  expect(isProgramExtendable({ status: 'reserved', startTime: 0, endTime: SAFE_TIME })).toBe(
     false,
   );
-  expect(isProgramExtendable({ status: 'test', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(false);
-  expect(isProgramExtendable({ status: 'onAir', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(true);
-  expect(isProgramExtendable({ status: 'end', startTime: 0, endTime: 5.5 * 60 * 60 })).toBe(false);
-  expect(isProgramExtendable({ status: 'onAir', startTime: 0, endTime: 6 * 60 * 60 })).toBe(false);
+  expect(isProgramExtendable({ status: 'test', startTime: 0, endTime: SAFE_TIME })).toBe(false);
+  expect(isProgramExtendable({ status: 'onAir', startTime: 0, endTime: SAFE_TIME })).toBe(true);
+  expect(isProgramExtendable({ status: 'end', startTime: 0, endTime: SAFE_TIME })).toBe(false);
+  expect(isProgramExtendable({ status: 'onAir', startTime: 0, endTime: MAX_PROGRAM_DURATION_SECONDS })).toBe(false);
 });
 
 test('findSuitableProgram', () => {

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -7,11 +7,10 @@ import { CreateResult, EditResult, isOk, NicoliveClient } from './NicoliveClient
 import { NicoliveFailure, openErrorDialogFromFailure } from './NicoliveFailure';
 import { Community, ProgramSchedules } from './ResponseTypes';
 import { NicoliveProgramStateService } from './state';
+import { MAX_PROGRAM_DURATION_SECONDS } from './nicolive-constants';
 
 type Schedules = ProgramSchedules['data'];
 type Schedule = Schedules[0];
-
-const MAX_PROGRAM_DURATION_SECONDS = 24 * 60 * 60; // 番組の最大放送時間(秒)
 
 type ProgramState = {
   programID: string;

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -11,7 +11,7 @@ import { NicoliveProgramStateService } from './state';
 type Schedules = ProgramSchedules['data'];
 type Schedule = Schedules[0];
 
-const CREATED_NOTICE_DURATION = 5000; // 番組作成通知の表示時間(ミリ秒)
+const MAX_PROGRAM_DURATION_SECONDS = 24 * 60 * 60; // 番組の最大放送時間(秒)
 
 type ProgramState = {
   programID: string;
@@ -176,7 +176,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   static isProgramExtendable(state: INicoliveProgramState): boolean {
-    return state.status === 'onAir' && state.endTime - state.startTime < 6 * 60 * 60;
+    return state.status === 'onAir' && state.endTime - state.startTime < MAX_PROGRAM_DURATION_SECONDS;
   }
 
   static format(timeInSeconds: number): string {


### PR DESCRIPTION
# このpull requestが解決する内容
判定ないかと思ったらUI用の判定関数があったので6時間を越えた延長ができていなかったのを修正します...

