### PR TITLE
修正: ニコ生配信最適化でOBS29のNVENCのエンコーダープリセット選択肢の変更に対応(llhq -> p3)

### DIFF
--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -52,7 +52,7 @@ export function getBestSettingsForNiconico(
       encoderSettings = {
         encoder: EncoderType.nvencNew,
         simpleUseAdvanced: true,
-        NVENCPreset: 'llhq',
+        NVENCPreset2: 'p3',
       };
     } else if (
       settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.nvenc) ||
@@ -61,7 +61,7 @@ export function getBestSettingsForNiconico(
       encoderSettings = {
         encoder: EncoderType.nvenc,
         simpleUseAdvanced: true,
-        NVENCPreset: 'llhq',
+        NVENCPreset2: 'p3',
       };
     } else if (
       settings.hasSpecificValue(OptimizationKey.encoder, EncoderType.qsv) ||

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -24,7 +24,7 @@ export enum OptimizationKey {
   simpleUseAdvanced = 'simpleUseAdvanced',
   targetUsage = 'targetUsage',
   encoderPreset = 'encoderPreset',
-  NVENCPreset = 'NVENCPreset',
+  NVENCPreset2 = 'NVENCPreset2',
   advRateControl = 'advRateControl',
   videoBitrate = 'videoBitrate',
   advKeyframeInterval = 'advKeyframeInterval',
@@ -54,7 +54,7 @@ export type OptimizeSettings = {
     | 'medium'
     | 'slow'
     | 'slower'; // for x264
-  NVENCPreset?: 'default' | 'mq' | 'hq' | 'hp' | 'll' | 'llhp' | 'llhq'; // for NVENC
+  NVENCPreset2?: 'p1' | 'p2' | 'p3' | 'p4' | 'p5' | 'p6' | 'p7'; // for NVENC
   advRateControl?: 'CBR' | 'VBR' | 'ABR' | 'CRF';
   videoBitrate?: number;
   advKeyframeInterval?: number;
@@ -223,7 +223,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                   // 'gpu' // int 0
                   // 'bf' // int 2 // B-フレーム
                   {
-                    key: OptimizationKey.NVENCPreset,
+                    key: OptimizationKey.NVENCPreset2,
                     category: CategoryName.output,
                     subCategory: 'Streaming',
                     setting: 'preset',
@@ -370,10 +370,10 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         values: [true],
                         params: [
                           {
-                            key: OptimizationKey.NVENCPreset,
+                            key: OptimizationKey.NVENCPreset2,
                             category: CategoryName.output,
                             subCategory: 'Streaming',
-                            setting: 'NVENCPreset',
+                            setting: 'NVENCPreset2',
                             lookupValueName: true,
                           },
                         ],


### PR DESCRIPTION
# このpull requestが解決する内容

before
![image](https://github.com/user-attachments/assets/d32bda42-62d6-4743-aa1c-929a58eb7d50)

after
![image](https://github.com/user-attachments/assets/4a03b622-a916-4c8c-bee7-366e9069b899)

従来ニコニコ最適化は `llhq` を選択していたが、それに対応するのは `p3` っぽいのでそれにします

# 動作確認手順

# 関連するIssue（あれば）
