### PR TITLE
修正: コメント削除の取り消しをしたときにスナックバーを消す

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -220,6 +220,7 @@ export default class CommentViewer extends Vue {
                   openErrorDialogFromFailure(e);
                 }
               });
+              this.snackbarService.hide(); // スナックバーを消す
             },
           });
         } else {

--- a/app/services/snackbar.ts
+++ b/app/services/snackbar.ts
@@ -34,7 +34,15 @@ export class SnackbarService extends StatefulService<SnackbarState> {
       latest: {
         position,
         message,
-        action,
+        action: action
+          ? {
+              label: action.label,
+              onClick: () => {
+                action.onClick();
+                this.hide(); // Hide snackbar after action is clicked
+              },
+            }
+          : null,
         hideDelay: hideDelay || DEFAULT_HIDE_DELAY,
       },
     });


### PR DESCRIPTION
# このpull requestが解決する内容
ニコニコ生放送のコメントパネルからコメント削除をして、コメント削除を取り消す確認のスナックバーが出ているときに:

1.  スナックバーから取り消したときには、スナックバーのActionの仕組みでスナックバーを消す
1. コメント一覧の削除コメントのメニューから取り消したときも、スナックバーを消す

ように修正します 

# 関連するIssue（あれば）
fix #951 