### PR TITLE
開発: stylelint対象から自動生成のcustom-icons.lessを除外

### DIFF
--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -1,3 +1,4 @@
+/** @type {import('stylelint').Config} */
 module.exports = {
   plugins: ['stylelint-less'],
   extends: [
@@ -31,6 +32,7 @@ module.exports = {
     },
     {
       files: ['**/*.less'],
+      ignoreFiles: ['app/styles/custom-icons.less'], // 自動生成のため除外
       customSyntax: 'postcss-less',
     },
   ],


### PR DESCRIPTION
自動生成なのでstylelintが違反を出しても直せないため。

あと stylelint.config.cjs に `@type` アノテーションを付けてVSCodeで型チェック・アシストがされるようにしました