### PR TITLE
修正: ニコ生パネル開閉ボタンの矢印の向きを反転

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -78,7 +78,7 @@
     display: block;
     font-size: @font-size2;
     color: var(--color-text);
-    transform: rotate(-90deg);
+    transform: rotate(90deg);
   }
 
   &:hover {
@@ -89,7 +89,7 @@
 
   &.nicolive-area--opened {
     > i {
-      transform: rotate(90deg);
+      transform: rotate(-90deg);
     }
   }
 }


### PR DESCRIPTION
# このpull requestが解決する内容

右側パネル開閉矢印を下パネルでの矢印と同様の向きにします


<img width="908" alt="Monosnap mogador 2025-04-11 10-42-13" src="https://github.com/user-attachments/assets/5acd2c91-531e-45fc-aa51-7a663fee7924" />

