### PR TITLE
開発: e2eテストをさらに分割して高速化する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,9 +161,9 @@ jobs:
     strategy:
       matrix:
         directory:
-          - 'test-dist/test/e2e/[^s]*.js'
-          - 'test-dist/test/e2e/s*.js'
-          - 'test-dist/test/api/*.js'
+          - 'e2e/[^s]*.js'
+          - 'e2e/s*.js'
+          - 'api/*.js'
 
     steps:
       - name: Checkout code
@@ -185,4 +185,4 @@ jobs:
         run: yarn compile:ci
 
       - name: Run e2e tests
-        run: yarn test --fail-fast ${{ matrix.directory }}
+        run: yarn test --fail-fast test-dist/test/${{ matrix.directory }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,8 @@ jobs:
     strategy:
       matrix:
         directory:
-          - 'test-dist/test/e2e/*.js'
+          - 'test-dist/test/e2e/[^s]*.js'
+          - 'test-dist/test/e2e/s*.js'
           - 'test-dist/test/api/*.js'
 
     steps:


### PR DESCRIPTION
# このpull requestが解決する内容
e2eテストを2分割から3分割にして、さらにテスト時間を短縮します。あとmatrixの表示を見やすく

* [x] マージする時はBranch Protection Ruleを更新する

![image](https://github.com/n-air-app/n-air-app/assets/864587/62a297f6-3ec5-4f90-878d-95582a794940)

# 動作確認手順
Pull RequestなどによってGitHub Actionsのtest.ymlを実行させる
