### PR TITLE
開発: NicoliveClient クラスのリファクタリング

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -1,7 +1,6 @@
 import * as fetchMock from 'fetch-mock';
-import { WrappedResult } from './NicoliveClient';
+import { NicoliveClient, parseMaxQuality, WrappedResult } from './NicoliveClient';
 import { Communities, Community } from './ResponseTypes';
-const { NicoliveClient, parseMaxQuality } = require('./NicoliveClient');
 
 jest.mock('services/i18n', () => ({
   $t: (x: any) => x,
@@ -28,8 +27,7 @@ describe('parseMaxQuality', () => {
       height,
       fps,
     });
-  }
-  );
+  });
 });
 
 test('constructor', () => {
@@ -160,7 +158,8 @@ const suites: Suite[] = [
 
 suites.forEach((suite: Suite) => {
   test(`dataを取り出して返す - ${suite.name}`, async () => {
-    const client = new NicoliveClient();
+    // niconicoSession を与えないと、実行時の main process の cookieから取ろうとして失敗するので差し替える
+    const client = new NicoliveClient({ niconicoSession: 'dummy' });
 
     fetchMock[suite.method.toLowerCase()](suite.base + suite.path, dummyBody);
     const result = await client[suite.name](...(suite.args || []));
@@ -251,7 +250,7 @@ function setupMock() {
     loadURL(url: string) {
       this.url = url;
       for (const cb of this.webContentsCallbacks) {
-        cb({ preventDefault() { } }, url);
+        cb({ preventDefault() {} }, url);
       }
     }
     close = jest.fn().mockImplementation(() => {
@@ -284,7 +283,7 @@ function setupMock() {
       },
     },
     ipcRenderer: {
-      send() { },
+      send() {},
     },
   }));
 

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -242,6 +242,16 @@ export class NicoliveClient {
     }
   }
 
+  static jsonBody<T>(body: T, extraHeaders: HeadersInit = {}): RequestInit {
+    return {
+      headers: {
+        'Content-Type': 'application/json',
+        ...extraHeaders,
+      },
+      body: JSON.stringify(body),
+    };
+  }
+
   /** ユーザごとの番組スケジュールを取得 */
   async fetchProgramSchedules(): Promise<WrappedResult<ProgramSchedules['data']>> {
     return this.requestAPI<ProgramSchedules['data']>(
@@ -263,10 +273,7 @@ export class NicoliveClient {
     return this.requestAPI<Segment['data']>(
       'PUT',
       `${NicoliveClient.live2BaseURL}/watch/${programID}/segment`,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ state: 'on_air' }),
-      },
+      NicoliveClient.jsonBody({ state: 'on_air' }),
     );
   }
 
@@ -275,10 +282,7 @@ export class NicoliveClient {
     return this.requestAPI<Segment['data']>(
       'PUT',
       `${NicoliveClient.live2BaseURL}/watch/${programID}/segment`,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ state: 'end' }),
-      },
+      NicoliveClient.jsonBody({ state: 'end' }),
     );
   }
 
@@ -290,10 +294,7 @@ export class NicoliveClient {
     return this.requestAPI<Extension['data']>(
       'POST',
       `${NicoliveClient.live2BaseURL}/watch/${programID}/extension`,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ minutes }),
-      },
+      NicoliveClient.jsonBody({ minutes }),
     );
   }
 
@@ -305,10 +306,7 @@ export class NicoliveClient {
     return this.requestAPI<void>(
       'PUT',
       `${NicoliveClient.live2BaseURL}/watch/${programID}/operator_comment`,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text, isPermanent }),
-      },
+      NicoliveClient.jsonBody({ text, isPermanent }),
     );
   }
 
@@ -349,12 +347,7 @@ export class NicoliveClient {
     return this.requestAPI<AddFilterResult['data']>(
       'POST',
       `${NicoliveClient.live2BaseURL}/unama/tool/v2/programs/${programID}/ssng/create`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(records[0]),
-      },
+      NicoliveClient.jsonBody(records[0]),
     );
   }
 
@@ -362,12 +355,7 @@ export class NicoliveClient {
     return this.requestAPI<void>(
       'DELETE',
       `${NicoliveClient.live2BaseURL}/unama/tool/v2/programs/${programID}/ssng`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ id: ids }),
-      },
+      NicoliveClient.jsonBody({ id: ids }),
     );
   }
 
@@ -671,13 +659,13 @@ export class NicoliveClient {
   async fetchKonomiTags(userId: string): Promise<KonomiTag[]> {
     const res = await fetch(
       `${NicoliveClient.live2ApiBaseURL}/api/v1/konomiTags/GetFollowing`,
-      NicoliveClient.createRequest('POST', {
-        headers: {
-          'Content-Type': 'application/json',
-          'x-service-id': 'n-air-app',
-        },
-        body: JSON.stringify({ follower_id: { value: userId, type: 'USER' } }),
-      }),
+      NicoliveClient.createRequest(
+        'POST',
+        NicoliveClient.jsonBody(
+          { follower_id: { value: userId, type: 'USER' } },
+          { 'x-service-id': 'n-air-app' },
+        ),
+      ),
     );
     if (res.ok) {
       const json = (await res.json()) as KonomiTags;

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -688,7 +688,6 @@ export class NicoliveClient {
       NicoliveClient.userFollowEndpoint(userId),
       NicoliveClient.createRequest('GET', {
         headers: {
-          'Content-Type': 'application/json',
           'x-frontend-id': NicoliveClient.frontendID.toString(10),
         },
       }),
@@ -724,7 +723,6 @@ export class NicoliveClient {
       NicoliveClient.userFollowEndpoint(userId),
       NicoliveClient.createRequest('POST', {
         headers: {
-          'Content-Type': 'application/json',
           'x-frontend-id': NicoliveClient.frontendID.toString(10),
           'X-Request-With': 'N Air',
         },
@@ -746,7 +744,6 @@ export class NicoliveClient {
       NicoliveClient.userFollowEndpoint(userId),
       NicoliveClient.createRequest('DELETE', {
         headers: {
-          'Content-Type': 'application/json',
           'x-frontend-id': NicoliveClient.frontendID.toString(10),
           'X-Request-With': 'N Air',
         },

--- a/app/services/nicolive-program/speech/NVoiceClient.test.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.test.ts
@@ -20,5 +20,5 @@ describe('NVoiceClient', () => {
     const { wave, labels } = await client.talk(1.0, 'テスト', filename);
     expect(wave).not.toBeNull();
     expect(labels.map(l => l.phoneme)).toEqual(['silB', 't', 'e', 's', 'U', 't', 'o', 'silE']);
-  }, 10000 /* longer timeout */);
+  }, 20000 /* longer timeout */);
 });


### PR DESCRIPTION
# このpull requestが解決する内容
利用APIを増やすにあたって、ちょっと整理できてなかった部分を整理します。

* NicoliveClient内でAPI呼び出しを実装するときに使うサービスメソッドが複数系統あったので、1系統に整理して、ボイラープレート的に同じパターンを書いてた部分も共通化
  * 機能追加として、renderer process から呼び出されたのか、main process(service内)から呼び出されたかで session の取り出し方が違うため、APIごとに片方に固定で寄せた実装になっていたのを、実行時に動的分岐するようにした( `NicoliveClient.fetchSession`)
* user followと好みタグについてはちょっと間違った書き方をしていたので整理しきれていない(後日やる)

* ちょっと関係無いけど、NVoiceClientのテストがタイムアウトを起こしがちだったのでついでに延長も入れてます

# 動作確認手順
一通り動けばok

# 関連するIssue（あれば）
