### PR TITLE
修正: Webカメラ/映像入力機器ソースの追加時にプレビューが見えなかった

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -312,6 +312,15 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       resolvedSettings[propName] = device.id;
       */
     });
+
+    if (type === 'dshow_input') {
+      if (resolvedSettings.video_device_id === void 0) {
+        const devices = obs.NodeObs.OBS_settings_getVideoDevices();
+        if (devices.length > 0) {
+          resolvedSettings.video_device_id = devices[0].id;
+        }
+      }
+    }
     return resolvedSettings;
   }
 

--- a/obs-api/obs-api.d.ts
+++ b/obs-api/obs-api.d.ts
@@ -245,5 +245,5 @@ export const NodeObs: {
   OBS_settings_getListCategories(): string[];
   // OBS_settings_getInputAudioDevices(): { description: string; id: string; }[];
   // OBS_settings_getOutputAudioDevices(): { description: string; id: string; }[];
-  // OBS_settings_getVideoDevices(): { description: string; id: string; }[];
+  OBS_settings_getVideoDevices(): { description: string; id: string }[];
 };


### PR DESCRIPTION
# このpull requestが解決する内容
Webカメラ/映像入力機器ソースを追加した際のプロパティ画面で、デバイスがあるのにプレビュー部分が真っ黒になっていた。ここてデバイス欄からデバイスを変更すると表示されるようになっていたが、デバイスが一つしか無いとそれもできなかった。
これを修正します

before
![image](https://github.com/n-air-app/n-air-app/assets/864587/0bd2a3fd-b49c-47e1-bd5b-9e20f28504ec)

