### PR TITLE
追加: 新規ユーザー向けにヘルプボタンへの誘導のヘルプチップをつける

### DIFF
--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -50,15 +50,6 @@
         {{ $t('scenes.sceneCollectionSelectionDescription') }}
       </div>
     </help-tip>
-
-    <help-tip :dismissable-key="scenePresetHelpTipDismissable">
-      <div slot="title">
-        {{ $t('scenes.scenePreset') }}
-      </div>
-      <div slot="content">
-        {{ $t('scenes.scenePresetDescription') }}
-      </div>
-    </help-tip>
   </div>
 </template>
 

--- a/app/components/SceneSelector.vue.ts
+++ b/app/components/SceneSelector.vue.ts
@@ -151,10 +151,6 @@ export default class SceneSelector extends Vue {
     return EDismissable.SceneCollectionsHelpTip;
   }
 
-  get scenePresetHelpTipDismissable() {
-    return EDismissable.ScenePresetHelpTip;
-  }
-
   get isCompactMode(): boolean {
     return this.compactModeService.isCompactMode;
   }

--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -59,18 +59,18 @@
           <i class="icon-feedback" />
         </a>
       </div>
-      <div class="side-nav-item help-button help_tip_content">
-        <a @click="openHelp" class="link" :title="$t('common.help')">
+      <div class="side-nav-item help-button">
+        <a @click="openHelp" class="link help_tip_content" :title="$t('common.help')">
           <i class="icon-help" />
+          <help-tip :dismissable-key="InitialHelpTipDismissable" mode="login">
+            <div slot="title">
+              {{ $t('common.initialHelpTipTitle') }}
+            </div>
+            <div slot="content">
+              {{ $t('common.initialHelpTipContent') }}
+            </div>
+          </help-tip>
         </a>
-        <help-tip :dismissable-key="InitialHelpTipDismissable" mode="login">
-          <div slot="title">
-            {{ $t('common.initialHelpTipTitle') }}
-          </div>
-          <div slot="content">
-            {{ $t('common.initialHelpTipContent') }}
-          </div>
-        </help-tip>
       </div>
       <div class="side-nav-item information-button">
         <a @click="openInformations" class="link" :title="$t('informations.title')">

--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -59,10 +59,18 @@
           <i class="icon-feedback" />
         </a>
       </div>
-      <div class="side-nav-item help-button">
+      <div class="side-nav-item help-button help_tip_content">
         <a @click="openHelp" class="link" :title="$t('common.help')">
           <i class="icon-help" />
         </a>
+        <help-tip :dismissable-key="InitialHelpTipDismissable" mode="login">
+          <div slot="title">
+            {{ $t('common.initialHelpTipTitle') }}
+          </div>
+          <div slot="content">
+            {{ $t('common.initialHelpTipContent') }}
+          </div>
+        </help-tip>
       </div>
       <div class="side-nav-item information-button">
         <a @click="openInformations" class="link" :title="$t('informations.title')">
@@ -225,5 +233,9 @@
       border-radius: 50%;
     }
   }
+}
+
+.help_tip_content {
+  position: relative;
 }
 </style>

--- a/app/components/SideNav.vue.ts
+++ b/app/components/SideNav.vue.ts
@@ -4,6 +4,7 @@ import StreamingStatus from 'components/StreamingStatus.vue';
 import electron from 'electron';
 import { CompactModeService } from 'services/compact-mode';
 import { Inject } from 'services/core/injector';
+import { EDismissable } from 'services/dismissables';
 import { EAvailableFeatures, IncrementalRolloutService } from 'services/incremental-rollout';
 import { InformationsService } from 'services/informations';
 import { NavigationService } from 'services/navigation';
@@ -13,10 +14,12 @@ import { UserService } from 'services/user';
 import Utils from 'services/utils';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import HelpTip from './shared/HelpTip.vue';
 
 @Component({
   components: {
     Login,
+    HelpTip,
     StreamingStatus,
   },
 })
@@ -85,6 +88,10 @@ export default class SideNav extends Vue {
 
   openFeedback() {
     remote.shell.openExternal('https://form.nicovideo.jp/forms/n_air_feedback');
+  }
+
+  get InitialHelpTipDismissable() {
+    return EDismissable.InitialHelpTip;
   }
 
   openHelp() {

--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -69,6 +69,8 @@
     "niconico": "Tab related to niconico program",
     "studio": "Tab related to streaming"
   },
+  "initialHelpTipTitle": "First-time Users",
+  "initialHelpTipContent": "Learn how to use N Air here.",
   "loginHelpTipTitle": "Login",
   "loginHelpTipContent": "Click here to log in to niconico",
   "fieldIsRequired": "The field is required",

--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -12,7 +12,6 @@
   "defaultTitle": "Output",
   "manageAll": "Manage All",
   "sceneCollectionSelectionDescription": "This is where your Scene Collections live. Clicking the title will dropdown a menu where you can view & manage.",
-  "scenePresetDescription": "There are sample sources added. Coordinate your own broadcast by editing them freely!",
   "removeSceneCollectionConfirmTitle": "Remove Scene Collection",
   "removeSceneCollectionConfirm": "Are you sure you want to remove %{collectionName}?",
   "createSceneProjector": "Create Scene Projector",

--- a/app/i18n/ja-JP/common.json
+++ b/app/i18n/ja-JP/common.json
@@ -69,6 +69,8 @@
     "niconico": "ニコニコ生放送番組関連タブ",
     "studio": "配信関連タブ"
   },
+  "initialHelpTipTitle": "初めての方へ",
+  "initialHelpTipContent": "N Airの使用方法はこちら",
   "loginHelpTipTitle": "ログイン",
   "loginHelpTipContent": "ニコニコへのログインはこちら",
   "fieldIsRequired": "このフィールドは必須です",

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -12,7 +12,6 @@
   "defaultTitle": "",
   "manageAll": "シーンコレクションの管理",
   "sceneCollectionSelectionDescription": "こちらはシーンコレクションがある場所です。 タイトルをクリックすると、表示および管理できるメニューがプルダウン表示されます。",
-  "scenePresetDescription": "サンプルとなるソースを追加しています。自由に編集して、自分だけの放送をコーディネートしてみましょう！",
   "removeSceneCollectionConfirmTitle": "シーンコレクションを削除する",
   "removeSceneCollectionConfirm": "本当に%{collectionName}を削除してもよろしいですか？",
   "createSceneProjector": "シーンプロジェクターを作成する",

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -7,6 +7,7 @@ export enum EDismissable {
   SceneCollectionsHelpTip = 'scene_collections_help_tip',
   ScenePresetHelpTip = 'scene_preset_help_tip',
   LoginHelpTip = 'login_help_tip',
+  InitialHelpTip = 'initial_help_tip',
 }
 
 const InitiallyDismissed = new Set<EDismissable>([EDismissable.ScenePresetHelpTip]);

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -5,12 +5,11 @@ import { mutation } from './core/stateful-service';
 
 export enum EDismissable {
   SceneCollectionsHelpTip = 'scene_collections_help_tip',
-  ScenePresetHelpTip = 'scene_preset_help_tip',
   LoginHelpTip = 'login_help_tip',
   InitialHelpTip = 'initial_help_tip',
 }
 
-const InitiallyDismissed = new Set<EDismissable>([EDismissable.ScenePresetHelpTip]);
+const InitiallyDismissed = new Set<EDismissable>([]);
 
 interface IDismissablesServiceState {
   [key: string]: boolean;

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -172,8 +172,6 @@ export class SceneCollectionsService extends Service implements ISceneCollection
 
     this.finishLoadingOperation();
 
-    // activate tips for preset scene collection
-    this.dismissablesService.reset(EDismissable.ScenePresetHelpTip);
     // dismiss initial scene collections help tip if not yet(since its position is overlapped)
     this.dismissablesService.dismiss(EDismissable.SceneCollectionsHelpTip);
   }
@@ -645,9 +643,6 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     await this.saveCurrentApplicationStateAs(id);
     this.stateService.ADD_COLLECTION(id, name, new Date().toISOString());
     this.collectionAdded.next(this.collections.find(coll => coll.id === id));
-
-    // コレクションが増えたら scene preset help tipを消す
-    this.dismissablesService.dismiss(EDismissable.ScenePresetHelpTip);
   }
 
   /**


### PR DESCRIPTION
# このpull requestが解決する内容
初めて起動した人がまず何をすればいいのかわからないという話があるので、何かやってみる

シーンプリセットとシーンコレクションのヘルプチップが同じ場所に重なっていたが、ヘルプページ誘導で全部いける想定で両方消してみた
![image](https://github.com/user-attachments/assets/6082cae1-413e-43a6-9188-77500f05f52e)

あと、開発起動のときに設定画面に表れるDeveloperセクションで、このヘルプチップの表示フラグを変更できるようにした(消しても復活して試せる)
![image](https://github.com/user-attachments/assets/7319202e-ad81-4aa4-af9f-d9e275501e49)

# TODO
- [ ] リンク先のヘルプページ構成がちょっと難しいのをどうするか