### PR TITLE
開発: package.jsonに packageManagerを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ N Air は Streamlabs OBS をベースにした、生放送に便利な機能が�
 
 npm パッケージをインストールし、さまざまなスクリプトを実行するには Node が必要です。
 
-現在の LTS リリース 8.x.x を推奨します：<https://nodejs.org/>
+現在の LTS リリース 20.x.x を推奨します：<https://nodejs.org/>
 
 ### Yarn
 
 各ノードモジュールの正しいバージョンを使用するためには、yarn パッケージマネージャーを使用する必要があります。
 
-インストール方法については、こちらを参照してください：<https://yarnpkg.com/ja/docs/install>
+Corepack が有効なら自動的にインストールされます。
+手動インストール方法については、こちらを参照してください：<https://yarnpkg.com/ja/docs/install>
 
 ### Visual C++コンパイラ
 

--- a/package.json
+++ b/package.json
@@ -242,5 +242,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
# このpull requestが解決する内容
Nodeのcorepackが有効な環境で自動的にyarnが選択・インストールされるように `packageManager` フィールドを `package.json` に追加します
