### PR TITLE
修正: スタジオコントロール開閉アイコンの向きを開閉状態に合わせて変化させる

### DIFF
--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -91,8 +91,8 @@
       transform: rotate(-180deg);
     }
 
-    .opened & {
-      i {
+    &.studio-controls--opened {
+      > i {
         transform: rotate(0deg);
       }
     }


### PR DESCRIPTION
# このpull requestが解決する内容

シーンコレクションリスト上のコントロール開閉のボタンの表記修正
三角の方向を状況に合わせて変更

opened
<img width="278" height="211" alt="Monosnap mogador 2025-08-06 16-49-58" src="https://github.com/user-attachments/assets/459d49d8-ea40-4539-bcff-cf61eff23fd4" />

closed
<img width="261" height="71" alt="Monosnap mogador 2025-08-06 16-50-13" src="https://github.com/user-attachments/assets/88227e02-3887-4de0-9fc6-1f503be8e1bf" />
