### PR TITLE
修正: シーン切り替え画面の調整(設定項目が表示しきれていなかった、など)

### DIFF
--- a/app/components/Tabs.vue
+++ b/app/components/Tabs.vue
@@ -4,7 +4,7 @@
       <button
         v-for="tab in tabs"
         :key="tab.value"
-        class="tab-button"
+        class="button--tab"
         :class="{ active: tab.value === value }"
         @click="showTab(tab.value)"
       >
@@ -29,12 +29,18 @@
 }
 
 .tabs {
-  position: relative;
-  box-sizing: border-box;
   display: flex;
-  width: 100%;
-  height: 54px;
+  flex-shrink: 0;
+  align-items: center;
+  height: 40px;
   padding: 0 16px;
+  border-bottom: 1px solid var(--color-border-light);
+
+  > button {
+    flex-basis: 0;
+    flex-grow: 1;
+    height: 100%;
+  }
 }
 
 .tab-content {

--- a/app/components/obs/inputs/ObsSliderInput.vue
+++ b/app/components/obs/inputs/ObsSliderInput.vue
@@ -29,7 +29,7 @@
 
 .slider-container {
   position: relative;
-  height: 45px;
+  height: auto;
 }
 
 .slider-label {

--- a/app/components/shared/Slider.vue
+++ b/app/components/shared/Slider.vue
@@ -35,6 +35,7 @@
 
 .slider-container {
   display: flex;
+  align-items: center;
   width: 100%;
 
   > .slider {

--- a/app/components/windows/SceneTransitions.vue
+++ b/app/components/windows/SceneTransitions.vue
@@ -79,25 +79,35 @@
         </div>
       </tabs>
       <modal name="transition-settings" :height="550">
-        <div class="transition-settings-modal">
-          <transition-settings :transition-id="inspectedTransition" />
-          <button
-            class="button button--primary transition-done"
-            @click="dismissModal('transition-settings')"
-          >
-            {{ $t('common.done') }}
-          </button>
+        <div class="modal-layout transition-settings-modal">
+          <div class="modal-layout-content">
+            <div class="settings-container">
+              <div class="section">
+                <transition-settings :transition-id="inspectedTransition" />
+              </div>
+            </div>
+          </div>
+          <div class="modal-layout-controls">
+            <button class="button button--primary" @click="dismissModal('transition-settings')">
+              {{ $t('common.done') }}
+            </button>
+          </div>
         </div>
       </modal>
       <modal name="connection-settings" :height="550">
-        <div class="connection-settings-modal">
-          <connection-settings :connection-id="inspectedConnection" />
-          <button
-            class="button button--primary transition-done"
-            @click="dismissModal('connection-settings')"
-          >
-            {{ $t('common.done') }}
-          </button>
+        <div class="modal-layout connection-settings-modal">
+          <div class="modal-layout-content">
+            <div class="settings-container">
+              <div class="section">
+                <connection-settings :connection-id="inspectedConnection" />
+              </div>
+            </div>
+          </div>
+          <div class="modal-layout-controls">
+            <button class="button button--primary" @click="dismissModal('connection-settings')">
+              {{ $t('common.done') }}
+            </button>
+          </div>
         </div>
       </modal>
     </div>
@@ -124,18 +134,16 @@
   text-align: center;
 }
 
-.transition-settings-modal {
-  padding: 20px;
-}
-
-.connection-settings-modal {
-  padding: 20px;
-}
-
 .transition-tab {
   flex-grow: 1;
   padding: 16px;
   .flex__column;
+
+  .button {
+    flex-shrink: 0;
+    margin-bottom: 16px;
+    margin-left: auto;
+  }
 }
 
 .transition-default {
@@ -165,13 +173,6 @@
   color: @accent;
 }
 
-.button {
-  height: @item-generic-size;
-  margin-bottom: 16px;
-  margin-left: auto;
-  line-height: @item-generic-size;
-}
-
 .transition-done {
   position: absolute;
   right: 16px;
@@ -194,5 +195,55 @@ th,
 td {
   padding: 8px 16px;
   text-align: left;
+}
+
+.modal-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--color-bg-quinary);
+}
+
+.modal-layout-content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  height: 100%;
+  padding: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.modal-layout-controls {
+  .dividing-border(top);
+
+  z-index: @z-index-default-content;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  text-align: right;
+  background-color: var(--color-bg-primary);
+
+  div {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &:not(:empty) {
+    padding: 16px;
+  }
+
+  .button {
+    margin-left: 12px;
+  }
+}
+
+.settings-container {
+  flex-grow: 1;
+  padding: 16px 8px 0 16px;
+  margin: 0;
+  overflow-x: auto;
+  overflow-y: scroll;
 }
 </style>


### PR DESCRIPTION
# このpull requestが解決する内容

1. シーン切り替え編集モーダルのコンテンツが溢れてしまった場合に内部スクロールできるように修正（汎用モーダルとレイアウトを合わせた）（https://github.com/n-air-app/n-air-app/commit/a36bfae9f9be5dbabcf2eec4cdfc7003f6a15223 ）
2. スライダーの位置ずれを修正(https://github.com/n-air-app/n-air-app/commit/937dc8a19cb949f1519a2e7e4babd8a5eca41ce7 )
3. タブのデザインを修正(https://github.com/n-air-app/n-air-app/commit/04a114d90e459605f7fb21c179d864ed09f52ed5 )

## 修正前
![キャプチャ](https://github.com/user-attachments/assets/37e2d9b7-8a99-4e97-bbb1-08fb77bdbb03)
![キャプチャ2](https://github.com/user-attachments/assets/a021f482-1bc8-47c2-8733-1d851f839954)

## 修正後
![キャプチャ](https://github.com/user-attachments/assets/81a96ad5-196c-4bdf-8693-8d6296670fbd)
![キャプチャ2](https://github.com/user-attachments/assets/014a3a50-dbc5-4c2c-8d9e-837b5ec06e55)

# 動作確認手順
シーンコレクション設定→シーン切り替え編集→新規シーン切り替え

# 関連するIssue（あれば）
https://dwango.slack.com/archives/CGS6HB9ED/p1728545932378399
