### PR TITLE
開発: Sentryに上がっているエラー('offsetWidth' of undefined)修正 / 番組作成・編集ウィンドウからの想定外遷移の記録改善

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -496,7 +496,7 @@ export class NicoliveClient {
         } else if (!NicoliveClient.isAllowedURL(url)) {
           Sentry.withScope(scope => {
             scope.setLevel('warning');
-            scope.setExtra('url', url);
+            scope.setTag('url', url);
             scope.setFingerprint(['createProgram', 'did-navigate', url]);
             Sentry.captureMessage('createProgram did-navigate to unexpected URL');
           });
@@ -570,7 +570,7 @@ export class NicoliveClient {
         } else if (!NicoliveClient.isAllowedURL(url)) {
           Sentry.withScope(scope => {
             scope.setLevel('warning');
-            scope.setExtra('url', url);
+            scope.setTag('url', url);
             scope.setTag('programID', programID);
             scope.setFingerprint(['editProgram', 'did-navigate', url]);
             Sentry.captureMessage('editProgram did-navigate to unexpected URL');

--- a/app/services/patch-notes/index.ts
+++ b/app/services/patch-notes/index.ts
@@ -60,7 +60,13 @@ export class PatchNotesService extends PersistentStatefulService<IPatchNotesStat
     this.SET_LAST_VERSION_SEEN(currentVersion);
 
     // Only show the actual patch notes if they weren't onboarded
-    if (!onboarded) this.navigationService.navigate('PatchNotes');
+    if (!onboarded) {
+      // ここですぐ遷移してしまうと起動時の studio の vue-sliderの非同期処理が途中なため例外が発生する。
+      // それを回避するため setTimeoutで遅延させる
+      setTimeout(() => {
+        this.navigationService.navigate('PatchNotes');
+      }, 0);
+    }
   }
 
   get notes() {


### PR DESCRIPTION
# このpull requestが解決する内容
* 起動時にpatch-noteを表示するときに Studio modeにして即切り替えているため、非同期に初期化しているvue-sliderが 'offsetWidth' of undefined で例外を飛ばしていた(アプリの動作には問題はなかった)
* 番組作成・編集ウィンドウからの想定外のURLへの遷移報告のURL部分を extra から tagに変更して集計可能にする