### PR TITLE
修正: 0ptのギフト通知が undefinedpt と表示されていた

### DIFF
--- a/app/services/nicolive-program/ChatMessage/displaytext.ts
+++ b/app/services/nicolive-program/ChatMessage/displaytext.ts
@@ -18,7 +18,7 @@ function getNicoadComment(chat: WrappedMessage): string {
         const latest = nicoad.v0.latest;
         const advertiser = latest.advertiser;
         const message = latest.message ? `「${latest.message}」` : '';
-        return `提供：${advertiser}さん${message}（${latest.point}pt）`;
+        return `提供：${advertiser}さん${message}（${latest.point ?? 0}pt）`;
       }
     } else if (isNicoadMessageV1(nicoad)) {
       return nicoad.v1.message ?? '';
@@ -34,7 +34,9 @@ function getGiftComment(chat: WrappedMessage): string {
   const gift = chat.value;
   const { advertiserName, point, itemName, contributionRank } = gift;
   const contributionMessage = contributionRank ? `【ギフト貢献第${contributionRank}位】 ` : '';
-  return `${contributionMessage}${advertiserName}さんが「${itemName}（${point}pt）」を贈りました`;
+  return `${contributionMessage}${advertiserName}さんが「${itemName}（${
+    point ?? 0
+  }pt）」を贈りました`;
 }
 
 function getEmotionComment(chat: WrappedMessage): string {


### PR DESCRIPTION
- [x] 実際に 0pt のギフトを投げる検証をしてからマージする

# このpull requestが解決する内容

0ptのギフトが贈られたときの通知メッセージ(読み上げ)のポイント数欄が `0pt` であるべきところが `undefinedpt` になっていたのを修正します

ニコニコ広告のポイントも念のため同じガードをかけます

# 動作確認手順
N Air配信中に0ptのギフトを受け取る

# 関連するIssue（あれば）
