### PR TITLE
修正: アプリ終了時に番組作成/編集ウィンドウが開いているとそのまま残っていた

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -26,6 +26,7 @@ import * as obs from '../../../obs-api';
 import { RunInLoadingMode } from './app-decorators';
 import Utils from 'services/utils';
 import * as remote from '@electron/remote';
+import { NicoliveClient } from 'services/nicolive-program/NicoliveClient';
 
 interface IAppState {
   loading: boolean;
@@ -135,6 +136,7 @@ export class AppService extends StatefulService<IAppState> {
       // this.platformAppsService.unloadAllApps(); 未実装
       // await this.usageStatisticsService.flushEvents(); 未実装
       this.windowsService.closeAllOneOffs(); // intead .shutdown(); window.child.close is 'Object has been destroyed' in this time
+      NicoliveClient.closeOpenWindows();
       this.ipcServerService.stopListening();
       // await this.userService.flushUserSession(); 未実装
       await this.sceneCollectionsService.deinitialize();

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -131,6 +131,26 @@ export class NicoliveClient {
     'x-frontend-id': '134',
   } as const;
 
+  private static OpenWindows: { [key: string]: Electron.BrowserWindow | null } = {};
+
+  static registerWindow(key: 'createProgram' | 'editProgram', win: Electron.BrowserWindow) {
+    if (NicoliveClient.OpenWindows[key]) {
+      throw new Error(`NicoliveClient.registerWindow: Window already exists: ${key}`);
+    }
+    NicoliveClient.OpenWindows[key] = win;
+    win.on('close', () => {
+      NicoliveClient.OpenWindows[key] = null;
+    });
+  }
+  static closeOpenWindows() {
+    for (const key in NicoliveClient.OpenWindows) {
+      const win = NicoliveClient.OpenWindows[key];
+      if (win) {
+        win.close();
+      }
+    }
+  }
+
   /**
    *
    * @param options niconicoSession: ニコニコのセッションIDを外挿する場合に与える
@@ -454,6 +474,7 @@ export class NicoliveClient {
         nodeIntegrationInWorker: false,
       },
     });
+    NicoliveClient.registerWindow('createProgram', win);
     win.removeMenu();
     Sentry.addBreadcrumb({
       category: 'createProgram.open',
@@ -526,6 +547,7 @@ export class NicoliveClient {
         nodeIntegrationInWorker: false,
       },
     });
+    NicoliveClient.registerWindow('editProgram', win);
     win.removeMenu();
     this.editProgramWindow = win;
     this.editProgramId = programID;


### PR DESCRIPTION
# このpull requestが解決する内容
ニコ生の番組作成または番組編集ウィンドウが開いた状態でアプリを終了しても、番組作成/編集ウィンドウが閉じずにアプリが終了しなかったバグを修正します

# 動作確認手順
ニコ生の番組作成または番組編集ウィンドウが開いた状態でアプリを終了すると、N Airが終了すること

# メモ
この二つは NicoliveClient の中で作成され、Windows serviceなどで管理されていない。管理されるようにするには service をInject する必要があるが、ちょっと副作用が怖いので一旦現状を維持する形で解決しています