### PR TITLE
追加: 「リプレイ録画の再生」ソースを追加

### DIFF
--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -126,6 +126,8 @@ export default class AddSource extends Vue {
         this.name,
         this.sourceAddOptions,
       );
+    } else if (this.sourceType === 'ffmpeg_source_replay') {
+      s = this.createReplaySourceAndOption(this.name);
     } else {
       s = {
         source: this.sourcesService.createSource(
@@ -153,5 +155,24 @@ export default class AddSource extends Vue {
 
   get selectedSource() {
     return this.sourcesService.getSource(this.selectedSourceId);
+  }
+
+  createReplaySourceAndOption(name: string): {
+    source: ISourceApi;
+    options: ISourceAddOptions;
+    forceSkipProperties?: boolean;
+  } {
+    return {
+      source: this.sourcesService.createSource(
+        this.name,
+        'ffmpeg_source',
+        {},
+        {
+          propertiesManager: 'replay',
+          propertiesManagerSettings: this.sourceAddOptions.propertiesManagerSettings,
+        },
+      ),
+      options: {},
+    };
   }
 }

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -149,6 +149,14 @@
         <TextGdiplusIcon slot="media" />
       </add-source-info>
 
+      <add-source-info
+        v-if="inspectedSource === 'ffmpeg_source_replay'"
+        sourceType="ffmpeg_source_replay"
+        key="23"
+      >
+        <FfmpegSourceIcon slot="media" />
+      </add-source-info>
+
       <div class="source-info" v-if="inspectedSource === null">
         <div class="source-info__text">
           <h3>{{ $t('sources.sourcesWelcomeMessage') }}</h3>

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -511,5 +511,9 @@
   "custom_cast_ndi_guide": {
     "name": "CUSTOM CAST",
     "description": "Add CUSTOM CAST NDI® output stream to your scene."
+  },
+  "ffmpeg_source_replay": {
+    "name": "Replay Buffer",
+    "description": "Add a replay buffer to your scene."
   }
 }

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -513,7 +513,7 @@
     "description": "Add CUSTOM CAST NDI® output stream to your scene."
   },
   "ffmpeg_source_replay": {
-    "name": "Replay Buffer",
-    "description": "Add a replay buffer to your scene."
+    "name": "Replay playback",
+    "description": "Add a replay playback source to your scene."
   }
 }

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -511,5 +511,9 @@
   "custom_cast_ndi_guide": {
     "name": "カスタムキャスト",
     "description": "カスタムキャストの配信(NDI®)をシーンに追加します。"
+  },
+  "ffmpeg_source_replay": {
+    "name": "リプレイバッファ",
+    "description": "シーンにリプレイバッファを追加します。"
   }
 }

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -513,7 +513,7 @@
     "description": "カスタムキャストの配信(NDI®)をシーンに追加します。"
   },
   "ffmpeg_source_replay": {
-    "name": "リプレイバッファ",
-    "description": "シーンにリプレイバッファを追加します。"
+    "name": "リプレイ録画の再生",
+    "description": "シーンにリプレイ録画の再生を追加します。"
   }
 }

--- a/app/services/sources/properties-managers/replay-manager.ts
+++ b/app/services/sources/properties-managers/replay-manager.ts
@@ -1,0 +1,18 @@
+import { Inject } from 'services/core/injector';
+import { StreamingService } from 'services/streaming';
+import { PropertiesManager } from './properties-manager';
+
+export class ReplayManager extends PropertiesManager {
+  @Inject() streamingService: StreamingService;
+
+  blacklist = ['is_local_file', 'local_file'];
+
+  init() {
+    super.init();
+    this.obsSource.update({ local_file: '' });
+
+    this.streamingService.replayBufferFileWrite.subscribe(filePath => {
+      this.obsSource.update({ local_file: filePath });
+    });
+  }
+}

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -118,14 +118,16 @@ export type TSourceType =
 export type TSelectableSourceType =
   | TSourceType
   | 'near' // 登録後は browser_source
-  | 'text_transcription'; // 登録後は text_gdiplus
+  | 'text_transcription' // 登録後は text_gdiplus
+  | 'ffmpeg_source_replay'; // 登録後は ffmpeg_source
 
 // Register new properties manager here
 export type TPropertiesManager =
   | 'default'
   | 'nvoice-character'
   | 'custom-cast-ndi'
-  | 'text_transcription';
+  | 'text_transcription'
+  | 'replay';
 
 export function isNoAudioPropertiesManagerType(propertiesManagerType: TPropertiesManager): boolean {
   return ['nvoice-character'].includes(propertiesManagerType);

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -33,6 +33,7 @@ import {
 import { CustomCastNdiManager } from './properties-managers/custom-cast-ndi-manager';
 import { DefaultManager } from './properties-managers/default-manager';
 import { NVoiceCharacterManager } from './properties-managers/nvoice-character-manager';
+import { ReplayManager } from './properties-managers/replay-manager';
 import { TextTranscriptionManager } from './properties-managers/text-transcription-manager';
 
 const AudioFlag = obs.ESourceOutputFlags.Audio;
@@ -45,6 +46,7 @@ export const PROPERTIES_MANAGER_TYPES = {
   'nvoice-character': NVoiceCharacterManager,
   'custom-cast-ndi': CustomCastNdiManager,
   text_transcription: TextTranscriptionManager,
+  replay: ReplayManager,
 };
 
 interface IObsSourceCallbackInfo {
@@ -475,6 +477,8 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     }
 
     availableWhitelistedType.push('text_transcription'); // 自動文字起こしテキスト
+
+    availableWhitelistedType.push('ffmpeg_source_replay'); // リプレイバッファ
 
     const availableWhitelistedSourceType = availableWhitelistedType.map(value => ({
       value,


### PR DESCRIPTION
# このpull requestが解決する内容

リプレイ録画の再生のソースを追加し、リプレイ再生ができるようにします。
(元々リプレイとしての動作はあったが表示出力機能がなかったものを追加)

# 動作確認手順

ソースから「リプレイ録画の再生」を選択して追加
右下のリプレイ録画スタンバイのボタン（配信開始の左）をクリックし、リプレイ録画状態にする
設定秒数（デフォルト20秒 設定>出力>最大リプレイ時間) 待つ
右下のリプレイ保存ボタン(↓に◯のボタン)をクリック
設定時間前からの映像が再生される

# 関連するIssue（あれば）
