### PR TITLE
改善: コメント一覧に切り替えた際に最新コメントにスクロールさせる

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -318,6 +318,7 @@ export default class CommentViewer extends Vue {
     this.cleanup = () => {
       io.unobserve(sentinelEl);
     };
+    this.scrollToLatest();
   }
 
   beforeDestroy() {


### PR DESCRIPTION
# このpull requestが解決する内容
* スクロールする程度にコメントがある状態で
   * <strike>番組途中からN Airを開いたとき</strike> (このケースは最新までスクロールされていた)
   * 番組説明タブに切り替えたとき
   * コンパクトモードで配信関連画面とコメント画面を行き来したとき

のいずれでもスクロール位置が一番上(古いコメント)になってしまうのが不便なので、最新コメントにスクロールさせます。

# 動作確認手順
上記の状況にすると、最古のコメントではなく最新のコメントが見える位置がスクロール初期状態になっていること
