### PR TITLE
開発: ndgrのSimpleNotificationV2 に対応

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,7 @@
     "stylelint",
     "superfast",
     "systeminformation",
+    "Telop",
     "toplevel",
     "typedoc",
     "ultrafast",

--- a/app/services/nicolive-program/ChatMessage.ts
+++ b/app/services/nicolive-program/ChatMessage.ts
@@ -35,12 +35,16 @@ export const NotificationTypeTable = [
   'rankingIn',
   'rankingUpdated',
   'visited',
+  'supporterRegistered',
+  'userLevelUp',
 ] as const;
 
 export type NotificationType = (typeof NotificationTypeTable)[number] | 'unknown';
 export type NotificationMessage = DateComponent & {
   type: NotificationType;
   message: string;
+  showInTelop?: boolean;
+  showInList?: boolean;
 };
 
 export type GiftMessage = DateComponent & {

--- a/app/services/nicolive-program/ChatMessage/classifier.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.ts
@@ -39,6 +39,10 @@ export function classify(chat: MessageResponse) {
         return 'info' as const;
       case 'visited':
         return 'info' as const;
+      case 'supporterRegistered':
+        return 'info' as const;
+      case 'userLevelUp':
+        return 'info' as const;
       case 'unknown':
         return 'system' as const;
     }

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -145,6 +145,39 @@ function convertSimpleNotificationToMessageResponse(
   };
 }
 
+function convertSimpleNotificationV2ToMessageResponse(
+  common: CommonComponent,
+  notification: dwango.nicolive.chat.data.atoms.ISimpleNotificationV2,
+): MessageResponse | undefined {
+  const types = {
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.UNKNOWN]: 'unknown',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.ICHIBA]: 'ichiba',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.EMOTION]: 'emotion',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.CRUISE]: 'cruise',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.PROGRAM_EXTENDED]:
+      'programExtended',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.RANKING_IN]: 'rankingIn',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.VISITED]: 'visited',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.SUPPORTER_REGISTERED]:
+      'supporterRegistered',
+    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.USER_LEVEL_UP]:
+      'userLevelUp',
+  } as const;
+  let type: NotificationType = 'unknown';
+  if (notification.type in types) {
+    type = types[notification.type as keyof typeof types] as NotificationType;
+  }
+  return {
+    notification: {
+      ...common,
+      type,
+      message: notification.message,
+      showInList: notification.showInList,
+      showInTelop: notification.showInTelop,
+    },
+  };
+}
+
 function convertGiftToMessageResponse(
   common: CommonComponent,
   gift: dwango.nicolive.chat.data.IGift,
@@ -280,6 +313,8 @@ export function convertChunkedResponseToMessageResponse(
   if (msg.message) {
     if (msg.message.chat) {
       return convertChatToMessageResponse(common, msg.message.chat, msg.meta?.id);
+    } else if (msg.message.simpleNotificationV2) {
+      return convertSimpleNotificationV2ToMessageResponse(common, msg.message.simpleNotificationV2);
     } else if (msg.message.simpleNotification) {
       return convertSimpleNotificationToMessageResponse(common, msg.message.simpleNotification);
     } else if (msg.message.gift) {

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -313,22 +313,28 @@ export function convertChunkedResponseToMessageResponse(
   if (msg.message) {
     if (msg.message.chat) {
       return convertChatToMessageResponse(common, msg.message.chat, msg.meta?.id);
-    } else if (msg.message.simpleNotificationV2) {
+    }
+    if (msg.message.simpleNotificationV2) {
       return convertSimpleNotificationV2ToMessageResponse(common, msg.message.simpleNotificationV2);
-    } else if (msg.message.simpleNotification) {
+    }
+    if (msg.message.simpleNotification) {
       return convertSimpleNotificationToMessageResponse(common, msg.message.simpleNotification);
-    } else if (msg.message.gift) {
+    }
+    if (msg.message.gift) {
       return convertGiftToMessageResponse(common, msg.message.gift);
-    } else if (msg.message.nicoad) {
+    }
+    if (msg.message.nicoad) {
       return convertNicoadToMessageResponse(common, msg.message.nicoad);
-    } else if (msg.message.gameUpdate) {
+    }
+    if (msg.message.gameUpdate) {
       return convertGameUpdateToMessageResponse(common, msg.message.gameUpdate);
     }
   } else if (msg.state) {
     if (msg.state.marquee) {
       // 運コメ(放送者コメント)
       return convertMarqueeToMessageResponse(common, msg.state.marquee);
-    } else if (msg.state.programStatus) {
+    }
+    if (msg.state.programStatus) {
       return convertProgramStatusToMessageResponse(common, msg.state.programStatus);
     }
   } else if (msg.signal !== undefined) {

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -469,6 +469,7 @@ test('モデレーターによるSSNG追加・削除がきたらシステムメ�
           userId: parseInt(MODERATOR_ID, 10),
           userName: 'test',
         },
+        byModerator: true,
       },
       message: 'test さんがコメントのブロックを取り消しました',
     },

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -231,7 +231,10 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
 
           case 'removeSSNG':
             // 放送者自身が削除したときはすでにキャッシュも更新されているし通知も不要
-            if (!this.nicoliveCommentFilterService.isBroadcastersFilter(event.record)) {
+            if (
+              event.byModerator ||
+              !this.nicoliveCommentFilterService.isBroadcastersFilter(event.record)
+            ) {
               const { ssngId, userName, userId } = event.record;
               const record = this.nicoliveCommentFilterService.findFilterCache(ssngId);
 

--- a/app/services/nicolive-program/nicolive-moderators.test.ts
+++ b/app/services/nicolive-program/nicolive-moderators.test.ts
@@ -229,6 +229,7 @@ describe('connectModeratorStream', () => {
           userName: 'test',
           userId: 123,
         },
+        byModerator: false,
       },
     ],
   ])(`should notify on refreshObserver on %s`, async (_, ssngUpdated, event) => {

--- a/app/services/nicolive-program/nicolive-moderators.ts
+++ b/app/services/nicolive-program/nicolive-moderators.ts
@@ -36,7 +36,11 @@ export class NicoliveModeratorsService extends StatefulService<INicoliveModerato
   stateChange = this.stateChangeSubject.asObservable();
   private refreshSubject = new Subject<
     | { event: 'addSSNG'; record: FilterRecord }
-    | { event: 'removeSSNG'; record: { ssngId: number; userId?: number; userName?: string } }
+    | {
+        event: 'removeSSNG';
+        record: { ssngId: number; userId?: number; userName?: string };
+        byModerator: boolean;
+      }
   >();
   refreshObserver = this.refreshSubject.asObservable();
 
@@ -161,10 +165,14 @@ export class NicoliveModeratorsService extends StatefulService<INicoliveModerato
                 const userId = ssngUpdated.operator?.userId
                   ? toNumber(ssngUpdated.operator.userId)
                   : undefined;
+                const byModerator =
+                  ssngUpdated.operatorType ===
+                  dwango.nicolive.chat.data.atoms.SSNGUpdated.SSNGOperatorType.MODERATOR;
                 if (ssngId) {
                   this.refreshSubject.next({
                     event: 'removeSSNG',
                     record: { ssngId, userName, userId },
+                    byModerator,
                   });
                 }
               }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@electron/remote": "2.1.2",
     "@n-air-app/n-voice-package": "^1.0.2",
-    "@n-air-app/nicolive-comment-protobuf": "2024.801.103927",
+    "@n-air-app/nicolive-comment-protobuf": "2025.602.163750",
     "@sentry/electron": "6.6.0",
     "@sentry/vue": "9.18.0",
     "archiver": "^5.3.1",
@@ -107,7 +107,7 @@
     "obs-studio-node": "https://github.com/n-air-app/native-deps/releases/download/assets/osn-0.24.38-release-win64_rtvc1.tar.gz",
     "postcss-loader": "4.3.0",
     "progress": "~2.0.3",
-    "protobufjs": "^7.3.2",
+    "protobufjs": "^7.5.3",
     "recursive-readdir": "~2.2.3",
     "reflect-metadata": "~0.1.13",
     "rimraf": "~2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,12 +1729,12 @@
     rollup-plugin-typescript2 "^0.34.1"
     typescript "^4.9.5"
 
-"@n-air-app/nicolive-comment-protobuf@2024.801.103927":
-  version "2024.801.103927"
-  resolved "https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2024.801.103927/d7f86b60c812cbeb5f84a8ea4ade0344ddfc1183#d7f86b60c812cbeb5f84a8ea4ade0344ddfc1183"
-  integrity sha512-YHxejvH/dYsuGxV2dbbLrduXhvb32fUEEYm8vX9eN1Q1TqR9GVLaeCuNzIkSmRfW+IZBCfLOGixT98Xw2P+vnA==
+"@n-air-app/nicolive-comment-protobuf@2025.602.163750":
+  version "2025.602.163750"
+  resolved "https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2025.602.163750/275fa685d0bf4f3c1b30a8d3d2e1357036fbf025#275fa685d0bf4f3c1b30a8d3d2e1357036fbf025"
+  integrity sha512-cuvpxDmO6Fm1pjcchLtlBaqVLGEZo2Eszi6IKbQpTh1+b8kXD5JBMPc7sHtLIdj7JljICAa9RZFR8YRl8/URtg==
   dependencies:
-    protobufjs "^7.3.2"
+    protobufjs "^7.5.3"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -10889,10 +10889,10 @@ property-expr@^1.5.0:
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
   integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
 
-protobufjs@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
-  integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==
+protobufjs@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.3.tgz#13f95a9e3c84669995ec3652db2ac2fb00b89363"
+  integrity sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
# このpull requestが解決する内容
Ndgrのメッセージのバージョンを更新し、以下の更新に対応します
- ニコ生のシステムメッセージのうち、 `SimpleNotification` から `SimpleNotificationV2` への切り替え
- `UpdateSSNG` の `operatorType` 

依存モジュール更新
|module|before|after|
|----|----|----|
| `@n-air-app/nicolive-comment-protobuf` | `2024.801.103927` | `2025.602.163750` |
| `protobufjs` | `^7.3.2` | `^7.5.3` |

# TODO
- [x] SimpleNotificationV2動作確認
- [ ] UpdateSSNG opratorType動作確認

# 動作確認手順

# 関連するIssue（あれば）
