### PR TITLE
開発: 修正: add project actionをforkからのpull requestからも使用可能にする

### DIFF
--- a/.github/workflows/add_project.yml
+++ b/.github/workflows/add_project.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
+    branches: ['n-air_development']
 
 jobs:
   add-to-project:

--- a/.github/workflows/add_project.yml
+++ b/.github/workflows/add_project.yml
@@ -3,7 +3,7 @@ name: Add Issue or PR to Project v2
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-
       - name: Get Project ID
         env:
           GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
forkからの`on pull_request` だとrepository secretが読めないため、ProjectのAPIが失敗していました。
`on pull_request_target` にすることで、読めるようにします。
forkからのPRでも `pull_request_target` ならばworkflowはメインブランチのものが実行されるので、悪意があるPRでも大丈夫と想定します。

あと `jq` のインストールは不要だった(デフォルトで存在する)ので撤去します
