### PR TITLE
開発: electron-builder/stable.config.js にVS Codeでtype checkするように注記を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
     "niconicolive",
     "nicoru",
     "nicovideo",
+    "nsis",
     "NVENC",
     "nvoice",
     "Onair",

--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -1,3 +1,6 @@
+// @ts-check
+
+/** @type {import('electron-builder').Configuration} */
 const config = {
   appId: 'jp.nicovideo.nair',
   productName: 'N Air',
@@ -42,6 +45,7 @@ const config = {
 };
 
 if (process.env.CERTIFICATE_SUBJECT_NAME) {
+  // @ts-ignore winがnullableなのと、certificateSubjectNameが型宣言上ではpropertyで書き込めないというエラーになるのを回避
   config.win.certificateSubjectName = process.env.CERTIFICATE_SUBJECT_NAME;
 }
 


### PR DESCRIPTION
# このpull requestが解決する内容
electron-builderのconfigの共通設定の `stable.config.js` を VSCode上で編集するときに型宣言のアシストが効くようにします

note: このファイルは GitHub ActionsのCI起動条件のファイルリストにないので、CIは走りません