### PR TITLE
開発: クラッシュハンドラーの登録と解除をipcMain経由で行うように変更

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -28,8 +28,6 @@ import Utils from './services/utils';
 import { WindowsService } from './services/windows';
 import { createStore } from './store';
 
-const crashHandler = window['require']('crash-handler');
-
 const { ipcRenderer } = electron;
 
 import * as remote from '@electron/remote';
@@ -177,7 +175,8 @@ document.addEventListener('DOMContentLoaded', () => {
         ),
       );
 
-      crashHandler.registerProcess(appService.pid, false);
+      // Initialize crash handler
+      ipcRenderer.send('register-in-crash-handler', { pid: process.pid, critical: false });
 
       // await this.obsUserPluginsService.initialize();
 
@@ -193,7 +192,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const message = apiInitErrorResultToMessage(apiResult);
         showDialog(message);
 
-        crashHandler.unregisterProcess(appService.pid);
+        ipcRenderer.send('unregister-in-crash-handler', { pid: process.pid });
 
         obs.NodeObs.InitShutdownSequence();
         obs.IPC.disconnect();

--- a/main.js
+++ b/main.js
@@ -545,6 +545,14 @@ function initialize(crashHandler) {
         process.IPC_UUID,
       );
       crashHandler.registerProcess(pid, false);
+
+      ipcMain.on('register-in-crash-handler', (event, arg) => {
+        crashHandler.registerProcess(arg.pid, arg.critical);
+      });
+
+      ipcMain.on('unregister-in-crash-handler', (event, arg) => {
+        crashHandler.unregisterProcess(arg.pid);
+      });
     }
 
     const mainWindowState = windowStateKeeper({


### PR DESCRIPTION
# このpull requestが解決する内容

Streamlabs Desktopにあわせて、クラッシュハンドラーの登録と解除をipcMain経由で行うように変更

- [x] 登録されることを確認
- [ ] クラッシュで発動するか確認

# 動作確認手順

