### PR TITLE
修正: 音声デバイスが一つも無いときにボイスチェンジャーソースが削除できなくなっていた (rtvcライブラリを1.0.4に更新)

### DIFF
--- a/scripts/install-native-deps.js
+++ b/scripts/install-native-deps.js
@@ -74,7 +74,7 @@ async function rtvc() {
   // cwd is node_modules
   log_info('copy rtvc');
 
-  const url = 'https://api.github.com/repos/n-air-app/rtvc_runtime/releases/assets/156223196';
+  const url = 'https://github.com/n-air-app/rtvc_plugin/releases/download/1.0.4/nair-rtvc.tar.gz';
   const zip = './nair-rtvc.tar.gz';
   const dst = './obs-studio-node/obs-plugins/64bit/';
 


### PR DESCRIPTION
# このpull requestが解決する内容
rtvcライブラリの更新
https://github.com/n-air-app/n-air-app/issues/728 の解決


# 動作確認手順
音声デバイスが無い状態で起動・ボイチェン追加・ボイチェン削除
更新前なら削除時にハングアップするため再起動後に削除が行われていない
更新後で再起動して削除されていれば成功

# 関連するIssue（あれば）

https://github.com/n-air-app/n-air-app/issues/728