### PR TITLE
追加: コンパクトモード時にウィンドウを最前面にする設定

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -25,6 +25,7 @@
       </div>
       <ObsBoolInput :value="autoCompactModel" @input="setAutoCompact" />
       <ObsBoolInput :value="showAutoCompactDialogModel" @input="setShowAutoCompactDialog" />
+      <ObsBoolInput :value="compactAlwaysOnTopModel" @input="setCompactAlwaysOnTop" />
     </div>
 
     <div class="section">

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -114,6 +114,17 @@ export default class ExtraSettings extends Vue {
     this.customizationService.setShowAutoCompactDialog(model.value);
   }
 
+  get compactAlwaysOnTopModel(): IObsInput<boolean> {
+    return {
+      name: 'compact_mode_always_on_top',
+      description: $t('settings.compactAlwaysOnTop'),
+      value: this.customizationService.state.compactAlwaysOnTop,
+    };
+  }
+  setCompactAlwaysOnTop(model: IObsInput<boolean>) {
+    this.customizationService.setCompactAlwaysOnTop(model.value);
+  }
+
   showCacheDir() {
     remote.shell.openPath(remote.app.getPath('userData'));
   }

--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -53,22 +53,22 @@
             <i class="icon-studio-mode" />
           </a>
         </div>
-        <div class="side-nav-item feedback-button">
-          <a @click="openFeedback" class="link" :title="$t('common.feedback')">
-            <i class="icon-feedback" />
-          </a>
-        </div>
-        <div class="side-nav-item help-button">
-          <a @click="openHelp" class="link" :title="$t('common.help')">
-            <i class="icon-help" />
-          </a>
-        </div>
-        <div class="side-nav-item information-button">
-          <a @click="openInformations" class="link" :title="$t('informations.title')">
-            <i class="icon-notification" :class="{ isUnseen: hasUnseenInformation }" />
-          </a>
-        </div>
       </template>
+      <div class="side-nav-item feedback-button">
+        <a @click="openFeedback" class="link" :title="$t('common.feedback')">
+          <i class="icon-feedback" />
+        </a>
+      </div>
+      <div class="side-nav-item help-button">
+        <a @click="openHelp" class="link" :title="$t('common.help')">
+          <i class="icon-help" />
+        </a>
+      </div>
+      <div class="side-nav-item information-button">
+        <a @click="openInformations" class="link" :title="$t('informations.title')">
+          <i class="icon-notification" :class="{ isUnseen: hasUnseenInformation }" />
+        </a>
+      </div>
       <div class="side-nav-item">
         <a
           @click="openSettingsWindow"

--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -41,8 +41,8 @@
       </div>
     </div>
 
-    <template v-if="!isCompactMode">
-      <div class="bottom-tools">
+    <div class="bottom-tools">
+      <template v-if="!isCompactMode">
         <div class="side-nav-item">
           <a
             @click="studioMode"
@@ -68,18 +68,18 @@
             <i class="icon-notification" :class="{ isUnseen: hasUnseenInformation }" />
           </a>
         </div>
-        <div class="side-nav-item">
-          <a
-            @click="openSettingsWindow"
-            class="link"
-            data-test="OpenSettings"
-            :title="$t('common.settings')"
-          >
-            <i class="icon-settings" />
-          </a>
-        </div>
+      </template>
+      <div class="side-nav-item">
+        <a
+          @click="openSettingsWindow"
+          class="link"
+          data-test="OpenSettings"
+          :title="$t('common.settings')"
+        >
+          <i class="icon-settings" />
+        </a>
       </div>
-    </template>
+    </div>
     <div class="side-nav-profile">
       <login />
     </div>

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -673,7 +673,7 @@
     "setting": "Automatically switch to the compact mode in streaming",
     "showDialog": "Show the Compact Mode Automation Settings dialog."
   },
-  "compactAlwaysOnTop": "Compact Mode Always On Top",
+  "compactAlwaysOnTop": "Always on top in compact mode",
   "synthId": {
     "webSpeech": "Windows SpeechSynthesizer",
     "nVoice": "N Voice / KOTOYOMI Near",

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -673,6 +673,7 @@
     "setting": "Automatically switch to the compact mode in streaming",
     "showDialog": "Show the Compact Mode Automation Settings dialog."
   },
+  "compactAlwaysOnTop": "Compact Mode Always On Top",
   "synthId": {
     "webSpeech": "Windows SpeechSynthesizer",
     "nVoice": "N Voice / KOTOYOMI Near",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -673,6 +673,7 @@
     "setting": "配信中に自動でコンパクトモードに切り替える",
     "showDialog": "コンパクトモード自動化設定ダイアログを表示する"
   },
+  "compactAlwaysOnTop": "コンパクトモード時に常に最前面に表示する",
   "synthId": {
     "webSpeech": "Windowsの音声合成",
     "nVoice": "N Voice 琴詠ニア",

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -22,6 +22,7 @@ export interface ICustomizationServiceState {
   compactMaximized: boolean;
   autoCompactMode: boolean;
   showAutoCompactDialog: boolean;
+  compactAlwaysOnTop: boolean;
   experimental: any;
 }
 

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -38,6 +38,7 @@ export class CustomizationService
     compactMaximized: false,
     autoCompactMode: false,
     showAutoCompactDialog: true,
+    compactAlwaysOnTop: false,
 
     experimental: {
       // put experimental features here
@@ -135,6 +136,10 @@ export class CustomizationService
 
   setShowAutoCompactDialog(show: boolean) {
     this.setSettings({ showAutoCompactDialog: show });
+  }
+
+  setCompactAlwaysOnTop(compactAlwaysOnTop: boolean) {
+    this.setSettings({ compactAlwaysOnTop });
   }
 
   setFullModeWidthOffset(state: {

--- a/app/services/nicolive-program/state.ts
+++ b/app/services/nicolive-program/state.ts
@@ -32,7 +32,7 @@ export type HttpRelationState = {
   body: string;
 };
 
-interface IState {
+export interface IState {
   autoExtensionEnabled: boolean;
   panelOpened: boolean;
   speechSynthesizerSettings?: SpeechSynthesizerSettingsState;

--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -14,19 +14,6 @@ const setup = createSetupFunction({
         subscribe() {},
       },
     },
-    WindowsService: {
-      getWindow() {
-        return {
-          getMinimumSize: () => [800, 600],
-          setMinimumSize: () => {},
-          setMaximumSize: () => {},
-          getSize: () => [800, 600],
-          setSize: () => {},
-          isMaximized: () => false,
-          setMaximizable: () => {},
-        };
-      },
-    },
     UserService: {
       userLoginState: {
         subscribe() {},
@@ -49,7 +36,6 @@ const setup = createSetupFunction({
   },
 });
 
-jest.mock('services/windows', () => ({ WindowsService: {} }));
 jest.mock('services/user', () => ({ UserService: {} }));
 jest.mock('services/nicolive-program/state', () => ({ NicoliveProgramStateService: {} }));
 
@@ -173,19 +159,6 @@ describe('refreshWindowSize', () => {
           NicoliveProgramStateService: {
             state: {},
             updated,
-          },
-          WindowsService: {
-            getWindow() {
-              return {
-                getMinimumSize: () => [800, 600],
-                setMinimumSize,
-                setMaximumSize,
-                getSize: () => [800, 600],
-                setSize,
-                isMaximized: () => false,
-                setMaximizable: () => {},
-              };
-            },
           },
           NavigationService: {
             navigated: new Subject(),

--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -1,9 +1,7 @@
 import { createSetupFunction } from 'util/test-setup';
 import { Subject, BehaviorSubject } from 'rxjs';
 
-type WindowSizeService = import('./window-size').WindowSizeService;
 type PanelState = import('./window-size').PanelState;
-type TWindowSizeService = import('./window-size').WindowSizeService;
 
 const setup = createSetupFunction({
   state: {},
@@ -199,6 +197,9 @@ describe('refreshWindowSize', () => {
       // inject spy
       WindowSizeService.updateWindowSize = updateWindowSize;
 
+      const sendSync = jest.fn().mockName('sendSync');
+      jest.spyOn(require('electron').ipcRenderer, 'sendSync').mockImplementation(sendSync);
+
       // kick getter
       WindowSizeService.instance;
 
@@ -392,6 +393,7 @@ describe('updateWindowSize', () => {
         maximize: jest.fn(),
         unmaximize: jest.fn(),
         setMaximizable: jest.fn(),
+        setAlwaysOnTop: jest.fn(),
       };
 
       const nextSize = WindowSizeService.updateWindowSize(win, suite.prev, suite.next, {

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -7,6 +7,7 @@ import { NavigationService } from './navigation';
 import { NicoliveProgramStateService } from './nicolive-program/state';
 import { UserService } from './user';
 import { WindowsService } from './windows';
+import { compact } from 'lodash';
 
 interface IWindowSizeState {
   panelOpened: boolean | null; // 初期化前はnull、永続化された値の読み出し後に値が入る
@@ -92,9 +93,8 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
       next: compact => {
         if ('compactMode' in compact) {
           this.setState({ isCompact: compact.compactMode });
-          // setState isCompactの後でないと正しい計算にならないため、分ける
-          this.updateAlwaysOnTop();
-        } else if ('compactAlwaysOnTop' in compact) {
+        }
+        if ('compactAlwaysOnTop' in compact) {
           this.updateAlwaysOnTop();
         }
       },
@@ -123,6 +123,9 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
     this.refreshWindowSize(this.state, nextState);
     this.SET_STATE(nextState);
     this.stateChangeSubject.next(nextState);
+    if ('isCompact' in partialState) {
+      this.updateAlwaysOnTop();
+    }
   }
 
   @mutation()

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -6,7 +6,6 @@ import { CustomizationService } from './customization/customization';
 import { NavigationService } from './navigation';
 import { NicoliveProgramStateService } from './nicolive-program/state';
 import { UserService } from './user';
-import { WindowsService } from './windows';
 
 interface IWindowSizeState {
   panelOpened: boolean | null; // 初期化前はnull、永続化された値の読み出し後に値が入る
@@ -54,7 +53,6 @@ class MainWindowOperation {
 }
 
 export class WindowSizeService extends StatefulService<IWindowSizeState> {
-  @Inject() windowsService: WindowsService;
   @Inject() customizationService: CustomizationService;
   @Inject() userService: UserService;
   @Inject() nicoliveProgramStateService: NicoliveProgramStateService;
@@ -121,10 +119,10 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
     const nextState = { ...this.state, ...partialState };
     this.refreshWindowSize(this.state, nextState);
     this.SET_STATE(nextState);
-    this.stateChangeSubject.next(nextState);
     if ('isCompact' in partialState) {
       this.updateAlwaysOnTop();
     }
+    this.stateChangeSubject.next(nextState);
   }
 
   @mutation()

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -36,7 +36,7 @@ type BackupSizeInfo = {
 };
 
 const MWOpKey = 'mainwindow-operation';
-class MainWindowOperation {
+export class MainWindowOperation {
   getPosition = (): number[] => ipcRenderer.sendSync(MWOpKey, 'getPosition');
   setPosition = (a: number, b: number) => ipcRenderer.sendSync(MWOpKey, 'setPosition', a, b);
   getSize = (): number[] => ipcRenderer.sendSync(MWOpKey, 'getSize');
@@ -146,7 +146,7 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
     if (!isLoggedIn) return PanelState.INACTIVE;
     return panelOpened ? PanelState.OPENED : PanelState.CLOSED;
   }
-  mainWindowOperation = new MainWindowOperation();
+  static mainWindowOperation = new MainWindowOperation();
 
   /** パネルが出る幅の分だけ画面の最小幅を拡張する */
   refreshWindowSize(prevState: IWindowSizeState, nextState: IWindowSizeState): void {
@@ -155,7 +155,7 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
     if (nextPanelState !== null) {
       if (prevPanelState !== nextPanelState) {
         const newSize = WindowSizeService.updateWindowSize(
-          this.mainWindowOperation,
+          WindowSizeService.mainWindowOperation,
           prevPanelState,
           nextPanelState,
           {
@@ -177,7 +177,7 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
         }
       }
       if (prevState.isAlwaysOnTop !== nextState.isAlwaysOnTop) {
-        this.mainWindowOperation.setAlwaysOnTop(nextState.isAlwaysOnTop);
+        WindowSizeService.mainWindowOperation.setAlwaysOnTop(nextState.isAlwaysOnTop);
       }
     }
   }

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcRenderer } from 'electron';
+import { ipcRenderer } from 'electron';
 import { BehaviorSubject } from 'rxjs';
 import { Inject } from './core/injector';
 import { mutation, StatefulService } from './core/stateful-service';
@@ -7,7 +7,6 @@ import { NavigationService } from './navigation';
 import { NicoliveProgramStateService } from './nicolive-program/state';
 import { UserService } from './user';
 import { WindowsService } from './windows';
-import { compact } from 'lodash';
 
 interface IWindowSizeState {
   panelOpened: boolean | null; // 初期化前はnull、永続化された値の読み出し後に値が入る


### PR DESCRIPTION
# このpull requestが解決する内容

* 設定 - 一般に `コンパクトモード時に常に最前面に表示する` を追加(初期値off)
![image](https://github.com/user-attachments/assets/ccadbacc-7177-49de-b5d5-890660d2264e)
    * 英語は `Always on top in compact mode`    
![image](https://github.com/user-attachments/assets/55182b62-8d69-420a-b680-8cf5aa97d555)


* これをonにし、かつコンパクトモードになったときにメインウィンドウを「常に最前面に表示」します
* あと、コンパクトモードにすると左のナビゲーション領域の下端に設定などのアイコンを消していましたが、コンパクトモードから最前面設定を変更できるように、消さないように変更しました(コンパクトモードではレイアウト的に使えないスタジオモードだけは従来通り消します)

* TODO
   * [x] 前回終了時に最前面だった場合、起動時に最前面を復元する
   * [x] window-siize.test.ts が終わらなくなってるのを直す
   * [x] コンパクトモード中でも設定を変更できるUIをつける
   * [x] テスト書く

# 動作確認手順

* 設定の `コンパクトモード時に常に最前面に表示する` が offのとき:
   * 通常ウィンドウで起動すると 最前面ではない
   * コンパクトモードにしても最前面ではない
   * コンパクトモードで終了し、次に起動しても最前面ではない

* 設定の `コンパクトモード時に常に最前面に表示する` が onのとき:
   * 通常ウィンドウで起動すると 最前面ではない
   * コンパクトモードにする最前面になる
   * コンパクトモードで終了し、次に起動すると最前面になる

* 設定ウィンドウを出してからコンパクトモードにして
  * `コンパクトモード時に常に最前面に表示する` を切り替えると、on のときは最前面になり、offのときは最前面でなくなる
* 通常モードで設定ウィンドウを出して `コンパクトモード時に常に最前面に表示する` を切り替えても、どちらの値でも最前面にならない

# 関連するIssue（あれば）
fix #822