### PR TITLE
改善: アンインストール時にアプリデータを削除する画面を追加

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -83,9 +83,7 @@ var /GLOBAL CheckBoxState
     ${If} $CheckBoxState == ${BST_CHECKED}
         ; change APPDATA ProgramData to Roming
         SetShellVarContext current
-        ; RMDir /r "$APPDATA\${APP_PACKAGE_NAME}"
-        ; DEBUG
-        MessageBox MB_OK "RMDir /r $APPDATA\${APP_PACKAGE_NAME}"
+        RMDir /r "$APPDATA\${APP_PACKAGE_NAME}"
     ${EndIf}
   FunctionEnd
 

--- a/installer.nsh
+++ b/installer.nsh
@@ -68,12 +68,14 @@ var /GLOBAL CheckBoxState
     GetDlgItem $0 $HWNDPARENT 2
     EnableWindow $0 0
 
-    ${NSD_CreateCheckbox} 10u 50u 200u 12u "アプリデータを削除する"
+    ${NSD_CreateCheckbox} 10u 40u 200u 12u "アプリデータを削除する"
     Pop $CheckBox
     ${NSD_SetState} $CheckBox 0
     ${If} $CheckBoxState == ${BST_CHECKED}
       ${NSD_SetState} $CheckBox ${BST_CHECKED}
     ${EndIf}
+
+    ${NSD_CreateLabel} 20u 54u 190u 36u "N Air上で設定したデータを完全に削除します。$\nアプリが起動できなくなってしまった場合は、アプリデータの削除をした上で再インストールをお試しください。"
 
     nsDialogs::Show
   FunctionEnd

--- a/installer.nsh
+++ b/installer.nsh
@@ -50,6 +50,55 @@ LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ �
   !insertMacro registerProtocol "n-air-app"
 !macroend
 
+!include "MUI2.nsh"
+!include "nsDialogs.nsh"
+
+Var Dialog
+Var CheckBox
+var /GLOBAL CheckBoxState
+
+!macro customUninstallPage
+  UninstPage custom un.removeAppDataPage un.removeAppDataPageLeave
+
+  Function un.removeAppDataPage
+    nsDialogs::Create 1018
+    Pop $Dialog
+
+    ; 既にアンインストールは完了してしまっているためキャンセルボタンは無効化する
+    GetDlgItem $0 $HWNDPARENT 2
+    EnableWindow $0 0
+
+    ${NSD_CreateCheckbox} 10u 50u 200u 12u "アプリデータを削除する"
+    Pop $CheckBox
+    ${NSD_SetState} $CheckBox 0
+    ${If} $CheckBoxState == ${BST_CHECKED}
+      ${NSD_SetState} $CheckBox ${BST_CHECKED}
+    ${EndIf}
+
+    nsDialogs::Show
+  FunctionEnd
+
+  Function un.removeAppDataPageLeave
+    ${NSD_GetState} $CheckBox $CheckBoxState
+    ${If} $CheckBoxState == ${BST_CHECKED}
+        ; change APPDATA ProgramData to Roming
+        SetShellVarContext current
+        ; RMDir /r "$APPDATA\${APP_PACKAGE_NAME}"
+        ; DEBUG
+        MessageBox MB_OK "RMDir /r $APPDATA\${APP_PACKAGE_NAME}"
+    ${EndIf}
+  FunctionEnd
+
+  ; MUI_UNPAGE_FINISHの戻るボタンを無効化する
+  !define MUI_PAGE_CUSTOMFUNCTION_SHOW un.disableBack
+  Function un.disableBack
+    Push $0
+    GetDlgItem $0 $HWNDPARENT 3
+    EnableWindow $0 0
+    Pop $0
+  FunctionEnd
+!macroend
+
 !macro customUninstall
   !insertMacro unregisterProtocol "n-air-app"
 !macroend

--- a/installer.nsh
+++ b/installer.nsh
@@ -55,6 +55,7 @@ LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ �
 
 Var Dialog
 Var CheckBox
+Var Label
 var /GLOBAL CheckBoxState
 
 !macro customUninstallPage
@@ -76,6 +77,7 @@ var /GLOBAL CheckBoxState
     ${EndIf}
 
     ${NSD_CreateLabel} 20u 54u 190u 36u "N Air上で設定したデータを完全に削除します。$\nアプリが起動できなくなってしまった場合は、アプリデータの削除をした上で再インストールをお試しください。"
+    Pop $Label
 
     nsDialogs::Show
   FunctionEnd


### PR DESCRIPTION
# このpull requestが解決する内容

アプリの削除の後に、`アプリデータを削除する` checkboxを追加。デフォルトはチェックされていない

![image](https://github.com/user-attachments/assets/3a6bbe12-ebc0-4259-8abf-d0ebc37c2c75)

# 動作確認手順
1. `yarn package:local`
2. dist にできたexeを起動してインストール(N Airは起動しない)
3. 設定のアプリからアンインストール

# 関連するIssue（あれば）
#857

# 謝辞
[VOIXVOXが同じようなことをやっていた](https://github.com/VOICEVOX/voicevox/blob/fee6a45372b47cfcc82cc6eed8c77f22af0482a0/build/installer.nsh#L820) ので参考にしました