### PR TITLE
修正: ニコ生の番組作成ウィンドウの2つ目が作れてしまうと真っ白いウィンドウになっていた

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue.ts
+++ b/app/components/nicolive-area/NicoliveArea.vue.ts
@@ -69,16 +69,11 @@ export default class NicolivePanelRoot extends Vue {
     return this.customizationService.state.compactMode;
   }
 
-  isCreating: boolean = false;
   async createProgram(): Promise<void> {
-    if (this.isCreating) throw new Error('createProgram is running');
     try {
-      this.isCreating = true;
       await this.nicoliveProgramService.createProgram();
     } catch (e) {
       console.error(e);
-    } finally {
-      this.isCreating = false;
     }
   }
 

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -43,11 +43,8 @@ export default class ToolBar extends Vue {
     return NicoliveProgramService.format(timeInSeconds);
   }
 
-  isCreating: boolean = false;
   async createProgram() {
-    if (this.isCreating) throw new Error('createProgram is running');
     try {
-      this.isCreating = true;
       return await this.nicoliveProgramService.createProgram();
     } catch (caught) {
       if (caught instanceof NicoliveFailure) {
@@ -56,7 +53,6 @@ export default class ToolBar extends Vue {
         throw caught;
       }
     } finally {
-      this.isCreating = false;
       this.selectButton('start');
     }
   }


### PR DESCRIPTION
# このpull requestが解決する内容
ニコ生の番組作成ウィンドウを開ける場所が複数あります:

- ニコ生パネルの初期状態
- 番組終了後の下の部分
- 配信開始ボタンから番組作成を選択

この任意の1つで番組作成ウィンドウを開いたまま番組を作らず、別の物で番組を作ろうとすると、番組作成ウィンドウが既にあるにもかかわらず追加で開こうとして、真っ白のウィンドウが現れていました。

この修正では、すでに開いているウィンドウがあったら再利用してアクティブにし、共通の結果をそれぞれの呼び出し元に返すようにすることで、期待通り動くようにします。
このため、従来は番組作成ウィンドウを開いたボタンは完了するまでdisabledにしていたのを廃止し、すでに出ているときに押せばアクティブになるようにもします。

# 関連するIssue（あれば）
fix #961