### PR TITLE
変更: コミュニティアイコンからユーザーアイコンへの表示変更

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="program-info">
-    <div class="community-icon" :class="{ 'is-onAir': isOnAir }">
-      <img :src="communitySymbol" class="community-thumbnail" :alt="communityName" />
+    <div class="user-icon" :class="{ 'is-onAir': isOnAir }">
+      <img :src="userIcon" class="user-thumbnail" :alt="userName" />
     </div>
     <div class="program-info-description">
       <h1 class="program-title">
@@ -14,21 +14,6 @@
           {{ programTitle }}
         </a>
       </h1>
-      <h2 class="community-name">
-        <i
-          v-if="programIsMemberOnly"
-          class="icon-lock"
-          v-tooltip.bottom="programIsMemberOnlyTooltip"
-        ></i>
-        <a
-          :href="communityPageURL"
-          @click.prevent="openInDefaultBrowser($event)"
-          class="community-name-link link"
-          v-tooltip.bottom="communityName"
-        >
-          {{ communityName }}
-        </a>
-      </h2>
     </div>
     <popper
       trigger="click"
@@ -100,7 +85,7 @@
 .program-title {
   display: flex;
   align-items: center;
-  margin-bottom: 4px;
+  margin-bottom: 0;
 }
 
 .program-title-link {
@@ -116,26 +101,7 @@
   margin-left: 16px;
 }
 
-.community-name {
-  display: flex;
-  align-items: center;
-  margin: 0;
-
-  .icon-lock {
-    margin-right: 8px;
-    font-size: @font-size1;
-    color: var(--color-text);
-  }
-}
-
-.community-name-link {
-  .text-ellipsis;
-
-  display: inline-block;
-  font-size: @font-size2;
-}
-
-.community-icon {
+.user-icon {
   position: relative;
   flex-shrink: 0;
   width: 40px;
@@ -144,7 +110,7 @@
   border: 2px solid var(--color-border-accent);
   border-radius: 50%;
 
-  .community-thumbnail {
+  .user-thumbnail {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -9,6 +9,8 @@ import Popper from 'vue-popperjs';
 import * as moment from 'moment';
 import { HostsService } from 'services/hosts';
 import * as remote from '@electron/remote';
+import { UserService } from 'services/user';
+import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 
 @Component({
   components: {
@@ -20,9 +22,7 @@ export default class ProgramInfo extends Vue {
   nicoliveProgramService: NicoliveProgramService;
   @Inject() streamingService: StreamingService;
   @Inject() hostsService: HostsService;
-
-  // TODO: 後でまとめる
-  programIsMemberOnlyTooltip = 'コミュニティ限定放送';
+  @Inject() userService: UserService;
 
   private subscription: Subscription = null;
 
@@ -61,20 +61,18 @@ export default class ProgramInfo extends Vue {
     return this.nicoliveProgramService.state.title;
   }
 
-  get programIsMemberOnly(): boolean {
-    return this.nicoliveProgramService.state.isMemberOnly;
+  get userName(): string {
+    if (isFakeMode) {
+      return FakeUserAuth.platform.username;
+    }
+    return this.userService.username;
   }
 
-  get communityID(): string {
-    return this.nicoliveProgramService.state.communityID;
-  }
-
-  get communityName(): string {
-    return this.nicoliveProgramService.state.communityName;
-  }
-
-  get communitySymbol(): string {
-    return this.nicoliveProgramService.state.communitySymbol;
+  get userIcon(): string {
+    if (isFakeMode) {
+      return FakeUserAuth.platform.userIcon;
+    }
+    return this.userService.userIcon;
   }
 
   get autoExtensionEnabled() {
@@ -94,10 +92,6 @@ export default class ProgramInfo extends Vue {
 
   get watchPageURL(): string {
     return this.hostsService.getWatchPageURL(this.programID);
-  }
-
-  get communityPageURL(): string {
-    return this.hostsService.getCommunityPageURL(this.communityID);
   }
 
   async editProgram() {

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -10,7 +10,6 @@ import * as moment from 'moment';
 import { HostsService } from 'services/hosts';
 import * as remote from '@electron/remote';
 import { UserService } from 'services/user';
-import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 
 @Component({
   components: {
@@ -62,16 +61,10 @@ export default class ProgramInfo extends Vue {
   }
 
   get userName(): string {
-    if (isFakeMode) {
-      return FakeUserAuth.platform.username;
-    }
     return this.userService.username;
   }
 
   get userIcon(): string {
-    if (isFakeMode) {
-      return FakeUserAuth.platform.userIcon;
-    }
     return this.userService.userIcon;
   }
 

--- a/app/services/nicolive-program/nicolive-comment-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.ts
@@ -8,6 +8,7 @@ import { map, distinctUntilChanged } from 'rxjs/operators';
 import { NicoliveFailure } from './NicoliveFailure';
 import { WrappedChat } from './WrappedChat';
 import { Subject } from 'rxjs';
+import { isFakeMode } from 'util/fakeMode';
 
 interface INicoliveCommentFilterState {
   filters: FilterRecord[];
@@ -94,7 +95,7 @@ export class NicoliveCommentFilterService extends StatefulService<INicoliveComme
   }
 
   async deleteFilters(ids: number[]) {
-    if (process.env.DEV_SERVER) {
+    if (isFakeMode()) {
       return;
     }
 

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -37,6 +37,7 @@ import { NicoliveCommentSynthesizerService } from './nicolive-comment-synthesize
 import { NicoliveProgramStateService } from './state';
 import { NicoliveModeratorsService } from './nicolive-moderators';
 import { FilterRecord } from './ResponseTypes';
+import { isFakeMode } from 'util/fakeMode';
 
 function makeEmulatedChat(
   content: string,
@@ -241,7 +242,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
     // 予約番組は30分前にならないとURLが来ない
     if (!roomURL || !roomThreadID) return;
 
-    if (process.env.DEV_SERVER) {
+    if (isFakeMode()) {
       // yarn dev 時はダミーでコメントを5秒ごとに出し続ける
       this.client = new DummyMessageServerClient();
     } else {

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -8,6 +8,7 @@ import { NicoliveFailure, openErrorDialogFromFailure } from './NicoliveFailure';
 import { Community, ProgramSchedules } from './ResponseTypes';
 import { NicoliveProgramStateService } from './state';
 import { MAX_PROGRAM_DURATION_SECONDS } from './nicolive-constants';
+import { isFakeMode } from 'util/fakeMode';
 
 type Schedules = ProgramSchedules['data'];
 type Schedule = Schedules[0];
@@ -223,6 +224,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   async createProgram(): Promise<CreateResult> {
+    if (isFakeMode()) {
+      await this.fetchProgram();
+      return CreateResult.CREATED;
+    }
     const result = await this.client.createProgram();
     if (result === 'CREATED') {
       await this.fetchProgram();
@@ -232,6 +237,25 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
   async fetchProgram(): Promise<void> {
     this.setState({ isFetching: true });
+    if (isFakeMode()) {
+      const now = Math.floor(Date.now() / 1000);
+      this.setState({
+        programID: 'lvDEBUG',
+        status: 'onAir',
+        title: 'DEBUG番組',
+        description: 'N Airデザイン作業用番組',
+        startTime: now,
+        vposBaseTime: now,
+        endTime: now + 60 * 60,
+        isMemberOnly: true,
+        communityID: 'coDEBUG',
+        communityName: 'DEBUGコミュニティ',
+        communitySymbol: '',
+        roomURL: 'URL',
+        roomThreadID: 'thread',
+      });
+      return;
+    }
     try {
       const schedulesResponse = await this.client.fetchProgramSchedules();
       if (!isOk(schedulesResponse)) {
@@ -302,6 +326,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   async refreshProgram(): Promise<void> {
+    if (isFakeMode()) {
+      await this.fetchProgram();
+      return;
+    }
     const programResponse = await this.client.fetchProgram(this.state.programID);
     if (!isOk(programResponse)) {
       throw NicoliveFailure.fromClientError('fetchProgram', programResponse);
@@ -323,6 +351,9 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   async editProgram(): Promise<EditResult> {
+    if (isFakeMode()) {
+      return;
+    }
     const result = await this.client.editProgram(this.state.programID);
     if (result === 'EDITED') {
       await this.refreshProgram();
@@ -347,6 +378,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   async endProgram(): Promise<void> {
+    if (isFakeMode()) {
+      this.setState({ status: 'end' });
+      return;
+    }
     this.setState({ isEnding: true });
     try {
       const result = await this.client.endProgram(this.state.programID);
@@ -368,7 +403,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   async extendProgram(): Promise<void> {
     this.setState({ isExtending: true });
     try {
-      if (process.env.DEV_SERVER) {
+      if (isFakeMode()) {
         const endTime = this.state.endTime + 30 * 60;
         this.setState({ endTime });
         return;
@@ -414,6 +449,9 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   updateStatistics(programID: string): Promise<any> {
+    if (isFakeMode()) {
+      return Promise.resolve();
+    }
     const stats = this.client
       .fetchStatistics(programID)
       .then(res => {
@@ -442,6 +480,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   async sendOperatorComment(text: string, isPermanent: boolean): Promise<void> {
+    if (isFakeMode()) {
+      // TODO
+      return;
+    }
     const result = await this.client.sendOperatorComment(this.state.programID, {
       text,
       isPermanent,

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -10,6 +10,7 @@ import { parseString } from 'xml2js';
 import { StreamingService, EStreamingState } from 'services/streaming';
 import { WindowsService } from 'services/windows';
 import { NicoliveClient } from 'services/nicolive-program/NicoliveClient';
+import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 
 export type INiconicoProgramSelection = {
   info: LiveProgramInfo;
@@ -35,7 +36,7 @@ type Program = {
 };
 
 type SocialGroup = {
-  type: 'community' | 'channel';
+  tfakeype: 'community' | 'channel';
   id: string;
   name: string;
   thumbnailUrl: string;
@@ -62,6 +63,9 @@ export class NiconicoService extends Service implements IPlatformService {
   client: NicoliveClient = new NicoliveClient();
 
   async getUserId(): Promise<string> {
+    if (isFakeMode()) {
+      return FakeUserAuth.platform.id; // dummy user ID
+    }
     const url = `${this.hostsService.niconicoAccount}/api/public/v1/user/id.json`;
     const request = new Request(url, { credentials: 'same-origin' });
 
@@ -83,6 +87,9 @@ export class NiconicoService extends Service implements IPlatformService {
   }
 
   async isPremium(token: string): Promise<boolean> {
+    if (isFakeMode()) {
+      return true;
+    }
     const url = `${this.hostsService.niconicoOAuth}/v1/user/premium.json`;
     const headers = authorizedHeaders(token);
     const request = new Request(this.hostsService.replaceHost(url), { headers });
@@ -92,6 +99,9 @@ export class NiconicoService extends Service implements IPlatformService {
   }
 
   async logout(): Promise<void> {
+    if (isFakeMode()) {
+      return;
+    }
     const url = `${this.hostsService.niconicoAccount}/logout`;
     const request = new Request(this.hostsService.replaceHost(url), { credentials: 'same-origin' });
     const response = await fetch(request);

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -21,6 +21,7 @@ import { OnboardingService } from './onboarding';
 import { UuidService } from './uuid';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import * as remote from '@electron/remote';
+import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 
 // Eventually we will support authing multiple platforms at once
 interface IUserServiceState {
@@ -225,6 +226,13 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }) {
     const service = getPlatformService(platform);
     console.log('startAuth service = ' + JSON.stringify(service));
+    if (isFakeMode()) {
+      this.login(service, FakeUserAuth).then(() => {
+        onAuthFinish();
+        onAuthClose();
+      });
+      return;
+    }
 
     const authWindow = new remote.BrowserWindow({
       ...service.authWindowOptions,

--- a/app/util/fakeMode.ts
+++ b/app/util/fakeMode.ts
@@ -12,6 +12,6 @@ export const FakeUserAuth: IPlatformAuth = {
     username: 'fake',
     token: 'fake',
     id: '2',
-    userIcon: '',
+    userIcon: 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
   },
 };

--- a/app/util/fakeMode.ts
+++ b/app/util/fakeMode.ts
@@ -1,0 +1,17 @@
+import { IPlatformAuth } from 'services/platforms';
+
+// 開発テスト用
+export function isFakeMode(): boolean {
+  return !!process.env.DEV_SERVER || !!process.env.NAIR_FAKE_PROGRAM;
+}
+
+export const FakeUserAuth: IPlatformAuth = {
+  apiToken: 'fake',
+  platform: {
+    type: 'niconico',
+    username: 'fake',
+    token: 'fake',
+    id: '2',
+    userIcon: '',
+  },
+};


### PR DESCRIPTION
# このpull requestが解決する内容
- サムネイルをコミュニティからユーザーに変更
- コミュニティ情報を削除
- yarn devと環境変数指定時に発動する fakeMode (ニコニコログインと番組情報をダミー化する)を追加

### 修正前
![image](https://github.com/n-air-app/n-air-app/assets/43235200/1fb08c6e-accc-48ea-a71f-456881a88f9b)

### 修正後
![image](https://github.com/n-air-app/n-air-app/assets/43235200/51af1884-576b-45a5-a35b-1f4dea176499)