### PR TITLE
修正: N Airの外で番組を終了させたときにもN Airの番組状態に即時反映する

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -168,7 +168,8 @@ test('status=endedが流れてきたらunsubscribeする', () => {
     };
   });
   jest.spyOn(window, 'setTimeout').mockImplementation(callback => callback() as any);
-  setup({ injectee: { NicoliveProgramService: { stateChange } } });
+  const refreshProgram = jest.fn().mockName('refreshProgram');
+  setup({ injectee: { NicoliveProgramService: { stateChange, refreshProgram } } });
 
   const { NicoliveCommentViewerService } = require('./nicolive-comment-viewer');
   const instance = NicoliveCommentViewerService.instance as NicoliveCommentViewerService;
@@ -181,8 +182,13 @@ test('status=endedが流れてきたらunsubscribeする', () => {
   expect(clientSubject.observers).toHaveLength(1);
   expect(unsubscribe).toHaveBeenCalledTimes(1);
 
+  expect(refreshProgram).toHaveBeenCalledTimes(0);
+
   clientSubject.next({ state: { state: 'ended' } });
   expect(unsubscribe).toHaveBeenCalledTimes(2);
+
+  // ended が来たら refreshProgramも呼ばれる
+  expect(refreshProgram).toHaveBeenCalledTimes(1);
 });
 
 const MODERATOR_ID = '123';

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -154,7 +154,7 @@ test('接続先情報が欠けていたら接続しない', () => {
   expect(clientSubject.observers).toHaveLength(0);
 });
 
-test('status=endedが流れてきたらunsubscribeする', () => {
+test('status=endedが流れてきたらunsubscribeし、refreshProgramも呼ぶ', () => {
   const stateChange = new Subject();
   const clientSubject = new Subject<MessageResponse>();
   jest.doMock('./NdgrCommentReceiver', () => {

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -410,6 +410,8 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
                     // completeが発生しないのでサーバーとの接続終了メッセージは出ない
                     // `/disconnect` の代わりのメッセージは出さない仕様なので問題ない
                     this.unsubscribe();
+                    // 番組情報を更新する
+                    this.nicoliveProgramService.refreshProgram();
                   }
                 }),
                 ignoreElements(),


### PR DESCRIPTION
# このpull requestが解決する内容

* N Airの外で番組が終了したときに、コメントサーバーからの終了通知をトリガーに番組状態を更新することで終了を検出します。
* 参考: テスト配信モードからN Airの外で配信開始をしたのには相変わらず気づけないので番組更新ボタンが必要です

- [x] テスト書く

# 動作確認手順
* 番組を開始して、webから番組を終了するとN Airがすぐに番組終了状態になること

# 関連するIssue（あれば）
