### PR TITLE
開発: mini-release.js: 再リリース機能(途中でこけたとき用)

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -424,11 +424,12 @@ async function releaseRoutine() {
   // eslint-disable-next-line import/no-dynamic-require
   const config = require(`./configs/${environment}-${channel}`);
 
-  if (getTagCommitId(`v${nextVersion}`)) {
-    error(`Tag "v${nextVersion}" has already been released.`);
+  const tagCommitId = getTagCommitId(`v${nextVersion}`);
+  if (tagCommitId) {
+    error(`Tag "v${nextVersion}" has already been released: commit ${tagCommitId}.`);
     info('Generate new patchNote with new version.');
     info('If you want to retry current release, remove the tag and related release commit.');
-    if (!(await confirm('Do you want to remove the tag and revert HEAD?', false))) {
+    if (!(await confirm(`Do you want to remove the tag and revert ${tagCommitId}?`, false))) {
       sh.exit(1);
     }
     // remove tag
@@ -438,8 +439,8 @@ async function releaseRoutine() {
     log(`removing tag v${nextVersion} from remote ...`);
     executeCmd(`git push ${config.target.remote} :v${nextVersion} || true`); // ignore error
     // revert last commit
-    log('reverting HEAD ...');
-    executeCmd('git revert --no-edit HEAD');
+    log(`reverting ${tagCommitId} ...`);
+    executeCmd(`git revert --no-edit ${tagCommitId}`);
   }
 
   info('checking current version ...');

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -424,25 +424,6 @@ async function releaseRoutine() {
   // eslint-disable-next-line import/no-dynamic-require
   const config = require(`./configs/${environment}-${channel}`);
 
-  const tagCommitId = getTagCommitId(`v${nextVersion}`);
-  if (tagCommitId) {
-    error(`Tag "v${nextVersion}" has already been released: commit ${tagCommitId}.`);
-    info('Generate new patchNote with new version.');
-    info('If you want to retry current release, remove the tag and related release commit.');
-    if (!(await confirm(`Do you want to remove the tag and revert ${tagCommitId}?`, false))) {
-      sh.exit(1);
-    }
-    // revert last commit
-    log(`reverting ${tagCommitId} ...`);
-    executeCmd(`git revert --no-edit ${tagCommitId}`);
-    // remove tag
-    log(`removing tag v${nextVersion} ...`);
-    executeCmd(`git tag -d v${nextVersion}`);
-    // remove tag from remote
-    log(`removing tag v${nextVersion} from remote ...`);
-    executeCmd(`git push ${config.target.remote} :v${nextVersion} || true`); // ignore error
-  }
-
   info('checking current version ...');
   const previousVersion = pjson.version;
   const previousVersionContext = getVersionContext(previousVersion);
@@ -460,6 +441,25 @@ async function releaseRoutine() {
       );
       throw new Error(msg);
     }
+  }
+
+  const tagCommitId = getTagCommitId(`v${nextVersion}`);
+  if (tagCommitId) {
+    error(`Tag "v${nextVersion}" has already been released: commit ${tagCommitId}.`);
+    info('Generate new patchNote with new version.');
+    info('If you want to retry current release, remove the tag and related release commit.');
+    if (!(await confirm(`Do you want to remove the tag and revert ${tagCommitId}?`, false))) {
+      sh.exit(1);
+    }
+    // revert last commit
+    log(`reverting ${tagCommitId} ...`);
+    executeCmd(`git revert --no-edit ${tagCommitId}`);
+    // remove tag
+    log(`removing tag v${nextVersion} ...`);
+    executeCmd(`git tag -d v${nextVersion}`);
+    // remove tag from remote
+    log(`removing tag v${nextVersion} from remote ...`);
+    executeCmd(`git push ${config.target.remote} :v${nextVersion} || true`); // ignore error
   }
 
   await runScript({

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -432,15 +432,15 @@ async function releaseRoutine() {
     if (!(await confirm(`Do you want to remove the tag and revert ${tagCommitId}?`, false))) {
       sh.exit(1);
     }
+    // revert last commit
+    log(`reverting ${tagCommitId} ...`);
+    executeCmd(`git revert --no-edit ${tagCommitId}`);
     // remove tag
     log(`removing tag v${nextVersion} ...`);
     executeCmd(`git tag -d v${nextVersion}`);
     // remove tag from remote
     log(`removing tag v${nextVersion} from remote ...`);
     executeCmd(`git push ${config.target.remote} :v${nextVersion} || true`); // ignore error
-    // revert last commit
-    log(`reverting ${tagCommitId} ...`);
-    executeCmd(`git revert --no-edit ${tagCommitId}`);
   }
 
   info('checking current version ...');

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -197,11 +197,6 @@ function readPatchNote({ patchNoteFileName }) {
     throw new Error(`${patchNoteFileName} is absent.`);
   }
 
-  if (getTagCommitId(`v${patchNote.version}`)) {
-    error(`tag 'v${patchNote.version}' has already been released.`);
-    throw new Error(`tag 'v${patchNote.version}' has already been released.`);
-  }
-
   return {
     version: patchNote.version,
     notes: patchNote.lines.join('\n'),

--- a/bin/release/scripts/prompt.js
+++ b/bin/release/scripts/prompt.js
@@ -18,7 +18,7 @@ function error(msg) {
 
 function executeCmd(cmd, options) {
   log(`Executing: ${cmd}`);
-  const result = sh.exec(cmd, options);
+  const result = /** @type {sh.ExecOutputReturnValue} */ (sh.exec(cmd, options));
 
   if (result.code !== 0) {
     error(`Command Failed >>> ${cmd}`);

--- a/bin/release/scripts/util.js
+++ b/bin/release/scripts/util.js
@@ -4,7 +4,11 @@ const sh = require('shelljs');
 const { executeCmd, error } = require('./prompt');
 
 function getTagCommitId(tag) {
-  return executeCmd(`git rev-parse -q --verify "refs/tags/${tag}" || cat /dev/null`, { silent: true }).stdout;
+  const line = executeCmd(`git rev-parse -q --verify "refs/tags/${tag}" || cat /dev/null`, {
+    silent: true,
+  }).stdout;
+  // 末尾の改行を除去する
+  return line.replace(/\n$/, '');
 }
 
 function checkEnv(varName) {


### PR DESCRIPTION
# このpull requestが解決する内容
リリーススクリプトが中でこけたときなどに tag がすでについててバージョンコミットがある状態から同じバージョンでリリースできる機能を追加します。

patch-note.txt にあるversion と一致するタグがすでに存在する場合に、確認の上で、そのtagとtagが付いたcommitをrevertした上で再度リリースを実行できるようにします。
従来はタグが付いたもののリリースが完了せず失敗したときに、手でいちいう削除してから再リリースしていました。

- [x] 実際に非公開でリリースしてみたりする
- [x] HEADではなく tagのついていたcommitをrevertするようにする