### PR TITLE
修正: ウィンドウを最小化したり裏に回したりして少し経つとコメントの受信(読み上げ)が止まっていた

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -141,6 +141,8 @@ export class WindowsService extends StatefulService<IWindowsState> {
     this.windows.main = windows[0];
     this.windows.child = windows[1];
 
+    this.windows.main.webContents.setBackgroundThrottling(false);
+
     this.updateScaleFactor('main');
     this.updateScaleFactor('child');
     this.windows.main.on('move', () => this.updateScaleFactor('main'));


### PR DESCRIPTION
# このpull requestが解決する内容
ウィンドウを最小化したり裏に回した状態でしばらくするとコメントの受信が止まり、読み上げも止まってしまう現象を、main windowの `webContents.setBackgroundThrottling(false);` によって回避します

#817 をマージした状態でないと正しく動作しないため、そちらを先にマージする必要があります

# 動作確認手順
ニコ生の番組情報を認識し、コメントを受信できる状態で最小化して、ブラウザ等からしばらくコメントをしつづけると、途中から反応がなくなっていたのが、ちゃんと反応しつづけるようになること

# 関連するIssue（あれば）
fix #812