### PR TITLE
開発: 修正: yarn start のために yarn install --cwd bin を不要にする

### DIFF
--- a/bin/release/generatePatchNote.js
+++ b/bin/release/generatePatchNote.js
@@ -5,7 +5,8 @@ const path = require('node:path');
 const { Octokit } = require('@octokit/rest');
 const sh = require('shelljs');
 const colors = require('colors/safe');
-const { log, info, error, input, confirm, executeCmd } = require('./scripts/prompt');
+const { log, info, error, executeCmd } = require('./scripts/log');
+const { input, confirm } = require('./scripts/prompt');
 const { checkEnv, getTagCommitId } = require('./scripts/util');
 const {
   getVersionContext,

--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -10,7 +10,8 @@ const sh = require('shelljs');
 const colors = require('colors/safe');
 const yaml = require('js-yaml');
 const fetch = require('node-fetch');
-const { log, info, error, executeCmd, confirm } = require('./scripts/prompt');
+const { log, info, error, executeCmd } = require('./scripts/log');
+const { confirm } = require('./scripts/prompt');
 const { checkEnv, getTagCommitId } = require('./scripts/util');
 const {
   getVersionContext,

--- a/bin/release/scripts/log.js
+++ b/bin/release/scripts/log.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+const sh = require('shelljs');
+const colors = require('colors/safe');
+
+/**
+ * @param {string[]} msg
+ */
+function log(...msg) {
+  sh.echo(...msg);
+}
+
+/**
+ * @param {string} msg
+ */
+function info(msg) {
+  sh.echo(colors.magenta(msg));
+}
+
+/**
+ * @param {string} msg
+ */
+function error(msg) {
+  sh.echo(colors.red(`ERROR: ${msg}`));
+}
+
+function executeCmd(cmd, options) {
+  log(`Executing: ${cmd}`);
+  const result = /** @type {sh.ExecOutputReturnValue} */ (sh.exec(cmd, options));
+
+  if (result.code !== 0) {
+    error(`Command Failed >>> ${cmd}`);
+    sh.exit(1);
+  }
+
+  // returns {code:..., stdout:..., stderr:...}
+  return result;
+}
+
+module.exports = {
+  log,
+  info,
+  error,
+  executeCmd,
+};

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const { DateTime } = require('luxon');
-const { info, error, executeCmd } = require('./prompt');
+const { info, error, executeCmd } = require('./log');
 const { getTagCommitId } = require('./util');
 
 // previous tag should be following rule:

--- a/bin/release/scripts/prompt.js
+++ b/bin/release/scripts/prompt.js
@@ -1,42 +1,6 @@
 // @ts-check
 
-const sh = require('shelljs');
-const colors = require('colors/safe');
 const inq = require('@inquirer/prompts');
-
-/**
- * @param {string[]} msg
- */
-function log(...msg) {
-  sh.echo(...msg);
-}
-
-/**
- * @param {string} msg
- */
-function info(msg) {
-  sh.echo(colors.magenta(msg));
-}
-
-/**
- * @param {string} msg
- */
-function error(msg) {
-  sh.echo(colors.red(`ERROR: ${msg}`));
-}
-
-function executeCmd(cmd, options) {
-  log(`Executing: ${cmd}`);
-  const result = /** @type {sh.ExecOutputReturnValue} */ (sh.exec(cmd, options));
-
-  if (result.code !== 0) {
-    error(`Command Failed >>> ${cmd}`);
-    sh.exit(1);
-  }
-
-  // returns {code:..., stdout:..., stderr:...}
-  return result;
-}
 
 /**
  * @param {string} msg
@@ -66,10 +30,6 @@ async function input(message, defaultValue) {
 }
 
 module.exports = {
-  log,
-  info,
-  error,
-  executeCmd,
   confirm,
   input,
 };

--- a/bin/release/scripts/uploadArtifacts.js
+++ b/bin/release/scripts/uploadArtifacts.js
@@ -6,7 +6,7 @@ const { S3, S3Client } = require('@aws-sdk/client-s3');
 const { Upload } = require('@aws-sdk/lib-storage');
 const sh = require('shelljs');
 const ProgressBar = require('progress');
-const { info, error } = require('./prompt');
+const { info, error } = require('./log');
 
 /**
  *

--- a/bin/release/scripts/util.js
+++ b/bin/release/scripts/util.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const sh = require('shelljs');
-const { executeCmd, error } = require('./prompt');
+const { executeCmd, error } = require('./log');
 
 function getTagCommitId(tag) {
   const line = executeCmd(`git rev-parse -q --verify "refs/tags/${tag}" || cat /dev/null`, {


### PR DESCRIPTION
# このpull requestが解決する内容
`yarn start` から呼ぶ `bin/start-with-auto-env.js` が間接的に `@inquirer/prompt` に依存しているが、これは `bin/` のみでインストールされるため、 `bin/` で `yarn install` しないとインストールされず、知らずにビルド実行すると依存エラーになってしまっていた。
そもそも `bin/start-with-auto-env.js` は inquirer を使う関数をひとつも呼んでいないので、呼ばない関数群を `log.js` に分割しました。

# 動作確認手順
1. `cd bin ; rm -Rf node_modules ; cd ..`
2. `yarn start`
