### PR TITLE
開発: nicolive-program.test.ts: 型をちゃんと使うように修正

### DIFF
--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -21,7 +21,7 @@ import { ProgramSchedules } from './ResponseTypes';
 import { NicoliveProgramStateService } from './state';
 
 type Schedules = ProgramSchedules['data'];
-type Schedule = Schedules[0];
+export type Schedule = Schedules[0];
 
 type ProgramState = {
   programID: string;
@@ -42,7 +42,7 @@ type ProgramState = {
   password?: string;
 };
 
-interface INicoliveProgramState extends ProgramState {
+export interface INicoliveProgramState extends ProgramState {
   /**
    * 永続化された状態をコンポーネントに伝えるための一時置き場
    * 直接ここを編集してはいけない、stateService等の操作結果を反映するだけにする


### PR DESCRIPTION
# このpull requestが解決する内容
`nicolive-program.test.ts` は古くからあるため、テストが型をあまり重視しておらず `any` だらけになっていて、その後のデータ型の変更にも追従できていなかったのに気付いたので、型をちゃんと使うようにして変更に追従しました。
あとはfail時にわかりやすいように、`jest.fn()` には `mockName` を付けてます。

# 動作確認手順
`yarn test:unit:app`
