### PR TITLE
修正: Windowsの音声合成の再生途中で「再生テスト」などで止めると、以後音声合成が鳴らなくなっていた

### DIFF
--- a/app/components/SpeechEngineSettings.vue.ts
+++ b/app/components/SpeechEngineSettings.vue.ts
@@ -21,7 +21,7 @@ export default class SpeechEngineSettings extends Vue {
 
   async testSpeechPlay(synthId: SynthesizerId) {
     const service = this.nicoliveCommentSynthesizerService;
-    await service.startTestSpeech('これは読み上げ設定のテスト音声です', synthId);
+    service.startTestSpeech('これは読み上げ設定のテスト音声です', synthId);
   }
 
   get enabled(): boolean {

--- a/app/components/SpeechEngineSettings.vue.ts
+++ b/app/components/SpeechEngineSettings.vue.ts
@@ -19,7 +19,7 @@ export default class SpeechEngineSettings extends Vue {
     this.$emit('close');
   }
 
-  async testSpeechPlay(synthId: SynthesizerId) {
+  testSpeechPlay(synthId: SynthesizerId) {
     const service = this.nicoliveCommentSynthesizerService;
     service.startTestSpeech('これは読み上げ設定のテスト音声です', synthId);
   }


### PR DESCRIPTION
# このpull requestが解決する内容
Windowsの音声合成の再生を途中でcancelする行為(例: `設定`-`音声エンジン`の`読み上げテスト`を押す)で、以後一切音声合成が鳴らなくなっていたのを修正します

# 動作確認手順
`設定` - `音声エンジン` で `Windowsの音声合成` の `読み上げテスト` を連打する
