### PR TITLE
修正: シーンコレクションをクリックした際のプルダウンが左側に見切れて表示される

### DIFF
--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -98,5 +98,6 @@
   .text-ellipsis;
 
   display: flex;
+  width: 100%;
 }
 </style>

--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -97,7 +97,6 @@
 @import url('../styles/index');
 
 .studio-controls-panel {
-  position: relative;
   display: flex;
   flex-direction: column;
   flex-grow: 1;

--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -238,7 +238,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: fit-content;
+  width: 100%;
   padding: 8px;
   pointer-events: none;
   transform: translate(-50%, -50%);

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <popper trigger="click" :options="{ placement: placement || 'bottom-end' }">
+  <popper trigger="click" :options="{ placement: placement || 'bottom-start' }">
     <div class="popper dropdown-menu">
       <slot></slot>
     </div>
@@ -20,6 +20,7 @@
 .popper.dropdown-menu {
   .popper-styling;
 
+  max-width: 100%;
   max-height: 152px;
   overflow-y: auto;
 }

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -20,7 +20,7 @@
 .popper.dropdown-menu {
   .popper-styling;
 
-  max-width: 240px;
+  width: 100%;
   max-height: 152px;
   overflow-y: auto;
 }

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -20,7 +20,7 @@
 .popper.dropdown-menu {
   .popper-styling;
 
-  max-width: 100%;
+  width: 100%;
   max-height: 152px;
   overflow-y: auto;
 }
@@ -28,6 +28,7 @@
 .dropdown-menu__toggle {
   display: flex;
   align-items: center;
+  width: 100%;
   overflow: hidden;
   font-size: @font-size4;
   color: var(--color-text);

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <popper trigger="click" :options="{ placement: placement || 'bottom-start' }">
+  <popper trigger="click" :options="{ placement: placement || 'bottom-end' }">
     <div class="popper dropdown-menu">
       <slot></slot>
     </div>
@@ -20,7 +20,6 @@
 .popper.dropdown-menu {
   .popper-styling;
 
-  width: 100%;
   max-height: 152px;
   overflow-y: auto;
 }

--- a/app/styles/mixins.less
+++ b/app/styles/mixins.less
@@ -337,7 +337,6 @@
   .shadow;
 
   z-index: @z-index-popper;
-  min-width: 200px;
   max-width: 300px;
   padding: 0;
   background-color: var(--color-popper-bg-light);


### PR DESCRIPTION
# このpull requestが解決する内容

### シーンコレクションをクリックした際に表示されるブルダウンが左側に見切れて表示されるバグの修正（ https://github.com/n-air-app/n-air-app/pull/771/commits/50fc80fb33d35deb35eb1286fd48f7d55666273c ）

プルダウンの最大幅をボタン幅に合わせることで見切れないようにした

#### 修正前
![スクリーンショット 2024-06-07 183831](https://github.com/n-air-app/n-air-app/assets/43235200/2fb6d452-f6ea-4abc-b10b-9a67f6b81b4e)

#### 修正後
![スクリーンショット 2024-06-07 184137](https://github.com/n-air-app/n-air-app/assets/43235200/acf26809-d20b-4af7-8de0-9732606ff559)

### テスト放送中のコメントエリアの文言の改行位置の修正（ https://github.com/n-air-app/n-air-app/pull/771/commits/e2719eeb56056eab9ce55115d3ffe16be2b038b8 ）

#### 修正前
![スクリーンショット 2024-06-07 122127](https://github.com/n-air-app/n-air-app/assets/43235200/916cc1fe-9d34-4353-8c4a-6574e98c4e6b)

#### 修正後
![スクリーンショット 2024-06-07 184919](https://github.com/n-air-app/n-air-app/assets/43235200/6b991a72-1832-4eff-8bc2-04ee47ee98f9)

# 関連するIssue（あれば）
https://dwango.slack.com/archives/CGS6HB9ED/p1717665339418889