### PR TITLE
追加: 番組の合い言葉のコピー機能

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -49,6 +49,17 @@
               >番組URLをコピーする</a
             >
           </li>
+          <li class="popup-menu-item" v-if="existsProgramPassword">
+            <a
+              @click="
+                copyProgramPassword();
+                popper.doClose();
+              "
+              class="link"
+              ><i :class="hasProgramUrlCopied ? 'icon-check' : 'icon-clipboard-copy'"></i
+              >番組の合い言葉をコピーする</a
+            >
+          </li>
         </ul>
         <ul class="popup-menu-list">
           <li class="popup-menu-item">

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -45,8 +45,7 @@
                 popper.doClose();
               "
               class="link"
-              ><i :class="hasProgramUrlCopied ? 'icon-check' : 'icon-clipboard-copy'"></i
-              >番組URLをコピーする</a
+              ><i class="icon-clipboard-copy"></i>番組URLをコピーする</a
             >
           </li>
           <li class="popup-menu-item" v-if="existsProgramPassword">
@@ -56,8 +55,7 @@
                 popper.doClose();
               "
               class="link"
-              ><i :class="hasProgramUrlCopied ? 'icon-check' : 'icon-clipboard-copy'"></i
-              >番組の合い言葉をコピーする</a
+              ><i class="icon-clipboard-copy"></i>番組の合い言葉をコピーする</a
             >
           </li>
         </ul>

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -145,24 +145,11 @@ export default class ProgramInfo extends Vue {
     return this.nicoliveProgramService.state.isFetching;
   }
 
-  hasProgramUrlCopied: boolean = false;
-  clearTimer: number = 0;
-  indicateProgramUrlCopied() {
-    this.hasProgramUrlCopied = true;
-    window.clearTimeout(this.clearTimer);
-
-    this.clearTimer = window.setTimeout(() => {
-      this.hasProgramUrlCopied = false;
-      this.clearTimer = null;
-    }, 1000);
-  }
-
   copyProgramURL() {
     if (this.isFetching) throw new Error('fetchProgram is running');
     clipboard.writeText(
       this.hostsService.getWatchPageURL(this.nicoliveProgramService.state.programID),
     );
-    this.indicateProgramUrlCopied();
   }
   get existsProgramPassword(): boolean {
     return !!this.nicoliveProgramService.state.password;

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -147,11 +147,7 @@ export default class ProgramInfo extends Vue {
 
   hasProgramUrlCopied: boolean = false;
   clearTimer: number = 0;
-  copyProgramURL() {
-    if (this.isFetching) throw new Error('fetchProgram is running');
-    clipboard.writeText(
-      this.hostsService.getWatchPageURL(this.nicoliveProgramService.state.programID),
-    );
+  indicateProgramUrlCopied() {
     this.hasProgramUrlCopied = true;
     window.clearTimeout(this.clearTimer);
 
@@ -159,5 +155,20 @@ export default class ProgramInfo extends Vue {
       this.hasProgramUrlCopied = false;
       this.clearTimer = null;
     }, 1000);
+  }
+
+  copyProgramURL() {
+    if (this.isFetching) throw new Error('fetchProgram is running');
+    clipboard.writeText(
+      this.hostsService.getWatchPageURL(this.nicoliveProgramService.state.programID),
+    );
+    this.indicateProgramUrlCopied();
+  }
+  get existsProgramPassword(): boolean {
+    return !!this.nicoliveProgramService.state.password;
+  }
+  copyProgramPassword() {
+    if (this.isFetching) throw new Error('fetchProgram is running');
+    clipboard.writeText(this.nicoliveProgramService.state.password);
   }
 }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -17,6 +17,7 @@ import {
   OnairChannelProgramData,
   OnairUserProgramData,
   ProgramInfo,
+  ProgramPassword,
   ProgramSchedules,
   Segment,
   Statistics,
@@ -749,6 +750,13 @@ export class NicoliveClient {
     return this.requestAPI<Supporters['data']>(
       'GET',
       `${NicoliveClient.live2ApiBaseURL}/api/v1/broadcaster/supporters?limit=${limit}&offset=${offset}`,
+    );
+  }
+
+  async fetchProgramPassword(programID: string): Promise<WrappedResult<ProgramPassword['data']>> {
+    return this.requestAPI<ProgramPassword['data']>(
+      'GET',
+      `${NicoliveClient.live2BaseURL}/unama/api/v4/programs/${programID}/password`,
     );
   }
 }

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -246,3 +246,10 @@ export interface Supporters {
     supporterIds: string[];
   };
 }
+
+export interface ProgramPassword {
+  meta: {
+    status: 200;
+  };
+  data: { password: string };
+}

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -96,6 +96,11 @@ const programs: Dictionary<Partial<ProgramInfo['data']>> = {
   },
 };
 
+// fetchProgramPassword でパスワードが設定されていない番組のエラー値
+const PROGRAM_PASSWORD_NOT_SET = {
+  meta: { status: 404, errorCode: 'NOT_PASSWORD_PROGRAM' },
+} as const;
+
 const setup = createSetupFunction({
   state: {
     NicoliveProgramService: {
@@ -265,7 +270,10 @@ test('fetchProgram:testのときはshowPlaceholderをtrueにする', async () =>
     .fn()
     .mockResolvedValue({ ok: true, value: [schedules.test] });
   instance.client.fetchProgram = jest.fn().mockResolvedValue({ ok: true, value: programs.test });
-
+  instance.client.fetchProgramPassword = jest.fn().mockResolvedValue({
+    ok: false,
+    value: PROGRAM_PASSWORD_NOT_SET,
+  });
   (instance as any).setState = jest.fn();
 
   await expect(instance.fetchProgram()).resolves.toBeUndefined();
@@ -315,6 +323,10 @@ test('fetchProgram:成功', async () => {
     .fn()
     .mockResolvedValue({ ok: true, value: [schedules.onAir] });
   instance.client.fetchProgram = jest.fn().mockResolvedValue({ ok: true, value: programs.onAir });
+  instance.client.fetchProgramPassword = jest.fn().mockResolvedValue({
+    ok: true,
+    value: { password: 'password' },
+  });
 
   // TODO: StatefulServiceのモックをVue非依存にする
   (instance as any).setState = jest.fn();
@@ -334,6 +346,7 @@ test('fetchProgram:成功', async () => {
           "description": "番組詳細情報",
           "endTime": 150,
           "isMemberOnly": true,
+          "password": "password",
           "programID": "lv1",
           "serverClockOffsetSec": 0,
           "startTime": 100,
@@ -394,6 +407,10 @@ test('fetchProgramでコミュ情報がエラーでも番組があったら先�
   instance.client.fetchProgram = jest.fn().mockResolvedValue({
     ok: true,
     value: programs.onAir,
+  });
+  instance.client.fetchProgramPassword = jest.fn().mockResolvedValue({
+    ok: false,
+    value: PROGRAM_PASSWORD_NOT_SET,
   });
 
   (instance as any).setState = jest.fn();


### PR DESCRIPTION
# このpull requestが解決する内容

番組に合い言葉が設定されている場合、右上のメニューの番組URLのコピーの下に合い言葉にコピーする項目を追加します
![image](https://github.com/user-attachments/assets/74991ca7-0455-4898-8233-5ecf538b50ac)

# 関連するIssue（あれば）
fix #869