### PR TITLE
修正: 画面間ウィンドウ移動時の画面の表示倍率の変化に追従できないことがあった

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -136,16 +136,10 @@ export class WindowsService extends StatefulService<IWindowsState> {
   private windows: Dictionary<Electron.BrowserWindow> = {};
 
   init() {
-    const windows = BrowserWindow.getAllWindows();
+    const windowIds = ipcRenderer.sendSync('getWindowIds');
 
-    // main の後に child を作成しているのでidは昇順になるが、getAllWindowsの返す順序は保証されていない
-    if (windows[0].id < windows[1].id) {
-      this.windows.main = windows[0];
-      this.windows.child = windows[1];
-    } else {
-      this.windows.main = windows[1];
-      this.windows.child = windows[0];
-    }
+    this.windows.main = BrowserWindow.fromId(windowIds.main);
+    this.windows.child = BrowserWindow.fromId(windowIds.child);
 
     this.updateScaleFactor('main');
     this.updateScaleFactor('child');

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -138,8 +138,14 @@ export class WindowsService extends StatefulService<IWindowsState> {
   init() {
     const windows = BrowserWindow.getAllWindows();
 
-    this.windows.main = windows[0];
-    this.windows.child = windows[1];
+    // main の後に child を作成しているのでidは昇順になるが、getAllWindowsの返す順序は保証されていない
+    if (windows[0].id < windows[1].id) {
+      this.windows.main = windows[0];
+      this.windows.child = windows[1];
+    } else {
+      this.windows.main = windows[1];
+      this.windows.child = windows[0];
+    }
 
     this.updateScaleFactor('main');
     this.updateScaleFactor('child');
@@ -162,7 +168,12 @@ export class WindowsService extends StatefulService<IWindowsState> {
         });
         return;
       }
-      this.UPDATE_SCALE_FACTOR(windowId, currentDisplay.scaleFactor);
+      if (currentDisplay.scaleFactor !== this.state[windowId].scaleFactor) {
+        console.log(
+          `${windowId} currentDisplay.scaleFactor ${this.state[windowId].scaleFactor} -> ${currentDisplay.scaleFactor}`,
+        );
+        this.UPDATE_SCALE_FACTOR(windowId, currentDisplay.scaleFactor);
+      }
     }
   }
 

--- a/main.js
+++ b/main.js
@@ -870,4 +870,11 @@ function initialize(crashHandler) {
   ipcMain.handle('recollectUserSessionCookie', async () => {
     await recollectUserSessionCookie();
   });
+
+  ipcMain.on('getWindowIds', e => {
+    e.returnValue = {
+      main: mainWindow.id,
+      child: childWindow.id,
+    };
+  });
 }


### PR DESCRIPTION
# このpull requestが解決する内容
複数画面がある環境で、画面毎に表示倍率が異なるときに、その間でウィンドウを移動したときに倍率追従がうまくうごいておらず、結果としてOBS表示部分の表示がずれていたのを修正します

原因: WindowsServiceの初期化時の window オブジェクト取得時に、main window, child windowが入れ替わることがあったため、main windowの移動時にchild windowにイベントが来ており、スケール追従がされなかった


# 関連するIssue（あれば）
fix #816