### PR TITLE
修正:「リプレイ録画をスタンバイ状態にする」を押した時に操作不能にならないように設定ウィンドウを閉じる

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -559,6 +559,8 @@ export class StreamingService
   startReplayBuffer() {
     if (this.state.replayBufferStatus !== EReplayBufferState.Offline) return;
 
+    this.windowsService.closeChildWindow();
+
     try {
       Sentry.addBreadcrumb({
         category: 'obs',


### PR DESCRIPTION
```
以下の操作を行うと設定ウィンドウ出力タブの操作が不可能の状態になり復帰できなくなります。
1.設定ウィンドウの出力タブを開く
2.出力タブを開いた状態でメインウィンドウの「リプレイ録画をスタンバイ状態にする」ボタンを押す
3.出力タブ最下部の「リプレイ録画を有効にする」のチェックを外すと出力タブの操作が不可となる
4.メインウィンドウの「リプレイ録画をスタンバイ状態にする」ボタンも非表示となりスタンバイ状態も解除できなくなる
```
有効/無効トグルはリプレイ停止時のみ操作できる。
有効/無効トグルの操作可/不可は設定画面を開いた時に反映される。
設定ウインドウを開いたままリプレイ開始、有効/無効トグルで無効にして閉じ、
再度設定ウインドを開いた場合にこのトグルが操作できなくなる。

対処としてリプレイを開始した時に設定ウインドウを強制的に閉じる。
リプレイ中に再び設定ウインドウを開いた時は操作不可になっているので無効には出来ない。
これによリプレイ中に無効にすることを防止する。
無効にするには一旦止めてから行う。


