### PR TITLE
改善: ウィンドウキャプチャソースのプロパティウィンドウを開く時のちらつきを解消

### DIFF
--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -46,7 +46,9 @@ export default class SourceProperties extends Vue {
   }
 
   get sourceId() {
-    return this.windowsService.getWindowOptions(this.windowId).sourceId;
+    // このビューはoneOffWindow と childWindow どちらからも開かれる可能性があるため
+    // どちらか有効な方のクエリパラメータから sourceId を取得する
+    return this.windowsService.getWindowOptions(this.windowId).sourceId || this.windowsService.getChildWindowQueryParams().sourceId;
   }
 
   refreshTimer: NodeJS.Timeout = undefined;
@@ -98,7 +100,7 @@ export default class SourceProperties extends Vue {
   }
 
   closeWindow() {
-    this.sourcesService.closeSourcePropertiesWindow();
+    this.windowsService.closeChildWindow();
   }
 
   done() {

--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -46,9 +46,7 @@ export default class SourceProperties extends Vue {
   }
 
   get sourceId() {
-    // このビューはoneOffWindow と childWindow どちらからも開かれる可能性があるため
-    // どちらか有効な方のクエリパラメータから sourceId を取得する
-    return this.windowsService.getWindowOptions(this.windowId).sourceId || this.windowsService.getChildWindowQueryParams().sourceId;
+    return this.windowsService.getWindowOptions(this.windowId).sourceId;
   }
 
   refreshTimer: NodeJS.Timeout = undefined;
@@ -100,11 +98,7 @@ export default class SourceProperties extends Vue {
   }
 
   closeWindow() {
-    if (this.sourceId.startsWith("window_capture")) {
-      this.sourcesService.closeSourcePropertiesWindow();
-    } else {
-      this.windowsService.closeChildWindow();
-    }
+    this.sourcesService.closeSourcePropertiesWindow();
   }
 
   done() {

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -63,7 +63,6 @@ export interface ISourcesServiceApi {
   getSources(): ISourceApi[];
   getSource(sourceId: string): ISourceApi;
   getSourcesByName(name: string): ISourceApi[];
-  closeSourcePropertiesWindow(): Promise<void>;
 
   /**
    * creates a source from a file

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -56,8 +56,6 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     temporarySources: {}, // don't save temporarySources in the config file
   } as ISourcesState;
 
-  private static readonly sourcePropertiesWindowId = 'sourcePropertiesWindow';
-
   sourceAdded = new Subject<ISource>();
   sourceUpdated = new Subject<ISource>();
   sourceRemoved = new Subject<ISource>();
@@ -567,38 +565,15 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
     if (source.type === 'nair-rtvc-source') baseConfig.componentName = 'RtvcSourceProperties';
 
-    // HACK: childWindow で表示してしまうとウィンドウキャプチャでクラッシュするので OneOffWindow で代替している
-    // StreamLabs 1.3.0 まで追従したらこのワークアラウンドはなくせる
-    this.windowsService.closeChildWindow();
-    (this.windowsService.getWindow(SourcesService.sourcePropertiesWindowId)
-      ? this.closeSourcePropertiesWindow()
-      : Promise.resolve()
-    ).then(() => {
-      if (!sourceId.startsWith('window_capture')) {
-        this.windowsService.showWindow(baseConfig);
-        return;
-      }
-      this.windowsService.createOneOffWindow(
-        {
-          componentName: 'SourceProperties',
-          title: $t('sources.propertyWindowTitle', { sourceName: source.name }),
-          queryParams: { sourceId },
-          size: {
-            width: 600,
-            height: 600,
-          },
-          limitMinimumSize: true, // 小さくできなくする
-          // alwaysOnTop を利用した場合、メインウィンドウの背面に隠れることは防げるが、
-          // N Air 以外のウィンドウよりも前面に出てしまう
-          alwaysOnTop: true,
-        },
-        SourcesService.sourcePropertiesWindowId,
-      );
+    this.windowsService.showWindow({
+      componentName: 'SourceProperties',
+      title: $t('sources.propertyWindowTitle', { sourceName: source.name }),
+      queryParams: { sourceId },
+      size: {
+        width: 600,
+        height: 600,
+      },
     });
-  }
-
-  async closeSourcePropertiesWindow() {
-    await this.windowsService.closeOneOffWindow(SourcesService.sourcePropertiesWindowId);
   }
 
   showShowcase() {

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -580,7 +580,13 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       }
       this.windowsService.createOneOffWindow(
         {
-          ...baseConfig,
+          componentName: 'SourceProperties',
+          title: $t('sources.propertyWindowTitle', { sourceName: source.name }),
+          queryParams: { sourceId },
+          size: {
+            width: 600,
+            height: 600,
+          },
           limitMinimumSize: true, // 小さくできなくする
           // alwaysOnTop を利用した場合、メインウィンドウの背面に隠れることは防げるが、
           // N Air 以外のウィンドウよりも前面に出てしまう
@@ -592,7 +598,6 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   async closeSourcePropertiesWindow() {
-    this.windowsService.closeChildWindow();
     await this.windowsService.closeOneOffWindow(SourcesService.sourcePropertiesWindowId);
   }
 

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -553,7 +553,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       return;
     }
 
-    const baseConfig = {
+    const config = {
       componentName: 'SourceProperties',
       title: $t('sources.propertyWindowTitle', { sourceName: source.name }),
       queryParams: { sourceId },
@@ -563,17 +563,9 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       },
     };
 
-    if (source.type === 'nair-rtvc-source') baseConfig.componentName = 'RtvcSourceProperties';
+    if (source.type === 'nair-rtvc-source') config.componentName = 'RtvcSourceProperties';
 
-    this.windowsService.showWindow({
-      componentName: 'SourceProperties',
-      title: $t('sources.propertyWindowTitle', { sourceName: source.name }),
-      queryParams: { sourceId },
-      size: {
-        width: 600,
-        height: 600,
-      },
-    });
+    this.windowsService.showWindow(config);
   }
 
   showShowcase() {

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -175,12 +175,6 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
     ipcRenderer.send('window-showChildWindow', options);
     this.updateChildWindowOptions(options);
-
-    // HACK: ソースプロパティウィンドウを oneOffWindow で開いている場合は閉じる
-    // (childウィンドウで開く場合を模倣するため)
-    if (this.windows['sourcePropertiesWindow']) {
-      this.closeOneOffWindow('sourcePropertiesWindow');
-    }
   }
 
   closeChildWindow() {

--- a/test/e2e/sources.js
+++ b/test/e2e/sources.js
@@ -17,7 +17,7 @@ const sourceTypes = [
   'wasapi_output_capture',
   'wasapi_input_capture',
   'game_capture',
-  // 'window_capture', // TODO: oneOffWindow にしているが、addSource() がchildWindow 専用なのでテストできない
+  'window_capture',
   'monitor_capture',
   'image_source',
   'slideshow',

--- a/test/e2e/sources.js
+++ b/test/e2e/sources.js
@@ -17,7 +17,7 @@ const sourceTypes = [
   'wasapi_output_capture',
   'wasapi_input_capture',
   'game_capture',
-  'window_capture',
+  // 'window_capture', // TODO: oneOffWindow にしているが、addSource() がchildWindow 専用なのでテストできない
   'monitor_capture',
   'image_source',
   'slideshow',

--- a/test/helpers/spectron/index.ts
+++ b/test/helpers/spectron/index.ts
@@ -31,9 +31,8 @@ async function focusWindow(t: any, regex: RegExp) {
   for (const handle of handles.value) {
     await t.context.app.client.window(handle);
     const url = await t.context.app.client.getUrl();
-    if (url.match(regex)) return true;
+    if (url.match(regex)) return;
   }
-  return false;
 }
 
 // Focuses the main window
@@ -44,12 +43,6 @@ export async function focusMain(t: any) {
 // Focuses the child window
 export async function focusChild(t: any) {
   await focusWindow(t, /windowId=child/);
-}
-
-export async function focusSourcePropertiesWindow(t: any) {
-  while (!(await focusWindow(t, /windowId=sourcePropertiesWindow/))) {
-    await sleep(500);
-  }
 }
 
 export async function waitForLoader(t: any) {

--- a/test/helpers/spectron/sources.js
+++ b/test/helpers/spectron/sources.js
@@ -1,5 +1,5 @@
 // Source helper functions
-import { focusMain, focusChild, focusSourcePropertiesWindow } from '.';
+import { focusMain, focusChild } from '.';
 import { contextMenuClick } from './context-menu';
 import { dialogDismiss } from './dialog';
 
@@ -64,16 +64,9 @@ export async function addSource(t, type, name, closeProps = true) {
 
   // Close source properties too
   if (closeProps) {
-    if (type === 'window_capture') {
-      await focusSourcePropertiesWindow(t);
-    }
     await app.client.click('[data-test="Done"]');
   } else {
-    if (type === 'window_capture') {
-      await focusSourcePropertiesWindow(t);
-    } else {
-      await focusChild(t);
-    }
+    await focusChild(t);
   }
 }
 


### PR DESCRIPTION
# このpull requestが解決する内容
OBS Studio 本体のバージョンアップによって、SourceProperties ウィンドウを child ウィンドウで開いてもクラッシュしなくなったので、OneOffWindow を使ったワークアラウンドを取り消します。

これにより、 SourceProperties ウィンドウが一瞬真っ白にならず、スムースに開くようになります。

# 動作確認手順
- yarn compile
- yarn start
- ウィンドウキャプチャソースを選択

# 関連するIssue（あれば）
reverts https://github.com/koizuka/n-air-app/pull/29
https://github.com/n-air-app/n-air-app/pull/574