### PR TITLE
修正: 「新しいソースの追加」ボタンの連打対策

### DIFF
--- a/app/components/windows/AddSource.vue
+++ b/app/components/windows/AddSource.vue
@@ -16,7 +16,12 @@
         </div>
         <div class="row">
           <div class="columns small-12 buttons">
-            <button @click="addNew" class="button button--primary" data-test="AddNewSource">
+            <button
+              @click="addNew"
+              class="button button--primary"
+              data-test="AddNewSource"
+              :disabled="adding"
+            >
               {{ $t('sources.addNewSource') }}
             </button>
           </div>
@@ -58,7 +63,12 @@
 
       <div class="row" v-if="existingSources.length">
         <div class="columns small-12 buttons">
-          <button @click="addExisting" class="button button--primary" data-test="AddExistingSource">
+          <button
+            @click="addExisting"
+            class="button button--primary"
+            data-test="AddExistingSource"
+            :disabled="adding"
+          >
             {{ $t('sources.addExistingSource') }}
           </button>
         </div>

--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -29,6 +29,7 @@ export default class AddSource extends Vue {
     .sourceAddOptions as ISourceAddOptions;
 
   canAddNew = true;
+  adding = false;
 
   get nVoiceCharacterType(): NVoiceCharacterType {
     return this.sourceAddOptions.propertiesManagerSettings.nVoiceCharacterType || 'near';
@@ -84,6 +85,7 @@ export default class AddSource extends Vue {
       alert($t('sources.circularReferenceMessage'));
       return;
     }
+    this.adding = true;
     this.scenesService.activeScene.addSource(this.selectedSourceId);
     this.close();
   }
@@ -120,6 +122,7 @@ export default class AddSource extends Vue {
         };
       }
 
+      this.adding = true;
       this.scenesService.activeScene.addSource(s.source.sourceId, s.options);
 
       if (s.source.hasProps()) {


### PR DESCRIPTION
# このpull requestが解決する内容
* ソースの追加 -> ソースを選択 -> `新しいソースの追加` ボタンを連打すると押せた回数だけ追加されてしまっていたので、1回押したらガードを入れます
