### PR TITLE
変更: AMDのときのニコ生配信最適化の設定を調整(詳細をオフに)

### DIFF
--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -66,7 +66,7 @@ export function getBestSettingsForNiconico(
     } else if (settings.hasSpecificValue(OptimizationKey.encoder, EncoderFamily.amd)) {
       encoderSettings = {
         encoder: EncoderFamily.amd,
-        simpleUseAdvanced: true,
+        simpleUseAdvanced: false,
       };
     } else if (
       settings.hasSpecificValue(OptimizationKey.encoder, EncoderFamily.qsv) ||


### PR DESCRIPTION
# このpull requestが解決する内容

自動最適化においてamdにて詳細の設定がなされていないため一部エラーがでる可能性がある
詳細オフでも動作は問題ないようなのでそちらにふるパターン

# 動作確認手順

# 関連するIssue（あれば）
