### PR TITLE
追加: 読み上げ有効時、番組が終了したときに「番組が終了しました」と読み上げる

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue
+++ b/app/components/nicolive-area/CommentViewer.vue
@@ -37,7 +37,7 @@
           :class="{
             row: true,
             name: getDisplayName(item),
-            hint: item.value.no === nameplateHintNo,
+            hint:hasNamePlateHint(item),
           }"
           v-for="item of items"
           :key="item.seqId"
@@ -46,7 +46,7 @@
           :getFormattedLiveTime="getFormattedLiveTime"
           :commentMenuOpened="commentMenuTarget === item"
           :speaking="speakingSeqId === item.seqId"
-          :nameplateHint="nameplateHintNo && item.value.no === nameplateHintNo"
+          :nameplateHint="hasNamePlateHint(item)"
           @pinned="pin(item)"
           @commentMenu="showCommentMenu(item)"
           @commentUser="showUserInfo(item)"

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -4,7 +4,7 @@ import { CustomizationService } from 'services/customization';
 import { ChatMessage } from 'services/nicolive-program/ChatMessage';
 import { ChatComponentType } from 'services/nicolive-program/ChatMessage/ChatComponentType';
 import {
-  WrappedChat,
+  isWrappedChat,
   WrappedChatWithComponent,
   WrappedMessage,
   WrappedMessageWithComponent,
@@ -93,7 +93,7 @@ export default class CommentViewer extends Vue {
 
   isLatestVisible = true;
 
-  get pinnedComment(): WrappedChat | null {
+  get pinnedComment(): WrappedChatWithComponent | null {
     return this.nicoliveCommentViewerService.state.pinnedMessage;
   }
 
@@ -139,6 +139,10 @@ export default class CommentViewer extends Vue {
 
   getDisplayName(item: WrappedMessage): string {
     return getDisplayName(item);
+  }
+
+  hasNamePlateHint(item: WrappedMessage): boolean {
+    return this.nameplateHintNo && isWrappedChat(item) && this.nameplateHintNo === item.value.no;
   }
 
   componentMap = componentMap;
@@ -287,13 +291,15 @@ export default class CommentViewer extends Vue {
     menu.popup();
   }
 
-  showUserInfo(item: WrappedChatWithComponent) {
-    this.nicoliveCommentViewerService.showUserInfo(
-      item.value.user_id,
-      item.value.name,
-      (item.value.premium & 1) !== 0,
-      item.isSupporter,
-    );
+  showUserInfo(item: WrappedMessageWithComponent) {
+    if (isWrappedChat(item)) {
+      this.nicoliveCommentViewerService.showUserInfo(
+        item.value.user_id,
+        item.value.name,
+        (item.value.premium & 1) !== 0,
+        item.isSupporter,
+      );
+    }
   }
 
   private cleanup: () => void = undefined;

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -128,7 +128,7 @@ test('接続先情報が来たら接続する', async () => {
   const instance = NicoliveCommentViewerService.instance as NicoliveCommentViewerService;
 
   expect(clientSubject.observers).toHaveLength(0);
-  expect(stateChange.observers).toHaveLength(1);
+  expect(stateChange.observers).toHaveLength(2);
   stateChange.next({ viewUri: 'https://example.com' });
   expect(clientSubject.observers).toHaveLength(1);
 });
@@ -149,7 +149,7 @@ test('接続先情報が欠けていたら接続しない', () => {
   const instance = NicoliveCommentViewerService.instance as NicoliveCommentViewerService;
 
   expect(clientSubject.observers).toHaveLength(0);
-  expect(stateChange.observers).toHaveLength(1);
+  expect(stateChange.observers).toHaveLength(2);
   stateChange.next({ viewUri: '' });
   expect(clientSubject.observers).toHaveLength(0);
 });

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -250,6 +250,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   }
 
   private onProgramEnd() {
+    // addSystemMessage だと番組終了によるコメント通信切断後だと流れないため、onMessageで直接追加する
     this.onMessage([{ ...AddComponent(makeEmulatedChat('番組が終了しました')), seqId: -1 }]);
   }
 

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -452,7 +452,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
   }
 
   static TIMER_PADDING_SECONDS = 3;
-  static REFRESH_TARGET_TIME_TABLE = {
+  static REFRESH_TARGET_TIME_TABLE: { [state: string]: 'startTime' | 'endTime' } = {
     reserved: 'startTime',
     test: 'startTime',
     onAir: 'endTime',


### PR DESCRIPTION
# このpull requestが解決する内容
番組が終了したときに「番組が終了しました」というメッセージを追加し、読み上げが有効ならそれが読み上げられることによって、画面を見ていなくても終了に気付くことができるようにします。

あとソース上でTypeScriptの型警告が出ていた部分を修正するのも混ぜてます


![image](https://github.com/user-attachments/assets/cb9eaa7f-0abc-440f-b020-71e85b0cb058)

# 動作確認手順

# 関連するIssue（あれば）
#619 