### PR TITLE
調査用: ボイスチェンジャーソースが一覧に出ないときに音声ソース一覧とOBSログをSentryに送信する

### DIFF
--- a/app/components/Mixer.vue.ts
+++ b/app/components/Mixer.vue.ts
@@ -32,9 +32,7 @@ export default class Mixer extends Vue {
   }
 
   get audioSources() {
-    return this.audioService.getSourcesForCurrentScene().filter(source => {
-      return !source.mixerHidden && source.isControlledViaObs;
-    });
+    return this.audioService.getVisibleSourcesForCurrentScene();
   }
 
   get isCompactMode(): boolean {

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -117,6 +117,12 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     return this.getSourcesForScene(this.scenesService.activeSceneId);
   }
 
+  getVisibleSourcesForCurrentScene(): AudioSource[] {
+    return this.getSourcesForCurrentScene().filter(
+      source => !source.mixerHidden && source.isControlledViaObs,
+    );
+  }
+
   getSourcesForScene(sceneId: string): AudioSource[] {
     const scene = this.scenesService.getScene(sceneId);
     if (!scene) {

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -377,9 +377,10 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
         .getVisibleSourcesForCurrentScene()
         .map(source => source.name);
       const obsLog = ipcRenderer.sendSync('get-latest-obs-log');
+      const obsPluginFiles = ipcRenderer.sendSync('get-obs-plugin-files-list');
       console.info({
         audioDevices,
-        obsLog: { filename: obsLog.filename, length: obsLog.data.length },
+        obsLog: { filename: obsLog.filename, length: obsLog.data.length, obsPluginFiles },
       });
 
       Sentry.withScope(scope => {
@@ -396,8 +397,10 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
           contentType: 'text/plain',
         });
 
-        // get list of available audio sources
+        // list of available audio sources
         scope.setExtra('audioSource', audioDevices);
+        // list of OBS plugin files
+        scope.setExtra('obsPluginFiles', obsPluginFiles);
 
         scope.setFingerprint(['nair-rtvc-source']);
         Sentry.captureMessage('nair-rtvc-source is not available');

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -29,6 +29,8 @@ import { UserService } from 'services/user';
 import { NVoiceCharacterTypes } from 'services/nvoice-character';
 import { InitAfter } from 'services/core';
 import { RtvcStateService } from '../../services/rtvcStateService';
+import * as Sentry from '@sentry/vue';
+import { ipcRenderer } from 'electron';
 
 const AudioFlag = obs.ESourceOutputFlags.Audio;
 const VideoFlag = obs.ESourceOutputFlags.Video;
@@ -367,6 +369,41 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     const availableWhitelistedType = whitelistedTypes.filter(type =>
       obsAvailableTypes.includes(type),
     );
+
+    // for investigation: if 'nair-rtvc-source' is not in the list, send a log via Sentry
+    if (!availableWhitelistedType.includes('nair-rtvc-source')) {
+      console.info('nair-rtvc-source is not available');
+      const audioDevices = this.audioService
+        .getVisibleSourcesForCurrentScene()
+        .map(source => source.name);
+      const obsLog = ipcRenderer.sendSync('get-latest-obs-log');
+      console.info({
+        audioDevices,
+        obsLog: { filename: obsLog.filename, length: obsLog.data.length },
+      });
+
+      Sentry.withScope(scope => {
+        scope.setLevel('error');
+        scope.setTags({
+          'nair-rtvc-source': 'not-available',
+          audioDevices: audioDevices.length,
+        });
+
+        // attach obs log
+        scope.addAttachment({
+          filename: obsLog.filename,
+          data: obsLog.data,
+          contentType: 'text/plain',
+        });
+
+        // get list of available audio sources
+        scope.setExtra('audioSource', audioDevices);
+
+        scope.setFingerprint(['nair-rtvc-source']);
+        Sentry.captureMessage('nair-rtvc-source is not available');
+      });
+    }
+
     // 'scene' is not an obs input type so we have to set it manually
     availableWhitelistedType.push('scene');
 

--- a/main.js
+++ b/main.js
@@ -147,6 +147,24 @@ function initialize(crashHandler) {
     });
   }
 
+  ipcMain.on('get-latest-obs-log', e => {
+    const logDir = path.join(app.getPath('userData'), 'node-obs', 'logs');
+
+    // get the latest log file pattern: 'yyyy-mm-dd hh-mm-ss.txt'; sort by name
+    const files = fs.readdirSync(logDir);
+    files.sort();
+    const latestFilename = files.pop();
+    const latestPathname = path.join(logDir, latestFilename);
+
+    // get file body and return
+    const data = fs.readFileSync(latestPathname, 'utf8');
+    console.log('Read OBS log file:', latestPathname, data.length, 'bytes');
+    e.returnValue = {
+      filename: latestFilename,
+      data,
+    };
+  });
+
   const consoleLog = console.log;
   console.log = (...args) => {
     if (!process.env.NAIR_DISABLE_MAIN_LOGGING) {

--- a/main.js
+++ b/main.js
@@ -152,6 +152,14 @@ function initialize(crashHandler) {
 
     // get the latest log file pattern: 'yyyy-mm-dd hh-mm-ss.txt'; sort by name
     const files = fs.readdirSync(logDir);
+    if (files.length === 0) {
+      e.returnValue = {
+        filename: 'no log file found',
+        data: null,
+      };
+      return;
+    }
+
     files.sort();
     const latestFilename = files.pop();
     const latestPathname = path.join(logDir, latestFilename);

--- a/main.js
+++ b/main.js
@@ -194,9 +194,10 @@ function initialize(crashHandler) {
       'obs-plugins',
       '64bit',
     );
+    console.log('get-obs-plugin-files-list:', pluginDir);
 
     const files = getFileListRecursive(pluginDir);
-    e.returnValue = files;
+    e.returnValue = { path: pluginDir, files };
   });
 
   const consoleLog = console.log;

--- a/main.js
+++ b/main.js
@@ -173,6 +173,32 @@ function initialize(crashHandler) {
     };
   });
 
+  function getFileListRecursive(dir, prefix = '') {
+    const files = fs.readdirSync(path.join(dir, prefix));
+    return files.flatMap(file => {
+      const pathname = path.join(dir, prefix, file);
+      const stat = fs.statSync(pathname);
+      if (stat.isDirectory()) {
+        return getFileListRecursive(dir, path.join(prefix, file));
+      } else {
+        return [path.join(prefix, file)];
+      }
+    });
+  }
+
+  ipcMain.on('get-obs-plugin-files-list', e => {
+    const pluginDir = path.join(
+      app.getAppPath().replace('app.asar', 'app.asar.unpacked'),
+      'node_modules',
+      'obs-studio-node',
+      'obs-plugins',
+      '64bit',
+    );
+
+    const files = getFileListRecursive(pluginDir);
+    e.returnValue = files;
+  });
+
   const consoleLog = console.log;
   console.log = (...args) => {
     if (!process.env.NAIR_DISABLE_MAIN_LOGGING) {


### PR DESCRIPTION
# このpull requestが解決する内容
#733 の調査用
* extra に以下の内容を追加
  * audioSource: 音声ソースの名前一覧
  * obsPluginFiles: OBSプラグインディレクトリのファイル名一覧(再帰的に検索し、相対パスをファイル名にprefix)
* attachmentsにnode-obs ログファイルの最新の内容を添付

ソース追加ウィンドウを開く度に送信してしまうけど、回数はそんなに出ないはずなので、単純化のために送信削減ロジックは入れてません

- [x] Sentryにログを試しに送信してみる

# 関連するIssue（あれば）
#733 