### PR TITLE
修正: シーン作成時の名前入力ダイアログのタイトルを「シーンの追加」に

### DIFF
--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -33,7 +33,7 @@
   "addGroupTooltip": "Add a Group so you can move multiple Sources at the same time.",
   "goLiveAnyway": "Go Live Anyway",
   "wait": "Wait",
-  "nameScene": "Name Scene",
+  "nameScene": "Add New Scene",
   "nameSceneCollection": "Name Scene Collection",
   "renameScene": "Rename Scene",
   "newSceneName": "New Scene",

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -33,7 +33,7 @@
   "addGroupTooltip": "複数のソースを同時に移動できるようにフォルダを作成できます。",
   "goLiveAnyway": "配信を開始する",
   "wait": "待機する",
-  "nameScene": "シーンの名前",
+  "nameScene": "シーンの追加",
   "nameSceneCollection": "シーンコレクションの名前",
   "renameScene": "シーンの名前を変更",
   "newSceneName": "シーン",


### PR DESCRIPTION
# このpull requestが解決する内容
before
![image](https://github.com/n-air-app/n-air-app/assets/864587/bef2547c-746f-4cb7-8217-29d3226db815)

after
![image](https://github.com/n-air-app/n-air-app/assets/864587/d85ec8e2-6d1d-495f-a8f0-e442762b76c5)


# 動作確認手順
シーンを追加する

# 関連するIssue（あれば）
fix #525 