### PR TITLE
修正: 番組自動終了時にコメントリストを消さないようにする

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -248,11 +248,12 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   nextConfigLoaded: Subject<void> = new Subject();
   private onNextConfig({ viewUri }: MessageServerConfig): void {
     this.unsubscribe();
-    this.clearList();
-    this.pinComment(null);
 
     // 予約番組は30分前にならないとURLが来ない
     if (!viewUri) return;
+
+    this.clearList();
+    this.pinComment(null);
 
     if (isFakeMode() && FakeModeConfig.dummyComment) {
       // yarn dev 時はダミーでコメントを5秒ごとに出し続ける


### PR DESCRIPTION
# このpull requestが解決する内容
時間切れで番組が終了した場合に、コメント一覧の内容が消去されてしまっていたのを、残るように修正します

# 動作確認手順
1. 番組を開始して、適当にコメントして(自動延長offで)30分放置して番組終了を待つ
2. コメントが残っていること

# 関連するIssue（あれば）
fix #703