### PR TITLE
改善: n-air-app://settings で設定ウィンドウを開くようにする

### DIFF
--- a/bin/start-with-auto-env.js
+++ b/bin/start-with-auto-env.js
@@ -1,10 +1,11 @@
-const { exec } = require('child_process');
+const { exec } = require('node:child_process');
+const process = require('node:process');
 const { version } = require('../package.json');
 const { getVersionContext } = require('./release/scripts/patchNote');
 
 const { channel } = getVersionContext(`v${version}`);
 
-const childProcess = exec(`yarn start:${channel}`);
+const childProcess = exec(`yarn start:${channel} ${process.argv.slice(2).join(' ')}`);
 
 process.stdin.pipe(childProcess.stdin);
 childProcess.stdout.pipe(process.stdout);

--- a/main.js
+++ b/main.js
@@ -648,6 +648,15 @@ function initialize(crashHandler) {
   app.setAsDefaultProtocolClient('n-air-app');
 
   app.on('second-instance', (event, argv, cwd) => {
+    console.log('second-instance', argv, cwd);
+    SentryElectron.addBreadcrumb({
+      category: 'app',
+      message: 'second-instance',
+      data: {
+        argv,
+        cwd,
+      },
+    });
     // Check for protocol links in the argv of the other process
     argv.forEach(arg => {
       if (arg.match(/^n-air-app:\/\//)) {


### PR DESCRIPTION
# このpull requestが解決する内容
`n-air-app://` protocol linkからアプリを開いたときに、handlerが一つも無いために `Cannot read properties of undefined (reading '')` という例外が sentryに上がっていた(動作は無害)のをつぶすついでに `n-air-app://settings` で設定ウィンドウが開くようにします。`openSettings` handler自体は [Streamlabsからのbackport](https://github.com/stream-labs/desktop/blob/efc54a80680ed08dfb691df9df0bfddee293d4a6/app/services/protocol-links.ts#L135-L140)です。

`n-air-app://settings/Output` などのようにカテゴリ名をパスに付けるとそのタブも開けます。(大文字小文字は個別)

それとこれに関連した起動はSentryにbreadcrumbにつけるので、動作履歴から追えるようになります。

あと yarn start の引数も起動時引数として渡されるようにします


# 動作確認手順
`yarn start n-air-app://settings/Output` などで起動したり、起動後に別プロセスのシェルからこの起動をすると設定が開く
