### PR TITLE
改善: 画面キャプチャソースを追加したときにシーンサイズに合わせる

### DIFF
--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -24,6 +24,7 @@ import * as fs from 'fs';
 import uuid from 'uuid/v4';
 import { assertIsDefined } from 'util/properties-type-guards';
 import { VideoSettingsService, TDisplayType } from 'services/settings-v2';
+import { filter } from 'rxjs/operators';
 
 export type TSceneNode = SceneItem | SceneItemFolder;
 
@@ -180,6 +181,17 @@ export class Scene {
     }
 
     this.scenesService.itemAdded.next(sceneItem.getModel());
+    if (source.type === 'monitor_capture') {
+      const subscription = this.sourcesService.sourceUpdated
+        .pipe(filter(patch => patch.sourceId === sourceId))
+        .subscribe(patch => {
+          // 初期サイズが入った後にfitToScreenする
+          if (patch.width && patch.height) {
+            sceneItem.fitToScreen();
+            subscription.unsubscribe();
+          }
+        });
+    }
     return sceneItem;
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容
画面キャプチャソースを新しく追加したときにサイズを自動的にシーン全体にフィットさせます。

画面キャプチャソースに関しては、初期状態が画面全体の解像度で作られ、ほぼ常にシーンより大きいサイズで作られてしまうため、固定で最大フィットで大丈夫という判断をしました。

メモ: ソースを追加した直後にはサイズが入っておらず、OBSからの更新通知がきたときに初期サイズが入るので、それを監視して更新するというトリッキーな処理です。

#211 で過去に同種の検討をしていますが、より少ない更新で実現しています。ただし今回は画面キャプチャソースの新規追加のみ限定で実装してます。

# 動作確認手順

# 関連するIssue（あれば）
#766