### PR TITLE
修正: コメント一覧に被っていたボタンを邪魔にならない位置に移動

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -2,6 +2,20 @@
   <div class="container">
     <div class="header" v-if="!isCompactMode">
       <i
+        class="icon-reload icon-btn"
+        v-tooltip.bottom="commentReloadTooltip"
+        @click="refreshConnection"
+      ></i>
+      <i
+        class="icon-btn"
+        :class="speakingEnabled ? 'icon-speaker' : 'icon-mute'"
+        v-tooltip.bottom="
+          speakingEnabled ? commentSynthesizerOnTooltip : commentSynthesizerOffTooltip
+        "
+        @click="speakingEnabled = !speakingEnabled"
+      ></i>
+      <div class="divider"></div>
+      <i
         class="icon-ng icon-btn"
         v-tooltip.bottom="filterTooltip"
         @click="isFilterOpened = true"
@@ -60,26 +74,10 @@
         <button
           type="button"
           @click="scrollToLatest"
-          class="scroll-to-latest button--tertiary"
+          class="button--circle button--tertiary"
           v-if="!isLatestVisible && items.length > 0"
         >
-          <i class="icon-down-arrow"></i>最新のコメントへ移動
-        </button>
-        <button
-          class="button--circle button--tertiary"
-          v-tooltip.bottom="commentReloadTooltip"
-          @click="refreshConnection"
-        >
-          <i class="icon-reload"></i>
-        </button>
-        <button
-          class="button--circle button--tertiary"
-          v-tooltip.bottom="
-            speakingEnabled ? commentSynthesizerOnTooltip : commentSynthesizerOffTooltip
-          "
-          @click="speakingEnabled = !speakingEnabled"
-        >
-          <i :class="speakingEnabled ? 'icon-speaker' : 'icon-mute'"></i>
+          <i class="icon-down-arrow"></i>
         </button>
       </div>
       <div class="created-notice" v-if="showPlaceholder">
@@ -114,17 +112,17 @@
   display: flex;
   flex-shrink: 0;
   align-items: center;
+  justify-content: flex-end;
   width: 100%;
   height: 48px;
   padding: 4px 16px;
   border-bottom: 1px solid var(--color-border-light);
 
-  > .icon-btn {
+  .divider {
+    width: 1px;
+    height: 14px;
     margin-left: 16px;
-
-    &:first-child {
-      margin-left: auto;
-    }
+    background-color: var(--color-border-light);
   }
 }
 

--- a/app/components/windows/UserInfo.vue
+++ b/app/components/windows/UserInfo.vue
@@ -173,10 +173,10 @@
             <button
               type="button"
               @click="scrollToLatest"
-              class="scroll-to-latest button--tertiary"
+              class="button--circle button--tertiary"
               v-if="!isLatestVisible && comments.length > 0"
             >
-              <i class="icon-down-arrow"></i>最新のコメントへ移動
+              <i class="icon-down-arrow"></i>
             </button>
           </div>
         </div>

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -171,13 +171,9 @@ button {
 .icon-btn {
   .icon-hover();
 
-  margin-left: 12px;
+  margin-left: 16px;
   font-size: @font-size4;
   cursor: pointer;
-
-  &:first-child {
-    margin-left: inherit;
-  }
 }
 
 .icon-btn--sm {


### PR DESCRIPTION
# このpull requestが解決する内容

- コメント読み上げ、コメント再取得ボタンの位置をヘッダーに移動
- 最新コメント移動ボタンをアイコンのみに変更

### 修正前
![3](https://github.com/user-attachments/assets/88d405c1-f978-4c6f-8bb7-bd6fbfe5d2a9)
### 修正後
![キャプチャ](https://github.com/user-attachments/assets/199100db-eec3-4752-a05d-6251f5469c79)


# 関連するIssue（あれば）
fix #808