### PR TITLE
開発: GitHub Actions: unit testをappとbinに分割

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ on:
       - .github/workflows/test.yml
 
 jobs:
-  setup:
-    name: setup
+  setup-app:
+    name: setup(app)
     runs-on: windows-2019
     steps:
       - name: Checkout code
@@ -76,9 +76,32 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --check-files
 
-  unit_test:
-    name: unit tests
-    needs: setup
+  setup-bin:
+    name: setup(bin)
+    runs-on: windows-2019
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: cache node modules(bin)
+        id: cache-node-modules-bin
+        uses: actions/cache@v4
+        with:
+          path: bin/node_modules
+          key: ${{ runner.os }}-node-bin-${{ hashFiles('bin/yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules-bin.outputs.cache-hit != 'true'
+        run: yarn install --cwd=bin --frozen-lockfile --check-files
+
+  unit_test-app:
+    name: unit tests(app)
+    needs: setup-app
     runs-on: windows-2019
 
     steps:
@@ -97,12 +120,43 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
 
-      - name: Run unit tests
-        run: yarn test:unit
+      - name: Run unit tests(app)
+        run: yarn test:unit:app
+
+  unit_test-bin:
+    name: unit tests(bin)
+    needs: [setup-app, setup-bin]
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
+
+      - name: cache node modules(bin)
+        id: cache-node-modules-bin
+        uses: actions/cache@v4
+        with:
+          path: bin/node_modules
+          key: ${{ runner.os }}-node-bin-${{ hashFiles('bin/yarn.lock') }}
+
+      - name: Run unit tests(bin)
+        run: yarn test:unit:bin
 
   e2e_test:
     name: e2e tests
-    needs: setup
+    needs: setup-app
     runs-on: windows-2019
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,11 @@ on:
       - tsconfig.json
       - webpack.config.js
       - main.js
+      - test-main.js
       - app/**
+      - bin/package.json
+      - bin/yarn.lock
+      - bin/**/*.js
       - media/**
       - nvoice/**
       - obs-api/**
@@ -31,7 +35,11 @@ on:
       - tsconfig.json
       - webpack.config.js
       - main.js
+      - test-main.js
       - app/**
+      - bin/package.json
+      - bin/yarn.lock
+      - bin/**/*.js
       - media/**
       - nvoice/**
       - obs-api/**


### PR DESCRIPTION
# このpull requestが解決する内容
* `yan test:unit` は実際には `yarn test:unit:app` と `yarn test:unit:bin` を順次実行していて、 bin のほうは bin/ の yarn install が必要だったので依存関係をバラして並列化します。あとでe2e testのほうを高速化できたらテスト全体の時短が可能になります。
  * あと bin/ の`yarn install` も通信エラーで不安定なことがあるので、キャッシュで安定化もします
* イメージ
![image](https://github.com/n-air-app/n-air-app/assets/864587/92715b27-281f-49de-b104-6be134974ea6)

* 発動条件の `paths`  に漏れがあったので追加
  * 同じ内容が2セットあるけど、YAML のalias参照みたいなのは VSCodeの拡張が対応してなくてエラーになるのでまとめられない...
 
- [x] マージするときは branch protection ruleのcheck項目をこれにあわせて修正すること

# 動作確認手順
GitHub Actionsのtestを実行する
