### PR TITLE
改善: ソースセレクターの各アイテムの表示/非表示アイコン、非表示時の状態を改善

### DIFF
--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -68,7 +68,7 @@
           :data-test="`Remove` + node.title"
         />
         <i
-          class="source-selector-action icon-delete icon-settings"
+          class="source-selector-action icon-settings"
           @click="sourceProperties"
           v-tooltip.bottom="openSourcePropertiesTooltip"
           data-test="Edit"
@@ -181,14 +181,15 @@
     color: var(--color-text-light);
     opacity: 1;
   }
-}
 
-i.disabled {
-  cursor: inherit;
-  opacity: @opacity-disabled;
+  &.keep-on {
+    color: var(--color-text-light);
+    opacity: 1;
 
-  :hover {
-    opacity: inherit;
+    .sl-vue-tree-node-item:hover & {
+      color: var(--color-text-light);
+      opacity: 1;
+    }
   }
 }
 

--- a/app/components/SourceSelector.vue.ts
+++ b/app/components/SourceSelector.vue.ts
@@ -192,11 +192,7 @@ export default class SourceSelector extends Vue {
   visibilityClassesForSource(sceneNodeId: string) {
     const selection = this.scene.getSelection(sceneNodeId);
     const visible = selection.isVisible();
-
-    return {
-      'icon-unhide': visible,
-      'icon-hide': !visible,
-    };
+    return visible ? 'icon-unhide' : 'keep-on icon-hide';
   }
 
   lockClassesForSource(sceneNodeId: string) {


### PR DESCRIPTION
# このpull requestが解決する内容

ソースセレクターで表示/非表示のアイコンを非表示時には常時点灯にして、
非表示になっているのをわかりやすくする

# 動作確認手順

各アイテムをの表示をon/offする

# 関連するIssue（あれば）

<img width="359" alt="Monosnap mogador 2025-07-01 14-30-27" src="https://github.com/user-attachments/assets/733e5c12-e1f7-44ee-9ac2-9a8414ddea33" />
