### PR TITLE
改善: いくつかのポップアップメニューを選択したら自動的に閉じる

### DIFF
--- a/app/components/nicolive-area/AreaSwitcher.vue
+++ b/app/components/nicolive-area/AreaSwitcher.vue
@@ -12,7 +12,10 @@
               :class="{ active: content.slotName === activeContent.slotName }"
               :key="content.slotName"
               v-for="content in contents"
-              @click="select(content.slotName)"
+              @click="
+                select(content.slotName);
+                popper.doClose();
+              "
             >
               <p class="item-name">{{ content.name }}</p>
               <p class="item-text">{{ content.text }}</p>

--- a/app/components/nicolive-area/AreaSwitcher.vue
+++ b/app/components/nicolive-area/AreaSwitcher.vue
@@ -4,7 +4,7 @@
       <slot :name="activeContent.slotName" />
     </div>
     <div class="header" v-if="!isCompactMode">
-      <popper trigger="click" :options="{ placement: 'bottom-start' }">
+      <popper trigger="click" :options="{ placement: 'bottom-start' }" @show="popper = $event">
         <div class="popper">
           <ul class="popup-menu-list">
             <li

--- a/app/components/nicolive-area/AreaSwitcher.vue.ts
+++ b/app/components/nicolive-area/AreaSwitcher.vue.ts
@@ -1,3 +1,4 @@
+import { PascalizedProperty } from 'humps';
 import { Inject } from 'services/core/injector';
 import { CustomizationService } from 'services/customization';
 import Vue from 'vue';
@@ -8,6 +9,7 @@ interface IArea {
   name: string;
   slotName: string;
   defaultSelected?: boolean;
+  text: string;
 }
 
 @Component({
@@ -19,6 +21,8 @@ export default class AreaSwitcher extends Vue {
 
   @Inject()
   private customizationService: CustomizationService;
+
+  popper: PopperEvent;
 
   get isCompactMode(): boolean {
     return this.customizationService.state.compactMode;
@@ -32,6 +36,7 @@ export default class AreaSwitcher extends Vue {
   }
 
   select(slotName: string) {
+    this.popper?.doClose();
     this.selectedContent = this.contents.find(c => c.slotName === slotName)!;
   }
 }

--- a/app/components/nicolive-area/AreaSwitcher.vue.ts
+++ b/app/components/nicolive-area/AreaSwitcher.vue.ts
@@ -36,7 +36,6 @@ export default class AreaSwitcher extends Vue {
   }
 
   select(slotName: string) {
-    this.popper?.doClose();
     this.selectedContent = this.contents.find(c => c.slotName === slotName)!;
   }
 }

--- a/app/components/nicolive-area/AreaSwitcher.vue.ts
+++ b/app/components/nicolive-area/AreaSwitcher.vue.ts
@@ -5,7 +5,7 @@ import Vue from 'vue';
 import Popper from 'vue-popperjs';
 import { Component, Prop } from 'vue-property-decorator';
 
-interface IArea {
+export interface IArea {
   name: string;
   slotName: string;
   defaultSelected?: boolean;

--- a/app/components/nicolive-area/CommentFilter.vue
+++ b/app/components/nicolive-area/CommentFilter.vue
@@ -10,7 +10,10 @@
         <popper
           trigger="click"
           :options="{ placement: 'bottom' }"
-          @show="showPopupMenu = true"
+          @show="
+            showPopupMenu = true;
+            popper = $event;
+          "
           @hide="showPopupMenu = false"
         >
           <div class="popper">
@@ -18,21 +21,30 @@
               <li
                 class="popup-menu-item"
                 :class="{ active: currentFilterBy === 'all' }"
-                @click="currentFilterBy = 'all'"
+                @click="
+                  currentFilterBy = 'all';
+                  popper.doClose();
+                "
               >
                 <span>すべて</span>
               </li>
               <li
                 class="popup-menu-item"
                 :class="{ active: currentFilterBy === 'broadcaster' }"
-                @click="currentFilterBy = 'broadcaster'"
+                @click="
+                  currentFilterBy = 'broadcaster';
+                  popper.doClose();
+                "
               >
                 <span>放送者が登録</span>
               </li>
               <li
                 class="popup-menu-item"
                 :class="{ active: currentFilterBy === 'moderator' }"
-                @click="currentFilterBy = 'moderator'"
+                @click="
+                  currentFilterBy = 'moderator';
+                  popper.doClose();
+                "
               >
                 <span>モデレーターが登録</span>
               </li>

--- a/app/components/nicolive-area/CommentFilter.vue.ts
+++ b/app/components/nicolive-area/CommentFilter.vue.ts
@@ -36,6 +36,7 @@ export default class CommentFilter extends Vue {
   private nicoliveCommentFilterService: NicoliveCommentFilterService;
 
   showPopupMenu = false;
+  popper: PopperEvent;
 
   adjusterTooltip = '登録者で絞り込み';
 

--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -10,7 +10,7 @@ import ProgramInfo from './ProgramInfo.vue';
 import ProgramStatistics from './ProgramStatistics.vue';
 import ToolBar from './ToolBar.vue';
 import ControlsArrow from '../../../media/images/controls-arrow-vertical.svg';
-import AreaSwitcher from './AreaSwitcher.vue';
+import AreaSwitcher, { IArea } from './AreaSwitcher.vue';
 import PerformanceMetrics from '../PerformanceMetrics.vue';
 import {
   NicoliveFailure,
@@ -42,7 +42,7 @@ export default class NicolivePanelRoot extends Vue {
     this.nicoliveProgramService.hidePlaceholder();
   }
 
-  get contents() {
+  get contents(): IArea[] {
     return [
       {
         name: 'コメント',

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -18,7 +18,10 @@
     <popper
       trigger="click"
       :options="{ placement: 'bottom-end' }"
-      @show="showPopupMenu = true"
+      @show="
+        showPopupMenu = true;
+        popper = $event;
+      "
       @hide="showPopupMenu = false"
     >
       <div class="popper">

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -28,12 +28,23 @@
         <div class="popup-menu-head">{{ programTitle }}</div>
         <ul class="popup-menu-list">
           <li class="popup-menu-item">
-            <a @click.prevent="openInDefaultBrowser($event)" :href="watchPageURL" class="link"
+            <a
+              @click.prevent="
+                openInDefaultBrowser($event);
+                popper.doClose();
+              "
+              :href="watchPageURL"
+              class="link"
               ><i class="icon-browser"></i>番組ページを開く</a
             >
           </li>
           <li class="popup-menu-item">
-            <a @click="copyProgramURL" class="link"
+            <a
+              @click="
+                copyProgramURL();
+                popper.doClose();
+              "
+              class="link"
               ><i :class="hasProgramUrlCopied ? 'icon-check' : 'icon-clipboard-copy'"></i
               >番組URLをコピーする</a
             >
@@ -41,22 +52,47 @@
         </ul>
         <ul class="popup-menu-list">
           <li class="popup-menu-item">
-            <a @click="editProgram" class="link"><i class="icon-edit"></i>番組を編集する</a>
+            <a
+              @click="
+                editProgram();
+                popper.doClose();
+              "
+              class="link"
+              ><i class="icon-edit"></i>番組を編集する</a
+            >
           </li>
         </ul>
         <ul class="popup-menu-list">
           <li class="popup-menu-item">
-            <a @click.prevent="openInDefaultBrowser($event)" :href="xShareURL" class="link"
+            <a
+              @click.prevent="
+                openInDefaultBrowser($event);
+                popper.doClose();
+              "
+              :href="xShareURL"
+              class="link"
               ><i class="icon-x"></i>Xでポストする</a
             >
           </li>
           <li class="popup-menu-item">
-            <a @click.prevent="openInDefaultBrowser($event)" :href="contentTreeURL" class="link"
+            <a
+              @click.prevent="
+                openInDefaultBrowser($event);
+                popper.doClose();
+              "
+              :href="contentTreeURL"
+              class="link"
               ><i class="icon-contents-tree"></i>コンテンツツリーを見る</a
             >
           </li>
           <li class="popup-menu-item">
-            <a @click.prevent="openInDefaultBrowser($event)" :href="creatorsProgramURL" class="link"
+            <a
+              @click.prevent="
+                openInDefaultBrowser($event);
+                popper.doClose();
+              "
+              :href="creatorsProgramURL"
+              class="link"
               ><i class="icon-creator-promotion-program"></i>この番組で収入を得る</a
             >
           </li>

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -77,7 +77,6 @@ export default class ProgramInfo extends Vue {
   }
 
   openInDefaultBrowser(event: MouseEvent): void {
-    this.popper?.doClose();
     const href = (event.currentTarget as HTMLAnchorElement).href;
     const url = new URL(href);
     if (/^https?/.test(url.protocol)) {
@@ -90,7 +89,6 @@ export default class ProgramInfo extends Vue {
   }
 
   async editProgram() {
-    this.popper?.doClose();
     try {
       return await this.nicoliveProgramService.editProgram();
     } catch (e) {
@@ -150,7 +148,6 @@ export default class ProgramInfo extends Vue {
   hasProgramUrlCopied: boolean = false;
   clearTimer: number = 0;
   copyProgramURL() {
-    this.popper?.doClose();
     if (this.isFetching) throw new Error('fetchProgram is running');
     clipboard.writeText(
       this.hostsService.getWatchPageURL(this.nicoliveProgramService.state.programID),

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -26,6 +26,7 @@ export default class ProgramInfo extends Vue {
   private subscription: Subscription = null;
 
   showPopupMenu: boolean = false;
+  popper: PopperEvent;
 
   get isOnAir(): boolean {
     return this.nicoliveProgramService.state.status === 'onAir';
@@ -76,6 +77,7 @@ export default class ProgramInfo extends Vue {
   }
 
   openInDefaultBrowser(event: MouseEvent): void {
+    this.popper?.doClose();
     const href = (event.currentTarget as HTMLAnchorElement).href;
     const url = new URL(href);
     if (/^https?/.test(url.protocol)) {
@@ -88,6 +90,7 @@ export default class ProgramInfo extends Vue {
   }
 
   async editProgram() {
+    this.popper?.doClose();
     try {
       return await this.nicoliveProgramService.editProgram();
     } catch (e) {
@@ -147,6 +150,7 @@ export default class ProgramInfo extends Vue {
   hasProgramUrlCopied: boolean = false;
   clearTimer: number = 0;
   copyProgramURL() {
+    this.popper?.doClose();
     if (this.isFetching) throw new Error('fetchProgram is running');
     clipboard.writeText(
       this.hostsService.getWatchPageURL(this.nicoliveProgramService.state.programID),

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -14,7 +14,10 @@
       <popper
         trigger="click"
         :options="{ placement: 'bottom-end' }"
-        @show="showPopupMenu = true"
+        @show="
+          showPopupMenu = true;
+          popper1 = $event;
+        "
         @hide="showPopupMenu = false"
       >
         <div class="popper">
@@ -92,7 +95,10 @@
         <popper
           trigger="click"
           :options="{ placement: 'bottom-end' }"
-          @show="showButtonSelector = true"
+          @show="
+            showButtonSelector = true;
+            popper2 = $event;
+          "
           @hide="showButtonSelector = false"
         >
           <div class="popper">

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -28,7 +28,10 @@
                 ><input
                   type="checkbox"
                   :checked="autoExtensionEnabled"
-                  @click="toggleAutoExtension"
+                  @click="
+                    toggleAutoExtension();
+                    popper1.doClose();
+                  "
                   class="toggle-button"
                 />
               </div>
@@ -36,7 +39,10 @@
             <li class="popup-menu-item">
               <button
                 class="manual-extension link"
-                @click="extendProgram"
+                @click="
+                  extendProgram();
+                  popper1.doClose();
+                "
                 :disabled="
                   autoExtensionEnabled ||
                   isExtending ||
@@ -106,7 +112,10 @@
               <li class="item">
                 <button
                   :class="{ 'button-selector': true, current: selectedButton === 'start' }"
-                  @click="selectButton('start')"
+                  @click="
+                    selectButton('start');
+                    popper2.doClose();
+                  "
                 >
                   <span class="item-name">番組開始</span>
                   <span class="item-text">番組を開始して視聴者に公開します</span>
@@ -115,7 +124,10 @@
               <li class="item">
                 <button
                   :class="{ 'button-selector': true, current: selectedButton === 'end' }"
-                  @click="selectButton('end')"
+                  @click="
+                    selectButton('end');
+                    popper2.doClose();
+                  "
                 >
                   <span class="item-name">番組終了</span>
                   <span class="item-text">番組を視聴者に公開せず終了します</span>

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -28,7 +28,11 @@ export default class ToolBar extends Vue {
   selectedButton: 'start' | 'end' = 'start';
   showButtonSelector: boolean = false;
 
+  popper1: PopperEvent;
+  popper2: PopperEvent;
+
   selectButton(button: 'start' | 'end') {
+    this.popper2?.doClose();
     this.selectedButton = button;
   }
 
@@ -78,6 +82,7 @@ export default class ToolBar extends Vue {
     return this.nicoliveProgramService.state.isExtending;
   }
   async extendProgram() {
+    this.popper1?.doClose();
     if (this.isExtending) throw new Error('extendProgram is running');
     try {
       return await this.nicoliveProgramService.extendProgram();
@@ -91,6 +96,7 @@ export default class ToolBar extends Vue {
   }
 
   toggleAutoExtension() {
+    this.popper1?.doClose();
     this.nicoliveProgramService.toggleAutoExtension();
   }
 

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -32,7 +32,6 @@ export default class ToolBar extends Vue {
   popper2: PopperEvent;
 
   selectButton(button: 'start' | 'end') {
-    this.popper2?.doClose();
     this.selectedButton = button;
   }
 
@@ -82,7 +81,6 @@ export default class ToolBar extends Vue {
     return this.nicoliveProgramService.state.isExtending;
   }
   async extendProgram() {
-    this.popper1?.doClose();
     if (this.isExtending) throw new Error('extendProgram is running');
     try {
       return await this.nicoliveProgramService.extendProgram();
@@ -96,7 +94,6 @@ export default class ToolBar extends Vue {
   }
 
   toggleAutoExtension() {
-    this.popper1?.doClose();
     this.nicoliveProgramService.toggleAutoExtension();
   }
 

--- a/app/components/windows/RtvcSourceProperties.vue
+++ b/app/components/windows/RtvcSourceProperties.vue
@@ -66,7 +66,6 @@
               <span class="name">{{ v.name }}</span>
             </div>
             <popper
-              ref="ppp"
               trigger="click"
               :options="{ placement: 'bottom-end' }"
               @show="

--- a/app/components/windows/RtvcSourceProperties.vue
+++ b/app/components/windows/RtvcSourceProperties.vue
@@ -66,15 +66,16 @@
               <span class="name">{{ v.name }}</span>
             </div>
             <popper
+              ref="ppp"
               trigger="click"
               :options="{ placement: 'bottom-end' }"
               @show="
                 showPopupMenu = true;
-                currentPopupMenu = $event;
+                popper = $event;
               "
               @hide="
                 showPopupMenu = false;
-                currentPopupMenu = undefined;
+                popper = undefined;
               "
             >
               <div class="popper">

--- a/app/components/windows/RtvcSourceProperties.vue.ts
+++ b/app/components/windows/RtvcSourceProperties.vue.ts
@@ -70,7 +70,7 @@ export default class RtvcSourceProperties extends SourceProperties {
   canAdd = false;
 
   showPopupMenu = false;
-  currentPopupMenu: any = undefined;
+  popper: PopperEvent;
 
   primaryVoiceModel: IObsListOption<number> = { description: '', value: 0 };
   secondaryVoiceModel: IObsListOption<number> = { description: '', value: 0 };
@@ -405,9 +405,8 @@ export default class RtvcSourceProperties extends SourceProperties {
   }
 
   closePopupMenu() {
-    if (!this.currentPopupMenu) return;
-    this.currentPopupMenu.doClose();
-    this.currentPopupMenu = undefined;
+    this.popper?.doClose();
+    this.popper = undefined;
   }
 
   async onDelete(index: string) {

--- a/app/components/windows/UserInfo.vue
+++ b/app/components/windows/UserInfo.vue
@@ -30,7 +30,10 @@
           <popper
             trigger="click"
             :options="{ placement: 'bottom-end' }"
-            @show="showPopupMenu = true"
+            @show="
+              showPopupMenu = true;
+              popper = $event;
+            "
             @hide="showPopupMenu = false"
           >
             <div class="popper">

--- a/app/components/windows/UserInfo.vue
+++ b/app/components/windows/UserInfo.vue
@@ -39,27 +39,78 @@
             <div class="popper">
               <ul class="popup-menu-list">
                 <li class="popup-menu-item">
-                  <a @click="copyUserId" class="link">ユーザーIDをコピー</a>
+                  <a
+                    @click="
+                      copyUserId();
+                      popper.doClose();
+                    "
+                    class="link"
+                    >ユーザーIDをコピー</a
+                  >
                 </li>
               </ul>
               <ul class="popup-menu-list">
                 <li class="popup-menu-item">
-                  <a @click="blockUser" class="link" v-if="!isBlockedUser">配信からブロック</a>
-                  <a @click="unBlockUser" class="link" v-if="isBlockedUser"
+                  <a
+                    @click="
+                      blockUser();
+                      popper.doClose();
+                    "
+                    class="link"
+                    v-if="!isBlockedUser"
+                    >配信からブロック</a
+                  >
+                  <a
+                    @click="
+                      unBlockUser();
+                      popper.doClose();
+                    "
+                    class="link"
+                    v-if="isBlockedUser"
                     >配信用ブロックから削除</a
                   >
                 </li>
               </ul>
               <ul class="popup-menu-list">
                 <li class="popup-menu-item">
-                  <a @click="unFollowUser" class="link" v-if="isFollowing">フォローを解除</a>
-                  <a @click="followUser" class="link" v-if="!isFollowing">ユーザーをフォロー</a>
+                  <a
+                    @click="
+                      unFollowUser();
+                      popper.doClose();
+                    "
+                    class="link"
+                    v-if="isFollowing"
+                    >フォローを解除</a
+                  >
+                  <a
+                    @click="
+                      followUser();
+                      popper.doClose();
+                    "
+                    class="link"
+                    v-if="!isFollowing"
+                    >ユーザーをフォロー</a
+                  >
                 </li>
               </ul>
               <ul class="popup-menu-list">
                 <li class="popup-menu-item">
-                  <a @click="addModerator" class="link" v-if="!isModerator">モデレーターに追加</a>
-                  <a @click="removeModerator" class="link text--red" v-if="isModerator"
+                  <a
+                    @click="
+                      addModerator();
+                      popper.doClose();
+                    "
+                    class="link"
+                    v-if="!isModerator"
+                    >モデレーターに追加</a
+                  >
+                  <a
+                    @click="
+                      removeModerator();
+                      popper.doClose();
+                    "
+                    class="link text--red"
+                    v-if="isModerator"
                     >モデレーターから削除</a
                   >
                 </li>

--- a/app/components/windows/UserInfo.vue.ts
+++ b/app/components/windows/UserInfo.vue.ts
@@ -162,21 +162,18 @@ export default class UserInfo extends Vue {
   }
 
   followUser(): void {
-    this.popper?.doClose();
     this.nicoliveProgramService.client.followUser(this.userId).then(() => {
       this.isFollowing = true;
     });
   }
 
   unFollowUser(): void {
-    this.popper?.doClose();
     this.nicoliveProgramService.client.unFollowUser(this.userId).then(() => {
       this.isFollowing = false;
     });
   }
 
   async blockUser() {
-    this.popper?.doClose();
     await this.nicoliveCommentFilterService
       .addFilter({
         type: 'user',
@@ -189,7 +186,6 @@ export default class UserInfo extends Vue {
       });
   }
   async unBlockUser() {
-    this.popper?.doClose();
     const filterRecord = this.nicoliveCommentFilterService.state.filters.find(
       filter => filter.type === 'user' && filter.body === this.userId,
     );
@@ -206,7 +202,6 @@ export default class UserInfo extends Vue {
   }
 
   async addModerator() {
-    this.popper?.doClose();
     return this.nicoliveModeratorsService.addModeratorWithConfirm({
       userId: this.userId,
       userName: this.userName,
@@ -214,7 +209,6 @@ export default class UserInfo extends Vue {
   }
 
   async removeModerator() {
-    this.popper?.doClose();
     return this.nicoliveModeratorsService.removeModeratorWithConfirm({
       userId: this.userId,
       userName: this.userName,
@@ -270,10 +264,8 @@ export default class UserInfo extends Vue {
 
   openUserPage() {
     remote.shell.openExternal(this.hostsService.getUserPageURL(this.userId));
-    this.popper?.doClose();
   }
   copyUserId() {
-    this.popper?.doClose();
     remote.clipboard.writeText(this.userId);
   }
 

--- a/app/components/windows/UserInfo.vue.ts
+++ b/app/components/windows/UserInfo.vue.ts
@@ -64,6 +64,7 @@ export default class UserInfo extends Vue {
   private cleanup: () => void = undefined;
   isLatestVisible = true;
   showPopupMenu = false;
+  popper: PopperEvent;
 
   isBlockedUser = false;
   isFollowing = false;
@@ -161,18 +162,21 @@ export default class UserInfo extends Vue {
   }
 
   followUser(): void {
+    this.popper?.doClose();
     this.nicoliveProgramService.client.followUser(this.userId).then(() => {
       this.isFollowing = true;
     });
   }
 
   unFollowUser(): void {
+    this.popper?.doClose();
     this.nicoliveProgramService.client.unFollowUser(this.userId).then(() => {
       this.isFollowing = false;
     });
   }
 
   async blockUser() {
+    this.popper?.doClose();
     await this.nicoliveCommentFilterService
       .addFilter({
         type: 'user',
@@ -185,6 +189,7 @@ export default class UserInfo extends Vue {
       });
   }
   async unBlockUser() {
+    this.popper?.doClose();
     const filterRecord = this.nicoliveCommentFilterService.state.filters.find(
       filter => filter.type === 'user' && filter.body === this.userId,
     );
@@ -201,6 +206,7 @@ export default class UserInfo extends Vue {
   }
 
   async addModerator() {
+    this.popper?.doClose();
     return this.nicoliveModeratorsService.addModeratorWithConfirm({
       userId: this.userId,
       userName: this.userName,
@@ -208,6 +214,7 @@ export default class UserInfo extends Vue {
   }
 
   async removeModerator() {
+    this.popper?.doClose();
     return this.nicoliveModeratorsService.removeModeratorWithConfirm({
       userId: this.userId,
       userName: this.userName,
@@ -263,8 +270,10 @@ export default class UserInfo extends Vue {
 
   openUserPage() {
     remote.shell.openExternal(this.hostsService.getUserPageURL(this.userId));
+    this.popper?.doClose();
   }
   copyUserId() {
+    this.popper?.doClose();
     remote.clipboard.writeText(this.userId);
   }
 

--- a/app/index.d.ts
+++ b/app/index.d.ts
@@ -68,3 +68,7 @@ declare module 'emojione';
 // defined in webpack.config.js
 declare const SENTRY_DSN: string;
 declare const SENTRY_MINIDUMP_URL: string;
+
+interface PopperEvent {
+  doClose(): void;
+}


### PR DESCRIPTION
# このpull requestが解決する内容

popupで表示される項目を選択した際にpopupを自動的に閉じる

- コメント一覧画面での コメント/番組説明文 の切り替え
- 配信用ブロック設定で すべて/放送者が登録/モデレータが登録 の切り替え
- コメント一覧画面　右上のタグ
- コメント一覧画面　右下ボタンのタグ
- ユーザー詳細画面の詳細タグ

(ボイチェンのpopupにも改修があるがこれは揃えとして)

# 動作確認手順

上記選択肢にて、項目を選択するとpopupが閉じる
