### PR TITLE
修正: シーン切り替え画面などに使われるオーバーレイの外側の背景色が透過していなかった(黒い額縁に見えていた)

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -395,7 +395,7 @@ th {
 }
 
 .v--modal-overlay {
-  background: rgb(0, 0, 0, 30%);
+  background: rgba(0, 0, 0, 30%);
 }
 
 .v--modal {


### PR DESCRIPTION
# このpull requestが解決する内容
モーダルオーバーレイの背景色が透過していなかったバグを修正しました。

### 修正前
![image (1)](https://github.com/user-attachments/assets/809ec62c-8380-40fe-bc89-87775de1dba1)

### 修正後
<img width="600" alt="キャプチャ" src="https://github.com/user-attachments/assets/dae5649f-f556-4137-8973-7b74d6a35565">


# 動作確認手順
シーンコレクション設定→シーン切り替え編集→新規シーン切り替え

# 関連するIssue（あれば）
https://dwango.slack.com/archives/CGS6HB9ED/p1727840951702319