### PR TITLE
開発: GitHub Actions: testのe2eテスト/apiを2分割して時間を短縮する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,8 @@ jobs:
         directory:
           - 'e2e/[^s]*.js'
           - 'e2e/s*.js'
-          - 'api/*.js'
+          - 'api/[^s]*.js'
+          - 'api/s*.js'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# このpull requestが解決する内容
GitHub Actionsのtestで `e2e tests(api/*.js)` がボトルネックだったので2分割して、テスト実行時間を1～2分短縮します

![image](https://github.com/user-attachments/assets/5182415e-368f-4a85-aee1-15b8f5d2bdd5)

↓

![image](https://github.com/user-attachments/assets/281551b2-bc36-4fa7-81a1-9f90739e9066)

* [ ] マージしたら branch protectionを更新する