### PR TITLE
修正: ボイスチェンジャーソースを含むシーンを複製するとダイアログが閉じず、ボイスチェンジャーソースもコピーされなかった

### DIFF
--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -147,7 +147,7 @@ export class Scene {
     return this.addSource(source.sourceId, options);
   }
 
-  addSource(sourceId: string, options: ISceneNodeAddOptions = {}): SceneItem {
+  addSource(sourceId: string, options: ISceneNodeAddOptions = {}): SceneItem | null {
     const source = this.sourcesService.getSource(sourceId);
     if (!source) throw new Error(`Source ${sourceId} not found`);
 
@@ -423,7 +423,7 @@ export class Scene {
 
     // 同一scene上では1つだけ
     if (source.type === 'nair-rtvc-source') {
-      for (const s of this.scenesService.activeScene.items) {
+      for (const s of this.items) {
         if (this.sourcesService.getSourceById(s.sourceId).type === 'nair-rtvc-source') return false;
       }
     }

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -202,7 +202,7 @@ export class ScenesService extends StatefulService<IScenesState> {
         .reverse()
         .forEach(item => {
           const newItem = newScene.addSource(item.sourceId);
-          newItem.setSettings(item.getSettings());
+          if (newItem) newItem.setSettings(item.getSettings());
         });
     }
 


### PR DESCRIPTION


# 動作確認手順

ボイチェンを含むシーンを、シーンリスト＞右クリック＞複製
にてコピー

修正前：コピーのダイアログが閉じない・ボイチェンがコピーされていない



