### PR TITLE
修正: ソースの追加ウィンドウの Application Audio Captureの文言（英語）が長くてレイアウトが崩れていたのを短縮して修正

### DIFF
--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -407,7 +407,7 @@
     "description": "Add a character to your scene that reads comments to the \"N Voice\" voice."
   },
   "wasapi_process_output_capture": {
-    "name": "Application Audio Capture (BETA)",
+    "name": "App Audio Capture (BETA)",
     "description": "Capture the audio coming from a specific application."
   },
   "nair-rtvc-source": {


### PR DESCRIPTION
# このpull requestが解決する内容
Application Audio Capture (BETA) → App Audio Capture (BETA)

### 修正前
![キャプチャ](https://github.com/n-air-app/n-air-app/assets/43235200/1b187d78-ce76-4d5d-bcac-11fcd1e9fcb9)

### 修正後
![キャプチャ](https://github.com/n-air-app/n-air-app/assets/43235200/c8ccfa85-0ccf-4a1e-9804-02c7c3b7bfa0)
