### PR TITLE
追加: クッキー削除機能(ログイン状態が保存されないケースのトラブルシューティング用)

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -58,6 +58,9 @@
           {{ $t('settings.cacheIdCopy') }}
         </button>
       </div>
+      <a class="button button--secondary" @click="deleteCookies">
+        {{ $t('settings.deleteCookiesAndRestart') }}
+      </a>
     </div>
 
     <div class="section">

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -131,7 +131,13 @@ export default class ExtraSettings extends Vue {
 
   deleteCacheDir() {
     if (confirm($t('settings.clearCacheConfirm'))) {
-      this.appService.relaunch({ clearCacheDir: true });
+      this.appService.relaunch({ clearCacheDir: 'all' });
+    }
+  }
+
+  deleteCookies() {
+    if (confirm($t('settings.deleteCookiesConfirm'))) {
+      this.appService.relaunch({ clearCacheDir: 'cookie' });
     }
   }
 

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -668,7 +668,7 @@
   "clearCacheConfirm": "WARNING! You will lose all scenes, sources, and settings. This cannot be undone!",
   "restartConfirm": "This action will restart the application. Continue?",
   "deleteCookiesAndRestart": "(If the login state is not saved) Delete cookies and restart",
-  "deleteCookiesConfirm": "Warning: To resolve the issue of being logged out every time the app starts, cookies will be deleted. You will be logged out temporarily.",
+  "deleteCookiesConfirm": "Warning: Cookies will be deleted (if you are logged in, you will be logged out). If you are experiencing an issue where you are logged out every time the app starts, this may help resolve it.",
   "itemNotFoundMessage": "No elements found. Consider changing the search query.",
   "desktopAudioDevice": "Desktop Audio Device",
   "micAuxDevice": "Mic / Auxiliary Device",

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -667,6 +667,8 @@
   "confirmStreamTitleAndGameBeforeGoingLive": "Confirm stream title and game before going live",
   "clearCacheConfirm": "WARNING! You will lose all scenes, sources, and settings. This cannot be undone!",
   "restartConfirm": "This action will restart the application. Continue?",
+  "deleteCookiesAndRestart": "(If the login state is not saved) Delete cookies and restart",
+  "deleteCookiesConfirm": "Warning: To resolve the issue of being logged out every time the app starts, cookies will be deleted. You will be logged out temporarily.",
   "itemNotFoundMessage": "No elements found. Consider changing the search query.",
   "desktopAudioDevice": "Desktop Audio Device",
   "micAuxDevice": "Mic / Auxiliary Device",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -668,7 +668,7 @@
   "clearCacheConfirm": "警告: すべてのシーン、ソース、設定を抹消します。この操作は元に戻せません。",
   "restartConfirm": "N Airを再起動します。よろしいですか？",
   "deleteCookiesAndRestart": "(ログイン状態が保存されない場合)クッキーを削除して再起動",
-  "deleteCookiesConfirm": "警告: 起動の度にログアウトしている問題の解消のため、クッキーを削除します。一旦ログアウトします",
+  "deleteCookiesConfirm": "警告: クッキーを削除します(ログインしていた場合、ログアウトします)。起動の度にログアウト状態になっている問題が発生している場合、これを行うことで解消が期待出来ます",
   "itemNotFoundMessage": "要素が見つかりませんでした。 検索する語句を変更してみてください。",
   "desktopAudioDevice": "デスクトップ音声デバイス",
   "micAuxDevice": "マイク",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -667,6 +667,8 @@
   "confirmStreamTitleAndGameBeforeGoingLive": "ライブになる前にストリームのタイトルとゲームを確認して下さい。",
   "clearCacheConfirm": "警告: すべてのシーン、ソース、設定を抹消します。この操作は元に戻せません。",
   "restartConfirm": "N Airを再起動します。よろしいですか？",
+  "deleteCookiesAndRestart": "(ログイン状態が保存されない場合)クッキーを削除して再起動",
+  "deleteCookiesConfirm": "警告: 起動の度にログアウトしている問題の解消のため、クッキーを削除します。一旦ログアウトします",
   "itemNotFoundMessage": "要素が見つかりませんでした。 検索する語句を変更してみてください。",
   "desktopAudioDevice": "デスクトップ音声デバイス",
   "micAuxDevice": "マイク",

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -263,13 +263,19 @@ export class AppService extends StatefulService<IAppState> {
     return returningValue;
   }
 
-  relaunch({ clearCacheDir }: { clearCacheDir?: boolean } = {}) {
+  relaunch({ clearCacheDir }: { clearCacheDir?: 'all' | 'cookie' } = {}) {
     const originalArgs: string[] = remote.process.argv.slice(1);
 
+    const args = originalArgs.filter(x => !['--clearCacheDir', '--clearCookies'].includes(x));
     // キャッシュクリアしたいときだけつくようにする
-    const args = clearCacheDir
-      ? originalArgs.concat('--clearCacheDir')
-      : originalArgs.filter(x => x !== '--clearCacheDir');
+    switch (clearCacheDir) {
+      case 'cookie':
+        args.push('--clearCookies');
+        break;
+      case 'all':
+        args.push('--clearCacheDir');
+        break;
+    }
 
     remote.app.relaunch({ args });
     remote.app.quit();


### PR DESCRIPTION
# このpull requestが解決する内容
Electron のバージョンが上がってcookieの下位互換性がなくなったときに、新バージョンを起動したあと旧バージョンを起動すると発生する問題対策です

![image](https://github.com/user-attachments/assets/9a8cd34f-09e7-4ae8-af8b-ddfd4332847c)
![image](https://github.com/user-attachments/assets/de840a10-b4e8-4c2c-a860-5d3a17d1c32a)

- [x] 文言確認

# 動作確認手順
- cookieが書き込めない状況を発生させる:
  1. N Air がniconicoログイン済み状態で、
  2. Electron 29 ブランチ #908 のアプリを1回起動してから
  3. こちらのビルドを起動する
  4. 未ログイン状態になっている。ここでログインしても次に起動するときには未ログインに戻っている
- 設定のキャッシュ管理の最下部に追加された「クッキーを削除して再起動」を押してから起動すると、以後のログインは再起動しても維持される

# 関連するIssue（あれば）
