### PR TITLE
開発: CI: paths-filterを使ってコードテスト以外だとtest skip(=succeess)になってbranch protectionを満たすようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,6 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
-      - name: fail test
-        run: exit 1
-
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -82,9 +79,6 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
-      - name: fail test
-        run: exit 1
-
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,16 +43,14 @@ jobs:
               - 'test/**'
               - 'updater/**'
               - 'vendor/**'
-  #              - '.github/workflows/test.yml'
+              - '.github/workflows/test.yml'
+
   setup-app:
     name: setup(app)
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
-      - name: fail test
-        run: exit 1
-
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -81,9 +79,6 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
-      - name: fail test
-        run: exit 1
-
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,6 +194,7 @@ jobs:
         run: yarn test --fail-fast test-dist/test/${{ matrix.directory }}
 
   test-summary:
+    # 注意: needs に setupも入れないと、setupで失敗すると後段のresultが `skipped` になってしまい、すりぬけてしまう
     needs: [setup-app, setup-bin, unit_test-app, unit_test-bin, e2e_test]
     if: always()
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,52 +4,51 @@ on:
   push:
     branches:
       - n-air_development
-    paths:
-      - package.json
-      - yarn.lock
-      - installer.nsh
-      - tsconfig.json
-      - webpack.config.js
-      - main.js
-      - test-main.js
-      - app/**
-      - bin/package.json
-      - bin/yarn.lock
-      - bin/**/*.js
-      - media/**
-      - nvoice/**
-      - obs-api/**
-      - scripts/**
-      - test/**
-      - updater/**
-      - vendor/**
-      - .github/workflows/test.yml
 
   pull_request:
-    paths:
-      - package.json
-      - yarn.lock
-      - installer.nsh
-      - tsconfig.json
-      - webpack.config.js
-      - main.js
-      - test-main.js
-      - app/**
-      - bin/package.json
-      - bin/yarn.lock
-      - bin/**/*.js
-      - media/**
-      - nvoice/**
-      - obs-api/**
-      - scripts/**
-      - test/**
-      - updater/**
-      - vendor/**
-      - .github/workflows/test.yml
 
 jobs:
+  changes:
+    runs-on: windows-2019
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout if push
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'push' }}
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'package.json'
+              - 'yarn.lock'
+              - 'installer.nsh'
+              - 'tsconfig.json'
+              - 'webpack.config.js'
+              - 'main.js'
+              - 'test-main.js'
+              - 'app/**'
+              - 'bin/package.json'
+              - 'bin/yarn.lock'
+              - 'bin/**/*.js'
+              - 'media/**'
+              - 'nvoice/**'
+              - 'obs-api/**'
+              - 'scripts/**'
+              - 'test/**'
+              - 'updater/**'
+              - 'vendor/**'
+              - '.github/workflows/test.yml'
+
   setup-app:
     name: setup(app)
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
       - name: Checkout code
@@ -76,6 +75,8 @@ jobs:
 
   setup-bin:
     name: setup(bin)
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
       - name: Checkout code
@@ -99,7 +100,8 @@ jobs:
 
   unit_test-app:
     name: unit tests(app)
-    needs: setup-app
+    needs: [changes, setup-app]
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
 
     steps:
@@ -123,7 +125,8 @@ jobs:
 
   unit_test-bin:
     name: unit tests(bin)
-    needs: [setup-app, setup-bin]
+    needs: [changes, setup-app, setup-bin]
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
 
     steps:
@@ -154,7 +157,7 @@ jobs:
 
   e2e_test:
     name: e2e tests
-    needs: setup-app
+    needs: [changes, setup-app]
     runs-on: windows-2019
     strategy:
       matrix:
@@ -166,14 +169,17 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ needs.changes.outputs.code == 'true' }}
         uses: actions/checkout@v4
 
       - name: Set up Node.js
+        if: ${{ needs.changes.outputs.code == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: cache node modules
+        if: ${{ needs.changes.outputs.code == 'true' }}
         id: cache-node-modules
         uses: actions/cache@v4
         with:
@@ -181,7 +187,26 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'scripts/preinstall.js', 'scripts/install-native-deps.js', 'scripts/repositories.json') }}
 
       - name: Compile
+        if: ${{ needs.changes.outputs.code == 'true' }}
         run: yarn compile:ci
 
       - name: Run e2e tests
+        if: ${{ needs.changes.outputs.code == 'true' }}
         run: yarn test --fail-fast test-dist/test/${{ matrix.directory }}
+
+  test-summary:
+    needs: [setup-app, setup-bin, unit_test-app, unit_test-bin, e2e_test]
+    if: always()
+    steps:
+      - name: test-summary
+        run: |
+          echo '${{ toJson(needs) }}'
+          RESULT=${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+          echo RESULT=$RESULT
+          if [[ $RESULT == true ]]; then
+            echo "All tests passed"
+          else
+            echo "Some tests failed"
+            exit 1
+          fi
+    runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
               - 'media/**'
               - 'nvoice/**'
               - 'obs-api/**'
-              - 'scripts/**'
               - 'test/**'
               - 'updater/**'
               - 'vendor/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
+      - name: fail test
+        run: exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -79,6 +82,9 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
+      - name: fail test
+        run: exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,14 +43,16 @@ jobs:
               - 'test/**'
               - 'updater/**'
               - 'vendor/**'
-              - '.github/workflows/test.yml'
-
+  #              - '.github/workflows/test.yml'
   setup-app:
     name: setup(app)
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
+      - name: fail test
+        run: exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -79,6 +81,9 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2019
     steps:
+      - name: fail test
+        run: exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# このpull requestが解決する内容
* README.mdだけをいじったときなどにCIがスキップされるために branch protectionにひっかかってmergeできなくなるのを避けるため、 https://github.com/dorny/paths-filter を使って分岐するようにします

- [x] test.ymlをpathに入れた状態ではテストがすべて実行されて `test-summary` が成功することを確認
- [x] test.ymlをpathsから除外して、テストをスキップしたときにも `test-summary` が成功することを確認
- [x] 一部のテストが失敗したときは `test-summary` が失敗することを確認
- [x] mergeするときは branch protectionのcheckを `test-summary` ひとつにする
