### PR TITLE
修正: コメントを再読み込みするとブロックしたはずのコメントのブロックが解除されたように見えていた

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -194,6 +194,8 @@ test('status=endedが流れてきたらunsubscribeし、refreshProgramも呼ぶ'
 const MODERATOR_ID = '123';
 const NOT_MODERATOR_ID = '456';
 
+const NG_WORD = 'abc';
+
 function connectionSetup(options: { speechEnabled?: boolean; httpRelationEnabled?: boolean } = {}) {
   const stateChange = new Subject();
   const clientSubject = new Subject<MessageResponse>();
@@ -230,8 +232,11 @@ function connectionSetup(options: { speechEnabled?: boolean; httpRelationEnabled
       },
       NicoliveCommentFilterService: {
         addFilterCache: () => {},
-        findFilterCache: () => ({ type: 'word', body: 'abc' } as FilterRecord),
+        findFilterCache: () => ({ type: 'word', body: NG_WORD } as FilterRecord),
         deleteFiltersCache: () => {},
+        applyFilter: (msg: WrappedMessage) => {
+          return { ...msg, filtered: isWrappedChat(msg) && msg.value.content === NG_WORD };
+        },
       },
       NicoliveCommentLocalFilterService: {
         filterFn: (msg: WrappedMessage) => (isWrappedChat(msg) ? msg.value.content !== 'NG' : true),
@@ -449,7 +454,7 @@ test('モデレーターによるSSNG追加・削除がきたらシステムメ�
         record: {
           id: 1,
           type: 'word',
-          body: 'abc',
+          body: NG_WORD,
           userId: parseInt(MODERATOR_ID, 10),
           userName: 'test',
         },
@@ -707,4 +712,22 @@ test('HTTP連携: コメント送信', async () => {
   expect(
     sendChatMock.mock.calls.map(([msg]) => (isWrappedChat(msg) ? msg.value.content : 'not chat')),
   ).toEqual(['new', 'サーバーとの接続が終了しました']);
+});
+
+test('NGワードにかかるコメントが来たら ##このコメントは表示されません## になる', async () => {
+  const { clientSubject, instance } = connectionSetup();
+  await sleep(0);
+
+  clientSubject.next({
+    chat: {
+      content: NG_WORD,
+      user_id: '123',
+    },
+  });
+
+  // bufferTime tweaks
+  clientSubject.complete();
+
+  expect(instance.state.messages.length).toEqual(2);
+  expect(getDisplayText(instance.state.messages[0])).toEqual('##このコメントは表示されません##');
 });

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -462,11 +462,11 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
         map(arr =>
           arr.map(m => {
             if (isWrappedChat(m) && m.type === 'normal' && m.value.user_id) {
-              return {
+              return this.nicoliveCommentFilterService.applyFilter({
                 ...m,
                 isModerator: this.nicoliveModeratorsService.isModerator(m.value.user_id),
                 isSupporter: isSupporter(m.value.user_id),
-              };
+              });
             }
             return m;
           }),


### PR DESCRIPTION
# このpull requestが解決する内容
コメントを配信用ブロックしたあと、コメントを再読み込みすると、ブロックした対象のコメントが復活していた。

原因:
コメントサーバー(NDGR)は、配信用ブロックを追加したコメント自体については読み込み直してもフィルターを過去遡及せず送信されるため、クライアントでフィルターしないといけなかった

- [x] テスト追加する

# 動作確認手順
1. コメントを配信用ブロックに追加する ( `##このコメントは表示されません##` になる)
2. コメント一覧の再読み込みボタンを押す
3. 当該コメントが引き続き `##このコメントは表示されません##` になっていること
