### PR TITLE
開発: GitHub Actionsのnodeを20.12.2でも通す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.12.1
+          node-version: 20.12.2
           cache: yarn
 
       - name: npm login

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.12.2
+          node-version: 20
           cache: yarn
 
       - name: npm login

--- a/scripts/install-native-deps.js
+++ b/scripts/install-native-deps.js
@@ -96,7 +96,20 @@ async function rtvc() {
   sh.rm(zip);
 }
 
+function spectronFix() {
+  const fn = './node_modules/spectron/lib/launcher.js';
+  console.log(`spectron fix ${fn}`);
+  const s = fs.readFileSync(fn, 'utf8');
+  const t = s.replace(
+    'ChildProcess.spawn(executablePath, args)',
+    'ChildProcess.spawn(executablePath, args,{shell:true})',
+  );
+  fs.writeFileSync(fn, t, 'utf8');
+}
+
 async function runScript() {
+  spectronFix();
+
   colors.blue('----Streamlabs Desktop native dependecies installation----');
 
   try {


### PR DESCRIPTION
# このpull requestが解決する内容
fix #747
#748 続き
20.12.2 でも通るようにspectronの処理を書き換えます。

- [x] CIが成功すれば ok

# 関連するIssue（あれば）
#747

https://github.com/n-air-app/n-air-app/pull/748 からの流れの改修