### PR TITLE
改善: シーンコレクション・ソースの削除ボタンなどを各アイテム右に移動

### DIFF
--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -28,7 +28,6 @@
 
       <div class="studio-controls-top-sidebar">
         <i class="icon-add icon-btn" @click="addScene" data-test="Add" />
-        <i class="icon-delete icon-btn" @click="removeScene" data-test="Remove" />
         <i class="icon-settings icon-btn" @click="showTransitions" data-test="Edit" />
       </div>
     </div>
@@ -40,7 +39,15 @@
       @select="makeActive"
       @sort="handleSort"
       @contextmenu="showContextMenu"
-    />
+    >
+      <template slot="actions" slot-scope="p">
+        <i
+          class="icon-delete icon-btn"
+          @click="removeScene(p.item.value)"
+          :data-test="'Remove' + p.item.name"
+        />
+      </template>
+    </selector>
 
     <help-tip :dismissable-key="helpTipDismissable">
       <div slot="title" v-text="$t('scenes.sceneCollections')"></div>

--- a/app/components/SceneSelector.vue.ts
+++ b/app/components/SceneSelector.vue.ts
@@ -76,7 +76,8 @@ export default class SceneSelector extends Vue {
     this.scenesService.showNameScene();
   }
 
-  removeScene() {
+  removeScene(id?: string) {
+    this.makeActive(id || this.activeSceneId);
     const name = this.scenesService.activeScene.name;
     remote.dialog
       .showMessageBox(remote.getCurrentWindow(), {

--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -17,20 +17,6 @@
           v-tooltip.bottom="addSourceTooltip"
           data-test="Add"
         />
-        <i
-          class="icon-delete icon-btn"
-          :class="{ disabled: activeItemIds.length === 0 }"
-          @click="removeItems"
-          v-tooltip.bottom="removeSourcesTooltip"
-          data-test="Remove"
-        />
-        <i
-          :class="{ disabled: !canShowProperties() }"
-          class="icon-settings icon-btn"
-          @click="sourceProperties"
-          v-tooltip.bottom="openSourcePropertiesTooltip"
-          data-test="Edit"
-        />
       </div>
     </div>
 
@@ -74,6 +60,18 @@
           :class="visibilityClassesForSource(node.data.id)"
           @click.stop="toggleVisibility(node.data.id)"
           @dblclick.stop="() => {}"
+        />
+        <i
+          class="source-selector-action icon-delete"
+          @click="removeItems"
+          v-tooltip.bottom="removeSourcesTooltip"
+          :data-test="`Remove` + node.title"
+        />
+        <i
+          class="source-selector-action icon-delete icon-settings"
+          @click="sourceProperties"
+          v-tooltip.bottom="openSourcePropertiesTooltip"
+          data-test="Edit"
         />
       </template>
     </sl-vue-tree>

--- a/test/e2e/mixer.ts
+++ b/test/e2e/mixer.ts
@@ -21,7 +21,7 @@ test('Adding and removing a AudioSource', async t => {
   t.false(await client.$('.mixer-panel').$('div=Source Without Audio').isExisting());
 
   await selectSource('Source With Audio');
-  await clickRemoveSource();
+  await clickRemoveSource('Source With Audio');
 
   await client
     .$('.mixer-panel')

--- a/test/e2e/rtvc.ts
+++ b/test/e2e/rtvc.ts
@@ -25,7 +25,7 @@ test('rtvc Adding and removing source', async t => {
   t.true(await sourceIsExisting(sourceName));
 
   await selectSource(sourceName);
-  await clickRemoveSource();
+  await clickRemoveSource(sourceName);
 
   await waitForSourceExist(sourceName, true);
 });

--- a/test/e2e/scenes.ts
+++ b/test/e2e/scenes.ts
@@ -43,7 +43,7 @@ test('Adding and removing a scene', async (t: TExecutionContext) => {
 
   await selectScene(sceneName);
   await checkDefaultSources();
-  await clickRemoveScene();
+  await clickRemoveScene(sceneName);
 
   t.false(await sceneIsExisting(sceneName));
 });

--- a/test/e2e/sources.ts
+++ b/test/e2e/sources.ts
@@ -37,7 +37,7 @@ test('Adding and removing some sources', async t => {
     t.true(await sourceIsExisting(sourceName));
 
     await selectSource(sourceName);
-    await clickRemoveSource();
+    await clickRemoveSource(sourceName);
 
     await waitForSourceExist(sourceName, true);
   }

--- a/test/helpers/modules/scenes.ts
+++ b/test/helpers/modules/scenes.ts
@@ -14,8 +14,8 @@ export async function clickAddScene() {
   await clickSceneAction('[data-test="Add"]');
 }
 
-export async function clickRemoveScene() {
-  await clickSceneAction('[data-test="Remove"]');
+export async function clickRemoveScene(name?: string) {
+  await clickSceneAction(`[data-test="Remove${name || ''}"]`);
   await dialogDismiss('OK');
 }
 

--- a/test/helpers/modules/sources.ts
+++ b/test/helpers/modules/sources.ts
@@ -13,8 +13,8 @@ export async function clickAddSource() {
   await clickSourceAction('[data-test="Add"]');
 }
 
-export async function clickRemoveSource() {
-  await clickSourceAction('[data-test="Remove"]');
+export async function clickRemoveSource(name?: string) {
+  await clickSourceAction(`[data-test="Remove${name || ''}"]`);
   await dialogDismiss('OK');
 }
 


### PR DESCRIPTION
# このpull requestが解決する内容

シーンコレクションの削除ボタンおよびソースの削除ボタン・設定ボタンを
各データの横に移動します


# 動作確認手順

移動したそれぞのボタンが動作する

# 関連するIssue（あれば）
before
<img width="789" alt="Monosnap mogador 2025-06-26 14-11-23" src="https://github.com/user-attachments/assets/36622504-0310-4696-99ee-d7f9b89ae398" />

after
<img width="709" alt="Monosnap mogador 2025-06-26 14-12-55" src="https://github.com/user-attachments/assets/f8c23de3-8628-42ef-9ddd-2f78f841b0d8" />
