### PR TITLE
開発: GitHub Actions testの時間を短縮する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
 
-      - name: cache ndoe modules
+      - name: cache node modules
         id: cache-node-modules
         uses: actions/cache@v4
         with:
@@ -82,21 +81,15 @@ jobs:
         with:
           node-version: 20
 
-      - name: cache ndoe modules
+      - name: cache node modules
         id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
 
-      - name: Compile
-        run: yarn compile:ci
-
       - name: Run unit tests
         run: yarn test:unit
-
-      - name: Run e2e tests
-        run: yarn test
 
   e2e_test:
     name: e2e tests
@@ -112,12 +105,15 @@ jobs:
         with:
           node-version: 20
 
-      - name: cache ndoe modules
+      - name: cache node modules
         id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
+
+      - name: Compile
+        run: yarn compile:ci
 
       - name: Run e2e tests
         run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,11 @@ jobs:
     name: e2e tests
     needs: setup
     runs-on: windows-2019
+    strategy:
+      matrix:
+        directory:
+          - 'test-dist/test/e2e/*.js'
+          - 'test-dist/test/api/*.js'
 
     steps:
       - name: Checkout code
@@ -117,4 +122,4 @@ jobs:
         run: yarn compile:ci
 
       - name: Run e2e tests
-        run: yarn test --fail-fast
+        run: yarn test --fail-fast ${{ matrix.directory }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,4 +117,4 @@ jobs:
         run: yarn compile:ci
 
       - name: Run e2e tests
-        run: yarn test
+        run: yarn test --fail-fast

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ on:
       - .github/workflows/test.yml
 
 jobs:
-  test:
+  setup:
+    name: setup
     runs-on: windows-2019
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -55,17 +55,69 @@ jobs:
           node-version: 20
           cache: yarn
 
+      - name: cache ndoe modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
+
       - name: npm login
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> $env:USERPROFILE\.npmrc
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --check-files
 
+  unit_test:
+    name: unit tests
+    needs: setup
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: cache ndoe modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
+
       - name: Compile
         run: yarn compile:ci
 
       - name: Run unit tests
         run: yarn test:unit
+
+      - name: Run e2e tests
+        run: yarn test
+
+  e2e_test:
+    name: e2e tests
+    needs: setup
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: cache ndoe modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
 
       - name: Run e2e tests
         run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> $env:USERPROFILE\.npmrc
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --check-files
 
   unit_test:


### PR DESCRIPTION
# このpull requestが解決する内容
node_modules自体をcacheした jobを作り、それの後続として unit testとe2e testを並列実行します
* e2eが長いのでとりあえず大分類の e2e と api を分けて並列化
* e2eのタイムアウトは一度起きると後ろみんな死ぬのに確定までものすごく長くなっていたので --fail-fast をつけてひとつこけたらすぐ止まるようにしてリトライを早くできるようにする

とりあえず15〜20分かかっていたものが、キャッシュが効いたら8分台にまで削減(e2eをさらに分割したらもっと減らせそうだけど一旦ここまで)

