### PR TITLE
修正: 出力設定(出力モード=詳細)の録画フォーマットの下の音声トラック選択肢が出ていなかった

### DIFF
--- a/app/components/obs/inputs/ObsBitMaskInput.vue
+++ b/app/components/obs/inputs/ObsBitMaskInput.vue
@@ -4,16 +4,20 @@
     class="input-container"
     :class="{ disabled: value.enabled == false }"
   >
-    <div class="input-label" v-if="value.showDescription !== false"></div>
+    <div class="input-label" v-if="value.showDescription !== false">
+      <label>{{ value.description }}</label>
+    </div>
     <div class="input-wrapper">
-      <div v-for="(flag, index) in flags" class="checkbox">
-        <input
-          type="checkbox"
-          :checked="flag"
-          :disabled="value.enabled == false"
-          @change="event => onChangeHandler(index, !!event.target['checked'])"
-        />
-        <label>{{ index + 1 }}</label>
+      <div class="bit-mask-input">
+        <div v-for="(flag, index) in flags" :key="index" class="checkbox">
+          <input
+            type="checkbox"
+            :checked="flag"
+            :disabled="value.enabled == false"
+            @change="event => onChangeHandler(index, !!event.target['checked'])"
+          />
+          <label>{{ index + 1 }}</label>
+        </div>
       </div>
     </div>
   </div>
@@ -24,6 +28,11 @@
 <style lang="less" scoped>
 .input-wrapper {
   width: auto;
+}
+
+.bit-mask-input {
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .checkbox {

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -253,6 +253,13 @@ export function obsValuesToInputValues(
       if (obsProp.subType === 'OBS_NUMBER_SLIDER') {
         prop.type = 'OBS_PROPERTY_SLIDER';
       }
+    } else if (obsProp.type === 'OBS_PROPERTY_BITMASK') {
+      prop = {
+        ...prop,
+        value: Number(prop.value),
+        showDescription: true,
+        size: 6,
+      } as IObsBitmaskInput;
     } else if (obsProp.type === 'OBS_PROPERTY_PATH') {
       if (valueObject && valueObject.type === 'OBS_PATH_FILE') {
         prop = {

--- a/app/components/windows/AdvancedAudio.vue
+++ b/app/components/windows/AdvancedAudio.vue
@@ -113,10 +113,4 @@ td {
 .column-monitoringType {
   width: 350px;
 }
-
-// TODO: 暫定対応
-& /deep/ .input-wrapper {
-  display: flex;
-  margin-bottom: 0;
-}
 </style>

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -105,6 +105,10 @@
       width: 100%;
     }
 
+    .bitmask-input > div {
+      width: auto;
+    }
+
     .input-label {
       label {
         margin-bottom: 12px;

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -105,10 +105,6 @@
       width: 100%;
     }
 
-    .bitmask-input > div {
-      width: auto;
-    }
-
     .input-label {
       label {
         margin-bottom: 12px;


### PR DESCRIPTION
# このpull requestが解決する内容
fix #884
`OBS_PROPERTY_BITMASK`対応をStreamlabsからバックポートして機能を補完します

![image](https://github.com/user-attachments/assets/6ad08a83-6c5d-47fb-8c7c-609de7f77f20)

- [x] デザイン修正

# 動作確認手順
- 設定 - 出力 - 出力モード=詳細で 録画フォーマットの下までスクロールすると音声トラック設定が現れ、操作できること
- ミキサーの歯車から高度な音声設定ダイアログを出して右にスクロールしても同じものが出ていること

# 関連するIssue（あれば）
#884