### PR TITLE
追加: ソース・シーンのアイテムにツールチップを追加

### DIFF
--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -27,8 +27,18 @@
       </div>
 
       <div class="studio-controls-top-sidebar">
-        <i class="icon-add icon-btn" @click="addScene" data-test="Add" />
-        <i class="icon-settings icon-btn" @click="showTransitions" data-test="Edit" />
+        <i
+          class="icon-add icon-btn"
+          v-tooltip.bottom="addSceneTooltip"
+          @click="addScene"
+          data-test="Add"
+        />
+        <i
+          class="icon-settings icon-btn"
+          v-tooltip.bottom="openSceneSwitcherTooltip"
+          @click="showTransitions"
+          data-test="Edit"
+        />
       </div>
     </div>
 
@@ -43,6 +53,7 @@
       <template slot="actions" slot-scope="p">
         <i
           class="icon-delete icon-btn"
+          v-tooltip.bottom="removeSceneTooltip"
           @click="removeScene(p.item.value)"
           :data-test="'Remove' + p.item.name"
         />

--- a/app/components/SceneSelector.vue.ts
+++ b/app/components/SceneSelector.vue.ts
@@ -31,6 +31,10 @@ export default class SceneSelector extends Vue {
 
   searchQuery = '';
 
+  removeSceneTooltip = $t('scenes.removeSceneTooltip');
+  addSceneTooltip = $t('scenes.addSceneTooltip');
+  openSceneSwitcherTooltip = $t('scenes.openSceneSwitcherTooltip');
+
   showContextMenu() {
     const menu = new Menu();
     menu.append({

--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -52,12 +52,14 @@
         <i
           class="source-selector-action"
           :class="lockClassesForSource(node.data.id)"
+          v-tooltip.bottom="lockTooltip"
           @click.stop="toggleLock(node.data.id)"
           @dblclick.stop="() => {}"
         />
         <i
           class="source-selector-action"
           :class="visibilityClassesForSource(node.data.id)"
+          v-tooltip.bottom="visibilityTooltip"
           @click.stop="toggleVisibility(node.data.id)"
           @dblclick.stop="() => {}"
         />

--- a/app/components/SourceSelector.vue.ts
+++ b/app/components/SourceSelector.vue.ts
@@ -46,6 +46,8 @@ export default class SourceSelector extends Vue {
   removeSourcesTooltip = $t('scenes.removeSourcesTooltip');
   openSourcePropertiesTooltip = $t('scenes.openSourcePropertiesTooltip');
   addGroupTooltip = $t('scenes.addGroupTooltip');
+  lockTooltip = $t('scenes.lockTooltip');
+  visibilityTooltip = $t('scenes.visibilityTooltip');
 
   private expandedFoldersIds: string[] = [];
 

--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -36,5 +36,10 @@
   "nameSceneCollection": "Name Scene Collection",
   "renameScene": "Rename Scene",
   "newSceneName": "New Scene",
-  "newSceneGroupName": "%{activeSceneName} Group"
+  "newSceneGroupName": "%{activeSceneName} Group",
+  "lockTooltip": "Lock the source to prevent accidental movement.",
+  "visibilityTooltip": "Toggle the visibility of the source.",
+  "addSceneTooltip": "Add a new scene.",
+  "removeSceneTooltip": "Remove the scene.",
+  "openSceneSwitcherTooltip": "Open the scene switcher properties."
 }

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -36,5 +36,10 @@
   "nameSceneCollection": "シーンコレクションの名前",
   "renameScene": "シーンの名前を変更",
   "newSceneName": "シーン",
-  "newSceneGroupName": "%{activeSceneName} グループ"
+  "newSceneGroupName": "%{activeSceneName} グループ",
+  "lockTooltip": "ソースをロックして、誤って移動しないようにします。",
+  "visibilityTooltip": "ソースの表示/非表示を切り替えます。",
+  "removeSceneTooltip": "シーンを削除します。",
+  "addSceneTooltip": "新しいシーンを追加します。",
+  "openSceneSwitcherTooltip": "シーン切り替えのプロパティを開きます。"
 }


### PR DESCRIPTION
# このpull requestが解決する内容

ソース・シーンのアイテムにツールチップを追加します。

以下スクリーンショット（ツールチップのため撮影しづらくマウスカーソルは写っていません・・）

<img width="503" height="355" alt="Monosnap Image 2025-07-31 14-31-07" src="https://github.com/user-attachments/assets/b3206bfc-6d3a-4a99-b075-ae8a065c79cd" />
<img width="412" height="268" alt="Monosnap Image 2025-07-31 14-32-31" src="https://github.com/user-attachments/assets/01843590-d44c-47fa-8bfd-e3c9399117b0" />
<img width="401" height="258" alt="Monosnap Image 2025-07-31 14-32-51" src="https://github.com/user-attachments/assets/23a3d09a-bb19-4f75-a351-0c9ace5453b9" />
<img width="492" height="281" alt="Monosnap Image 2025-07-31 14-33-11" src="https://github.com/user-attachments/assets/9ba29cd3-da12-415b-90ee-398af2fd0eea" />
<img width="395" height="316" alt="Monosnap Image 2025-07-31 14-33-43" src="https://github.com/user-attachments/assets/9d6973df-459c-4298-9fe0-c1e6d9a9a5a1" />
