### PR TITLE
開発: Bump typescript from 4.9.5 to 5.5.4

### DIFF
--- a/app/components/ApiSettings.vue.ts
+++ b/app/components/ApiSettings.vue.ts
@@ -5,6 +5,7 @@ import GenericFormGroups from 'components/obs/inputs/GenericFormGroups.vue';
 import ObsTextInput from 'components/obs/inputs/ObsTextInput.vue';
 import { ITcpServerServiceApi, ITcpServersSettings } from '../services/api/tcp-server';
 import { ISettingsSubCategory } from '../services/settings';
+import { TObsValue } from './obs/inputs/ObsInput';
 
 @Component({
   components: { GenericFormGroups, ObsTextInput },
@@ -39,7 +40,7 @@ export default class ApiSettings extends Vue {
   }
 
   save(settingsData: ISettingsSubCategory[]) {
-    const settings: Partial<ITcpServersSettings> = {};
+    const settings: Dictionary<Dictionary<TObsValue>> = {};
     settingsData.forEach(subCategory => {
       subCategory.parameters.forEach(parameter => {
         if (!settings[subCategory.codeSubCategory]) settings[subCategory.codeSubCategory] = {};

--- a/app/components/AppearanceSettings.vue.ts
+++ b/app/components/AppearanceSettings.vue.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Inject } from '../services/core/injector';
 import GenericForm from 'components/obs/inputs/GenericForm.vue';
-import { TObsFormData } from 'components/obs/inputs/ObsInput';
+import { TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { ICustomizationServiceApi, ICustomizationSettings } from 'services/customization';
 
 @Component({
@@ -18,7 +18,7 @@ export default class AppearanceSettings extends Vue {
   }
 
   saveSettings(formData: TObsFormData) {
-    const settings: Partial<ICustomizationSettings> = {};
+    const settings: Dictionary<TObsValue> = {};
     formData.forEach(formInput => {
       settings[formInput.name] = formInput.value;
     });

--- a/app/components/NotificationsSettings.vue.ts
+++ b/app/components/NotificationsSettings.vue.ts
@@ -3,7 +3,7 @@ import { Component } from 'vue-property-decorator';
 import { Inject } from '../services/core/injector';
 import GenericForm from 'components/obs/inputs/GenericForm.vue';
 import { INotificationsServiceApi, INotificationsSettings } from 'services/notifications';
-import { TObsFormData } from 'components/obs/inputs/ObsInput';
+import { TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { ITroubleshooterServiceApi, ITroubleshooterSettings } from 'services/troubleshooter';
 
 @Component({
@@ -21,7 +21,7 @@ export default class NotificationsSettings extends Vue {
   }
 
   saveNotificationsSettings(formData: TObsFormData) {
-    const settings: Partial<INotificationsSettings> = {};
+    const settings: Dictionary<TObsValue> = {};
     formData.forEach(formInput => {
       settings[formInput.name] = formInput.value;
     });
@@ -30,7 +30,7 @@ export default class NotificationsSettings extends Vue {
   }
 
   saveTroubleshooterSettings(formData: TObsFormData) {
-    const settings: Partial<ITroubleshooterSettings> = {};
+    const settings: Dictionary<TObsValue> = {};
     formData.forEach(formInput => {
       settings[formInput.name] = formInput.value;
     });

--- a/app/components/SourceSelector.vue.ts
+++ b/app/components/SourceSelector.vue.ts
@@ -83,7 +83,7 @@ export default class SourceSelector extends Vue {
       case 'custom-cast-ndi':
         return sourceIconMap['custom_cast_ndi_source'];
       default:
-        return sourceIconMap[sourceDetails.type] || 'icon-file';
+        return (sourceIconMap as Dictionary<string>)[sourceDetails.type] || 'icon-file';
     }
   }
 

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -14,7 +14,7 @@ import { TransitionsService } from 'services/transitions';
 import { CustomizationService } from 'services/customization';
 
 interface IResizeRegion {
-  name: string;
+  name: 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
   x: number;
   y: number;
   width: number;

--- a/app/components/obs/inputs/Components.ts
+++ b/app/components/obs/inputs/Components.ts
@@ -7,6 +7,7 @@ const inputComponents = comps as any as { [key: string]: typeof TsxComponent };
 
 export function propertyComponentForType(type: TObsType): typeof TsxComponent {
   const componentName = Object.keys(inputComponents).find(name => {
+    // @ts-expect-error ts7053
     const componentObsType = inputComponents[name]['obsType'];
     return Array.isArray(componentObsType)
       ? componentObsType.includes(type)

--- a/app/components/obs/inputs/ObsFontInput.vue.ts
+++ b/app/components/obs/inputs/ObsFontInput.vue.ts
@@ -41,6 +41,7 @@ class ObsFontInput extends ObsInput<IObsInput<IObsFont>> {
   }
 
   setFontType(e: Event) {
+    // @ts-expect-error ts7053
     this.isGoogleFont = e.target['checked'];
   }
 }

--- a/app/components/obs/inputs/ObsFontInput.vue.ts
+++ b/app/components/obs/inputs/ObsFontInput.vue.ts
@@ -41,8 +41,7 @@ class ObsFontInput extends ObsInput<IObsInput<IObsFont>> {
   }
 
   setFontType(e: Event) {
-    // @ts-expect-error ts7053
-    this.isGoogleFont = e.target['checked'];
+    this.isGoogleFont = (e.target as HTMLInputElement)['checked'];
   }
 }
 

--- a/app/components/obs/inputs/ObsTextInput.vue.ts
+++ b/app/components/obs/inputs/ObsTextInput.vue.ts
@@ -16,8 +16,7 @@ class ObsTextInput extends ObsInput<IObsInput<string>> {
   }
 
   onInputHandler(event: Event) {
-    // @ts-expect-error ts7053
-    this.emitInput({ ...this.value, value: event.target['value'] });
+    this.emitInput({ ...this.value, value: (event.target as HTMLInputElement)['value'] });
   }
 }
 

--- a/app/components/obs/inputs/ObsTextInput.vue.ts
+++ b/app/components/obs/inputs/ObsTextInput.vue.ts
@@ -16,6 +16,7 @@ class ObsTextInput extends ObsInput<IObsInput<string>> {
   }
 
   onInputHandler(event: Event) {
+    // @ts-expect-error ts7053
     this.emitInput({ ...this.value, value: event.target['value'] });
   }
 }

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 import { Component, Prop } from 'vue-property-decorator';
 import uuid from 'uuid/v4';
 import { IInputMetadata } from './index';
+import { getKeys } from 'util/getKeys';
 
 export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends Vue {
   @Prop()
@@ -35,8 +36,7 @@ export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends
    */
   get validate() {
     const validations = this.getValidations();
-    Object.keys(validations).forEach(k => {
-      const key = k as keyof typeof validations;
+    getKeys(validations).forEach(key => {
       // VeeValidate recognizes undefined values as valid constraints
       // so just remove it
       if (validations[key] === void 0) delete validations[key];

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -22,6 +22,7 @@ export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends
 
   emitInput(eventData: TValueType, event?: any) {
     this.$emit('input', eventData, event);
+    // @ts-expect-error ts7053
     if (this.$parent['emitInput']) this.$parent['emitInput'](eventData, event);
   }
 
@@ -34,7 +35,8 @@ export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends
    */
   get validate() {
     const validations = this.getValidations();
-    Object.keys(validations).forEach(key => {
+    Object.keys(validations).forEach(k => {
+      const key = k as keyof typeof validations;
       // VeeValidate recognizes undefined values as valid constraints
       // so just remove it
       if (validations[key] === void 0) delete validations[key];

--- a/app/components/tsx-component.ts
+++ b/app/components/tsx-component.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 export function createProps<TProps extends new () => any>(
   propsClass: TProps,
 ): Dictionary<{ default: any }> {
-  const propsObj = {};
+  const propsObj: Dictionary<any> = {};
   const props = new propsClass();
   Object.keys(props).forEach((key: string) => {
     propsObj[key] = { default: props[key] };

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -38,7 +38,7 @@ export class ServicesManager extends Service {
   init() {
     // this helps to debug services from the console
     if (Utils.isDevMode()) {
-      // @ts-ignore
+      // @ts-expect-error ts7015 consoleデバッグ用
       window['sm'] = this;
     }
 

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -38,6 +38,7 @@ export class ServicesManager extends Service {
   init() {
     // this helps to debug services from the console
     if (Utils.isDevMode()) {
+      // @ts-ignore
       window['sm'] = this;
     }
 
@@ -71,7 +72,7 @@ export class ServicesManager extends Service {
   }
 
   getStatefulServicesAndMutators(): Dictionary<typeof StatefulService> {
-    const statefulServices = {};
+    const statefulServices: Dictionary<any> = {};
     Object.keys(this.services).forEach(serviceName => {
       const ServiceClass = this.services[serviceName];
       const isStatefulService = ServiceClass['initialState'];

--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -73,6 +73,7 @@ export class ExternalApiService extends RpcApi {
   init() {
     // initialize all singletons
     Object.keys(this.resources).forEach(resourceName => {
+      // @ts-expect-error
       const Resource = this.resources[resourceName];
       if (Resource.isSingleton) this.instances[resourceName] = new Resource();
     });
@@ -91,6 +92,7 @@ export class ExternalApiService extends RpcApi {
     const helperName = resourceId.split('[')[0];
     const constructorArgsStr = resourceId.substr(helperName.length);
     const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : void 0;
+    // @ts-expect-error ts7053
     const Helper = this.resources[helperName];
     if (Helper) {
       return this.applyFallbackProxy(new (Helper as any)(...constructorArgs));

--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -64,7 +64,7 @@ export class ExternalApiService extends RpcApi {
    * List of all API resources
    * @see RpcApi.getResource()
    */
-  private resources = { ...apiResources };
+  private resources: Dictionary<any> = { ...apiResources };
   /**
    * Instances of singleton resources
    */
@@ -73,7 +73,6 @@ export class ExternalApiService extends RpcApi {
   init() {
     // initialize all singletons
     Object.keys(this.resources).forEach(resourceName => {
-      // @ts-expect-error ts7053
       const Resource = this.resources[resourceName];
       if (Resource.isSingleton) this.instances[resourceName] = new Resource();
     });
@@ -92,7 +91,6 @@ export class ExternalApiService extends RpcApi {
     const helperName = resourceId.split('[')[0];
     const constructorArgsStr = resourceId.substr(helperName.length);
     const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : void 0;
-    // @ts-expect-error ts7053
     const Helper = this.resources[helperName];
     if (Helper) {
       return this.applyFallbackProxy(new (Helper as any)(...constructorArgs));

--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -73,7 +73,7 @@ export class ExternalApiService extends RpcApi {
   init() {
     // initialize all singletons
     Object.keys(this.resources).forEach(resourceName => {
-      // @ts-expect-error
+      // @ts-expect-error ts7053
       const Resource = this.resources[resourceName];
       if (Resource.isSingleton) this.instances[resourceName] = new Resource();
     });

--- a/app/services/api/internal-api-client.ts
+++ b/app/services/api/internal-api-client.ts
@@ -41,22 +41,29 @@ export class InternalApiClient {
 
     return new Proxy(service, {
       get: (target, property, receiver) => {
+        // @ts-expect-error ts7053
         if (!target[property]) return target[property];
 
+        // @ts-expect-error ts7053
         if (target[property]._isHelper) {
+          // @ts-expect-error ts7053
           return this.applyIpcProxy(target[property]);
         }
 
         if (Reflect.getMetadata('executeInCurrentWindow', target, property as string)) {
+          // @ts-expect-error ts7053
           return target[property];
         }
 
+        // @ts-expect-error ts7053
         if (typeof target[property] !== 'function' && !(target[property] instanceof Observable)) {
+          // @ts-expect-error ts7053
           return target[property];
         }
 
         const serviceName = target.constructor.name;
         const methodName = property;
+        // @ts-expect-error ts7053
         const isHelper = target['_isHelper'];
 
         const handler = (...args: any[]) => {
@@ -74,6 +81,7 @@ export class InternalApiClient {
           const response: IJsonRpcResponse<any> = electron.ipcRenderer.sendSync(
             'services-request',
             this.jsonrpc.createRequestWithOptions(
+              // @ts-expect-error ts7053
               isHelper ? target['_resourceId'] : serviceName,
               methodName as string,
               { compactMode: true, fetchMutations: true },
@@ -124,7 +132,9 @@ export class InternalApiClient {
           return result;
         };
 
+        // @ts-expect-error ts7053
         if (typeof target[property] === 'function') return handler;
+        // @ts-expect-error ts7053
         if (target[property] instanceof Observable) return handler();
       },
     });

--- a/app/services/api/internal-api-client.ts
+++ b/app/services/api/internal-api-client.ts
@@ -40,30 +40,23 @@ export class InternalApiClient {
     if (!availableServices.includes(service.constructor.name)) return service;
 
     return new Proxy(service, {
-      get: (target, property, receiver) => {
-        // @ts-expect-error ts7053
+      get: (target: { [key: string | symbol]: any }, property, receiver) => {
         if (!target[property]) return target[property];
 
-        // @ts-expect-error ts7053
         if (target[property]._isHelper) {
-          // @ts-expect-error ts7053
           return this.applyIpcProxy(target[property]);
         }
 
         if (Reflect.getMetadata('executeInCurrentWindow', target, property as string)) {
-          // @ts-expect-error ts7053
           return target[property];
         }
 
-        // @ts-expect-error ts7053
         if (typeof target[property] !== 'function' && !(target[property] instanceof Observable)) {
-          // @ts-expect-error ts7053
           return target[property];
         }
 
         const serviceName = target.constructor.name;
         const methodName = property;
-        // @ts-expect-error ts7053
         const isHelper = target['_isHelper'];
 
         const handler = (...args: any[]) => {
@@ -81,7 +74,6 @@ export class InternalApiClient {
           const response: IJsonRpcResponse<any> = electron.ipcRenderer.sendSync(
             'services-request',
             this.jsonrpc.createRequestWithOptions(
-              // @ts-expect-error ts7053
               isHelper ? target['_resourceId'] : serviceName,
               methodName as string,
               { compactMode: true, fetchMutations: true },
@@ -132,12 +124,10 @@ export class InternalApiClient {
           return result;
         };
 
-        // @ts-expect-error ts7053
         if (typeof target[property] === 'function') return handler;
-        // @ts-expect-error ts7053
         if (target[property] instanceof Observable) return handler();
       },
-    });
+    }) as Service;
   }
 
   getResource(resourceId: string) {

--- a/app/services/api/rpc-api.ts
+++ b/app/services/api/rpc-api.ts
@@ -248,7 +248,7 @@ export abstract class RpcApi extends Service {
       this.requestErrors.push(`Resource not found: ${resourceId}`);
       return null;
     }
-    const resourceScheme = {};
+    const resourceScheme: Dictionary<any> = {};
 
     // collect resource keys from the whole prototype chain
     const keys: string[] = [];
@@ -265,7 +265,7 @@ export abstract class RpcApi extends Service {
     return resourceScheme;
   }
 
-  private getResourceModel(helper: Object): Object {
+  private getResourceModel(helper: Dictionary<any>): Object {
     if (helper['getModel'] && typeof helper['getModel'] === 'function') {
       return helper['getModel']();
     }

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -25,6 +25,7 @@ import {
 import { $t } from 'services/i18n';
 import uuid from 'uuid/v4';
 import { omit } from 'lodash';
+import { getKeys } from 'util/getKeys';
 
 export enum E_AUDIO_CHANNELS {
   OUTPUT_1 = 1,
@@ -224,8 +225,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     // Fader is ignored by this method.  Use setFader instead
     const newPatch = omit(patch, 'fader');
 
-    Object.keys(newPatch).forEach(n => {
-      const name = n as keyof typeof newPatch;
+    getKeys(newPatch).forEach(name => {
       if (newPatch[name] === void 0) return;
 
       if (name === 'syncOffset') {

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -224,21 +224,26 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     // Fader is ignored by this method.  Use setFader instead
     const newPatch = omit(patch, 'fader');
 
-    Object.keys(newPatch).forEach(name => {
-      const value = newPatch[name];
-      if (value === void 0) return;
+    Object.keys(newPatch).forEach(n => {
+      const name = n as keyof typeof newPatch;
+      if (newPatch[name] === void 0) return;
 
       if (name === 'syncOffset') {
+        const value = newPatch[name];
         obsInput.syncOffset = AudioService.msToTimeSpec(value);
       } else if (name === 'forceMono') {
+        const value = newPatch[name];
         if (this.getSource(sourceId).forceMono !== value) {
           value
             ? (obsInput.flags = obsInput.flags | obs.ESourceFlags.ForceMono)
             : (obsInput.flags -= obs.ESourceFlags.ForceMono);
         }
       } else if (name === 'muted') {
+        const value = newPatch[name];
         this.sourcesService.setMuted(sourceId, value);
       } else {
+        const value = newPatch[name];
+        // @ts-expect-error
         obsInput[name] = value;
       }
     });

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -243,7 +243,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
         this.sourcesService.setMuted(sourceId, value);
       } else {
         const value = newPatch[name];
-        // @ts-expect-error
+        // @ts-expect-error ts7053 obs.IInputのpropertyに宣言が無いキーを扱うため
         obsInput[name] = value;
       }
     });

--- a/app/services/core/service.ts
+++ b/app/services/core/service.ts
@@ -9,6 +9,8 @@ const singletonEnforcer = Symbol('singletonEnforcer');
 const instances: Dictionary<Service> = {};
 
 export abstract class Service {
+  static [singleton]: Service;
+
   static isSingleton = true;
 
   /**
@@ -26,7 +28,6 @@ export abstract class Service {
   serviceName = this.constructor.name;
 
   static get instance() {
-    // @ts-expect-error ts7053
     const instance = !this.hasInstance ? Service.createInstance(this) : this[singleton];
     return this.proxyFn ? this.proxyFn(instance) : instance;
   }

--- a/app/services/core/service.ts
+++ b/app/services/core/service.ts
@@ -6,7 +6,7 @@ import { Subject } from 'rxjs';
 
 const singleton = Symbol('singleton');
 const singletonEnforcer = Symbol('singletonEnforcer');
-const instances: Service[] = [];
+const instances: Dictionary<Service> = {};
 
 export abstract class Service {
   static isSingleton = true;
@@ -26,6 +26,7 @@ export abstract class Service {
   serviceName = this.constructor.name;
 
   static get instance() {
+    // @ts-expect-error ts7053
     const instance = !this.hasInstance ? Service.createInstance(this) : this[singleton];
     return this.proxyFn ? this.proxyFn(instance) : instance;
   }

--- a/app/services/core/stateful-service.ts
+++ b/app/services/core/stateful-service.ts
@@ -134,7 +134,7 @@ export abstract class StatefulService<TState extends object> extends Service {
  */
 export function getModule(ModuleContainer: any): Module<any, any> {
   const prototypeMutations = (<any>ModuleContainer.prototype).mutations;
-  const mutations = {};
+  const mutations: Dictionary<any> = {};
 
   // filter inherited mutations
   for (const mutationName in prototypeMutations) {

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -40,7 +40,7 @@ export class DismissablesService extends PersistentStatefulService<IDismissables
   }
 
   resetAll() {
-    getKeys(EDismissable).forEach(key => this.dismiss(EDismissable[key]));
+    getKeys(EDismissable).forEach(key => this.reset(EDismissable[key]));
   }
 
   @mutation()

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -35,11 +35,15 @@ export class DismissablesService extends PersistentStatefulService<IDismissables
   }
 
   dismissAll() {
-    Object.keys(EDismissable).forEach(key => this.dismiss(EDismissable[key]));
+    Object.keys(EDismissable).forEach(key =>
+      this.dismiss(EDismissable[key as keyof typeof EDismissable]),
+    );
   }
 
   resetAll() {
-    Object.keys(EDismissable).forEach(key => this.reset(EDismissable[key]));
+    Object.keys(EDismissable).forEach(key =>
+      this.dismiss(EDismissable[key as keyof typeof EDismissable]),
+    );
   }
 
   @mutation()

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -1,6 +1,7 @@
 import { PersistentStatefulService } from 'services/core/persistent-stateful-service';
 import { mutation } from './core/stateful-service';
 import Vue from 'vue';
+import { getKeys } from 'util/getKeys';
 
 export enum EDismissable {
   SceneCollectionsHelpTip = 'scene_collections_help_tip',
@@ -35,15 +36,11 @@ export class DismissablesService extends PersistentStatefulService<IDismissables
   }
 
   dismissAll() {
-    Object.keys(EDismissable).forEach(key =>
-      this.dismiss(EDismissable[key as keyof typeof EDismissable]),
-    );
+    getKeys(EDismissable).forEach(key => this.dismiss(EDismissable[key]));
   }
 
   resetAll() {
-    Object.keys(EDismissable).forEach(key =>
-      this.dismiss(EDismissable[key as keyof typeof EDismissable]),
-    );
+    getKeys(EDismissable).forEach(key => this.dismiss(EDismissable[key]));
   }
 
   @mutation()

--- a/app/services/i18n/i18n.ts
+++ b/app/services/i18n/i18n.ts
@@ -47,7 +47,7 @@ const LANG_CODE_MAP = {
   sk: { lang: 'Slovak', locale: 'sk-SK' },
   th: { lang: 'Thai', locale: 'th-TH' },
   tr: { lang: 'Turkish', locale: 'tr-TR' },
-  'zh-CN': { lang: 'Chinese (Simplified)' },
+  'zh-CN': { lang: 'Chinese (Simplified)', locale: 'zh-CN' },
 };
 
 export class I18nService extends PersistentStatefulService<II18nState> implements I18nServiceApi {
@@ -88,7 +88,7 @@ export class I18nService extends PersistentStatefulService<II18nState> implement
     let locale = this.state.locale;
     if (!locale) {
       const electronLocale = remote.app.getLocale();
-      const langDescription = LANG_CODE_MAP[electronLocale];
+      const langDescription = LANG_CODE_MAP[electronLocale as keyof typeof LANG_CODE_MAP];
       locale = langDescription ? langDescription.locale : 'en-US';
     }
 

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -3,6 +3,7 @@ import { Observable, Subject, Subscription } from 'rxjs';
 import { IMessageServerClient } from './MessageServerClient';
 import { NdgrClient, toNumber } from './NdgrClient';
 import { MessageResponse, NotificationType, NotificationTypeTable } from './ChatMessage';
+import { getKeys } from 'util/getKeys';
 
 const NUM_BACKWARD_COMMENTS = 100;
 
@@ -130,7 +131,7 @@ function convertSimpleNotificationToMessageResponse(
   common: CommonComponent,
   notification: dwango.nicolive.chat.data.ISimpleNotification,
 ): MessageResponse | undefined {
-  const key = Object.keys(notification)[0] as keyof dwango.nicolive.chat.data.ISimpleNotification;
+  const key = getKeys(notification)[0];
   let type = key as NotificationType;
   if (!NotificationTypeTable.includes(key)) {
     type = 'unknown';

--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -96,11 +96,11 @@ test('wrapResultはbodyがJSONでなければSyntaxErrorをwrapして返す', as
 });
 
 interface Suite {
-  name: string;
-  method: string;
+  name: keyof NicoliveClient;
+  method: 'get' | 'post' | 'put' | 'delete';
   base: string;
   path: string;
-  args?: any[];
+  args: any[];
 }
 const suites: Suite[] = [
   {
@@ -108,6 +108,7 @@ const suites: Suite[] = [
     base: NicoliveClient.live2BaseURL,
     method: 'get',
     path: '/unama/tool/v1/program_schedules',
+    args: [],
   },
   {
     name: 'fetchProgram',
@@ -195,8 +196,9 @@ suites.forEach((suite: Suite) => {
       niconicoSession: 'dummy',
     });
 
-    fetchMock[suite.method.toLowerCase()](suite.base + suite.path, dummyBody);
-    const result = await client[suite.name](...(suite.args || []));
+    fetchMock[suite.method](suite.base + suite.path, dummyBody);
+    // @ts-expect-error 引数の型
+    const result = await client[suite.name](...suite.args);
 
     expect(result).toEqual({ ok: true, value: dummyBody.data });
     expect(fetchMock.done()).toBe(true);

--- a/app/services/nicolive-program/speech/NVoiceClient.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.ts
@@ -242,6 +242,7 @@ function loadLabelFile(filename: string): Label[] {
 
 class NVoiceEngineError extends Error {
   constructor(public code: string) {
+    // @ts-expect-error ts7015 code は数字の文字列
     const title = ErrorCodes[code];
     super(`${code}: ${title}`);
 

--- a/app/services/obs-api.ts
+++ b/app/services/obs-api.ts
@@ -8,7 +8,7 @@ import * as remote from '@electron/remote';
 export * from '../../obs-api';
 
 let idCounter = 0;
-const callbacks = {};
+const callbacks: Dictionary<any> = {};
 
 // Behaves just like the node-obs library, but proxies
 // all methods via the main process

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -65,12 +65,24 @@ interface IOBSConfigTransition {
   id: string;
 }
 
+interface IOBSAudioSourceConfigJSON {
+  id: TSourceType;
+  muted: boolean;
+  volume: number;
+}
+
 interface IOBSConfigJSON {
   sources: IOBSConfigSource[];
   current_scene: string;
   scene_order: { name: string }[];
   transitions: IOBSConfigTransition[];
   transition_duration: number;
+
+  DesktopAudioDevice1?: IOBSAudioSourceConfigJSON;
+  DesktopAudioDevice2?: IOBSAudioSourceConfigJSON;
+  AuxAudioDevice1?: IOBSAudioSourceConfigJSON;
+  AuxAudioDevice2?: IOBSAudioSourceConfigJSON;
+  AuxAudioDevice3?: IOBSAudioSourceConfigJSON;
 }
 
 export class ObsImporterService extends Service {
@@ -308,7 +320,7 @@ export class ObsImporterService extends Service {
       'AuxAudioDevice1',
       'AuxAudioDevice2',
       'AuxAudioDevice3',
-    ];
+    ] as const;
     channelNames.forEach((channelName, i) => {
       const audioSource = configJSON[channelName];
       if (audioSource) {

--- a/app/services/patch-notes/index.ts
+++ b/app/services/patch-notes/index.ts
@@ -29,7 +29,7 @@ export class PatchNotesService extends PersistentStatefulService<IPatchNotesStat
 
     if (Util.isDevMode()) {
       // Useful for previewing patch notes in dev mode
-      // @ts-ignore
+      // @ts-expect-error ts7015 consoleデバッグ用
       window['showPatchNotes'] = () => {
         this.navigationService.navigate('PatchNotes');
       };

--- a/app/services/patch-notes/index.ts
+++ b/app/services/patch-notes/index.ts
@@ -29,6 +29,7 @@ export class PatchNotesService extends PersistentStatefulService<IPatchNotesStat
 
     if (Util.isDevMode()) {
       // Useful for previewing patch notes in dev mode
+      // @ts-ignore
       window['showPatchNotes'] = () => {
         this.navigationService.navigate('PatchNotes');
       };

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -41,7 +41,7 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
   @mutation()
   SET_PERFORMANCE_STATS(stats: Partial<IPerformanceState>) {
     Object.keys(stats).forEach(stat => {
-      Vue.set(this.state, stat, stats[stat]);
+      Vue.set(this.state, stat, stats[stat as keyof IPerformanceState]);
     });
   }
 

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -8,6 +8,7 @@ import electron from 'electron';
 import * as obs from '../../../obs-api';
 import * as Sentry from '@sentry/vue';
 import * as remote from '@electron/remote';
+import { getKeys } from 'util/getKeys';
 
 interface IPerformanceState {
   CPU: number;
@@ -40,8 +41,8 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
 
   @mutation()
   SET_PERFORMANCE_STATS(stats: Partial<IPerformanceState>) {
-    Object.keys(stats).forEach(stat => {
-      Vue.set(this.state, stat, stats[stat as keyof IPerformanceState]);
+    getKeys(stats).forEach(stat => {
+      Vue.set(this.state, stat, stats[stat]);
     });
   }
 

--- a/app/services/protocol-links.ts
+++ b/app/services/protocol-links.ts
@@ -48,6 +48,7 @@ export class ProtocolLinksService extends Service {
     };
 
     if (this.handlers[info.base]) {
+      // @ts-expect-error ts7053
       this[this.handlers[info.base]](info);
     }
   }

--- a/app/services/scene-collections/nodes/hotkeys.ts
+++ b/app/services/scene-collections/nodes/hotkeys.ts
@@ -1,6 +1,7 @@
 import { ArrayNode } from './array-node';
 import { HotkeysService, IHotkey, Hotkey } from '../../hotkeys';
 import { Inject } from '../../core/injector';
+import { getKeys } from 'util/getKeys';
 
 interface IContext {
   sceneId?: string;
@@ -30,7 +31,7 @@ export class HotkeysNode extends ArrayNode<IHotkey, IContext, Hotkey> {
 
   saveItem(hotkey: Hotkey, context: IContext): Promise<IHotkey> {
     const hotkeyObj = hotkey.getModel();
-    Object.keys(context).forEach(key => delete hotkeyObj[key as keyof IContext]);
+    getKeys(context).forEach(key => delete hotkeyObj[key]);
     return Promise.resolve(hotkeyObj);
   }
 

--- a/app/services/scene-collections/nodes/hotkeys.ts
+++ b/app/services/scene-collections/nodes/hotkeys.ts
@@ -30,7 +30,7 @@ export class HotkeysNode extends ArrayNode<IHotkey, IContext, Hotkey> {
 
   saveItem(hotkey: Hotkey, context: IContext): Promise<IHotkey> {
     const hotkeyObj = hotkey.getModel();
-    Object.keys(context).forEach(key => delete hotkeyObj[key]);
+    Object.keys(context).forEach(key => delete hotkeyObj[key as keyof IContext]);
     return Promise.resolve(hotkeyObj);
   }
 

--- a/app/services/scene-collections/nodes/overlays/nvoice-character.ts
+++ b/app/services/scene-collections/nodes/overlays/nvoice-character.ts
@@ -28,7 +28,7 @@ export class NVoiceCharacterNode extends Node<ISchema, IContext> {
     context.sceneItem.source.replacePropertiesManager('nvoice-character', {});
 
     // Make sure we don't override the url setting
-    delete this.data.settings['url'];
+    delete (this.data.settings as Dictionary<any>)['url'];
     context.sceneItem.getSource().updateSettings(this.data.settings);
   }
 }

--- a/app/services/scene-collections/nodes/overlays/video.ts
+++ b/app/services/scene-collections/nodes/overlays/video.ts
@@ -47,7 +47,7 @@ export class VideoNode extends Node<ISchema, IContext> {
 
   async load(context: IContext) {
     const filePath = path.join(context.assetsPath, this.data.filename);
-    const settings = { ...this.data.settings };
+    const settings: Dictionary<any> = { ...this.data.settings };
     settings['local_file'] = filePath;
     context.sceneItem.getObsInput().update(settings);
 

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -56,7 +56,7 @@ export class RootNode extends Node<ISchema, {}> {
 
   migrate(version: number) {
     if (version === 1) {
-      this.data.transitions = this.data['transition'];
+      this.data.transitions = (this.data as Dictionary<any>)['transition'];
     }
   }
 }

--- a/app/services/scene-collections/nodes/transitions.ts
+++ b/app/services/scene-collections/nodes/transitions.ts
@@ -89,13 +89,14 @@ export class TransitionsNode extends Node<ISchema, {}> {
     // Migrate from version 1 schemas, where we only had a single global
     // transition and no support for connections.
     if (version === 1) {
+      const data: Dictionary<any> = this.data;
       const transition: ITransition = {
         id: null,
         name: 'Global Transition',
-        type: this.data['type'],
-        duration: this.data['duration'],
-        settings: this.data['settings'],
-        propertiesManagerSettings: this.data['propertiesManagerSettings'],
+        type: data['type'],
+        duration: data['duration'],
+        settings: data['settings'],
+        propertiesManagerSettings: data['propertiesManagerSettings'],
       };
       this.data.transitions = [transition];
       this.data.connections = [];

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { FileManagerService } from 'services/file-manager';
 import { Inject } from 'services/core/injector';
 import * as remote from '@electron/remote';
+import { getKeys } from 'util/getKeys';
 
 interface ISceneCollectionsManifest {
   activeId: string;
@@ -259,8 +260,8 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
 
   @mutation()
   LOAD_STATE(state: ISceneCollectionsManifest) {
-    Object.keys(state).forEach(key => {
-      Vue.set(this.state, key, state[key as keyof ISceneCollectionsManifest]);
+    getKeys(state).forEach(key => {
+      Vue.set(this.state, key, state[key]);
     });
   }
 }

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -267,7 +267,7 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     this.contexts[display].video = legacySettings;
 
     Object.keys(legacySettings).forEach((key: any) => {
-      this.SET_VIDEO_SETTING(key, legacySettings[key], 'horizontal');
+      this.SET_VIDEO_SETTING(key, legacySettings[key as keyof typeof legacySettings], 'horizontal');
     });
   }
 

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -4,6 +4,7 @@ import { mutation, StatefulService } from '../core/stateful-service';
 import { IVideoInfo, EScaleType, EFPSType, IVideo, VideoFactory, Video } from '../../../obs-api';
 import { SettingsService } from 'services/settings';
 import { Subject } from 'rxjs';
+import { getKeys } from 'util/getKeys';
 
 /**
  * Display Types
@@ -266,8 +267,8 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     const legacySettings = this.contexts[display].legacySettings;
     this.contexts[display].video = legacySettings;
 
-    Object.keys(legacySettings).forEach((key: any) => {
-      this.SET_VIDEO_SETTING(key, legacySettings[key as keyof typeof legacySettings], 'horizontal');
+    getKeys(legacySettings).forEach(key => {
+      this.SET_VIDEO_SETTING(key, legacySettings[key], 'horizontal');
     });
   }
 

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -902,7 +902,8 @@ export class Optimizer {
     expect: OptimizeSettings,
   ): IterableIterator<OptimizeSettings> {
     // 最適化の必要な値を抽出する
-    for (const key of Object.getOwnPropertyNames(expect)) {
+    for (const k of Object.getOwnPropertyNames(expect)) {
+      const key = k as keyof OptimizeSettings;
       if (current[key] !== expect[key]) {
         yield { [key]: expect[key] };
       }

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/vue';
 import { IObsInput, IObsListInput, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { $t } from 'services/i18n';
 import { ISettingsSubCategory } from './settings-api';
+import { getKeys } from 'util/getKeys';
 
 export enum EncoderType {
   x264 = 'obs_x264',
@@ -902,8 +903,7 @@ export class Optimizer {
     expect: OptimizeSettings,
   ): IterableIterator<OptimizeSettings> {
     // 最適化の必要な値を抽出する
-    for (const k of Object.getOwnPropertyNames(expect)) {
-      const key = k as keyof OptimizeSettings;
+    for (const key of getKeys(expect)) {
       if (current[key] !== expect[key]) {
         yield { [key]: expect[key] };
       }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -104,7 +104,9 @@ export class SettingsService
     for (const groupName in settingsFormData) {
       settingsFormData[groupName].forEach(subGroup => {
         subGroup.parameters.forEach(parameter => {
+          // @ts-expect-error ts7053
           settingsState[groupName] = settingsState[groupName] || {};
+          // @ts-expect-error ts7053
           settingsState[groupName][parameter.name] = parameter.value;
         });
       });
@@ -132,7 +134,7 @@ export class SettingsService
 
   loadSettingsIntoStore() {
     // load configuration from nodeObs to state
-    const settingsFormData = {};
+    const settingsFormData: Dictionary<any> = {};
     this.getCategories().forEach(categoryName => {
       settingsFormData[categoryName] = this.getSettingsFormData(categoryName);
     });

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -31,6 +31,7 @@ import { InitAfter } from 'services/core';
 import { RtvcStateService } from '../../services/rtvcStateService';
 import * as Sentry from '@sentry/vue';
 import { IPCWrapper } from 'services/ipc-wrapper';
+import { getKeys } from 'util/getKeys';
 
 const AudioFlag = obs.ESourceOutputFlags.Audio;
 const VideoFlag = obs.ESourceOutputFlags.Video;
@@ -253,7 +254,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     ext = ext.toLowerCase();
     const filename = path.split('\\').splice(-1)[0];
 
-    const types = Object.keys(SUPPORTED_EXT) as (keyof typeof SUPPORTED_EXT)[];
+    const types = getKeys(SUPPORTED_EXT);
     for (const type of types) {
       if (!(SUPPORTED_EXT[type] as readonly string[]).includes(ext)) continue;
       let settings: Dictionary<TObsValue>;

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -9,6 +9,7 @@ import { SceneCollectionsService } from 'services/scene-collections';
 import { $t } from 'services/i18n';
 import { DefaultManager } from 'services/sources/properties-managers/default-manager';
 import { Subject } from 'rxjs';
+import { getKeys } from 'util/getKeys';
 
 export enum ETransitionType {
   Cut = 'cut_transition',
@@ -420,8 +421,7 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     const transition = this.state.transitions.find(tran => tran.id === id);
 
     if (transition) {
-      Object.keys(patch).forEach(k => {
-        const key = k as keyof ITransition;
+      getKeys(patch).forEach(key => {
         // @ts-expect-error ts2332
         transition[key] = patch[key];
       });
@@ -456,8 +456,7 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     const connection = this.state.connections.find(conn => conn.id === id);
 
     if (connection) {
-      Object.keys(patch).forEach(k => {
-        const key = k as keyof ITransitionConnection;
+      getKeys(patch).forEach(key => {
         connection[key] = patch[key];
       });
     }

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -420,7 +420,9 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     const transition = this.state.transitions.find(tran => tran.id === id);
 
     if (transition) {
-      Object.keys(patch).forEach(key => {
+      Object.keys(patch).forEach(k => {
+        const key = k as keyof ITransition;
+        // @ts-expect-error ts2332
         transition[key] = patch[key];
       });
     }
@@ -454,7 +456,8 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     const connection = this.state.connections.find(conn => conn.id === id);
 
     if (connection) {
-      Object.keys(patch).forEach(key => {
+      Object.keys(patch).forEach(k => {
+        const key = k as keyof ITransitionConnection;
         connection[key] = patch[key];
       });
     }

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -14,7 +14,7 @@ export default class Utils {
       Object.defineProperty(target, propName, {
         configurable: true,
         get() {
-          return source[propName];
+          return (source as Dictionary<any>)[propName];
         },
       });
     });
@@ -116,8 +116,9 @@ export default class Utils {
 
   static getChangedParams<T>(obj: T, patch: T): Partial<T> {
     const result: Dictionary<any> = {};
-    Object.keys(patch).forEach(key => {
-      if (!isEqual(obj[key], patch[key])) result[key] = patch[key];
+    Object.keys(patch).forEach(k => {
+      const key = k as keyof T;
+      if (!isEqual(obj[key], patch[key])) result[k] = patch[key];
     });
     return result as Partial<T>;
   }
@@ -127,12 +128,13 @@ export default class Utils {
 
     if (obj == null) return patch;
 
-    Object.keys(patch).forEach(key => {
+    Object.keys(patch).forEach(k => {
+      const key = k as keyof T;
       if (!isEqual(obj[key], patch[key])) {
         if (patch[key] && typeof patch[key] === 'object' && !Array.isArray(patch[key])) {
-          result[key] = this.getDeepChangedParams(obj[key], patch[key]);
+          result[k] = this.getDeepChangedParams(obj[key], patch[key]);
         } else {
-          result[key] = patch[key];
+          result[k] = patch[key];
         }
       }
     });

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -1,7 +1,7 @@
 import URI from 'urijs';
 import { isEqual } from 'lodash';
-import electron from 'electron';
 import * as remote from '@electron/remote';
+import { getKeys } from 'util/getKeys';
 
 export const enum EBit {
   ZERO,
@@ -115,30 +115,29 @@ export default class Utils {
   }
 
   static getChangedParams<T>(obj: T, patch: T): Partial<T> {
-    const result: Dictionary<any> = {};
-    Object.keys(patch).forEach(k => {
-      const key = k as keyof T;
-      if (!isEqual(obj[key], patch[key])) result[k] = patch[key];
+    const result: Partial<T> = {};
+    getKeys(patch).forEach(key => {
+      if (!isEqual(obj[key], patch[key])) result[key] = patch[key];
     });
-    return result as Partial<T>;
+    return result;
   }
 
   static getDeepChangedParams<T>(obj: T, patch: T): Partial<T> {
-    const result: Dictionary<any> = {};
+    const result: Partial<T> = {};
 
     if (obj == null) return patch;
 
-    Object.keys(patch).forEach(k => {
-      const key = k as keyof T;
+    getKeys(patch).forEach(key => {
       if (!isEqual(obj[key], patch[key])) {
         if (patch[key] && typeof patch[key] === 'object' && !Array.isArray(patch[key])) {
-          result[k] = this.getDeepChangedParams(obj[key], patch[key]);
+          // @ts-expect-error ts2322 再帰的に子要素もPartialなのだが型解決が難しい
+          result[key] = this.getDeepChangedParams(obj[key], patch[key]);
         } else {
-          result[k] = patch[key];
+          result[key] = patch[key];
         }
       }
     });
-    return result as Partial<T>;
+    return result;
   }
 
   /**

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -91,7 +91,7 @@ plugins.push((store: Store<any>) => {
 let store: Store<any> = null;
 
 export function createStore(): Promise<Store<any>> {
-  const statefulServiceModules = {};
+  const statefulServiceModules: Dictionary<any> = {};
   const servicesManager: ServicesManager = ServicesManager.instance;
   const statefulServices = servicesManager.getStatefulServicesAndMutators();
   Object.keys(statefulServices).forEach(serviceName => {

--- a/app/util/getKeys.ts
+++ b/app/util/getKeys.ts
@@ -1,0 +1,3 @@
+export function getKeys<T extends {}>(obj: T): (keyof T)[] {
+  return Object.keys(obj) as (keyof T)[];
+}

--- a/app/util/profanity.ts
+++ b/app/util/profanity.ts
@@ -1,4 +1,5 @@
 import { Service } from '../services/core/service';
+import { getKeys } from './getKeys';
 
 interface IProfanityFilterOptions {
   useDefaultRegex?: boolean;
@@ -118,10 +119,10 @@ export class ProfanityFilterService extends Service {
     });
     let badWordsStrings = badWordsStringsArray.join('|');
 
-    Object.keys(this.leetReplace).forEach(letter => {
+    getKeys(this.leetReplace).forEach(letter => {
       badWordsStrings = badWordsStrings.replace(
         new RegExp(/([^\\])/.source + letter, 'gi'),
-        '$1' + this.leetReplace[letter as keyof typeof this.leetReplace],
+        '$1' + this.leetReplace[letter],
       );
     });
 

--- a/app/util/profanity.ts
+++ b/app/util/profanity.ts
@@ -121,7 +121,7 @@ export class ProfanityFilterService extends Service {
     Object.keys(this.leetReplace).forEach(letter => {
       badWordsStrings = badWordsStrings.replace(
         new RegExp(/([^\\])/.source + letter, 'gi'),
-        '$1' + this.leetReplace[letter],
+        '$1' + this.leetReplace[letter as keyof typeof this.leetReplace],
       );
     });
 

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "ts-jest": "^29.1.5",
     "ts-loader": "^9.5.1",
     "typedoc": "^0.9.0",
-    "typescript": "^4.9.5",
+    "typescript": "5.0.4",
     "vue-loader": "15.10.1",
     "vue-svg-loader": "0.12.0",
     "vue-template-compiler": "2.7.14",

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "ts-jest": "^29.1.5",
     "ts-loader": "^9.5.1",
     "typedoc": "^0.9.0",
-    "typescript": "5.0.4",
+    "typescript": "5.5.4",
     "vue-loader": "15.10.1",
     "vue-svg-loader": "0.12.0",
     "vue-template-compiler": "2.7.14",

--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -21,7 +21,12 @@ export class ApiClient {
   private socket: any;
   private resolveConnection: Function;
   private rejectConnection: Function;
-  private requests = {};
+  private requests: Dictionary<{
+    resolve: (value: unknown) => void;
+    reject: (reason?: any) => void;
+    body: IJsonRpcRequest;
+    completed: boolean;
+  }> = {};
   private subscriptions: Dictionary<Subject<any>> = {};
   private connectionStatus: TConnectionStatus = 'disconnected';
 
@@ -237,7 +242,10 @@ export class ApiClient {
     );
   }
 
-  getResource<TResourceType>(resourceId: string, resourceModel = {}): TResourceType {
+  getResource<TResourceType>(
+    resourceId: string,
+    resourceModel: Dictionary<any> = {},
+  ): TResourceType {
     const handleRequest = (resourceId: string, property: string, ...args: any[]): any => {
       const result = this.requestSync(resourceId, property as string, ...args);
 
@@ -341,7 +349,7 @@ class ApiEventWatcher {
     // start watching for events
     this.subscriptions = this.eventNames.map(eventName => {
       const [resourceId, prop] = eventName.split('.');
-      const observable = this.apiClient.getResource(resourceId)[prop] as Observable<any>;
+      const observable = this.apiClient.getResource<Dictionary<Observable<any>>>(resourceId)[prop];
       return observable.subscribe(() => void 0);
     });
 

--- a/test/helpers/modules/forms/form.ts
+++ b/test/helpers/modules/forms/form.ts
@@ -290,5 +290,6 @@ function getInputControllerForType<
   TReturnType extends new (...args: any) => BaseInputController<any>,
 >(type: string): TReturnType {
   const controllerName = pascalize(type) + 'InputController';
+  // @ts-expect-error ts7053
   return inputControllers[controllerName];
 }

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -42,7 +42,7 @@ const testTimings: Record<string, number> = (() => {
     const records: { name: string; time: number }[] = JSON.parse(
       fs.readFileSync(TESTS_TIMINGS_PATH, 'utf-8'),
     );
-    const result = {};
+    const result: Record<string, number> = {};
 
     // convert the list to the map where key is a test name
     records.forEach(r => (result[r.name] = r.time));

--- a/test/helpers/webdriver/user.ts
+++ b/test/helpers/webdriver/user.ts
@@ -21,7 +21,8 @@ export async function logIn(t: TExecutionContext, isOnboardingTest = false): Pro
   };
 
   let canAuth = true;
-  Object.keys(authInfo).forEach(key => {
+  Object.keys(authInfo).forEach(k => {
+    const key = k as keyof typeof authInfo;
     authInfo[key] = env[key];
     if (!authInfo[key]) {
       console.warn(`Setup env.${key} to run this test`);

--- a/test/helpers/webdriver/user.ts
+++ b/test/helpers/webdriver/user.ts
@@ -4,6 +4,7 @@ import { testSourceExists, selectTestSource, clickRemoveSource } from '../module
 import { getApiClient } from '../api-client';
 import { UserService } from 'services/user';
 import { IPlatformAuth } from 'services/platforms';
+import { getKeys } from 'util/getKeys';
 
 export async function logOut(t: TExecutionContext) {
   await focusMain();
@@ -21,8 +22,7 @@ export async function logIn(t: TExecutionContext, isOnboardingTest = false): Pro
   };
 
   let canAuth = true;
-  Object.keys(authInfo).forEach(k => {
-    const key = k as keyof typeof authInfo;
+  getKeys(authInfo).forEach(key => {
     authInfo[key] = env[key];
     if (!authInfo[key]) {
       console.warn(`Setup env.${key} to run this test`);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,7 +12,6 @@
     "experimentalDecorators": true,
     "noImplicitThis": true,
     "removeComments": true,
-    "suppressImplicitAnyIndexErrors": true,
     "strictNullChecks": false,
     "emitDecoratorMetadata": true,
     "downlevelIteration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "isolatedModules": false,
     "experimentalDecorators": true,
     "removeComments": true,
-    "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "outDir": "bundles/ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13255,6 +13255,11 @@ typescript@2.4.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
   integrity sha512-3O/A1TbKiXlfWsBv+X9QpzylORsBSXZuIG8GMzYvPTFCrkc65iXKd4gAkVN/jmLgSkmdTDMRY5XyNu+DxZD7mQ==
 
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
 typescript@^3.9.3:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13255,10 +13255,10 @@ typescript@2.4.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
   integrity sha512-3O/A1TbKiXlfWsBv+X9QpzylORsBSXZuIG8GMzYvPTFCrkc65iXKd4gAkVN/jmLgSkmdTDMRY5XyNu+DxZD7mQ==
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 typescript@^3.9.3:
   version "3.9.10"


### PR DESCRIPTION
- [x] #768 がマージされたらやり直す

# このpull requestが解決する内容
typescriptを少し前進させます。

tsconfigのcompilerOptionsからdeprecatedな `suppressImplicitAnyIndexErrors` を外し、その結果出たエラー潰しで大量のannotationをつけてます...
(公式ドキュメント: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors )

基本的には objectをインデックスアクセスするとエラーになるというものを、`Dictionary` にできるものはすることで解消しているが、そうでないものは `@ts-expect-error` でスルーさせるという対応...

<strike>5.1に上げると `yarn test:unit:app` がこけるので一旦ここまで</strike>

- [x] #783 にて ts-jest 29.1.5に上がった
  - <strike>`ts-jest`が `typescript` 5.xに対応してなかった。</strike>
  - <strike>対応するのは `ts-jest` 29.1.0だが現在は26.5.6。</strike>
  - <strike>`ts-jest` 29は `jest` 29が必要。現在は26.6.3</strike>
- [x] #783 で @kayahr/jest-electron-runner に乗り替えた
  - `<strike>@jest-runner/electron` が jest 27で動かず終了している</strike>
  - <strike>electron の unit testをjestで書くの自体をやめないといかんのかなこれ</strike>

- [x] ということで typescript.5.0.4対応やり直す
- [x] `Object.keys(o).forEach(k => o[k])` で `k`の型がstringになってしまうのをごまかす型キャストがあちこちに発生したので、しなくてすむように型をラップした `getKeys` を作ったのでこれを使うように書き換え
- [x] typescript 5.5.4に前進