### PR TITLE
修正: 更新説明が多いときのアップデーターのレイアウト崩れを修正

### DIFF
--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -177,6 +177,7 @@ export default {
   flex-direction: column;
   height: 100%;
   margin: 0;
+  overflow: hidden;
   font-size: @font-size5;
   color: var(--color-text-light);
   text-align: center;
@@ -204,6 +205,7 @@ export default {
   flex-direction: column;
   flex-grow: 1;
   padding: 0;
+  overflow: hidden;
 }
 
 .label {


### PR DESCRIPTION
# このpull requestが解決する内容
更新が多いときにレイアウトが崩れてしまうのを修正

## 修正前
<img width="448" alt="キャプチャ" src="https://github.com/user-attachments/assets/f9120894-dd11-4386-ac53-c713fd653a33">

## 修正後
<img width="448" alt="キャプチャ" src="https://github.com/user-attachments/assets/8125653b-d895-4528-96e7-ab01817532e8">


# 動作確認手順
`NAIR_FORCE_AUTO_UPDATE=1 yarn dev ` でアップデーターを起動

# 関連するIssue（あれば）
