### PR TITLE
開発: 番組情報エリアからコミュニティ名を削除、コミュニティサムネイルをユーザーサムネイルに変更 (PRへのPR)

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="program-info">
-    <div class="community-icon" :class="{ 'is-onAir': isOnAir }">
-      <img :src="communitySymbol" class="community-thumbnail" :alt="communityName" />
+    <div class="user-icon" :class="{ 'is-onAir': isOnAir }">
+      <img :src="userIcon" class="user-thumbnail" :alt="userName" />
     </div>
     <div class="program-info-description">
       <h1 class="program-title">
@@ -14,21 +14,6 @@
           {{ programTitle }}
         </a>
       </h1>
-      <h2 class="community-name">
-        <i
-          v-if="programIsMemberOnly"
-          class="icon-lock"
-          v-tooltip.bottom="programIsMemberOnlyTooltip"
-        ></i>
-        <a
-          :href="communityPageURL"
-          @click.prevent="openInDefaultBrowser($event)"
-          class="community-name-link link"
-          v-tooltip.bottom="communityName"
-        >
-          {{ communityName }}
-        </a>
-      </h2>
     </div>
     <popper
       trigger="click"
@@ -100,7 +85,7 @@
 .program-title {
   display: flex;
   align-items: center;
-  margin-bottom: 4px;
+  margin-bottom: 0;
 }
 
 .program-title-link {
@@ -116,26 +101,7 @@
   margin-left: 16px;
 }
 
-.community-name {
-  display: flex;
-  align-items: center;
-  margin: 0;
-
-  .icon-lock {
-    margin-right: 8px;
-    font-size: @font-size1;
-    color: var(--color-text);
-  }
-}
-
-.community-name-link {
-  .text-ellipsis;
-
-  display: inline-block;
-  font-size: @font-size2;
-}
-
-.community-icon {
+.user-icon {
   position: relative;
   flex-shrink: 0;
   width: 40px;
@@ -144,7 +110,7 @@
   border: 2px solid var(--color-border-accent);
   border-radius: 50%;
 
-  .community-thumbnail {
+  .user-thumbnail {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -9,6 +9,8 @@ import Popper from 'vue-popperjs';
 import * as moment from 'moment';
 import { HostsService } from 'services/hosts';
 import * as remote from '@electron/remote';
+import { UserService } from 'services/user';
+import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 
 @Component({
   components: {
@@ -20,9 +22,7 @@ export default class ProgramInfo extends Vue {
   nicoliveProgramService: NicoliveProgramService;
   @Inject() streamingService: StreamingService;
   @Inject() hostsService: HostsService;
-
-  // TODO: 後でまとめる
-  programIsMemberOnlyTooltip = 'コミュニティ限定放送';
+  @Inject() userService: UserService;
 
   private subscription: Subscription = null;
 
@@ -61,20 +61,18 @@ export default class ProgramInfo extends Vue {
     return this.nicoliveProgramService.state.title;
   }
 
-  get programIsMemberOnly(): boolean {
-    return this.nicoliveProgramService.state.isMemberOnly;
+  get userName(): string {
+    if (isFakeMode) {
+      return FakeUserAuth.platform.username;
+    }
+    return this.userService.username;
   }
 
-  get communityID(): string {
-    return this.nicoliveProgramService.state.communityID;
-  }
-
-  get communityName(): string {
-    return this.nicoliveProgramService.state.communityName;
-  }
-
-  get communitySymbol(): string {
-    return this.nicoliveProgramService.state.communitySymbol;
+  get userIcon(): string {
+    if (isFakeMode) {
+      return FakeUserAuth.platform.userIcon;
+    }
+    return this.userService.userIcon;
   }
 
   get autoExtensionEnabled() {
@@ -94,10 +92,6 @@ export default class ProgramInfo extends Vue {
 
   get watchPageURL(): string {
     return this.hostsService.getWatchPageURL(this.programID);
-  }
-
-  get communityPageURL(): string {
-    return this.hostsService.getCommunityPageURL(this.communityID);
   }
 
   async editProgram() {

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -10,7 +10,6 @@ import * as moment from 'moment';
 import { HostsService } from 'services/hosts';
 import * as remote from '@electron/remote';
 import { UserService } from 'services/user';
-import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 
 @Component({
   components: {
@@ -62,16 +61,10 @@ export default class ProgramInfo extends Vue {
   }
 
   get userName(): string {
-    if (isFakeMode) {
-      return FakeUserAuth.platform.username;
-    }
     return this.userService.username;
   }
 
   get userIcon(): string {
-    if (isFakeMode) {
-      return FakeUserAuth.platform.userIcon;
-    }
     return this.userService.userIcon;
   }
 

--- a/app/util/fakeMode.ts
+++ b/app/util/fakeMode.ts
@@ -12,6 +12,6 @@ export const FakeUserAuth: IPlatformAuth = {
     username: 'fake',
     token: 'fake',
     id: '2',
-    userIcon: '',
+    userIcon: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
   },
 };


### PR DESCRIPTION
# このpull requestが解決する内容
- サムネイルをコミュニティからユーザーに変更
- コミュニティ情報を削除

### 修正前
![image](https://github.com/n-air-app/n-air-app/assets/43235200/1fb08c6e-accc-48ea-a71f-456881a88f9b)

### 修正後
![image](https://github.com/n-air-app/n-air-app/assets/43235200/51af1884-576b-45a5-a35b-1f4dea176499)