### PR TITLE
追加: ドラッグ操作によるコントロールの高さ調整機能

### DIFF
--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -14,7 +14,11 @@
       >
         <i class="icon-drop-down-arrow"></i>
       </button>
-      <div v-if="opened" class="drag-handle" @mousedown="onDragStart"></div>
+      <div v-if="opened" class="drag-handle" @mousedown="onDragStart">
+        <svg viewBox="0 0 24 24">
+          <path d="M1 10h22M1 14h22" />
+        </svg>
+      </div>
     </div>
     <template v-if="isCompactMode">
       <div class="studio-controls-compact">
@@ -178,23 +182,8 @@
   height: @toggle-button-size;
   cursor: ns-resize;
 
-  &::before,
-  &::after {
-    position: absolute;
-    left: 0;
-    width: 100%;
-    height: 2px;
-    content: '';
-    background-color: var(--color-text);
-    opacity: 0.5;
-  }
-
-  &::before {
-    top: calc(50% - 3px);
-  }
-
-  &::after {
-    top: calc(50% + 3px);
+  svg {
+    stroke: var(--color-text);
   }
 }
 </style>

--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -1,13 +1,21 @@
 <template>
-  <div class="studio-controls row expanded" :class="{ opened: opened || isCompactMode }">
-    <button
-      @click="onToggleControls"
-      class="studio-controls-toggle-button"
-      :class="{ 'studio-controls--opened': opened }"
-      v-if="!isCompactMode"
-    >
-      <i class="icon-drop-down-arrow"></i>
-    </button>
+  <div
+    class="studio-controls row expanded"
+    :class="{
+      opened: opened || isCompactMode,
+    }"
+    :style="opened ? { height: `${currentHeight}px` } : {}"
+  >
+    <div class="studio-controls-header" v-if="!isCompactMode">
+      <button
+        @click="onToggleControls"
+        class="studio-controls-toggle-button"
+        :class="{ 'studio-controls--opened': opened }"
+      >
+        <i class="icon-drop-down-arrow"></i>
+      </button>
+      <div v-if="opened" class="drag-handle" @mousedown="onDragStart"></div>
+    </div>
     <template v-if="isCompactMode">
       <div class="studio-controls-compact">
         <div class="studio-controls-tabs">
@@ -63,32 +71,9 @@
     width: @nicolive-area-width;
     padding-top: 0;
   }
-}
 
-.studio-controls-toggle-button {
-  position: absolute;
-  right: 0;
-  left: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 180px;
-  height: @toggle-button-size;
-  margin: -@toggle-button-size auto 0 auto;
-
-  > i {
-    .icon-hover;
-
-    display: block;
-    font-size: @font-size2;
-    color: var(--color-text);
-    transform: rotate(-180deg);
-  }
-
-  .opened & {
-    i {
-      transform: rotate(0deg);
-    }
+  &.draggable {
+    cursor: ns-resize;
   }
 }
 </style>
@@ -149,5 +134,67 @@
   overflow-y: auto;
   background: var(--color-bg-tertiary);
   .radius;
+}
+
+.studio-controls-header {
+  top: 0;
+  right: 0;
+  // position: absolute;
+  left: 0;
+  display: flex;
+  align-items: center;
+  margin-top: -@toggle-button-size;
+  margin-bottom: 16px;
+}
+
+.studio-controls-toggle-button {
+  position: relative;
+  width: 24px;
+  height: @toggle-button-size;
+  margin-left: 8px;
+
+  > i {
+    .icon-hover;
+
+    display: block;
+    font-size: @font-size2;
+    color: var(--color-text);
+    transform: rotate(-180deg);
+  }
+
+  .opened & {
+    i {
+      transform: rotate(0deg);
+    }
+  }
+}
+
+.drag-handle {
+  position: absolute;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  width: 24px;
+  height: @toggle-button-size;
+  cursor: ns-resize;
+
+  &::before,
+  &::after {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    content: '';
+    background-color: var(--color-text);
+    opacity: 0.5;
+  }
+
+  &::before {
+    top: calc(50% - 3px);
+  }
+
+  &::after {
+    top: calc(50% + 3px);
+  }
 }
 </style>

--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -76,8 +76,26 @@
     padding-top: 0;
   }
 
-  &.draggable {
-    cursor: ns-resize;
+  .studio-controls-toggle-button {
+    position: relative;
+    width: 24px;
+    height: @toggle-button-size;
+    margin-left: 8px;
+
+    > i {
+      .icon-hover;
+
+      display: block;
+      font-size: @font-size2;
+      color: var(--color-text);
+      transform: rotate(-180deg);
+    }
+
+    .opened & {
+      i {
+        transform: rotate(0deg);
+      }
+    }
   }
 }
 </style>
@@ -143,34 +161,11 @@
 .studio-controls-header {
   top: 0;
   right: 0;
-  // position: absolute;
   left: 0;
   display: flex;
   align-items: center;
   margin-top: -@toggle-button-size;
   margin-bottom: 16px;
-}
-
-.studio-controls-toggle-button {
-  position: relative;
-  width: 24px;
-  height: @toggle-button-size;
-  margin-left: 8px;
-
-  > i {
-    .icon-hover;
-
-    display: block;
-    font-size: @font-size2;
-    color: var(--color-text);
-    transform: rotate(-180deg);
-  }
-
-  .opened & {
-    i {
-      transform: rotate(0deg);
-    }
-  }
 }
 
 .drag-handle {

--- a/app/components/StudioControls.vue.ts
+++ b/app/components/StudioControls.vue.ts
@@ -44,16 +44,18 @@ export default class StudioControls extends Vue {
   }
 
   //-------------------------------------------------
+  // ドラッグ操作によるコントロール高さ変更
   private isDragging = false;
   private startY = 0;
-  currentHeight = 240;
+  currentHeight = CustomizationService.defaultState.studioControlsHeight;
 
   mounted() {
-    this.currentHeight = this.rangeHeight(this.customizationService.state.studioControlsHeight);
+    this.currentHeight = this.clampHeight(this.customizationService.state.studioControlsHeight);
   }
 
-  rangeHeight(h: number) {
-    const minHeight = 100;
+  clampHeight(h: number) {
+    if (h <= 0) return CustomizationService.defaultState.studioControlsHeight; // default height
+    const minHeight = 40;
     const maxHeight = window.innerHeight - 200;
     return Math.min(maxHeight, Math.max(minHeight, h));
   }
@@ -68,7 +70,7 @@ export default class StudioControls extends Vue {
   onDrag(e: MouseEvent) {
     if (!this.isDragging) return;
     const deltaY = this.startY - e.clientY;
-    this.currentHeight = this.rangeHeight(this.currentHeight + deltaY);
+    this.currentHeight = this.clampHeight(this.currentHeight + deltaY);
     this.startY = e.clientY;
   }
 

--- a/app/components/StudioControls.vue.ts
+++ b/app/components/StudioControls.vue.ts
@@ -42,4 +42,40 @@ export default class StudioControls extends Vue {
   onToggleControls() {
     this.customizationService.toggleStudioControls();
   }
+
+  //-------------------------------------------------
+  private isDragging = false;
+  private startY = 0;
+  currentHeight = 240;
+
+  mounted() {
+    this.currentHeight = this.rangeHeight(this.customizationService.state.studioControlsHeight);
+  }
+
+  rangeHeight(h: number) {
+    const minHeight = 100;
+    const maxHeight = window.innerHeight - 200;
+    return Math.min(maxHeight, Math.max(minHeight, h));
+  }
+
+  onDragStart(e: MouseEvent) {
+    this.isDragging = true;
+    this.startY = e.clientY;
+    document.addEventListener('mousemove', this.onDrag);
+    document.addEventListener('mouseup', this.onDragEnd);
+  }
+
+  onDrag(e: MouseEvent) {
+    if (!this.isDragging) return;
+    const deltaY = this.startY - e.clientY;
+    this.currentHeight = this.rangeHeight(this.currentHeight + deltaY);
+    this.startY = e.clientY;
+  }
+
+  onDragEnd() {
+    this.isDragging = false;
+    document.removeEventListener('mousemove', this.onDrag);
+    document.removeEventListener('mouseup', this.onDragEnd);
+    this.customizationService.setStudioControlsHeight(this.currentHeight);
+  }
 }

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -25,6 +25,7 @@ export interface ICustomizationServiceState {
   showAutoCompactDialog: boolean;
   compactAlwaysOnTop: boolean;
   experimental: any;
+  studioControlsHeight: number;
 }
 
 export interface ICustomizationSettings extends ICustomizationServiceState {}

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -41,6 +41,7 @@ export class CustomizationService
     showAutoCompactDialog: true,
     compactAlwaysOnTop: false,
 
+    studioControlsHeight: 240,
     experimental: {
       // put experimental features here
     },
@@ -172,6 +173,13 @@ export class CustomizationService
 
   restoreDefaults() {
     this.setSettings(CustomizationService.defaultState);
+  }
+
+  getStudioControlsHeight(): number {
+    return this.state.studioControlsHeight;
+  }
+  setStudioControlsHeight(height: number) {
+    this.setSettings({ studioControlsHeight: height });
   }
 
   @mutation()


### PR DESCRIPTION
# このpull requestが解決する内容

ドラッグ操作によるコントロールの高さ調整機能を追加

# 動作確認手順

- 画面中央にあるドラッグバーにてコントロールの高さ変更ができます
- 従来のopen/closeは左端にあります


# 関連するIssue（あれば）

resolve https://github.com/n-air-app/n-air-app/issues/110


https://github.com/user-attachments/assets/73b2e595-755e-4146-bfa3-62c95cac6ddb


