### PR TITLE
開発: CI(test)を GitHub Actionsで実行する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,68 @@
+name: Test
+
+on:
+  push:
+    paths:
+      - package.json
+      - yarn.lock
+      - installer.nsh
+      - tsconfig.json
+      - webpack.config.js
+      - main.js
+      - app/**
+      - media/**
+      - nvoice/**
+      - obs-api/**
+      - scripts/**
+      - test/**
+      - updater/**
+      - vendor/**
+      - .github/workflows/test.yml
+
+  pull_request:
+    branches:
+      - n-air_development
+    paths:
+      - package.json
+      - yarn.lock
+      - installer.nsh
+      - tsconfig.json
+      - webpack.config.js
+      - main.js
+      - app/**
+      - media/**
+      - nvoice/**
+      - obs-api/**
+      - scripts/**
+      - test/**
+      - updater/**
+      - vendor/**
+      - .github/workflows/test.yml
+
+jobs:
+  test:
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: npm login
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> $env:USERPROFILE\.npmrc
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --check-files
+
+      - name: Compile
+        run: yarn compile:ci
+
+      - name: Run unit tests
+        run: yarn test:unit
+
+      - name: Run e2e tests
+        run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: yarn
 
       - name: npm login
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> $env:USERPROFILE\.npmrc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ build: off
 
 skip_commits:
   files:
-    - .github/*
+    # - .github/*
     - README.md
 
 install:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "test-dist/test/e2e/*.js",
       "test-dist/test/api/*.js"
     ],
-    "timeout": "2min",
+    "timeout": "3min",
     "serial": true
   },
   "prettier": {


### PR DESCRIPTION
# このpull requestが解決する内容
* `n-air_development` へのpull requestと、このリポジトリへのpushに対してGitHub Actionsでテストを実行するようにします。
  * マージされたら AppVeyorの設定を消します
* dependabot によって GitHub Actionsの依存の更新をチェックします。

# メモ
`actions/setup-node` で `yarn cache` のキャッシュを有効にしているので、キャッシュヒット時にはそのダウンロードに結構時間がかかりますが、キャッシュがないときに `yarn install` で結構依存ダウンロードのリトライが発生してるみたいなので(不安定?)、安全のためにキャッシュを使おうかなと。
