### PR TITLE
修正: 放送者NG上限表示を一般会員もプレミアム会員と同じ500に

### DIFF
--- a/app/components/nicolive-area/CommentFilter.vue.ts
+++ b/app/components/nicolive-area/CommentFilter.vue.ts
@@ -88,7 +88,7 @@ export default class CommentFilter extends Vue {
   }
 
   get maxCount() {
-    return this.userService.isPremium ? 500 : 40;
+    return 500;
   }
 
   get invalid(): boolean {


### PR DESCRIPTION
# このpull requestが解決する内容
fix #734 

# 動作確認手順
* 一般会員でニコニコにログインし、ニコニコ生放送の番組を作成し、コメント一覧のNG設定画面を開くと、以下の様に上限が500になっていること
 
![image](https://github.com/n-air-app/n-air-app/assets/864587/29e012fd-6990-4205-9fd5-63d19f94daf0)


# 関連するIssue（あれば）
#734 