### PR TITLE
開発: mini-release: 古いInject to Sentryが残っていたせいでsourceMapが正しく認識されなくなっていたのを修正

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -246,11 +246,6 @@ async function runScript({
     info('Compiling assets...');
     executeCmd('yarn compile:production');
 
-    info('Injecting Sentry...');
-    executeCmd(`cp main.js bundles/`);
-    const bundles = path.resolve('.', 'bundles');
-    injectForSentry(bundles);
-
     info('Making the package...');
     executeCmd(`yarn package:${releaseEnvironment}-${releaseChannel}`);
   }


### PR DESCRIPTION
# このpull requestが解決する内容
`yarn compile:production` だと動くのにリリースするとおかしいと思ったら mini-release の中で sourcemapを上書きして破壊してしまっていたので、それを除去します

# 動作確認手順
リリースして実行して、Sentryで確認する
