### PR TITLE
修正: コメント一覧のギフト・ニコニ広告・エモーションの表示を調整する

### DIFF
--- a/app/components/nicolive-area/comment/GiftComment.vue
+++ b/app/components/nicolive-area/comment/GiftComment.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="root comment-root" :class="chat.type" :title="computedTitle">
-    <div class="comment-root">
+    <div class="comment-wrapper">
       <div class="comment-header"><i class="icon-gift"></i></div>
       <div class="comment-body">{{ computedContent }}</div>
     </div>

--- a/app/components/nicolive-area/comment/NicoadComment.vue
+++ b/app/components/nicolive-area/comment/NicoadComment.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="root comment-root" :class="chat.type" :title="computedTitle">
-    <div class="comment-root">
+    <div class="comment-wrapper">
       <div class="comment-header"><i class="icon-nicoad"></i></div>
       <div class="comment-body">{{ computedContent }}</div>
     </div>

--- a/app/services/nicolive-program/ChatMessage/displaytext.ts
+++ b/app/services/nicolive-program/ChatMessage/displaytext.ts
@@ -15,7 +15,10 @@ function getNicoadComment(chat: WrappedMessage): string {
     const nicoad = chat.value;
     if (isNicoadMessageV0(nicoad)) {
       if (nicoad.v0.latest) {
-        return nicoad.v0.latest.message ?? '';
+        const latest = nicoad.v0.latest;
+        const advertiser = latest.advertiser;
+        const message = latest.message ? `「${latest.message}」` : '';
+        return `提供：${advertiser}さん${message}（${latest.point}pt）`;
       }
     } else if (isNicoadMessageV1(nicoad)) {
       return nicoad.v1.message ?? '';

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/vue';
-import { EMPTY, Observable, Subject, Subscription, from, merge, of } from 'rxjs';
+import { EMPTY, Observable, Subject, Subscription, interval, merge, of } from 'rxjs';
 import {
   bufferTime,
   catchError,
@@ -47,13 +47,7 @@ import {
   isOperatorMessage,
   isStateMessage,
 } from './ChatMessage/util';
-import {
-  GiftMessage,
-  MessageResponse,
-  NicoadMessageV0,
-  NicoadMessageV1,
-  NotificationMessage,
-} from './ChatMessage';
+import { MessageResponse } from './ChatMessage';
 
 function makeEmulatedChat(
   content: string,
@@ -71,51 +65,11 @@ function makeEmulatedChat(
 // yarn dev 用: ダミーでコメントを5秒ごとに出し続ける
 class DummyMessageServerClient implements IMessageServerClient {
   connect(): Observable<MessageResponse> {
-    const date = Math.floor(Date.now() / 1000);
-    return from([
-      // ギフト
-      {
-        // GiftMessage
-        gift: {
-          itemId: '1',
-          advertiserUserId: 1,
-          advertiserName: '広告主',
-          point: 100,
-          message: 'ギフト',
-          itemName: 'アイテム',
-          contributionRank: 1,
-          date,
-        } as GiftMessage,
-      },
-      // ニコニ広告
-      {
-        nicoad: {
-          v0: {
-            latest: { advertiser: '広告主', point: 100, message: 'ニコニ広告v0' },
-            ranking: [
-              { advertiser: '広告主', rank: 1, message: 'ランキング1', userRank: 1 },
-              { advertiser: '広告主', rank: 2, message: 'ランキング2', userRank: 2 },
-            ],
-            totalPoint: 100,
-          },
-          date,
-        } as NicoadMessageV0,
-      },
-      {
-        nicoad: {
-          v1: { totalAdPoint: 100, message: 'ニコニ広告v1' },
-          date,
-        } as NicoadMessageV1,
-      },
-      // エモーション
-      {
-        notification: {
-          type: 'emotion',
-          message: 'エモーション',
-          date,
-        } as NotificationMessage,
-      },
-    ]);
+    return interval(5000).pipe(
+      map(res => ({
+        chat: makeEmulatedChat(`${res}`).value,
+      })),
+    );
   }
   close(): void {
     // do nothing


### PR DESCRIPTION
# このpull requestが解決する内容
before
![image](https://github.com/user-attachments/assets/58e88036-6b19-4a4b-9111-fccb86408f9c)

after
![image](https://github.com/user-attachments/assets/5b05af0e-617f-4077-82fc-a3666cd5224b)


* [x] デザイン修正
* ニコニ広告文言修正
  * [x] v1: 新しい番組はv1のみで、v1はmessageを出せばokなので変更不要
  * [x] v0: v0については組み立てが必要だが、古い番組のみなので、N Airは使わない
* [x] マージする前にDEBUGコミットを削除する

# 動作確認手順

# 関連するIssue（あれば）
