### PR TITLE
追加: 配信開始ボタンから番組作成

### DIFF
--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -36,6 +36,7 @@
   "recordTooltip": "Set path in Settings > Output.",
   "notBroadcasting": "There is no program",
   "notBroadcastingMessage": "There is no program to start streaming on. Make a program on niconico live service.",
+  "notBroadcastingCreateProgram": "Create a program",
   "broadcastStatusFetchingError": {
     "default": "Failed to get information on streaming server.  Please check your internet connection.",
     "httpError": "Failed to get information on streaming server. (%{requestURL}: %{statusText})"

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -36,6 +36,7 @@
   "recordTooltip": "設定 > 出力で録画パスを指定できます",
   "notBroadcasting": "番組が作成されていません",
   "notBroadcastingMessage": "N Airでログインしているアカウントでは番組が作成されていないため、配信ができません。ニコニコ生放送にて番組を作成してください。",
+  "notBroadcastingCreateProgram": "番組を作成する",
   "broadcastStatusFetchingError": {
     "default": "配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。",
     "httpError": "配信に必要な情報を取得できませんでした。（%{requestURL}: %{statusText}）"

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -239,7 +239,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       await this.fetchProgram();
       if (startStreaming) {
         if (this.streamingService.state.streamingStatus === EStreamingState.Offline) {
-          this.streamingService.toggleStreaming();
+          await this.streamingService.toggleStreamingAsync();
         }
       }
     }

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/vue';
 import { BehaviorSubject } from 'rxjs';
 import { Inject } from 'services/core/injector';
 import { mutation, StatefulService } from 'services/core/stateful-service';
+import { EStreamingState, StreamingService } from 'services/streaming';
 import { UserService } from 'services/user';
 import { isFakeMode } from 'util/fakeMode';
 import { MAX_PROGRAM_DURATION_SECONDS } from './nicolive-constants';
@@ -9,8 +10,10 @@ import {
   calcServerClockOffsetSec,
   CreateResult,
   EditResult,
+  FailedResult,
   isOk,
   NicoliveClient,
+  WrappedResult,
 } from './NicoliveClient';
 import { NicoliveFailure, openErrorDialogFromFailure } from './NicoliveFailure';
 import { OneCommeRelation } from './OneCommeRelation';
@@ -66,8 +69,8 @@ export enum PanelState {
 
 export class NicoliveProgramService extends StatefulService<INicoliveProgramState> {
   @Inject('NicoliveProgramStateService') private stateService: NicoliveProgramStateService;
-  @Inject()
-  userService: UserService;
+  @Inject() userService: UserService;
+  @Inject() private streamingService: StreamingService;
 
   private stateChangeSubject = new BehaviorSubject(this.state);
   stateChange = this.stateChangeSubject.asObservable();
@@ -226,7 +229,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     }
   }
 
-  async createProgram(): Promise<CreateResult> {
+  async createProgram(startStreaming = false): Promise<CreateResult> {
     if (isFakeMode()) {
       await this.fetchProgram();
       return CreateResult.CREATED;
@@ -234,6 +237,11 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     const result = await this.client.createProgram();
     if (result === 'CREATED') {
       await this.fetchProgram();
+      if (startStreaming) {
+        if (this.streamingService.state.streamingStatus === EStreamingState.Offline) {
+          this.streamingService.toggleStreaming();
+        }
+      }
     }
     return result;
   }
@@ -447,9 +455,9 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     }
   }
 
-  updateStatistics(programID: string): Promise<any> {
+  updateStatistics(programID: string): Promise<WrappedResult<any>[]> {
     if (isFakeMode()) {
-      return Promise.resolve();
+      return Promise.resolve([]);
     }
     const stats = this.client
       .fetchStatistics(programID)
@@ -459,9 +467,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
             viewers: res.value.watchCount,
             comments: res.value.commentCount,
           });
+          return res;
         }
       })
-      .catch(() => null);
+      .catch((): FailedResult => null);
     const adStats = this.client
       .fetchNicoadStatistics(programID)
       .then(res => {
@@ -471,8 +480,9 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
             giftPoint: res.value.totalGiftPoint,
           });
         }
+        return res;
       })
-      .catch(() => null);
+      .catch((): FailedResult => null);
 
     // return for testing
     return Promise.all([stats, adStats]);

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -222,7 +222,6 @@ export class StreamingService
 
           // 配信可能チャンネルがなく、配信できるユーザー生放送もない場合
           if (!broadcastableUserProgram.programId && !broadcastableUserProgram.nextProgramId) {
-            // TODO ここでユーザーに確認して、番組を作成するならそちらに誘導する
             return this.showNotBroadcastingMessageBoxForNicolive();
           }
         }

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -145,21 +145,22 @@ export class StreamingService
     this.toggleStreaming();
   }
 
-  private async showNotBroadcastingMessageBox() {
+  private async showNotBroadcastingMessageBoxForNicolive() {
     Sentry.addBreadcrumb({
       category: 'streaming',
       message: 'showNotBroadcastingMessageBox',
     });
-    return new Promise(resolve => {
-      remote.dialog
-        .showMessageBox(remote.getCurrentWindow(), {
-          title: $t('streaming.notBroadcasting'),
-          type: 'warning',
-          message: $t('streaming.notBroadcastingMessage'),
-          buttons: ['Close'],
-        })
-        .then(({ response: done }) => resolve(done));
+    const { response } = await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
+      title: $t('streaming.notBroadcasting'),
+      type: 'warning',
+      message: $t('streaming.notBroadcastingMessage'),
+      noLink: true,
+      buttons: [$t('streaming.notBroadcastingCreateProgram'), 'Close'],
     });
+    if (response === 0) {
+      await this.nicoliveProgramService.createProgram(true);
+    }
+    return response;
   }
 
   /**
@@ -221,7 +222,8 @@ export class StreamingService
 
           // 配信可能チャンネルがなく、配信できるユーザー生放送もない場合
           if (!broadcastableUserProgram.programId && !broadcastableUserProgram.nextProgramId) {
-            return this.showNotBroadcastingMessageBox();
+            // TODO ここでユーザーに確認して、番組を作成するならそちらに誘導する
+            return this.showNotBroadcastingMessageBoxForNicolive();
           }
         }
 
@@ -236,13 +238,13 @@ export class StreamingService
 
         // 配信番組選択ウィンドウでユーザー番組を選んだが、配信可能なユーザー番組がない場合
         if (!programId) {
-          return this.showNotBroadcastingMessageBox();
+          return this.showNotBroadcastingMessageBoxForNicolive();
         }
 
         const setting = await this.userService.updateStreamSettings(programId);
         const streamKey = setting.key;
         if (streamKey === '') {
-          return this.showNotBroadcastingMessageBox();
+          return this.showNotBroadcastingMessageBoxForNicolive();
         }
 
         // [番組情報を取得]してニコ生パネルを更新する


### PR DESCRIPTION
# このpull requestが解決する内容
ニコ生ログイン中で、番組を作成してない状態で `配信開始` を押した時は、番組を作成するよう案内を出すダイアログを出すだけで、一旦自分で番組作成ボタンを押し直さないといけませんでした。
この修正では、このダイアログに `番組を作成する` ボタンを追加します。
![image](https://github.com/user-attachments/assets/0702409e-8b9b-41d8-b579-a3d008db3026)
これを押した場合、番組作成画面を開き、作成完了したら同時にテスト配信も開始します。

- [x] ダイアログをなくして直接番組作成に遷移することを検討
  - 今回はこのまま出す

# 動作確認手順
1. ニコ生ログイン済み、番組のない状態で `配信開始` を押す
2. `番組を作成する` を押すと作成され、すぐテスト配信も始まる

# 関連するIssue（あれば）
#883 