### PR TITLE
修正: ボイスチェンジャーのソースプロパティウィンドウを開いたままアプリを終了したときに、音声プレビュー状態を元に戻す

### DIFF
--- a/app/components/windows/RtvcSourceProperties.vue.ts
+++ b/app/components/windows/RtvcSourceProperties.vue.ts
@@ -350,7 +350,7 @@ export default class RtvcSourceProperties extends SourceProperties {
     if (this.initialMonitoringType !== this.currentMonitoringType)
       this.audioService.setSettings(this.sourceId, { monitoringType: this.initialMonitoringType });
 
-    if (this.canceled || this.isShuttingDown) {
+    if (this.canceled) {
       this.source.setPropertiesFormData(this.initialProperties);
       return;
     }

--- a/app/components/windows/RtvcSourceProperties.vue.ts
+++ b/app/components/windows/RtvcSourceProperties.vue.ts
@@ -350,7 +350,7 @@ export default class RtvcSourceProperties extends SourceProperties {
     if (this.initialMonitoringType !== this.currentMonitoringType)
       this.audioService.setSettings(this.sourceId, { monitoringType: this.initialMonitoringType });
 
-    if (this.canceled) {
+    if (this.canceled || this.isShuttingDown) {
       this.source.setPropertiesFormData(this.initialProperties);
       return;
     }


### PR DESCRIPTION
# このpull requestが解決する内容
アプリシャットダウン中に開いていた子ウィンドウはクリーンアップを待てるようにします。
ソースプロパティウィンドウで有効にしています。

また、シャットダウン中かどうかも判定できるように `AppService` の `state` に `shuttingDown` を追加します。

<strike>ボイスチェンジャーソースでは `beforeDestroy` でキャンセル判定するときにこのフラグが立っていたらキャンセル扱いにします。</strike>

# 動作確認手順
ボイスチェンジャーソースのプロパティを開いて、音声プレビューを有効にしてアプリを閉じると、次に起動しても音声プレビューが解除されていること

# 関連するIssue（あれば）
