### PR TITLE
修正: スタジオモードにしたときにマウスカーソルの判定位置がずれていた

### DIFF
--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -57,23 +57,7 @@ export default class StudioEditor extends Vue {
     display: HTMLDivElement;
   };
 
-  get sourceId(): string {
-    return this.studioMode ? this.getStudioTransitionName() : void 0;
-  }
-
   onOutputResize(region: IRectangle) {
-    const sourceId = this.sourceId;
-    const info = {
-      sourceId,
-      region,
-      studioMode: this.studioMode,
-      square: region.width === region.height,
-    };
-    if (info.square) {
-      console.error('onOutputResize', info); // DEBUG
-    } else {
-      console.log('onOutputResize', info); // DEBUG
-    }
     this.renderedWidth = region.width;
     this.renderedHeight = region.height;
     this.renderedOffsetX = region.x;

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -57,7 +57,23 @@ export default class StudioEditor extends Vue {
     display: HTMLDivElement;
   };
 
+  get sourceId(): string {
+    return this.studioMode ? this.getStudioTransitionName() : void 0;
+  }
+
   onOutputResize(region: IRectangle) {
+    const sourceId = this.sourceId;
+    const info = {
+      sourceId,
+      region,
+      studioMode: this.studioMode,
+      square: region.width === region.height,
+    };
+    if (info.square) {
+      console.error('onOutputResize', info); // DEBUG
+    } else {
+      console.log('onOutputResize', info); // DEBUG
+    }
     this.renderedWidth = region.width;
     this.renderedHeight = region.height;
     this.renderedOffsetX = region.x;

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -101,13 +101,10 @@ export class Display {
   trackElement(element: HTMLElement) {
     if (this.trackingInterval) clearInterval(this.trackingInterval);
 
-    let retry = false;
-
     const trackingFun = () => {
       const rect = this.getScaledRectangle(element.getBoundingClientRect());
 
       if (
-        retry ||
         rect.x !== this.currentPosition.x ||
         rect.y !== this.currentPosition.y ||
         rect.width !== this.currentPosition.width ||
@@ -120,20 +117,10 @@ export class Display {
         }); // DEBUG
         this.move(rect.x, rect.y);
         this.resize(rect.width, rect.height);
-
-        // 変更後のサイズを確認してリトライする
-        const size = this.videoService.getOBSDisplayPreviewSize(this.name);
-        const invalid = size.width === size.height; // これでいいのか? シーンのサイズが正方形が正しいときに誤爆するかも
-        if (invalid) {
-          console.log(`Display(${this.name}).trackElement retry`); // DEBUG
-          retry = true;
-        } else {
-          retry = false;
-        }
       }
     };
 
-    trackingFun();
+    // trackingFun(); // ここで実行するとまだOBS側の状態が整っていないので、初回の位置がずれるため、延期する
     this.trackingInterval = window.setInterval(trackingFun, DISPLAY_ELEMENT_POLLING_INTERVAL);
   }
 

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -11,6 +11,7 @@ import { VideoSettingsService } from './settings-v2';
 import Utils from './utils';
 import { WindowsService } from './windows';
 
+const DISPLAY_ELEMENT_INITIAL_DELAY = 50;
 const DISPLAY_ELEMENT_POLLING_INTERVAL = 500;
 
 export interface IDisplayOptions {
@@ -120,7 +121,7 @@ export class Display {
       }
     };
 
-    // trackingFun(); // ここで実行するとまだOBS側の状態が整っていないので、初回の位置がずれるため、延期する
+    setTimeout(trackingFun, DISPLAY_ELEMENT_INITIAL_DELAY); // ここで実行するとまだOBS側の状態が整っていないので初回の位置がずれるため、延期する
     this.trackingInterval = window.setInterval(trackingFun, DISPLAY_ELEMENT_POLLING_INTERVAL);
   }
 

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -51,7 +51,6 @@ export class Display {
   displayDestroyed: boolean;
 
   constructor(public name: string, options: IDisplayOptions = {}) {
-    console.log(`Display(${name}).constructor`, { options }); // DEBUG
     this.sourceId = options.sourceId;
     this.electronWindowId = remote.getCurrentWindow().id;
 
@@ -111,11 +110,6 @@ export class Display {
         rect.width !== this.currentPosition.width ||
         rect.height !== this.currentPosition.height
       ) {
-        console.log(`Display(${this.name}).trackElement`, {
-          sourceId: this.sourceId,
-          rect,
-          currentPosition: this.currentPosition,
-        }); // DEBUG
         this.move(rect.x, rect.y);
         this.resize(rect.width, rect.height);
       }
@@ -167,10 +161,6 @@ export class Display {
 
   onOutputResize(cb: (region: IRectangle) => void) {
     this.outputRegionCallbacks.push(cb);
-    console.log(
-      `Display(${this.name}).onOutputResize outputRegionCallbacks.length`,
-      this.outputRegionCallbacks.length,
-    ); // DEBUG
   }
 
   async refreshOutputRegion() {
@@ -185,16 +175,6 @@ export class Display {
       ...position,
       ...size,
     };
-    const info = {
-      sourceId: this.sourceId,
-      outputRegion: this.outputRegion,
-      square: size.width === size.height,
-    };
-    if (info.square) {
-      console.error(`Display(${this.name}).outputRegion square`, info); // DEBUG
-    } else {
-      console.log(`Display(${this.name}).outputRegion`, info); // DEBUG
-    }
 
     this.outputRegionCallbacks.forEach(cb => {
       cb(this.outputRegion);

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -30,6 +30,7 @@ export class Display {
   outputRegion: IRectangle;
   isDestroyed = false;
 
+  trackingInitialTimeout: ReturnType<typeof setTimeout>;
   trackingInterval: number;
   currentPosition: IRectangle = {
     x: 0,
@@ -115,7 +116,10 @@ export class Display {
       }
     };
 
-    setTimeout(trackingFun, DISPLAY_ELEMENT_INITIAL_DELAY); // ここで実行するとまだOBS側の状態が整っていないので初回の位置がずれるため、延期する
+    this.trackingInitialTimeout = setTimeout(() => {
+      trackingFun();
+      this.trackingInitialTimeout = null;
+    }, DISPLAY_ELEMENT_INITIAL_DELAY); // ここで実行するとまだOBS側の状態が整っていないので初回の位置がずれるため、延期する
     this.trackingInterval = window.setInterval(trackingFun, DISPLAY_ELEMENT_POLLING_INTERVAL);
   }
 
@@ -145,6 +149,7 @@ export class Display {
 
   remoteClose() {
     this.outputRegionCallbacks = [];
+    if (this.trackingInitialTimeout) clearTimeout(this.trackingInitialTimeout);
     if (this.trackingInterval) clearInterval(this.trackingInterval);
     if (this.selectionSubscription) this.selectionSubscription.unsubscribe();
     if (!this.displayDestroyed) {


### PR DESCRIPTION
# このpull requestが解決する内容
fix #893
fix #725

<strike>スタジオモードにした直後は左側のシーン部分の座標系が正しくないのを、無理矢理検出して(500ms後に)再設定することで回避します</strike>
<strike>スタジオモードにした直後はサイズをすぐに取得せず、500msポーリングのみでやるようにすることで最初のおかしな値を回避します</strike>
500msポーリングだけだと画面切り替えが目に見えてラグってるので、初回取得を50ms秒後にすることにした。0msだとまだ正しくなっていない。この数字は環境によってはもしかすると間に合わない可能性はあるが、長くすると起動時やスタジオモード切替え時の画面変化が遅くなる。

- [x] デバッグ表示を消す

# 起きている現象
スタジオモードにした直後、 `resizeOBSDisplay` でサイズを変更したときに `getOBSDisplayPreviewOffset`, `getOBSDisplayPreviewSize` で得られる位置とサイズがおかしい(なぜか正方形になる)。
得られたサイズが間違っているためマウスイベントの座標計算が狂う。
少し経ってから `resizeOBSDisplay` し直すと正しい値になるようだ。

発生した状態では、アプリのウィンドウのサイズをすこし変更すると正しい座標に再設定される。

# 動作確認手順
スタジオモードにして、シーンの中央から遠いところに置いたシーンソースの位置に正しくマウスカーソルが反応し、クリック操作ができること
(修正前は、中央から遠いところは座標計算のずれが大きくなるため、リサイズノブなどを正確にクリックできなかった)

# 関連するIssue（あれば）
#893