### PR TITLE
修正: シーン変更などでボイスチェンジャー部分で "Error: [vuex] dont mutate vuex store state outside mutation handles"と出ていた

### DIFF
--- a/app/services/rtvcStateService.ts
+++ b/app/services/rtvcStateService.ts
@@ -138,8 +138,7 @@ export class RtvcStateService extends PersistentStatefulService<IRtvcState> {
   // -- state params
 
   getState(): StateParam {
-    let r = this.state.value as StateParam;
-    if (!r) r = {} as StateParam;
+    const r = { ...this.state.value } as StateParam;
 
     if (!r.presets) r.presets = [];
     while (r.presets.length < PresetValues.length) r.presets.push({ pitchShift: 0 });


### PR DESCRIPTION
# このpull requestが解決する内容

ボイチェンのstateがvueでmutate warning を起こす解決
objectのcopyを行う

# 動作確認手順

改修前
ボイチェンのプロパティを開け閉めしてシーンを変えて再度行う。この時デバッグログに
`Error in callback for watcher "funtion () { return this._data.$$state }" : "Error: [vuex] dont mutate vuex store state outside mutation handlers. ` 
といったワーニングが出る


# 関連するIssue（あれば）
