### PR TITLE
修正: 「##このコメントは表示されません##」を読み上げない

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -683,28 +683,26 @@ test('コメント読み上げ時に古いコメントは読み上げない', as
 });
 
 test('HTTP連携: コメント送信', async () => {
-  const { clientSubject, queueToSpeech } = connectionSetup({ httpRelationEnabled: true });
+  const { clientSubject } = connectionSetup({ httpRelationEnabled: true });
   const NOW_SEC = 600;
   const DROP_THRESHOLD_SEC = 60;
 
   jest.spyOn(Date, 'now').mockImplementation(() => NOW_SEC * 1000);
 
-  ['old', 'NG'].forEach(content => {
-    clientSubject.next({
-      chat: {
-        content,
-        date: NOW_SEC - DROP_THRESHOLD_SEC,
-      },
-    });
-  });
-  ['new', 'NG'].forEach(content => {
-    clientSubject.next({
-      chat: {
-        content,
-        date: NOW_SEC - DROP_THRESHOLD_SEC + 1,
-      },
-    });
-  });
+  [
+    { date: NOW_SEC - DROP_THRESHOLD_SEC, comment: 'old' },
+    { date: NOW_SEC - DROP_THRESHOLD_SEC + 1, comment: 'new' },
+  ].forEach(({ date, comment }) =>
+    [comment, 'NG', NG_WORD].forEach(content => {
+      clientSubject.next({
+        chat: {
+          content,
+          date,
+          user_id: '1', // anything not empty
+        },
+      });
+    }),
+  );
 
   // bufferTime tweaks
   clientSubject.complete();
@@ -721,7 +719,7 @@ test('NGワードにかかるコメントが来たら ##このコメントは表
   clientSubject.next({
     chat: {
       content: NG_WORD,
-      user_id: '123',
+      user_id: '123', // anything not empty
     },
   });
 

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -521,10 +521,13 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
       const nowSeconds = Date.now() / 1000;
 
       const valuesForSpeech = values.filter(c => {
-        if (!this.filterFn(c)) {
+        if (!c.value || !c.value.date) {
           return false;
         }
-        if (!c.value || !c.value.date) {
+        if (isWrappedChat(c) && c.filtered) {
+          return false;
+        }
+        if (!this.filterFn(c)) {
           return false;
         }
         return c.value.date > nowSeconds - recentSeconds;


### PR DESCRIPTION
# このpull requestが解決する内容
配信者フィルターに追加したコメントが直近に含まれる状態でコメント再読み込みや新規接続をしたときに、コメント一覧に現れるNGしたコメント( #844 後であれば `##このコメントは表示されません##` ) が読み上げられてしまっていたのを、読み上げないようにします

# 動作確認手順
1. 番組で直近のコメント(後段の作業まで1分以内)を NG する
2. コメントをリロードする
3. 1分以内のコメントが読み上げられる中に、 `##このコメントは表示されません##` が含まれている場合に、それは読み上げないこと

# 関連するIssue（あれば）
#844 