### PR TITLE
修正: 今後新しく追加されるシステムメッセージが表示されなくなっていた

### DIFF
--- a/app/services/nicolive-program/ChatMessage.ts
+++ b/app/services/nicolive-program/ChatMessage.ts
@@ -37,7 +37,7 @@ export const NotificationTypeTable = [
   'visited',
 ] as const;
 
-export type NotificationType = (typeof NotificationTypeTable)[number];
+export type NotificationType = (typeof NotificationTypeTable)[number] | 'unknown';
 export type NotificationMessage = DateComponent & {
   type: NotificationType;
   message: string;

--- a/app/services/nicolive-program/ChatMessage/classifier.test.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.test.ts
@@ -37,6 +37,10 @@ test.each<NotificationType>(['ichiba', 'quote', 'cruise'])(`system: %s`, type =>
   expect(classify({ notification: { type, message: '' } })).toBe('system');
 });
 
+it('system: from unknown notification', () => {
+  expect(classify({ notification: { type: 'unknown', message: '' } })).toBe('system');
+});
+
 test('invisible', () => {
   expect(classify({ state: { state: 'ended' } })).toBe('invisible');
   expect(classify({ signal: 'flushed' })).toBe('invisible');

--- a/app/services/nicolive-program/ChatMessage/classifier.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.ts
@@ -39,6 +39,8 @@ export function classify(chat: MessageResponse) {
         return 'info' as const;
       case 'visited':
         return 'info' as const;
+      case 'unknown':
+        return 'system' as const;
     }
   }
   if (isGiftMessage(chat)) return 'gift' as const;

--- a/app/services/nicolive-program/NdgrCommentReceiver.test.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.test.ts
@@ -190,6 +190,19 @@ describe('convertChunkedMessageToMessageResponse', () => {
       expected: { notification: { date, date_usec, type: 'cruise', message: 'cruise' } },
     },
     {
+      title: 'unknownNewNotification', // あり得ない値
+      msg: {
+        message: {
+          simpleNotification: {
+            unknownNewNotification: 'unknownNewNotification',
+          } as dwango.nicolive.chat.data.ISimpleNotification,
+        },
+      },
+      expected: {
+        notification: { date, date_usec, type: 'unknown', message: 'unknownNewNotification' },
+      },
+    },
+    {
       title: 'gift',
       msg: {
         message: {

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -120,15 +120,15 @@ function convertSimpleNotificationToMessageResponse(
   common: CommonComponent,
   notification: dwango.nicolive.chat.data.ISimpleNotification,
 ): MessageResponse | undefined {
-  const key = Object.keys(notification)[0] as NotificationType;
+  const key = Object.keys(notification)[0] as keyof dwango.nicolive.chat.data.ISimpleNotification;
+  let type = key as NotificationType;
   if (!NotificationTypeTable.includes(key)) {
-    console.warn('Unknown simpleNotification type', notification);
-    return undefined;
+    type = 'unknown';
   }
   return {
     notification: {
       ...common,
-      type: key,
+      type,
       message: notification[key],
     },
   };


### PR DESCRIPTION
# このpull requestが解決する内容
SimpleNotificationに追加される新しい未知のメッセージであっても、無視せずシステムメッセージとして表示させるように修正します
(NDGR以前の動作がそうだったため、意図せず動作が変わっていました)
