### PR TITLE
Sentry: 一度出始めると出続けるIPC error送信を削減

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -69,7 +69,6 @@ if (isProduction) {
       processType: 'renderer',
     },
   });
-
 }
 
 const SENTRY_SERVER_URL = getSentryCrashReportUrl(sentryParam);
@@ -110,10 +109,23 @@ window.addEventListener('unhandledrejection', e => {
 });
 
 if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.process.env.NAIR_IPC) {
-  Sentry.init({
-    sampleRate: /* isPreview ? */ 1.0 /* : 0.1 */,
-    Vue,
-  }, sentryVueInit);
+  Sentry.init(
+    {
+      sampleRate: /* isPreview ? */ 1.0 /* : 0.1 */,
+      Vue,
+      beforeSend(event) {
+        // 一度出始めると大量に送信しつづける IPC error のSentry送信を削減する(quota対策)
+        if (event.exception && event.exception.values) {
+          const value = event.exception.values[0].value;
+          if (value.match(/Failed to make IPC call/)) {
+            console.log(`skip send to Sentry(IPC): ${value}`, event);
+            return null;
+          }
+        }
+      },
+    },
+    sentryVueInit,
+  );
 
   const oldConsoleError = console.error;
 
@@ -175,7 +187,8 @@ export const apiInitErrorResultToMessage = (resultCode: obs.EVideoCodes) => {
 const showDialog = (message: string): void => {
   electron.remote.dialog.showErrorBox(
     locale === 'ja' ? '初期化エラー' : 'Initialization Error',
-    message);
+    message,
+  );
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/app.ts
+++ b/app/app.ts
@@ -122,6 +122,7 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !electron.remote.proc
             return null;
           }
         }
+        return event;
       },
     },
     sentryVueInit,


### PR DESCRIPTION
# このpull requestが解決する内容
Sentryの event数を大量消費している、`Failed to make IPC call` というエラーの送信を抑制して、Sentryのquota圧迫を抑えます...
![image](https://github.com/n-air-app/n-air-app/assets/864587/cbf0b2bb-5a6a-4cf2-a3c3-3388b8709573)

* このエラーは、一度起き始めると延々と送信されるため、Sentryの契約容量を圧迫しています。
* 送信を抑制する代わりに consoleに出すため、sentryの他のイベントが送信されたときにはログ部分で確認できます。また、このイベントをキャッチしてeventを送っている部分もあるため、二重送信になっていたというのもあります。
* 私の環境ではこのエラーを再現できていないため、これで本当に動作するかは確認できていません。(試しにほかのエラーについては確認ました)
