### PR TITLE
開発: Sentryの送信内容を少し改善

### DIFF
--- a/app/services/nicolive-program/NdgrClient.test.ts
+++ b/app/services/nicolive-program/NdgrClient.test.ts
@@ -258,18 +258,21 @@ describe('NdgrClient', () => {
   });
 
   it('should throw an NdgrFetchError when fetch throws an errors', async () => {
-    expect.assertions(1);
-    const target = new NdgrClient(NETWORK_ERROR_URL);
+    expect.assertions(2);
+    const MAX_RETRY = 3;
+    const target = new NdgrClient(NETWORK_ERROR_URL, { retryInterval: 0, maxRetry: MAX_RETRY });
     await expect(target.connect()).rejects.toThrow(
       `Failed to fetch(${NETWORK_ERROR_URL_WITH_TIMESTAMP}): TypeError: Network Error`,
     );
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_RETRY + 1);
   });
 
   it('should throw an NdgrFetchError when fetch returns a failed response', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const target = new NdgrClient(HTTP_ERROR_URL);
     await expect(target.connect()).rejects.toThrow(
       `Failed to fetch(${HTTP_ERROR_URL_WITH_TIMESTAMP}): 404`,
     );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/services/nicolive-program/NdgrClient.test.ts
+++ b/app/services/nicolive-program/NdgrClient.test.ts
@@ -189,7 +189,7 @@ describe('NdgrClient', () => {
             );
 
           case NETWORK_ERROR_URL_WITH_TIMESTAMP:
-            return Promise.reject(new TypeError('Network Error'));
+            return Promise.reject(new TypeError('network error'));
           case HTTP_ERROR_URL_WITH_TIMESTAMP:
             return Promise.resolve(new Response('Not Found', { status: 404 }));
         }
@@ -266,7 +266,7 @@ describe('NdgrClient', () => {
       maxRetry: MAX_RETRY,
     });
     await expect(target.connect()).rejects.toThrow(
-      `Failed to fetch[label](${NETWORK_ERROR_URL_WITH_TIMESTAMP}): TypeError: Network Error`,
+      `Failed to fetch[label](${NETWORK_ERROR_URL_WITH_TIMESTAMP}): TypeError: network error`,
     );
     expect(fetchMock).toHaveBeenCalledTimes(MAX_RETRY + 1);
   });

--- a/app/services/nicolive-program/NdgrClient.test.ts
+++ b/app/services/nicolive-program/NdgrClient.test.ts
@@ -260,9 +260,13 @@ describe('NdgrClient', () => {
   it('should throw an NdgrFetchError when fetch throws an errors', async () => {
     expect.assertions(2);
     const MAX_RETRY = 3;
-    const target = new NdgrClient(NETWORK_ERROR_URL, { retryInterval: 0, maxRetry: MAX_RETRY });
+    const target = new NdgrClient(NETWORK_ERROR_URL, {
+      label: 'label',
+      retryInterval: 0,
+      maxRetry: MAX_RETRY,
+    });
     await expect(target.connect()).rejects.toThrow(
-      `Failed to fetch(${NETWORK_ERROR_URL_WITH_TIMESTAMP}): TypeError: Network Error`,
+      `Failed to fetch[label](${NETWORK_ERROR_URL_WITH_TIMESTAMP}): TypeError: Network Error`,
     );
     expect(fetchMock).toHaveBeenCalledTimes(MAX_RETRY + 1);
   });
@@ -271,7 +275,7 @@ describe('NdgrClient', () => {
     expect.assertions(2);
     const target = new NdgrClient(HTTP_ERROR_URL);
     await expect(target.connect()).rejects.toThrow(
-      `Failed to fetch(${HTTP_ERROR_URL_WITH_TIMESTAMP}): 404`,
+      `Failed to fetch[ndgr](${HTTP_ERROR_URL_WITH_TIMESTAMP}): 404`,
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/app/services/nicolive-program/NdgrClient.ts
+++ b/app/services/nicolive-program/NdgrClient.ts
@@ -105,7 +105,7 @@ export class NdgrClient {
               try: this.options.maxRetry - retryRemain,
               label: this.options.label,
             });
-            scope.setFingerprint(['ndgr-fetch-error']);
+            scope.setFingerprint(['ndgr-fetch-error', this.options.label]);
             Sentry.captureMessage(`Failed to fetch(${uri}): ${error}`);
           });
         }

--- a/app/services/nicolive-program/NdgrClient.ts
+++ b/app/services/nicolive-program/NdgrClient.ts
@@ -95,7 +95,7 @@ export class NdgrClient {
         break;
       } catch (error) {
         if (retryRemain === 0) {
-          throw new NdgrFetchError(error as Error, uri);
+          throw new NdgrFetchError(error as Error, uri, this.options.label);
         } else {
           Sentry.withScope(scope => {
             scope.setLevel('warning');
@@ -112,7 +112,7 @@ export class NdgrClient {
         await sleep(this.options.retryInterval);
       }
     }
-    if (!response.ok) throw new NdgrFetchError(response.status, uri);
+    if (!response.ok) throw new NdgrFetchError(response.status, uri, this.options.label);
     return response;
   }
 

--- a/app/services/nicolive-program/NdgrClient.ts
+++ b/app/services/nicolive-program/NdgrClient.ts
@@ -35,10 +35,21 @@ export function convertSSNGType(
   }
 }
 
+type NdgrClientOptions = {
+  label: string;
+  maxRetry: number;
+  retryInterval: number;
+};
+
 export class NdgrClient {
   private isDisposed: boolean = false;
   public messages: Subject<dwango.nicolive.chat.service.edge.ChunkedMessage>;
-  private options = { label: 'ndgr', maxRetry: 3, retryInterval: 1000 };
+
+  private options: NdgrClientOptions = {
+    label: 'ndgr',
+    maxRetry: 3,
+    retryInterval: 1000,
+  };
 
   /**
    * @param uri 接続するURI
@@ -46,10 +57,7 @@ export class NdgrClient {
    * @param options.maxRetry fetch errorのリトライ回数
    * @param options.retryInterval fetch errorのリトライ間隔(ms)
    */
-  constructor(
-    private uri: string,
-    options: { label?: string; maxRetry?: number; retryInterval?: number } | string = {},
-  ) {
+  constructor(private uri: string, options: Partial<NdgrClientOptions> | string = {}) {
     if (typeof options === 'string') {
       this.options.label = options;
     } else {

--- a/app/services/nicolive-program/NdgrClient.ts
+++ b/app/services/nicolive-program/NdgrClient.ts
@@ -51,9 +51,10 @@ export class NdgrClient {
     options: { label?: string; maxRetry?: number; retryInterval?: number } | string = {},
   ) {
     if (typeof options === 'string') {
-      options = { label: options };
+      this.options.label = options;
+    } else {
+      this.options = { ...this.options, ...options };
     }
-    this.options = { ...this.options, ...options };
     this.messages = new Subject();
   }
 

--- a/app/services/nicolive-program/NdgrClient.ts
+++ b/app/services/nicolive-program/NdgrClient.ts
@@ -87,7 +87,7 @@ export class NdgrClient {
     }
   }
 
-  private async fetch(uri: string): Promise<Response> {
+  private async fetchWithHandling(uri: string): Promise<Response> {
     let response: Response;
     for (let retryRemain = this.options.maxRetry; retryRemain >= 0; retryRemain--) {
       try {
@@ -127,7 +127,7 @@ export class NdgrClient {
     let length = 0;
 
     while (length < want) {
-      const resp = await this.fetch(fetchUri);
+      const resp = await this.fetchWithHandling(fetchUri);
       const body = await resp.arrayBuffer();
       const packed = dwango.nicolive.chat.service.edge.PackedSegment.decode(new Uint8Array(body));
       buf.unshift(packed.messages);
@@ -160,7 +160,7 @@ export class NdgrClient {
     decoder: (reader: Reader) => T,
   ): AsyncGenerator<T, void, undefined> {
     let unread = new Uint8Array();
-    const response = await this.fetch(uri);
+    const response = await this.fetchWithHandling(uri);
     const reader = response.body.getReader();
     while (true) {
       const { done, value } = await reader.read();

--- a/app/services/nicolive-program/NdgrClient.ts
+++ b/app/services/nicolive-program/NdgrClient.ts
@@ -103,7 +103,7 @@ export class NdgrClient {
         response = await fetch(uri);
         break;
       } catch (error) {
-        if (retryRemain === 0) {
+        if (retryRemain === 0 || !`${error}`.includes('network error')) {
           throw new NdgrFetchError(error as Error, uri, this.options.label);
         } else {
           Sentry.withScope(scope => {

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -310,7 +310,6 @@ export class NdgrCommentReceiver implements IMessageServerClient {
       },
     });
     this.ndgrClient.connect('now', NUM_BACKWARD_COMMENTS).catch(err => {
-      console.warn('Failed to connect to ndgr', err);
       this.messageSubject.error(err);
     });
     return this.messageSubject.asObservable();

--- a/app/services/nicolive-program/NdgrFetchError.ts
+++ b/app/services/nicolive-program/NdgrFetchError.ts
@@ -1,5 +1,5 @@
 export class NdgrFetchError extends Error {
-  constructor(public status: number, public uri: string) {
+  constructor(public status: number | Error, public uri: string) {
     super(`Failed to fetch(${uri}): ${status}`);
 
     this.name = new.target.name;

--- a/app/services/nicolive-program/NdgrFetchError.ts
+++ b/app/services/nicolive-program/NdgrFetchError.ts
@@ -1,6 +1,6 @@
 export class NdgrFetchError extends Error {
-  constructor(public status: number | Error, public uri: string) {
-    super(`Failed to fetch(${uri}): ${status}`);
+  constructor(public status: number | Error, public uri: string, public label: string) {
+    super(`Failed to fetch[${label}](${uri}): ${status}`);
 
     this.name = new.target.name;
     Object.setPrototypeOf(this, new.target.prototype);

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -327,10 +327,10 @@ test('スレッドの参加失敗時にメッセージを表示する', () => {
   jest.spyOn(Date, 'now').mockImplementation(() => 1582175622000);
   const { instance, clientSubject } = connectionSetup();
 
-  const e = new NdgrFetchError(404, 'yay');
+  const e = new NdgrFetchError(404, 'yay', 'test');
   expect(e instanceof NdgrFetchError).toBeTruthy();
   expect(e.name).toBe('NdgrFetchError');
-  clientSubject.error(new NdgrFetchError(404, 'yay'));
+  clientSubject.error(new NdgrFetchError(404, 'yay', 'test'));
 
   // bufferTime tweaks
   clientSubject.complete();

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -363,7 +363,8 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
             Sentry.withScope(scope => {
               scope.setTags({
                 type: 'NdgrFetchError',
-                status: err.status,
+                uri: err.uri,
+                status: `${err.status}`,
               });
               scope.setFingerprint([
                 'NicoliveCommentViewerService.connect',

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -358,7 +358,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
           }
         }),
         catchError(err => {
-          console.error(err);
+          console.info(err);
           if (isNdgrFetchError(err)) {
             Sentry.withScope(scope => {
               scope.setTags({

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -126,6 +126,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     this.refreshStatisticsPolling(this.state, nextState);
     this.refreshProgramStatusTimer(this.state, nextState);
     this.refreshAutoExtensionTimer(this.state, nextState);
+    this.refreshSentryProgramInfo(this.state, nextState);
     this.SET_STATE(nextState);
     this.stateChangeSubject.next(nextState);
   }
@@ -541,6 +542,16 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     if (prev && !next) {
       clearTimeout(this.autoExtensionTimer);
       console.log('自動延長タイマーが解除されました');
+    }
+  }
+
+  private refreshSentryProgramInfo(
+    prevState: INicoliveProgramState,
+    nextState: INicoliveProgramState,
+  ) {
+    if (prevState.programID !== nextState.programID) {
+      const scope = Sentry.getCurrentScope();
+      scope.setTag('nicolive.programID', nextState.programID);
     }
   }
 


### PR DESCRIPTION
* NdgrFetchErrorで fetch 自体からの例外をキャッチしてリクエストURLを追加してSentryに送る(従来はなんだか分からない `TypeError: network error` だけが送信されていた)
* ニコ生の番組情報を得ている場合、Sentryのcontext(すべてのイベントに付与される)に `nicolive.programID` としてタグを追加します(エラーissueをタグ分類することで同じ番組からのエラーをまとめて確認できるようにする)
* [x] network errorのときはリトライ
* [x] moderatorのconnectで起きた NdgrFetchError もsentryに送る