### PR TITLE
修正: フィードバックページのURLを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ N Air はオープンソースであり、どなたでも開発に参加でき�
 ## バグ報告
 
 - フィードバックへのリンク
-  - <https://secure.nicovideo.jp/form/entry/n_air_feedback>
+  - <https://form.nicovideo.jp/forms/n_air_feedback>
 - issue
   - <https://github.com/n-air-app/n-air-app/issues>
 

--- a/app/components/SideNav.vue.ts
+++ b/app/components/SideNav.vue.ts
@@ -84,7 +84,7 @@ export default class SideNav extends Vue {
   }
 
   openFeedback() {
-    remote.shell.openExternal('https://secure.nicovideo.jp/form/entry/n_air_feedback');
+    remote.shell.openExternal('https://form.nicovideo.jp/forms/n_air_feedback');
   }
 
   openHelp() {


### PR DESCRIPTION
# このpull requestが解決する内容
従来のフィードバックページのサーバーがランサムウェア被害から復旧していないため、別のURLで用意したフィードバックページへのリンクに変更します

# 動作確認手順
アプリ左のナビゲーションバーの中からふきだしの形のフィードバックから開けること
