### PR TITLE
開発: package.jsonの重複行削除とstylelintをスペル辞書に追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,6 +69,7 @@
     "spectron",
     "ssng",
     "statusarea",
+    "stylelint",
     "superfast",
     "systeminformation",
     "toplevel",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "browserslist": [
     "chrome >= 76"
   ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "scripts": {
     "compile": "yarn clear && webpack-cli --progress --mode development",
     "compile:ci": "yarn clear && webpack-cli --mode development",


### PR DESCRIPTION
# このpull requestが解決する内容
`package.json` の `packageManager` 行が2つに分裂してたので片方消します。あと `package.json` 内に現れる `stylelint` をspell辞書に追加
