### PR TITLE
開発: n-air-appリポジトリにブランチを作ってPRを作るとテストが無駄に2つ実行されていたのを1つに減らす

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - n-air_development
     paths:
       - package.json
       - yarn.lock


### PR DESCRIPTION
# このpull requestが解決する内容
n-air-app repositoryのbranchでPRを作ると毎回二つtestが走るのは無駄なので、1個だけ走るようにします
(PR mergeのときも push event のため、こちらだけ残す形)

- [x] このPR自体もn-air-app repoでブランチだが、testは2個にならず1個だけ実行されている