### PR TITLE
変更: ニコニコのログイン時に、ウィンドウサイズを拡大しないように

### DIFF
--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -271,29 +271,30 @@ describe('updateWindowSize', () => {
   }
 
   const suites = [
-    ['INACTIVE', 'CLOSED', true],
-    ['INACTIVE', 'OPENED', true],
-    ['CLOSED', 'OPENED', true],
-    ['OPENED', 'CLOSED', true],
-    ['OPENED', 'INACTIVE', true],
-    ['CLOSED', 'INACTIVE', true],
-    ['INACTIVE', 'CLOSED', true],
-    ['INACTIVE', 'OPENED', true],
-    ['CLOSED', 'OPENED', true],
-    ['OPENED', 'CLOSED', true],
-    ['OPENED', 'INACTIVE', true],
-    ['CLOSED', 'INACTIVE', true],
-  ].map(([prev, next, isMaximized]) => ({
+    ['INACTIVE', 'CLOSED', false, true],
+    ['INACTIVE', 'OPENED', false, true],
+    ['CLOSED', 'OPENED', false, true],
+    ['OPENED', 'CLOSED', false, false],
+    ['OPENED', 'INACTIVE', false, false],
+    ['CLOSED', 'INACTIVE', false, false],
+    ['INACTIVE', 'CLOSED', true, false],
+    ['INACTIVE', 'OPENED', true, false],
+    ['CLOSED', 'OPENED', true, false],
+    ['OPENED', 'CLOSED', true, false],
+    ['OPENED', 'INACTIVE', true, false],
+    ['CLOSED', 'INACTIVE', true, false],
+  ].map(([prev, next, isMaximized, called]) => ({
     prev: prev as PanelState,
     next: next as PanelState,
     isMaximized: isMaximized as boolean,
+    called: called as boolean,
   }));
-  const WIDTH_DIFF = 32;
+  const WIDTH_DIFF = 0;
 
   for (const suite of suites) {
     test(`${stateName[suite.prev]}→${stateName[suite.next]} ${
       suite.isMaximized ? '最大化中は幅が変わらない' : '変化量を維持して幅を更新する'
-    }`, () => {
+    } setSize_called:${suite.called ? 'yes' : 'no'}`, () => {
       setup();
       const { WindowSizeService } = require('./window-size');
       const { WINDOW_MIN_WIDTH } = WindowSizeService;
@@ -317,7 +318,7 @@ describe('updateWindowSize', () => {
         BASE_HEIGHT,
       );
 
-      if (suite.isMaximized) {
+      if (!suite.called) {
         expect(win.setSize).toHaveBeenCalledTimes(0);
       } else {
         expect(win.setSize).toHaveBeenCalledTimes(1);

--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -271,12 +271,12 @@ describe('updateWindowSize', () => {
   }
 
   const suites = [
-    ['INACTIVE', 'CLOSED', false],
-    ['INACTIVE', 'OPENED', false],
-    ['CLOSED', 'OPENED', false],
-    ['OPENED', 'CLOSED', false],
-    ['OPENED', 'INACTIVE', false],
-    ['CLOSED', 'INACTIVE', false],
+    ['INACTIVE', 'CLOSED', true],
+    ['INACTIVE', 'OPENED', true],
+    ['CLOSED', 'OPENED', true],
+    ['OPENED', 'CLOSED', true],
+    ['OPENED', 'INACTIVE', true],
+    ['CLOSED', 'INACTIVE', true],
     ['INACTIVE', 'CLOSED', true],
     ['INACTIVE', 'OPENED', true],
     ['CLOSED', 'OPENED', true],

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -21,10 +21,10 @@ const NICOLIVE_PANEL_WIDTH = 400;
 const PANEL_DIVIDER_WIDTH = 24;
 
 export enum PanelState {
-  INACTIVE = 'INACTIVE',
-  OPENED = 'OPENED',
-  CLOSED = 'CLOSED',
-  COMPACT = 'COMPACT',
+  INACTIVE = 'INACTIVE', // not login
+  OPENED = 'OPENED', // logined and panel opened
+  CLOSED = 'CLOSED', // logined and panel closed
+  COMPACT = 'COMPACT', // compact mode
 }
 
 type BackupSizeInfo = {
@@ -235,10 +235,7 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
       if (!win.isMaximized()) {
         // コンパクトモード以外だったときは現在の幅と最小幅の差を保存する
         if (prevState !== PanelState.COMPACT) {
-          nextBackupSize.widthOffset = Math.max(
-            0,
-            width - WindowSizeService.WINDOW_MIN_WIDTH[prevState],
-          );
+          nextBackupSize.widthOffset = width;
         }
 
         // コンパクトモードになるときはパネルサイズを強制する
@@ -246,7 +243,7 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
           nextWidth = nextMinWidth;
           nextMaximize = false;
         } else {
-          nextWidth = nextMinWidth + nextBackupSize.widthOffset;
+          nextWidth = Math.max(nextBackupSize.widthOffset, nextMinWidth);
           nextMaximize = nextBackupSize.maximized;
         }
       }


### PR DESCRIPTION
# このpull requestが解決する内容

ログイン/ログアウト時の右パネル分のウインドウサイズ増減をやめます。
これにより画面サイズを超えるリサイズを防止します。

# 動作確認手順

ログイン/ログアウトを行う際にウインドウサイズの変更を行わない（内部レイアウトサイズのみでの変更）

# 関連するIssue（あれば）
