### PR TITLE
WIP 追加: 設定でニコニコ生放送のrtmps配信を可能にする

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -17,6 +17,7 @@
         @input="setOptimizeWithHardwareEncoder"
         class="optional-item"
       />
+      <ObsBoolInput v-model="enableRtmpsModel" />
     </div>
 
     <div class="section">

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -80,6 +80,18 @@ export default class ExtraSettings extends Vue {
     this.customizationService.setOptimizeWithHardwareEncoder(model.value);
   }
 
+  get enableRtmpsModel(): IObsInput<boolean> {
+    return {
+      name: 'enable_rtmps',
+      description: 'rtmps配信を有効にする', // TODO 翻訳
+      value: this.customizationService.state.enableRtmps,
+      enabled: this.streamingService.isStreaming === false,
+    };
+  }
+  set enableRtmpsModel(model: IObsInput<boolean>) {
+    this.customizationService.setEnableRtmps(model.value);
+  }
+
   get pollingPerformanceStatisticsModel(): IObsInput<boolean> {
     return {
       name: 'polling_performance_statistics',

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -11,6 +11,7 @@ export interface ICustomizationServiceState {
   optimizeForNiconico: boolean;
   showOptimizationDialogForNiconico: boolean;
   optimizeWithHardwareEncoder: boolean;
+  enableRtmps: boolean;
   pollingPerformanceStatistics: boolean;
   compactMode: boolean;
   compactModeTab: TCompactModeTab;

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -26,6 +26,7 @@ export class CustomizationService
     optimizeForNiconico: true,
     showOptimizationDialogForNiconico: true,
     optimizeWithHardwareEncoder: true,
+    enableRtmps: true,
     pollingPerformanceStatistics: true,
 
     compactMode: false,
@@ -100,6 +101,10 @@ export class CustomizationService
 
   setPollingPerformanceStatistics(activate: boolean) {
     this.setSettings({ pollingPerformanceStatistics: activate });
+  }
+
+  setEnableRtmps(enable: boolean) {
+    this.setSettings({ enableRtmps: enable });
   }
 
   toggleCompactMode() {

--- a/app/services/platforms/__snapshots__/niconico.test.ts.snap
+++ b/app/services/platforms/__snapshots__/niconico.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`setupStreamSettingsでストリーム情報がとれた場合 1`] = `
+exports[`setupStreamSettingsでストリーム情報がとれた場合 enableRtmps: false 1`] = `
 [
   "Stream",
   [
@@ -13,11 +13,36 @@ exports[`setupStreamSettingsでストリーム情報がとれた場合 1`] = `
         },
         {
           "name": "server",
-          "value": "url1",
+          "value": "rtmp url",
         },
         {
           "name": "key",
-          "value": "key1",
+          "value": "rtmp key",
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`setupStreamSettingsでストリーム情報がとれた場合 enableRtmps: true 1`] = `
+[
+  "Stream",
+  [
+    {
+      "nameSubCategory": "Untitled",
+      "parameters": [
+        {
+          "name": "service",
+          "value": "niconico ニコニコ生放送",
+        },
+        {
+          "name": "server",
+          "value": "rtmps url",
+        },
+        {
+          "name": "key",
+          "value": "rtmps key",
         },
       ],
     },
@@ -38,11 +63,11 @@ exports[`setupStreamSettingsで番組取得にリトライで成功する場合 
         },
         {
           "name": "server",
-          "value": "url1",
+          "value": "rtmp url",
         },
         {
           "name": "key",
-          "value": "key1",
+          "value": "rtmp key",
         },
       ],
     },

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -13,6 +13,11 @@ const setup = createSetupFunction({
       },
     },
     WindowsService: {},
+    CustomizationService: {
+      state: {
+        enableRtmps: false,
+      },
+    },
   },
 });
 
@@ -21,6 +26,7 @@ jest.mock('services/core/injector');
 jest.mock('services/streaming', () => ({}));
 jest.mock('services/user', () => ({}));
 jest.mock('services/settings', () => ({}));
+jest.mock('services/customization', () => ({}));
 jest.mock('services/windows', () => ({}));
 jest.mock('services/i18n', () => ({
   $t: (x: any) => x,
@@ -47,19 +53,19 @@ function setupInstance() {
 
   instance.client.fetchIngestInfo = jest_fn<
     typeof instance.client.fetchIngestInfo
-  >().mockImplementation((programId: string) =>
+  >().mockImplementation((_programId: string) =>
     Promise.resolve({
       ok: true,
       value: {
         rtmp: {
-          tcUrl: 'url1',
-          streamName: 'key1',
-          appName: 'app1',
+          tcUrl: 'rtmp url',
+          streamName: 'rtmp key',
+          appName: 'app name',
         },
         rtmps: {
-          tcUrl: 'url2', // この値は使わない
-          streamName: 'key2',
-          appName: 'app2',
+          tcUrl: 'rtmps url',
+          streamName: 'rtmps key',
+          appName: 'app name',
         },
       },
     }),
@@ -82,52 +88,61 @@ test('get instance', () => {
   expect(NiconicoService.instance).toBeInstanceOf(NiconicoService);
 });
 
-test('setupStreamSettingsでストリーム情報がとれた場合', async () => {
-  const updatePlatformChannelId = jest.fn();
-  const getSettingsFormData = jest.fn();
-  const setSettings = jest.fn();
-  const showWindow = jest.fn();
+describe('setupStreamSettingsでストリーム情報がとれた場合', () => {
+  for (const enableRtmps of [false, true]) {
+    test(`enableRtmps: ${enableRtmps}`, async () => {
+      const updatePlatformChannelId = jest.fn().mockName('updatePlatformChannelId');
+      const getSettingsFormData = jest.fn().mockName('getSettingsFormData');
+      const setSettings = jest.fn().mockName('setSettings');
+      const showWindow = jest.fn().mockName('showWindow');
 
-  getSettingsFormData.mockReturnValue([
-    {
-      nameSubCategory: 'Untitled',
-      parameters: [
-        { name: 'service', value: '' },
-        { name: 'server', value: '' },
-        { name: 'key', value: '' },
-      ],
-    },
-  ]);
+      getSettingsFormData.mockReturnValue([
+        {
+          nameSubCategory: 'Untitled',
+          parameters: [
+            { name: 'service', value: '' },
+            { name: 'server', value: '' },
+            { name: 'key', value: '' },
+          ],
+        },
+      ]);
 
-  const injectee = {
-    UserService: {
-      updatePlatformChannelId,
-    },
-    SettingsService: {
-      getSettingsFormData,
-      setSettings,
-    },
-    WindowsService: {
-      showWindow,
-    },
-  };
+      const injectee = {
+        UserService: {
+          updatePlatformChannelId,
+        },
+        SettingsService: {
+          getSettingsFormData,
+          setSettings,
+        },
+        WindowsService: {
+          showWindow,
+        },
+        CustomizationService: {
+          state: {
+            enableRtmps,
+          },
+        },
+      };
 
-  setup({ injectee });
-  const instance = setupInstance();
+      setup({ injectee });
+      const instance = setupInstance();
 
-  const result = await instance.setupStreamSettings('lv12345');
-  expect(result).toEqual({
-    url: 'url1',
-    key: 'key1',
-    quality: {
-      bitrate: 6000,
-      height: 720,
-      fps: 30,
-    },
-  });
+      const result = await instance.setupStreamSettings('lv12345');
+      expect(result).toEqual({
+        url: enableRtmps ? 'rtmps url' : 'rtmp url',
+        key: enableRtmps ? 'rtmps key' : 'rtmp key',
+        quality: {
+          bitrate: 6000,
+          height: 720,
+          fps: 30,
+        },
+      });
 
-  expect(setSettings).toHaveBeenCalledTimes(1);
-  expect(setSettings.mock.calls[0]).toMatchSnapshot();
+      expect(setSettings).toHaveBeenCalledTimes(1);
+      expect(setSettings.mock.calls[0]).toMatchSnapshot();
+    });
+  }
 });
 
 test('setupStreamSettingsで番組取得にリトライで成功する場合', async () => {
@@ -156,8 +171,8 @@ test('setupStreamSettingsで番組取得にリトライで成功する場合', a
 
   const result = await instance.setupStreamSettings('');
   expect(result).toEqual({
-    url: 'url1',
-    key: 'key1',
+    url: 'rtmp url',
+    key: 'rtmp key',
     quality: {
       bitrate: 6000,
       height: 720,

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -11,6 +11,7 @@ import { authorizedHeaders, handleErrors } from 'util/requests';
 import { sleep } from 'util/sleep';
 import { parseString } from 'xml2js';
 import { IPlatformService, IStreamingSetting } from '.';
+import { CustomizationService } from 'services/customization';
 
 export type INiconicoProgramSelection = {
   info: LiveProgramInfo;
@@ -54,6 +55,7 @@ export class NiconicoService extends Service implements IPlatformService {
   @Inject() userService: UserService;
   @Inject() streamingService: StreamingService;
   @Inject() windowsService: WindowsService;
+  @Inject() customizationService: CustomizationService;
 
   authWindowOptions: Electron.BrowserWindowConstructorOptions = {
     width: 800,
@@ -191,8 +193,11 @@ export class NiconicoService extends Service implements IPlatformService {
       return Promise.reject(stream.value);
     }
 
-    const url = stream.value.rtmp.tcUrl;
-    const key = stream.value.rtmp.streamName;
+    const selected = this.customizationService.state.enableRtmps
+      ? stream.value.rtmps
+      : stream.value.rtmp;
+    const url = selected.tcUrl;
+    const key = selected.streamName;
 
     const settings = this.settingsService.getSettingsFormData('Stream');
     settings.forEach(subCategory => {


### PR DESCRIPTION
- どうも環境によってrtmpsを有効にすると配信できないケースがあったのと、rtmps化は今のところ必須ではないため、保留中。
  - 配信できなかった環境は Visual C++ 再頒布パッケージをインストールしなおすことで解消したが、そもそもN Airのインストーラでも実行しているので謎

# このpull requestが解決する内容
- `設定`-`一般` の `ニコ生への最適化` セクションにスイッチを追加
<img width="863" height="344" alt="image" src="https://github.com/user-attachments/assets/14a9e560-e92b-4fd0-a171-49e8f9f308e0" />

- このスイッチは配信中はdisabledになる
- [ ] 設定の場所、文言確認
- [ ] 初期値`true`だが、それで良いのか検討
- [ ] その他、エラーフォールバック機能の検討

# 動作確認手順

- 配信開始してから`設定`の`配信`タブで配信URLを確認すると、protocol部が `rtmp`/`rtmps`の設定に従ったものになっている

# 関連するIssue（あれば）
