### PR TITLE
開発: 修正:Sentry/開発モードのsourcemapの送り先とeventの送り先を一致させる

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,16 +23,22 @@ function getSentryMiniDumpURLFromDSN(dsn) {
 /** @type function ({production: boolean}, {mode?:string}): import('webpack').Configuration */
 module.exports = function (env, argv) {
   const SENTRY_ORG = 'n-air-app2';
-  const SENTRY_PROJECT = package.name === 'n-air-app' ? 'n-air-app' : 'n-air-app-unstable';
+  const SENTRY_PROJECT = (() => {
+    if (argv.mode === 'production') {
+      return package.name === 'n-air-app' ? 'n-air-app' : 'n-air-app-unstable';
+    } else {
+      return 'n-air-app-dwango';
+    }
+  })();
   const SentryDSNTable = {
     'n-air-app':
       'https://35a02d8ebec14fd3aadc9d95894fabcf@o4507508755791872.ingest.us.sentry.io/1246812',
     'n-air-app-unstable':
       'https://7451aaa71b7640a69ee1d31d6fd9ef78@o4507508755791872.ingest.us.sentry.io/1546758',
+    'n-air-app-dwango':
+      'https://1cb5cdf6a93c466dad570861b8c82b61@o4507508755791872.ingest.us.sentry.io/1262580',
   };
-  const DevDSN =
-    'https://1cb5cdf6a93c466dad570861b8c82b61@o4507508755791872.ingest.us.sentry.io/1262580';
-  const SENTRY_DSN = argv.mode === 'production' ? SentryDSNTable[SENTRY_PROJECT] : DevDSN;
+  const SENTRY_DSN = SentryDSNTable[SENTRY_PROJECT];
   const SENTRY_MINIDUMP_URL = getSentryMiniDumpURLFromDSN(SENTRY_DSN);
 
   const definePlugin = new DefinePlugin({


### PR DESCRIPTION
# このpull requestが解決する内容
開発ビルド時のSentryのsourceMapの送り先とeventの送り先が違っていてちゃんとソース展開できなかったのを修正します

# 動作確認手順
```bash
# SENTRYの環境変数をセットアップた上で
yarn compile
NAIR_REPORT_TO_SENTRY=1 yarn start
```
ソースに `new Error('test');` みたいなのを仕込んだりして何かエラーを飛ばしてSentryのstackTraceがちゃんとソース展開されること
