### PR TITLE
開発: bump @types/node to 18.19.121

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.192",
     "@types/luxon": "^3.4.2",
-    "@types/node": "^12.14.0",
+    "@types/node": "^18.19.121",
     "@types/semver": "^7.5.0",
     "@types/sinonjs__fake-timers": "^8.1.5",
     "@types/urijs": "^1.19.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2720,15 +2720,17 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^12.14.0":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
-
 "@types/node@^18.0.0", "@types/node@^18.14.6":
   version "18.19.39"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.39.tgz#c316340a5b4adca3aee9dcbf05de385978590593"
   integrity sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.19.121":
+  version "18.19.121"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.121.tgz#c50d353ea2d1fb1261a8bbd0bf2850306f5af2b3"
+  integrity sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
# このpull requestが解決する内容

node.jsの型定義がv12だったのでv18の最後あたりまで進めます
この次のv20はfetchのシグネチャが変わってそのままだとコンパイル出来なくなるので一旦その前まで...

これにより 'node:' prefixをつけてインポートしたり、幾つかの追加APIが使える様になります
