### PR TITLE
修正: 自動コンパクトモードonでコンパクトモードで終了すると、次回起動時にサイズと位置が通常モードとコンパクトモードで入れ変わってしまっていた

### DIFF
--- a/app/services/compact-mode.ts
+++ b/app/services/compact-mode.ts
@@ -10,12 +10,14 @@ import { NavigationService } from './navigation';
 import { StreamingService } from './streaming';
 import { UserService } from './user';
 import Utils from './utils';
+import { WindowSizeService } from './window-size';
 import { WindowsService } from './windows';
 
 export interface ICompactModeServiceState {
   streaming: boolean;
   autoCompactMode: boolean;
-  navigating: boolean; // true if studio screen is onboarding or patch-note
+  /** true if studio screen is onboarding or patch-note */
+  navigating: boolean;
 }
 
 function shouldBeCompact(state: ICompactModeServiceState): boolean {
@@ -28,6 +30,7 @@ export class CompactModeService extends StatefulService<ICompactModeServiceState
   @Inject() streamingService: StreamingService;
   @Inject() windowsService: WindowsService;
   @Inject() navigationService: NavigationService;
+  @Inject() private windowSizeService: WindowSizeService;
 
   static defaultState: ICompactModeServiceState = {
     streaming: false,
@@ -38,7 +41,6 @@ export class CompactModeService extends StatefulService<ICompactModeServiceState
   init(): void {
     super.init();
     this.setState({
-      autoCompactMode: this.customizationService.state.autoCompactMode,
       streaming: this.streamingService.state.streamingStatus !== 'offline',
       navigating: this.navigationService.state.currentPage !== 'Studio',
     });
@@ -52,6 +54,13 @@ export class CompactModeService extends StatefulService<ICompactModeServiceState
     });
     this.navigationService.navigated.subscribe(state => {
       this.setState({ navigating: state.currentPage !== 'Studio' });
+    });
+
+    // WindowSizeServiceの初期化が完了したら、autoCompactModeを設定する
+    this.windowSizeService.waitReady().then(() => {
+      this.setState({
+        autoCompactMode: this.customizationService.state.autoCompactMode,
+      });
     });
   }
 


### PR DESCRIPTION
# このpull requestが解決する内容

* WindowSizeServiceに必要なデータが揃うまで autoCompactModeを有効にしないようにすることで、前回終了時の状態を1回安定化してからautoCompactModeの判定が入るようにしました。
* あと、 window-size.test.ts をTypeScriptの型がちゃんと反映するよう調整しました

# 動作確認手順
1. `設定` - `一般` - `コンパクトモード` - `配信中に自動でコンパクトモードに切り替える` をonにしておく
2. コンパクトモードにする
3. 通常時のウィンドウの位置から移動する
4. N Airを終了
5. N Airを起動すると、コンパクトモードの位置で通常サイズのウィンドウになってしまい、コンパクトモードにするとその逆になってしまっていた

# 関連するIssue（あれば）
fix #931