### PR TITLE
開発: GitHub Actionsのnodeを20.12.1に固定する(現行のe2e testを通すための一時的措置)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.12.1
           cache: yarn
 
       - name: npm login


### PR DESCRIPTION
# このpull requestが解決する内容
fix #747
[node.js 20.12.2](https://nodejs.org/en/blog/release/v20.12.2) の変更で落ちるようになったようなので、一旦 node 20.12.1 で固定します。

- [x] CIが成功すれば ok

# 関連するIssue（あれば）
#747