### PR TITLE
改善: 日本語・英語以外の言語データを削除してインストールサイズを削減

### DIFF
--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+const fs = require('fs');
+const path = require('path');
+
 /** @type {import('electron-builder').Configuration} */
 const config = {
   appId: 'jp.nicovideo.nair',
@@ -18,6 +21,18 @@ const config = {
   ],
   extraFiles: ['scene-presets', 'nvoice', 'LICENSE', 'AGREEMENT.sjis'],
   detectUpdateChannel: false,
+  afterPack: async context => {
+    const localesDir = path.join(context.appOutDir, 'locales');
+    if (fs.existsSync(localesDir)) {
+      const files = fs.readdirSync(localesDir);
+      files.forEach(file => {
+        if (file !== 'en-US.pak' && file !== 'ja.pak') {
+          fs.unlinkSync(path.join(localesDir, file));
+        }
+      });
+      console.log('remove unnecessary locales files');
+    }
+  },
   publish: {
     provider: 'generic',
     useMultipleRangeRequest: false,


### PR DESCRIPTION
# このpull requestが解決する内容

packageにおいて不要なローカライズファイルを削除する処理を実装
パッケージ段階 6.6MBほどの減少
展開後 36MBほどの減少

electronが自動的に付けるローカライズファイルのうちUS,JP以外を削除します。


# 動作確認手順

# 関連するIssue（あれば）
