### PR TITLE
修正: カスタムキャストNDIソースを初回追加したときにプロパティーウィンドウに何も出ない現象を修正

### DIFF
--- a/app/services/sources/properties-managers/custom-cast-ndi-manager.ts
+++ b/app/services/sources/properties-managers/custom-cast-ndi-manager.ts
@@ -66,7 +66,7 @@ export class CustomCastNdiManager extends PropertiesManager {
 
       // CUSTOMCAST NDIを強制選択する
       const ndi_source_name = customCastNdi.value;
-      if (this.obsSource.settings['ndi_source_name'].value !== ndi_source_name) {
+      if (this.obsSource.settings['ndi_source_name']?.value !== ndi_source_name) {
         this.obsSource.update({ ndi_source_name });
       }
     }


### PR DESCRIPTION
# このpull requestが解決する内容
NDIソース自動選択のときに、対象プロパティ自体が `undefined` のときにセットできずに落ちていました。その結果、プロパティーウィンドウが構築途中でなにも入っていないようなものとして表れました
<img width="480" height="470" alt="image" src="https://github.com/user-attachments/assets/abcf938d-cbf5-4364-bb5a-e80bc7016630" />

環境によって最初から `undefined` でないこともあるので正確な再現条件は不明ですが、発生していた環境でこの修正によって救済できました

# 動作確認手順
NDIをインストール・OS再起動後、カスタムキャストNDIソースを追加し、プロパティーを開くとちゃんとプロパティーウィンドウになっている
<img width="720" height="507" alt="image" src="https://github.com/user-attachments/assets/588fe112-7be1-4ba6-a28d-44f1a1d19dfd" />
