### PR TITLE
修正: 左下のログインアイコンをクリックしたときに開くリンクが旧マイページだったのでガレージに修正

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -59,7 +59,7 @@ export class HostsService extends Service {
     return `${this.nicoLiveWeb}/watch/${programID}`;
   }
   getMyPageURL(): string {
-    return `${this.nicoLiveWeb}/my`;
+    return `https://garage.nicovideo.jp/niconico-garage/live/history`;
   }
   getUserPageURL(userId: string): string {
     return `https://www.nicovideo.jp/user/${userId}`;


### PR DESCRIPTION
# このpull requestが解決する内容

ニコニコログイン済みのときにN Airアプリの左下(SiteNavの一番下のLogin)のアカウントアイコンをクリックしたときに開くリンクが `live.nicovideo.jp/my` という廃止済みページだったので、[ニコニコガレージの放送履歴ページ](https://garage.nicovideo.jp/niconico-garage/live/history)に修正します
