### PR TITLE
開発: fix NavigationService: logNavigationを mutation handlerから呼ばない

### DIFF
--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -25,6 +25,7 @@ export class NavigationService extends StatefulService<INavigationState> {
 
   navigate(page: TAppPage, params: Dictionary<string> = {}) {
     this.NAVIGATE(page, params);
+    this.logNavigation();
     this.navigated.next(this.state);
   }
 
@@ -48,6 +49,5 @@ export class NavigationService extends StatefulService<INavigationState> {
   private NAVIGATE(page: TAppPage, params: Dictionary<string>) {
     this.state.currentPage = page;
     this.state.params = params;
-    this.logNavigation();
   }
 }


### PR DESCRIPTION
# このpull requestが解決する内容
mutation handlerの中からlogNavigateメソッド呼び出しをしていると実行時エラーが出てるので、中から呼ばないように移動します

# 動作確認手順

# 関連するIssue（あれば）
