### PR TITLE
修正: 言語変更などで再起動するときにエラーが出ていた

### DIFF
--- a/main.js
+++ b/main.js
@@ -795,6 +795,7 @@ function initialize(crashHandler) {
 
   ipcMain.on('window-closeChildWindow', event => {
     // never close the child window, hide it instead
+    if (childWindow.isDestroyed()) return;
     childWindow.hide();
   });
 


### PR DESCRIPTION
# このpull requestが解決する内容
このエラーを出なくします
![image](https://github.com/user-attachments/assets/d3777cfd-fe92-4411-a2d9-ba278967ba7f)

シャットダウン過程ですでに閉じたchildWindowをhideしようとして出ていました。

# 動作確認手順
設定で言語を切り替えるなどしてアプリに自動再起動させる
