### PR TITLE
開発: 修正: 文字起こしソースの使用状況をActionLogに含める機能を復活

### DIFF
--- a/app/services/transcription/transcription-source-usage.ts
+++ b/app/services/transcription/transcription-source-usage.ts
@@ -1,3 +1,4 @@
+import { merge } from 'rxjs';
 import { mutation, StatefulService } from 'services/core';
 import { Inject } from 'services/core/injector';
 import { ScenesService } from 'services/scenes';
@@ -16,19 +17,25 @@ export class TranscriptionSourceUsageService extends StatefulService<ITranscript
   };
 
   init() {
-    this.reset();
+    super.init();
 
-    this.scenesService.sceneSwitched.subscribe(() => {
-      if (this.containsTranscriptionInActiveScene()) {
-        this.markTranscriptionUsed();
-      }
-    });
+    this.updateTranscriptionUsage();
 
-    this.scenesService.itemAdded.subscribe(item => {
-      if (this.isTranscriptionSourceId(item.sourceId)) {
-        this.markTranscriptionUsed();
-      }
+    merge(
+      this.scenesService.sceneSwitched,
+      this.scenesService.itemAdded,
+      this.scenesService.itemRemoved,
+    ).subscribe(() => {
+      this.updateTranscriptionUsage();
     });
+  }
+
+  updateTranscriptionUsage() {
+    if (this.containsTranscriptionInActiveScene()) {
+      this.markTranscriptionUsed();
+    } else {
+      this.reset();
+    }
   }
 
   markTranscriptionUsed() {
@@ -67,7 +74,7 @@ export class TranscriptionSourceUsageService extends StatefulService<ITranscript
   }
 
   setState(state: Partial<ITranscriptionSourceUsageState>) {
-    this.setState({ ...this.state, ...state });
+    this.SET_STATE({ ...this.state, ...state });
   }
 
   @mutation()

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -19,8 +19,7 @@ import {
 } from 'rxjs';
 import { $t } from 'services/i18n';
 import { TranscriptionLog } from 'services/usage-statistics';
-import { Inject } from 'vue-property-decorator';
-import { mutation, PersistentStatefulService } from '../core';
+import { Inject, mutation, PersistentStatefulService } from '../core';
 import { CommentColor, CommentFont, CommentPosition, CommentSize } from './CommentModifier';
 import { downloadAndUnzip, DownloadError, ExtractError } from './downloadAndUnzip';
 import { filterNoiseText } from './filterNoiseText';
@@ -284,19 +283,16 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       commentVposOffset: state.commentVposOffset,
       textFileMaxLine: state.textFileMaxLine,
       textFileLineTimeToLive: state.textFileLineTimeToLive,
-      // transcriptionSourceUsageService と StreamingService が循環参照になっている問題を解決するまではダミー
-      transcriptionSourceUsed: false, // this.transcriptionSourceUsageService.state.used,
+      transcriptionSourceUsed: this.transcriptionSourceUsageService?.state.used || false,
     };
   }
 
   startStreaming() {
-    // transcriptionSourceUsageService と StreamingService が循環参照になっている問題を解決するまでコメントアウト
-    // this.transcriptionSourceUsageService.startStreaming();
+    this.transcriptionSourceUsageService?.startStreaming();
   }
 
   stopStreaming() {
-    // transcriptionSourceUsageService と StreamingService が循環参照になっている問題を解決するまでコメントアウト
-    // this.transcriptionSourceUsageService.stopStreaming();
+    this.transcriptionSourceUsageService?.stopStreaming();
   }
 
   initTextFileWriter() {


### PR DESCRIPTION
- TranscriptionSourceUsageService の subscription を merge() で統一
- setState の循環呼び出しを修正 (setState → SET_STATE)
- 循環参照問題解決により transcriptionSourceUsed の計算を再有効化

# このpull requestが解決する内容
- ActionLogの `transcriptionSourceUsed` を正しく設定するようにします

# 動作確認手順
- 配信開始または終了をすると、アクティブなシーンに自動文字起こしソースがあるかどうかに応じて `transcriptionSourceUsed` が設定される(ActionLog送信時にconsoleに表示されます)
