### PR TITLE
開発: fix: i18n-not-found-keys.txtの改行文字補正

### DIFF
--- a/main.js
+++ b/main.js
@@ -896,7 +896,15 @@ function initialize(crashHandler) {
     if (process.env.NODE_ENV !== 'production') {
       // dev 実行でのみ読み込む
       if (fs.existsSync(I18N_NOT_FOUND_KEYS_FILE)) {
-        return fs.readFileSync(I18N_NOT_FOUND_KEYS_FILE, 'utf-8').split('\n').filter(Boolean);
+        const keys = fs
+          .readFileSync(I18N_NOT_FOUND_KEYS_FILE, 'utf-8')
+          .split('\n')
+          .map(l => l.trimEnd())
+          .filter(Boolean);
+        console.log(`file ${I18N_NOT_FOUND_KEYS_FILE} loaded: ${keys.length} keys`);
+        return keys;
+      } else {
+        console.warn(`file ${I18N_NOT_FOUND_KEYS_FILE} not found`);
       }
     }
     return [];


### PR DESCRIPTION
# このpull requestが解決する内容
#842 で作成された `i18n-not-found-keys.txt` の改行文字が CRLF になってると除去がマッチせず動作しない問題を修正します(Windowsのgitの設定によって発生する)
あと開発実行時、 `i18n-not-found-keys.txt` を読んだかどうかを表示します