### PR TITLE
開発: fix: 削除した番組作成中フラグの参照が残っていた

### DIFF
--- a/app/components/nicolive-area/NicoliveArea.vue
+++ b/app/components/nicolive-area/NicoliveArea.vue
@@ -35,7 +35,6 @@
             <button
               class="button button--primary button--create-program"
               @click="createProgram"
-              :disabled="isCreating"
               v-if="!isCompactMode"
             >
               新しく番組を作成する

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -90,7 +90,6 @@
         <button
           v-else-if="programStatus === 'end'"
           @click="createProgram"
-          :disabled="isCreating"
           class="button button--primary"
         >
           番組作成


### PR DESCRIPTION
# このpull requestが解決する内容
#962 で vue.ts 側で削除した NicoliveAreaとToolBarの `isCreating` をvue側で参照している部分が残っていたので、消します
動作はたまたま falsy なので常に無効にならないという動作にはなってました
