### PR TITLE
開発: rxjs を 7.8.1 に更新

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -587,7 +587,7 @@ describe('startUpdateSupporters', () => {
   });
 
   const INTERVAL = 100;
-  const closer = new Subject();
+  const closer = new Subject<void>();
 
   function prepare() {
     const update = jest_fn<NicoliveSupportersService['update']>();

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -308,7 +308,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
 
   startUpdateSupporters(
     interval_ms: number,
-    closer: Subject<unknown>,
+    closer: Subject<void>,
   ): { isSupporter: (userId: string) => boolean } {
     let supporters = new Set<string>();
     const isSupporter = (userId: string) => supporters.has(userId);
@@ -334,7 +334,7 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
 
   private connect() {
     // コメント接続が切断したときにすべて止めるためのSubject
-    const closer = new Subject();
+    const closer = new Subject<void>();
 
     const { isSupporter } = this.startUpdateSupporters(SUPPORTERS_REFRESH_INTERVAL, closer);
 

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -55,7 +55,7 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     //  vertical: null as IVideoInfo,
   };
 
-  establishedContext = new Subject();
+  establishedContext = new Subject<void>();
 
   init() {
     this.establishVideoContext();

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "recursive-readdir": "~2.2.3",
     "reflect-metadata": "~0.1.13",
     "rimraf": "~2.7.1",
-    "rxjs": "~6.5.2",
+    "rxjs": "^7.8.1",
     "semver": "^7.5.4",
     "sl-vue-tree": "https://github.com/stream-labs/sl-vue-tree",
     "socket.io": "4.7.5",

--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -343,7 +343,7 @@ export async function getApiClient() {
 class ApiEventWatcher {
   receivedEvents: IJsonRpcEvent[] = [];
   private subscriptions: Subscription[];
-  private eventReceived = new Subject();
+  private eventReceived = new Subject<void>();
 
   constructor(private apiClient: ApiClient, private eventNames: string[]) {
     // start watching for events

--- a/yarn.lock
+++ b/yarn.lock
@@ -11512,12 +11512,12 @@ rxjs@^6.3.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@~6.5.2:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
   dependencies:
-    tslib "^1.9.0"
+    tslib "^2.1.0"
 
 safe-array-concat@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
# このpull requestが解決する内容
|package|before|after|changelog|
|---|---|---|---|
|rxjs|6.5.2|7.8.1|[CHANGELOG.md](https://github.com/ReactiveX/rxjs/blob/7.x/CHANGELOG.md)|

* 7.0で型チェックが厳格化したため、値なしの `Subject` には `<void>` をつけるように修正