### PR TITLE
開発: 修正: TranscriptionSourceUsageServiceの循環参照問題を一時的に回避

### DIFF
--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -284,16 +284,19 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       commentVposOffset: state.commentVposOffset,
       textFileMaxLine: state.textFileMaxLine,
       textFileLineTimeToLive: state.textFileLineTimeToLive,
-      transcriptionSourceUsed: this.transcriptionSourceUsageService.state.used,
+      // transcriptionSourceUsageService と StreamingService が循環参照になっている問題を解決するまではダミー
+      transcriptionSourceUsed: false, // this.transcriptionSourceUsageService.state.used,
     };
   }
 
   startStreaming() {
-    this.transcriptionSourceUsageService.startStreaming();
+    // transcriptionSourceUsageService と StreamingService が循環参照になっている問題を解決するまでコメントアウト
+    // this.transcriptionSourceUsageService.startStreaming();
   }
 
   stopStreaming() {
-    this.transcriptionSourceUsageService.stopStreaming();
+    // transcriptionSourceUsageService と StreamingService が循環参照になっている問題を解決するまでコメントアウト
+    // this.transcriptionSourceUsageService.stopStreaming();
   }
 
   initTextFileWriter() {


### PR DESCRIPTION
transcriptionSourceUsageService と StreamingService の循環参照により発生している問題を解決するまで、 該当する部分をコメントアウトして一時的に回避します