### PR TITLE
開発: mini-release: public env のときに patchNotesから 開発: で始まる行を除去する

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -416,6 +416,14 @@ async function releaseRoutine() {
   const newVersionContext = getVersionContext(nextVersion);
   const { channel, environment } = newVersionContext;
 
+  if (environment === 'public') {
+    // patchNote.notes: 複数行テキストが一つの文字列になっている。行頭に '開発:' があったらその行を除去する
+    patchNote.notes = patchNote.notes
+      .split('\n')
+      .filter(line => !line.startsWith('開発:'))
+      .join('\n');
+  }
+
   /** @type {import('./configs/type').ReleaseConfig} */
   // eslint-disable-next-line import/no-dynamic-require
   const config = require(`./configs/${environment}-${channel}`);

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -135,6 +135,9 @@ async function collectPullRequestMerges({ octokit, owner, repo }, previousVersio
     if (line.startsWith('修正:')) {
       return 2;
     }
+    if (line.startsWith('開発:')) {
+      return 999; // 開発は最後に
+    }
     return 3;
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容
patchNotesを生成して確認したあと、公開版をリリースするときに `開発:` で始まる行を除去する運用を手作業でやっていたので、自動化します

# 動作確認手順
1. `開発:` 行が含まれる patch notesを用意して
2. mini-release.js の `runScript` の冒頭の情報表示か終わったあたりで `sh.exit()` でも突っ込んで止まるように書き換えてから、
3. publicリリースを実行して、
4. 表示される patch-notesに `開発:` 行が除去されていること
