### PR TITLE
開発: chore: SettingsCategory型を定義して設定に使用

### DIFF
--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -8,7 +8,11 @@ import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 import { Inject } from '../../services/core/injector';
 import { CustomizationService } from '../../services/customization';
-import { Category, ISettingsServiceApi, ISettingsSubCategory } from '../../services/settings';
+import {
+  ISettingsServiceApi,
+  ISettingsSubCategory,
+  SettingsCategory,
+} from '../../services/settings';
 import { StreamingService } from '../../services/streaming';
 import { UserService } from '../../services/user';
 import { WindowsService } from '../../services/windows';
@@ -46,7 +50,7 @@ export default class Settings extends Vue {
 
   $refs: { settingsContainer: HTMLElement };
 
-  categoryName: Category = 'General';
+  categoryName: SettingsCategory = 'General';
   settingsData: ISettingsSubCategory[] = [];
   // @ts-expect-error: ts2729: use before initialization
   categoryNames = this.settingsService.getCategories();
@@ -93,7 +97,7 @@ export default class Settings extends Vue {
   }
 
   @Watch('categoryName')
-  onCategoryNameChangedHandler(categoryName: Category) {
+  onCategoryNameChangedHandler(categoryName: SettingsCategory) {
     this.settingsData = this.settingsService.getSettingsFormData(categoryName);
     this.$refs.settingsContainer.scrollTop = 0;
   }

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -8,7 +8,7 @@ import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 import { Inject } from '../../services/core/injector';
 import { CustomizationService } from '../../services/customization';
-import { ISettingsServiceApi, ISettingsSubCategory } from '../../services/settings';
+import { Category, ISettingsServiceApi, ISettingsSubCategory } from '../../services/settings';
 import { StreamingService } from '../../services/streaming';
 import { UserService } from '../../services/user';
 import { WindowsService } from '../../services/windows';
@@ -46,7 +46,7 @@ export default class Settings extends Vue {
 
   $refs: { settingsContainer: HTMLElement };
 
-  categoryName: string = 'General';
+  categoryName: Category = 'General';
   settingsData: ISettingsSubCategory[] = [];
   // @ts-expect-error: ts2729: use before initialization
   categoryNames = this.settingsService.getCategories();
@@ -93,7 +93,7 @@ export default class Settings extends Vue {
   }
 
   @Watch('categoryName')
-  onCategoryNameChangedHandler(categoryName: string) {
+  onCategoryNameChangedHandler(categoryName: Category) {
     this.settingsData = this.settingsService.getSettingsFormData(categoryName);
     this.$refs.settingsContainer.scrollTop = 0;
   }

--- a/app/services/protocol-links.ts
+++ b/app/services/protocol-links.ts
@@ -4,7 +4,7 @@ import { Inject } from 'services/core/injector';
 import { Service } from 'services/core/service';
 import { NavigationService } from 'services/navigation';
 import { URL, URLSearchParams } from 'url';
-import { Category, SettingsService } from './settings';
+import { SettingsCategory, SettingsService } from './settings';
 import Utils from './utils';
 
 function protocolHandler(base: string) {
@@ -68,7 +68,7 @@ export class ProtocolLinksService extends Service {
 
   @protocolHandler('settings')
   private openSettings(info: IProtocolLinkInfo) {
-    const category = info.path.replace('/', '') as Category;
+    const category = info.path.replace('/', '') as SettingsCategory;
 
     this.settingsService.showSettings(category);
   }

--- a/app/services/protocol-links.ts
+++ b/app/services/protocol-links.ts
@@ -4,7 +4,7 @@ import { Inject } from 'services/core/injector';
 import { Service } from 'services/core/service';
 import { NavigationService } from 'services/navigation';
 import { URL, URLSearchParams } from 'url';
-import { SettingsService } from './settings';
+import { Category, SettingsService } from './settings';
 import Utils from './utils';
 
 function protocolHandler(base: string) {
@@ -68,7 +68,7 @@ export class ProtocolLinksService extends Service {
 
   @protocolHandler('settings')
   private openSettings(info: IProtocolLinkInfo) {
-    const category = info.path.replace('/', '');
+    const category = info.path.replace('/', '') as Category;
 
     this.settingsService.showSettings(category);
   }

--- a/app/services/settings/optimizer.test.ts
+++ b/app/services/settings/optimizer.test.ts
@@ -1,6 +1,5 @@
 import {
   AllKeyDescriptions,
-  CategoryName,
   EncoderFamily,
   filterKeyDescriptions,
   iterateKeyDescriptions,
@@ -23,7 +22,7 @@ test('filterKeyDescriptions', () => {
   expect(simpleOnly).toEqual([
     {
       key: OptimizationKey.outputMode,
-      category: CategoryName.output,
+      category: 'Output',
       subCategory: 'Untitled',
       setting: 'Mode',
       lookupValueName: true,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/vue';
 import { IObsInput, IObsListInput, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { $t } from 'services/i18n';
 import { getKeys } from 'util/getKeys';
-import { ISettingsSubCategory } from './settings-api';
+import { Category, ISettingsSubCategory } from './settings-api';
 
 export enum EncoderFamily {
   x264 = 'obs_x264',
@@ -65,16 +65,9 @@ export type OptimizeSettings = {
   audioSampleRate?: 44100 | 48000;
 };
 
-export enum CategoryName {
-  output = 'Output',
-  video = 'Video',
-  advanced = 'Advanced',
-  audio = 'Audio',
-}
-
 export type KeyDescription = {
   key: OptimizationKey;
-  category: CategoryName;
+  category: Category;
   subCategory: string;
   setting: string;
   label?: string;
@@ -85,7 +78,7 @@ export type KeyDescription = {
 export const AllKeyDescriptions: KeyDescription[] = [
   {
     key: OptimizationKey.outputMode,
-    category: CategoryName.output,
+    category: 'Output',
     subCategory: 'Untitled',
     setting: 'Mode',
     lookupValueName: true,
@@ -95,7 +88,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
         params: [
           {
             key: OptimizationKey.encoder,
-            category: CategoryName.output,
+            category: 'Output',
             subCategory: 'Streaming',
             setting: 'Encoder',
             lookupValueName: true,
@@ -105,7 +98,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 params: [
                   {
                     key: OptimizationKey.advRateControl,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'rate_control',
                     lookupValueName: true,
@@ -115,7 +108,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         params: [
                           {
                             key: OptimizationKey.videoBitrate,
-                            category: CategoryName.output,
+                            category: 'Output',
                             subCategory: 'Streaming',
                             setting: 'bitrate',
                             label: 'settings.videoBitrate',
@@ -126,28 +119,28 @@ export const AllKeyDescriptions: KeyDescription[] = [
                   },
                   {
                     key: OptimizationKey.advKeyframeInterval,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     label: 'settings.keyframeInterval',
                     setting: 'keyint_sec',
                   },
                   {
                     key: OptimizationKey.encoderPreset,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'preset',
                     label: 'settings.encoderPreset',
                   },
                   {
                     key: OptimizationKey.advProfile,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'profile',
                     lookupValueName: true,
                   },
                   {
                     key: OptimizationKey.advX264Tune,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'tune',
                     lookupValueName: true,
@@ -159,20 +152,20 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 params: [
                   {
                     key: OptimizationKey.targetUsage,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'QSVPreset',
                   },
                   {
                     key: OptimizationKey.advProfile,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'profile',
                     lookupValueName: true,
                   },
                   {
                     key: OptimizationKey.advKeyframeInterval,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     label: 'settings.keyframeInterval',
                     setting: 'keyint_sec',
@@ -185,7 +178,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                   // qpi, qpp, qpb, icq_quality, la_depth
                   {
                     key: OptimizationKey.advRateControl,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'rate_control',
                     lookupValueName: true,
@@ -195,7 +188,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         params: [
                           {
                             key: OptimizationKey.videoBitrate,
-                            category: CategoryName.output,
+                            category: 'Output',
                             subCategory: 'Streaming',
                             setting: 'bitrate',
                             label: 'settings.videoBitrate',
@@ -224,27 +217,27 @@ export const AllKeyDescriptions: KeyDescription[] = [
                   // 'bf' // int 2 // B-フレーム
                   {
                     key: OptimizationKey.NVENCPreset2,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'preset',
                   },
                   {
                     key: OptimizationKey.advProfile,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'profile',
                     lookupValueName: true,
                   },
                   {
                     key: OptimizationKey.advKeyframeInterval,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     label: 'settings.keyframeInterval',
                     setting: 'keyint_sec',
                   },
                   {
                     key: OptimizationKey.advRateControl,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'rate_control',
                     lookupValueName: true,
@@ -254,7 +247,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         params: [
                           {
                             key: OptimizationKey.videoBitrate,
-                            category: CategoryName.output,
+                            category: 'Output',
                             subCategory: 'Streaming',
                             setting: 'bitrate',
                             label: 'settings.videoBitrate',
@@ -269,20 +262,20 @@ export const AllKeyDescriptions: KeyDescription[] = [
           },
           {
             key: OptimizationKey.advAudioTrackIndex,
-            category: CategoryName.output,
+            category: 'Output',
             subCategory: 'Streaming',
             setting: 'TrackIndex',
           },
           {
             key: OptimizationKey.audioBitrate,
-            category: CategoryName.output,
+            category: 'Output',
             subCategory: 'Audio - Track 1',
             setting: 'Track1Bitrate',
             label: 'settings.audioBitrate',
           },
           {
             key: OptimizationKey.advColorSpace,
-            category: CategoryName.advanced,
+            category: 'Advanced',
             subCategory: 'Video',
             setting: 'ColorSpace',
           },
@@ -293,14 +286,14 @@ export const AllKeyDescriptions: KeyDescription[] = [
         params: [
           {
             key: OptimizationKey.videoBitrate,
-            category: CategoryName.output,
+            category: 'Output',
             subCategory: 'Streaming',
             setting: 'VBitrate',
             label: 'settings.videoBitrate',
           },
           {
             key: OptimizationKey.encoder,
-            category: CategoryName.output,
+            category: 'Output',
             subCategory: 'Streaming',
             setting: 'StreamEncoder',
             lookupValueName: true,
@@ -310,7 +303,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 params: [
                   {
                     key: OptimizationKey.simpleUseAdvanced,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'UseAdvanced',
                     lookupValueName: true,
@@ -320,7 +313,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         params: [
                           {
                             key: OptimizationKey.encoderPreset,
-                            category: CategoryName.output,
+                            category: 'Output',
                             subCategory: 'Streaming',
                             setting: 'Preset',
                             label: 'settings.encoderPreset',
@@ -336,7 +329,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 params: [
                   {
                     key: OptimizationKey.simpleUseAdvanced,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'UseAdvanced',
                     lookupValueName: true,
@@ -346,7 +339,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         params: [
                           {
                             key: OptimizationKey.targetUsage,
-                            category: CategoryName.output,
+                            category: 'Output',
                             subCategory: 'Streaming',
                             setting: 'QSVPreset',
                           },
@@ -361,7 +354,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 params: [
                   {
                     key: OptimizationKey.simpleUseAdvanced,
-                    category: CategoryName.output,
+                    category: 'Output',
                     subCategory: 'Streaming',
                     setting: 'UseAdvanced',
                     lookupValueName: true,
@@ -371,7 +364,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                         params: [
                           {
                             key: OptimizationKey.NVENCPreset2,
-                            category: CategoryName.output,
+                            category: 'Output',
                             subCategory: 'Streaming',
                             setting: 'NVENCPreset2',
                             lookupValueName: true,
@@ -386,7 +379,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
           },
           {
             key: OptimizationKey.audioBitrate,
-            category: CategoryName.output,
+            category: 'Output',
             subCategory: 'Streaming',
             setting: 'ABitrate',
           },
@@ -396,7 +389,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
   },
   {
     key: OptimizationKey.quality,
-    category: CategoryName.video,
+    category: 'Video',
     subCategory: 'Untitled',
     setting: 'Output',
     label: 'streaming.resolution',
@@ -404,7 +397,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
   },
   {
     key: OptimizationKey.fpsType,
-    category: CategoryName.video,
+    category: 'Video',
     subCategory: 'Untitled',
     setting: 'FPSType',
     lookupValueName: true,
@@ -414,7 +407,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
         params: [
           {
             key: OptimizationKey.fpsCommon,
-            category: CategoryName.video,
+            category: 'Video',
             subCategory: 'Untitled',
             setting: 'FPSCommon',
             label: 'streaming.FPS',
@@ -425,7 +418,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
   },
   {
     key: OptimizationKey.audioSampleRate,
-    category: CategoryName.audio,
+    category: 'Audio',
     subCategory: 'Untitled',
     setting: 'SampleRate',
     label: 'stream.sampleRate',
@@ -438,7 +431,7 @@ export interface OptimizedSettings {
   current: OptimizeSettings;
   delta: OptimizeSettings;
   info: [
-    CategoryName,
+    Category,
     {
       key: string;
       name: string;
@@ -471,7 +464,7 @@ function i18nPath(top: string, ...args: string[]): string {
 
 class OptKeyProperty {
   key: OptimizationKey;
-  category: CategoryName;
+  category: Category;
   subCategory: string;
   setting: string;
 
@@ -653,7 +646,7 @@ function validateKeyDescriptions(params: KeyDescription[]) {
 validateKeyDescriptions(AllKeyDescriptions);
 
 export interface ISettingsAccessor {
-  getSettingsFormData(categoryName: string): ISettingsSubCategory[];
+  getSettingsFormData(categoryName: Category): ISettingsSubCategory[];
   findSetting(
     settings: ISettingsSubCategory[],
     category: string,
@@ -664,7 +657,7 @@ export interface ISettingsAccessor {
     category: string,
     setting: string,
   ): TObsValue | undefined;
-  setSettings(categoryName: string, settingsData: ISettingsSubCategory[]): void;
+  setSettings(categoryName: Category, settingsData: ISettingsSubCategory[]): void;
 }
 
 /**
@@ -677,24 +670,24 @@ export class SettingsKeyAccessor {
     this.accessor = accessor;
   }
 
-  private categoryCache = new Map<CategoryName, ISettingsSubCategory[]>();
-  private modifiedCategories = new Set<CategoryName>();
+  private categoryCache = new Map<Category, ISettingsSubCategory[]>();
+  private modifiedCategories = new Set<Category>();
 
-  private getCategory(category: CategoryName, reload: boolean = false): ISettingsSubCategory[] {
+  private getCategory(category: Category, reload: boolean = false): ISettingsSubCategory[] {
     if (reload || !this.categoryCache.has(category)) {
       this.categoryCache.set(category, this.accessor.getSettingsFormData(category));
     }
     return this.categoryCache.get(category);
   }
 
-  private updateCategory(category: CategoryName) {
+  private updateCategory(category: Category) {
     if (this.categoryCache.has(category)) {
       console.log(`updateCategory: ${category}`);
       this.accessor.setSettings(category, this.getCategory(category));
     }
   }
 
-  writeBackCategory(category: CategoryName) {
+  writeBackCategory(category: Category) {
     if (this.modifiedCategories.has(category)) {
       this.updateCategory(category);
       this.modifiedCategories.delete(category);
@@ -708,7 +701,7 @@ export class SettingsKeyAccessor {
     this.modifiedCategories.clear();
   }
 
-  private forgetCategoryCache(category: CategoryName) {
+  private forgetCategoryCache(category: Category) {
     if (this.categoryCache.has(category)) {
       this.categoryCache.delete(category);
       if (this.modifiedCategories.has(category)) {
@@ -934,8 +927,8 @@ export class Optimizer {
   optimizeInfo(
     current: OptimizeSettings,
     optimized: OptimizeSettings,
-  ): [CategoryName, OptimizeItem[]][] {
-    const map = new Map<CategoryName, OptimizeItem[]>();
+  ): [Category, OptimizeItem[]][] {
+    const map = new Map<Category, OptimizeItem[]>();
     const merged = Object.assign({}, current, optimized);
     for (const keyDescription of iterateKeyDescriptions(merged, this.keyDescriptions)) {
       const opt = new OptKeyProperty(keyDescription);

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/vue';
 import { IObsInput, IObsListInput, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { $t } from 'services/i18n';
 import { getKeys } from 'util/getKeys';
-import { Category, ISettingsSubCategory } from './settings-api';
+import { ISettingsSubCategory, SettingsCategory } from './settings-api';
 
 export enum EncoderFamily {
   x264 = 'obs_x264',
@@ -67,7 +67,7 @@ export type OptimizeSettings = {
 
 export type KeyDescription = {
   key: OptimizationKey;
-  category: Category;
+  category: SettingsCategory;
   subCategory: string;
   setting: string;
   label?: string;
@@ -431,7 +431,7 @@ export interface OptimizedSettings {
   current: OptimizeSettings;
   delta: OptimizeSettings;
   info: [
-    Category,
+    SettingsCategory,
     {
       key: string;
       name: string;
@@ -464,7 +464,7 @@ function i18nPath(top: string, ...args: string[]): string {
 
 class OptKeyProperty {
   key: OptimizationKey;
-  category: Category;
+  category: SettingsCategory;
   subCategory: string;
   setting: string;
 
@@ -646,7 +646,7 @@ function validateKeyDescriptions(params: KeyDescription[]) {
 validateKeyDescriptions(AllKeyDescriptions);
 
 export interface ISettingsAccessor {
-  getSettingsFormData(categoryName: Category): ISettingsSubCategory[];
+  getSettingsFormData(categoryName: SettingsCategory): ISettingsSubCategory[];
   findSetting(
     settings: ISettingsSubCategory[],
     category: string,
@@ -657,7 +657,7 @@ export interface ISettingsAccessor {
     category: string,
     setting: string,
   ): TObsValue | undefined;
-  setSettings(categoryName: Category, settingsData: ISettingsSubCategory[]): void;
+  setSettings(categoryName: SettingsCategory, settingsData: ISettingsSubCategory[]): void;
 }
 
 /**
@@ -670,24 +670,24 @@ export class SettingsKeyAccessor {
     this.accessor = accessor;
   }
 
-  private categoryCache = new Map<Category, ISettingsSubCategory[]>();
-  private modifiedCategories = new Set<Category>();
+  private categoryCache = new Map<SettingsCategory, ISettingsSubCategory[]>();
+  private modifiedCategories = new Set<SettingsCategory>();
 
-  private getCategory(category: Category, reload: boolean = false): ISettingsSubCategory[] {
+  private getCategory(category: SettingsCategory, reload: boolean = false): ISettingsSubCategory[] {
     if (reload || !this.categoryCache.has(category)) {
       this.categoryCache.set(category, this.accessor.getSettingsFormData(category));
     }
     return this.categoryCache.get(category);
   }
 
-  private updateCategory(category: Category) {
+  private updateCategory(category: SettingsCategory) {
     if (this.categoryCache.has(category)) {
       console.log(`updateCategory: ${category}`);
       this.accessor.setSettings(category, this.getCategory(category));
     }
   }
 
-  writeBackCategory(category: Category) {
+  writeBackCategory(category: SettingsCategory) {
     if (this.modifiedCategories.has(category)) {
       this.updateCategory(category);
       this.modifiedCategories.delete(category);
@@ -701,7 +701,7 @@ export class SettingsKeyAccessor {
     this.modifiedCategories.clear();
   }
 
-  private forgetCategoryCache(category: Category) {
+  private forgetCategoryCache(category: SettingsCategory) {
     if (this.categoryCache.has(category)) {
       this.categoryCache.delete(category);
       if (this.modifiedCategories.has(category)) {
@@ -927,8 +927,8 @@ export class Optimizer {
   optimizeInfo(
     current: OptimizeSettings,
     optimized: OptimizeSettings,
-  ): [Category, OptimizeItem[]][] {
-    const map = new Map<Category, OptimizeItem[]>();
+  ): [SettingsCategory, OptimizeItem[]][] {
+    const map = new Map<SettingsCategory, OptimizeItem[]>();
     const merged = Object.assign({}, current, optimized);
     for (const keyDescription of iterateKeyDescriptions(merged, this.keyDescriptions)) {
       const opt = new OptKeyProperty(keyDescription);

--- a/app/services/settings/settings-api.ts
+++ b/app/services/settings/settings-api.ts
@@ -6,7 +6,7 @@ export interface ISettingsSubCategory {
   parameters: TObsFormData;
 }
 
-export type Category =
+export type SettingsCategory =
   | 'General'
   | 'Stream'
   | 'Output'
@@ -25,8 +25,8 @@ export type Category =
   | 'StreamSecond';
 
 export interface ISettingsServiceApi {
-  getCategories(): Category[];
-  getSettingsFormData(categoryName: Category): ISettingsSubCategory[];
-  setSettings(categoryName: Category, settingsData: ISettingsSubCategory[]): void;
-  showSettings(categoryName?: Category): void;
+  getCategories(): SettingsCategory[];
+  getSettingsFormData(categoryName: SettingsCategory): ISettingsSubCategory[];
+  setSettings(categoryName: SettingsCategory, settingsData: ISettingsSubCategory[]): void;
+  showSettings(categoryName?: SettingsCategory): void;
 }

--- a/app/services/settings/settings-api.ts
+++ b/app/services/settings/settings-api.ts
@@ -6,9 +6,27 @@ export interface ISettingsSubCategory {
   parameters: TObsFormData;
 }
 
+export type Category =
+  | 'General'
+  | 'Stream'
+  | 'Output'
+  | 'Audio'
+  | 'Video'
+  | 'Hotkeys'
+  | 'Advanced'
+  | 'Comment'
+  | 'SpeechEngine'
+  | 'Developer'
+  | 'Scene Collections'
+  | 'API'
+  | 'Notifications'
+  | 'Appearance'
+  | 'Experimental'
+  | 'StreamSecond';
+
 export interface ISettingsServiceApi {
-  getCategories(): string[];
-  getSettingsFormData(categoryName: string): ISettingsSubCategory[];
-  setSettings(categoryName: string, settingsData: ISettingsSubCategory[]): void;
-  showSettings(categoryName?: string): void;
+  getCategories(): Category[];
+  getSettingsFormData(categoryName: Category): ISettingsSubCategory[];
+  setSettings(categoryName: Category, settingsData: ISettingsSubCategory[]): void;
+  showSettings(categoryName?: Category): void;
 }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -31,7 +31,7 @@ import {
   Optimizer,
   SettingsKeyAccessor,
 } from './optimizer';
-import { Category, ISettingsServiceApi, ISettingsSubCategory } from './settings-api';
+import { ISettingsServiceApi, ISettingsSubCategory, SettingsCategory } from './settings-api';
 
 export interface ISettingsState {
   General: {
@@ -153,7 +153,7 @@ export class SettingsService
     }
   }
 
-  showSettings(categoryName?: Category) {
+  showSettings(categoryName?: SettingsCategory) {
     this.windowsService.showWindow({
       componentName: 'Settings',
       title: $t('common.settings'),
@@ -169,9 +169,9 @@ export class SettingsService
     return Utils.isDevMode() || this.appService.state.argv.includes('--adv-settings');
   }
 
-  getCategories(): Category[] {
-    const categories: Category[] = (
-      obs.NodeObs.OBS_settings_getListCategories() as Category[]
+  getCategories(): SettingsCategory[] {
+    const categories: SettingsCategory[] = (
+      obs.NodeObs.OBS_settings_getListCategories() as SettingsCategory[]
     ).filter(a => a !== 'StreamSecond'); // obs-studio-node 0.23.74で追加された分の非表示
 
     if (this.userService.isLoggedIn()) {
@@ -186,7 +186,7 @@ export class SettingsService
     return categories;
   }
 
-  getSettingsFormData(categoryName: Category): ISettingsSubCategory[] {
+  getSettingsFormData(categoryName: SettingsCategory): ISettingsSubCategory[] {
     let settings = obs.NodeObs.OBS_settings_getSettings(categoryName)
       .data as ISettingsSubCategory[];
     if (!settings) settings = [];
@@ -665,7 +665,7 @@ export class SettingsService
     return settingsFormData;
   }
 
-  setSettingValue(category: Category, name: string, value: TObsValue) {
+  setSettingValue(category: SettingsCategory, name: string, value: TObsValue) {
     const newSettings = this.patchSetting(this.getSettingsFormData(category), name, { value });
     this.setSettings(category, newSettings);
   }
@@ -752,7 +752,7 @@ export class SettingsService
     ];
   }
 
-  setSettings(categoryName: Category, settingsData: ISettingsSubCategory[]) {
+  setSettings(categoryName: SettingsCategory, settingsData: ISettingsSubCategory[]) {
     if (categoryName === 'Audio') this.setAudioSettings([settingsData.pop()]);
     if (categoryName === 'Developer') return this.setDeveloperSettings(settingsData);
 


### PR DESCRIPTION
# このpull requestが解決する内容
SettingsServiceのCategoryにどんな値があるのか一箇所にまとまっていなかったので、 settings-apiに型として定義してそれで制約をかけるようにしました。動作に変化はありません
