### PR TITLE
開発: webpack Electronターゲットを29に更新

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -160,5 +160,17 @@
   "stylelint.validate": ["css", "less", "vue"],
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    {
+      "text": "日本語で書いてください"
+    }
+  ],
+  "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+    {
+      "text": "日本語で書いてください。\n\n以下の形式で記載してください。\n\n# このpull requestが解決する内容\n# 動作確認手順\n# 関連するIssue（あれば）"
+    }
+  ],
+  "githubPullRequests.createDefaultBaseBranch": "createdFromBranch"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,7 @@ module.exports = function (env, argv) {
         'sentry-defs': './sentry-defs.js',
       },
       plugins: [definePlugin],
-      target: 'electron25-main',
+      target: 'electron29-main',
     },
     {
       ...common,
@@ -131,7 +131,7 @@ module.exports = function (env, argv) {
 
       devtool: 'source-map',
 
-      target: 'electron25-renderer',
+      target: 'electron29-renderer',
 
       resolve: {
         extensions: ['.js', '.ts', '.tsx'],


### PR DESCRIPTION
# このpull requestが解決する内容

webpack  Electronのターゲットを25から29に更新し、GitHub Copilotのコミットメッセージおよびプルリクエスト説明生成の指示を日本語に変更しました。

# 動作確認手順

変更後の設定が正しく反映されていることを確認します。

# 関連するIssue（あれば）

特になし。