### PR TITLE
開発: ニコニコ最適化失敗の情報出し(extraにbestを追加, 不要なconsole.log削除)

### DIFF
--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -816,7 +816,14 @@ export class SettingsKeyAccessor {
     );
   }
 
-  *getSettings(keyDescriptions: KeyDescription[]): IterableIterator<[OptimizationKey, any]> {
+  *getSettings(
+    keyDescriptions: KeyDescription[],
+  ): IterableIterator<
+    [
+      OptimizationKey,
+      (IObsInput<TObsValue> | IObsListInput<TObsValue>) & { options?: { value: any }[] },
+    ]
+  > {
     yield* this.traverseKeyDescriptions(
       keyDescriptions,
       (item: KeyDescription): [OptimizationKey, any] => {
@@ -825,7 +832,10 @@ export class SettingsKeyAccessor {
       },
     );
   }
-  getSetting(key: OptimizationKey, keyDescriptions: KeyDescription[]): any {
+  getSetting(
+    key: OptimizationKey,
+    keyDescriptions: KeyDescription[] = AllKeyDescriptions,
+  ): (IObsInput<TObsValue> | IObsListInput<TObsValue>) & { options?: { value: any }[] } {
     for (const kv of this.getSettings(keyDescriptions)) {
       if (kv[0] === key) {
         return kv[1];

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -682,7 +682,6 @@ export class SettingsKeyAccessor {
 
   private getCategory(category: CategoryName, reload: boolean = false): ISettingsSubCategory[] {
     if (reload || !this.categoryCache.has(category)) {
-      console.log(`getCategory: ${category}`);
       this.categoryCache.set(category, this.accessor.getSettingsFormData(category));
     }
     return this.categoryCache.get(category);
@@ -741,7 +740,6 @@ export class SettingsKeyAccessor {
    * 値を1つ設定する
    */
   setValue(item: KeyDescription, value: TObsValue) {
-    console.log(`setValue: ${item.category}/${item.key}: ${value}`);
     const setting = this.findSetting(item);
     if (setting) {
       if (setting.value !== value) {

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -24,6 +24,7 @@ import Utils from '../utils';
 import { getBestSettingsForNiconico } from './niconico-optimization';
 import {
   ISettingsAccessor,
+  OptimizationKey,
   OptimizeSettings,
   OptimizedSettings,
   Optimizer,
@@ -578,15 +579,21 @@ export class SettingsService
         }
         return;
       }
+
+      const encoder = accessor.getSetting(OptimizationKey.encoder);
       Sentry.withScope(scope => {
         scope.setLevel('warning');
         scope.setTag('optimizeForNiconico', 'partial');
         scope.setTag('retry', `${retry}`);
         scope.setFingerprint(['optimizeForNiconico', 'partial']);
         scope.setExtra('delta', delta);
+        if (encoder && encoder.options) {
+          scope.setExtra('encoder.options', encoder.options);
+        }
         Sentry.captureMessage(`optimizeForNiconico: optimization setting is not set perfectly`);
       });
     }
+
     // send to Sentry
     Sentry.withScope(scope => {
       scope.setLevel('error');

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -591,6 +591,7 @@ export class SettingsService
     Sentry.withScope(scope => {
       scope.setLevel('error');
       scope.setTag('optimizeForNiconico', 'failed');
+      scope.setExtra('best', best);
       scope.setFingerprint(['optimizeForNiconico', 'failed']);
       Sentry.captureMessage('optimizeForNiconico: 最適化リトライ満了したが設定できなかった');
     });


### PR DESCRIPTION
# このpull requestが解決する内容
Sentryになんかニコ生配信最適化で `simpleUseAdvanced: true` が失敗しているのがちらほら来ているので、エラーイベント(リトライオーバー時)に最適化の設定値全体を `best` として追加します。
あと設定失敗の方のイベントに encoderの選択肢も `encoder.options` として追加します(リトライオーバーのほうに書きたかったけど単にループ内のほうがこの情報にアクセスやすかった)

ついでにちょっと多すぎたデバッグ表示を減らして、一部のメソッドの戻り型をanyじゃなくしたりもしてます