### PR TITLE
改善: アップデート時はVisual C++再頒布ファイルの再インストールを省略

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -1,4 +1,3 @@
-
 !macro registerProtocol Protocol
   DetailPrint "Register ${Protocol} URI Handler"
 	DeleteRegKey HKCU "Software\Classes\${Protocol}"
@@ -24,6 +23,21 @@ LangString require_restart 1041 "インストールを完了するには、コ�
 LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ 再頒布可能パッケージをダウンロードできませんでした。"	
 
 !macro customInstall
+  ; Visual C++ Redistributable 2015-2022のインストール状況をチェック
+  ReadRegStr $2 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Version"
+  ${If} $2 != ""
+    DetailPrint "Visual C++ Redistributable is already installed (Version: $2). Skipping download and installation."
+    Goto vcredist_skip
+  ${EndIf}
+
+  ; 別のレジストリパスもチェック（より新しいバージョン用）
+  ReadRegStr $2 HKLM "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Version"
+  ${If} $2 != ""
+    DetailPrint "Visual C++ Redistributable is already installed (Version: $2). Skipping download and installation."
+    Goto vcredist_skip
+  ${EndIf}
+
+  DetailPrint "Visual C++ Redistributable not found. Downloading and installing..."
   NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  
 
   ${If} ${FileExists} `$INSTDIR\vc_redist.x64.exe`
@@ -39,9 +53,14 @@ LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ �
     #     MessageBox MB_OK|MB_ICONEXCLAMATION "$(require_restart)"
     # ${EndIf}
 
+    ; インストール後にファイルを削除
+    Delete "$INSTDIR\vc_redist.x64.exe"
+
   ${Else}
     MessageBox MB_OK|MB_ICONEXCLAMATION "$(failed_download)"
   ${EndIf}
+
+  vcredist_skip:
 
   FileOpen $0 "$INSTDIR\installername" w
   FileWrite $0 $EXEFILE

--- a/installer.nsh
+++ b/installer.nsh
@@ -23,20 +23,21 @@ LangString require_restart 1041 "インストールを完了するには、コ�
 LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ 再頒布可能パッケージをダウンロードできませんでした。"	
 
 !macro customInstall
-  ; Visual C++ Redistributable 2015-2022のインストール状況をチェック
-  ReadRegStr $2 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Version"
-  ${If} $2 != ""
-    DetailPrint "Visual C++ Redistributable is already installed (Version: $2). Skipping download and installation."
-    Goto vcredist_skip
+  ; --updated引数のチェック
+  ${GetParameters} $R0
+  ${GetOptions} $R0 "--updated" $R1
+  
+  ; エラーがない場合は--updated引数が存在
+  ${IfNot} ${Errors}
+    DetailPrint "Update mode: Checking Visual C++ Redistributable status..."
+    ReadRegStr $2 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Version"
+    ${If} $2 != ""
+      DetailPrint "Visual C++ Redistributable is already installed (Version: $2). Skipping download and installation."
+      Goto vcredist_skip
+    ${EndIf}
   ${EndIf}
-
-  ; 別のレジストリパスもチェック（より新しいバージョン用）
-  ReadRegStr $2 HKLM "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Version"
-  ${If} $2 != ""
-    DetailPrint "Visual C++ Redistributable is already installed (Version: $2). Skipping download and installation."
-    Goto vcredist_skip
-  ${EndIf}
-
+  
+  ; vc_redistのインストール処理
   DetailPrint "Visual C++ Redistributable not found. Downloading and installing..."
   NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  
 


### PR DESCRIPTION
# このpull requestが解決する内容

インストール時にVisual C++ Redistributableランタイムのインストール状況をチェックし可能ならスキップします

# 動作確認手順

ランタイムがインストール済みの状態でインストール -> スキップされる
ランタイムが未インストールの状態でインストール -> インストールが走る


# 関連するIssue（あれば）
