### PR TITLE
開発: 修正: 通常起動時にウィンドウ最小サイズ制約が設定されていなかった

### DIFF
--- a/app/services/compact-mode.ts
+++ b/app/services/compact-mode.ts
@@ -61,6 +61,8 @@ export class CompactModeService extends StatefulService<ICompactModeServiceState
       this.setState({
         autoCompactMode: this.customizationService.state.autoCompactMode,
       });
+      // 起動時のautoCompact判定の後に1回ウィンドウサイズを確定する
+      this.windowSizeService.forceRefresh();
     });
   }
 

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -1,5 +1,5 @@
 import { TObsFormData } from 'components/obs/inputs/ObsInput';
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import Utils from 'services/utils';
 import { PersistentStatefulService } from '../core/persistent-stateful-service';
 import { mutation } from '../core/stateful-service';

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -1,5 +1,5 @@
 import { TObsFormData } from 'components/obs/inputs/ObsInput';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import Utils from 'services/utils';
 import { PersistentStatefulService } from '../core/persistent-stateful-service';
 import { mutation } from '../core/stateful-service';

--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -120,7 +120,6 @@ describe('static getPanelState', () => {
   }
 });
 
-// TODO fix
 describe('refreshWindowSize', () => {
   const suites = [
     {
@@ -217,13 +216,13 @@ describe('refreshWindowSize', () => {
       // wait for stateChange to be ready
       await windowSizeService.waitReady();
 
-      const firstCall = 0;
+      const firstCall = 1;
       suite.states.forEach((item, index, arr) => {
         if (index < firstCall) return;
         expect(updateWindowSize).toHaveBeenNthCalledWith(
           index + 1 - firstCall,
           expect.anything(),
-          arr[index - 1] || null,
+          arr[index - 1] || item,
           item,
           {
             backupHeight: undefined,
@@ -231,7 +230,6 @@ describe('refreshWindowSize', () => {
             backupY: undefined,
             widthOffset: undefined,
           },
-          index === firstCall,
         );
       });
       expect(updateWindowSize).toHaveBeenCalledTimes(suite.states.length - firstCall);

--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -201,7 +201,8 @@ describe('refreshWindowSize', () => {
       });
 
       const { WindowSizeService } = target();
-      const updateWindowSize = jest_fn<(typeof WindowSizeService)['updateWindowSize']>();
+      const updateWindowSize =
+        jest_fn<(typeof WindowSizeService)['updateWindowSize']>().mockName('updateWindowSize');
       // inject spy
       WindowSizeService.updateWindowSize = updateWindowSize;
 
@@ -216,13 +217,13 @@ describe('refreshWindowSize', () => {
       // wait for stateChange to be ready
       await windowSizeService.waitReady();
 
-      const firstCall = 1;
+      const firstCall = 0;
       suite.states.forEach((item, index, arr) => {
         if (index < firstCall) return;
         expect(updateWindowSize).toHaveBeenNthCalledWith(
           index + 1 - firstCall,
           expect.anything(),
-          arr[index - 1] || item,
+          arr[index - 1] || null,
           item,
           {
             backupHeight: undefined,
@@ -230,6 +231,7 @@ describe('refreshWindowSize', () => {
             backupY: undefined,
             widthOffset: undefined,
           },
+          index === firstCall,
         );
       });
       expect(updateWindowSize).toHaveBeenCalledTimes(suite.states.length - firstCall);

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -214,7 +214,7 @@ export class WindowSizeService extends StatefulService<IWindowSizeState> {
         }
       } else if (forceUpdate) {
         // パネル状態が変わらないが、強制的に更新する必要がある場合
-        const nextBackupSize = WindowSizeService.updateWindowSize(
+        WindowSizeService.updateWindowSize(
           WindowSizeService.mainWindowOperation,
           prevPanelState,
           nextPanelState,


### PR DESCRIPTION
# このpull requestが解決する内容
#940 で発生したエンバグの修正です。
通常サイズ状態で起動してコンパクトモードなどの変更をしていない間、ウィンドウサイズが通常より小さく変更できてしまっていました。
コンパクトモード往復などをすると制限が正しく設定されていました。

#940 では、初期化中の段階ではウィンドウ関係を触らず、初期化後(`isReady` = `true` -> `true` のタイミングでのWindowSizeステート変化時)だけやるようにしていたんですが、これだと通常起動のときには `true` -> `true` のステート変化が発生せず、ウィンドウ関係の設定がスキップされてしまっていたのが問題です(サイズの復元自体は先にされている)

この修正では、起動時のautoCompactMode判定が終わったところで1回 WindowSize確定の処理を追加するようにしました。

# 動作確認手順
1. 普通に起動する
2. ウィンドウの横幅を小さくしようとすると、1272pxぐらいが最小なのが正常だが、448pxまで小さくできてしまったらバグ
3. 設定で自動コンパクト化をonにしておく(デフォルト)
4. コンパクトモードに変更して終了する
5. 起動すると通常モードに正しい位置で復元する( PR 940 から壊れていないことの確認)
6. 設定で自動コンパクト化をoffにする
7. コンバクトモードに変更して終了する
8. 起動するとコンパクトモードで開き、幅が変更できないこと

# 関連するIssue（あれば）
#911