### PR TITLE
改善: スタジオモードで終了すると、次回起動時にスタジオモードを復元する

### DIFF
--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -6,6 +6,7 @@ export type TCompactModeStudioController = 'scenes' | 'mixer';
 
 export interface ICustomizationServiceState {
   performanceMode: boolean;
+  studioMode: boolean;
   studioControlsOpened: boolean;
   optimizeForNiconico: boolean;
   showOptimizationDialogForNiconico: boolean;

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -21,6 +21,7 @@ export class CustomizationService
 {
   static defaultState: ICustomizationServiceState = {
     performanceMode: false,
+    studioMode: false,
     studioControlsOpened: true,
     optimizeForNiconico: true,
     showOptimizationDialogForNiconico: true,
@@ -150,6 +151,13 @@ export class CustomizationService
     compactMaximized: boolean;
   }) {
     this.setSettings(state);
+  }
+
+  getStudioMode(): boolean {
+    return this.state.studioMode;
+  }
+  setStudioMode(studioMode: boolean) {
+    this.setSettings({ studioMode });
   }
 
   getSettingsFormData(): TObsFormData {

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -25,6 +25,7 @@ export class NavigationService extends StatefulService<INavigationState> {
 
   navigate(page: TAppPage, params: Dictionary<string> = {}) {
     this.NAVIGATE(page, params);
+    this.logNavigation();
     this.navigated.next(this.state);
   }
 
@@ -48,6 +49,5 @@ export class NavigationService extends StatefulService<INavigationState> {
   private NAVIGATE(page: TAppPage, params: Dictionary<string>) {
     this.state.currentPage = page;
     this.state.params = params;
-    this.logNavigation();
   }
 }

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -25,7 +25,6 @@ export class NavigationService extends StatefulService<INavigationState> {
 
   navigate(page: TAppPage, params: Dictionary<string> = {}) {
     this.NAVIGATE(page, params);
-    this.logNavigation();
     this.navigated.next(this.state);
   }
 
@@ -49,5 +48,6 @@ export class NavigationService extends StatefulService<INavigationState> {
   private NAVIGATE(page: TAppPage, params: Dictionary<string>) {
     this.state.currentPage = page;
     this.state.params = params;
+    this.logNavigation();
   }
 }


### PR DESCRIPTION
# このpull requestが解決する内容
fix #882

# 詳細
* 永続設定値は `CustomizationService.state.studioMode` に保存します
* `OnboardingService`  に終了通知Subject (`completed`) を新設し、onboardingが不要なときと完了したときに発火させます
* 上記 OnboardingService.completedが発火したときから studio mode状態監視を開始し、CustomizationServiceに設定を保存します。(それ以前だと、シーンのロード時に studio modeが強制解除されてしまうため)
* `app_close` イベントが来たときには監視を停止します(クリーンアップ中に studio Modeが解除されるため)

# 動作確認手順
* 起動し、スタジオモードにして終了し、再起動するとスタジオモードになること

# 関連するIssue（あれば）
#882