### PR TITLE
修正: サブ配信のボタン幅を一部修正

### DIFF
--- a/app/components/SubStreamSettings.vue
+++ b/app/components/SubStreamSettings.vue
@@ -300,7 +300,7 @@
 }
 
 .toggle-key-button {
-  width: 100px;
+  width: 110px;
   height: 32px;
   margin: 0;
 }


### PR DESCRIPTION
# このpull requestが解決する内容

サブ配信設定画面での「貼り付け」ボタンの幅がよろしくなく、改行され見た目が悪いので修正

before
<img width="542" height="97" alt="Monosnap mogador 2025-07-30 14-31-26" src="https://github.com/user-attachments/assets/54e1fc22-d8a1-4079-8596-687f760bb769" />

after
<img width="553" height="100" alt="Monosnap mogador 2025-07-30 14-30-22" src="https://github.com/user-attachments/assets/adf6a425-b9d8-4b13-9836-238ac9dd3a74" />

