### PR TITLE
修正: 自動文字起こしの起動エラー修正とモデル変更が正しく反映されるように修正

### DIFF
--- a/app/components/TranscriptionSettings.vue.ts
+++ b/app/components/TranscriptionSettings.vue.ts
@@ -167,7 +167,10 @@ export default class TranscriptionSettings extends Vue {
   deleteButtonText = $t('settings.transcription.deleteVoskModel');
 
   get isDeleteButtonEnabled(): boolean {
-    return this.transcriptionService.state.voskModelName && this.modelStatus.state === 'downloaded';
+    return (
+      this.transcriptionService.state.voskModelName &&
+      (this.modelStatus.state === 'downloaded' || this.modelStatus.state === 'load_error')
+    );
   }
 
   deleteVoskModel(): void {

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -771,7 +771,8 @@
       "downloading": "Downloading...",
       "installing": "Installing...",
       "downloaded": "Downloaded",
-      "download_error": "Download error"
+      "download_error": "Download error",
+      "load_error": "Load error"
     },
     "downloadVoskModel": "Download model",
     "deleteVoskModel": "Delete downloaded model",
@@ -857,7 +858,10 @@
       "disabled": "Automatic transcription is disabled.",
       "noVoskModel": "Please select a downloaded model.",
       "noModelDownloaded": "Please download a model.",
-      "noAudioDevice": "Cannot be used because no audio source devices were found."
+      "noAudioDevice": "Cannot be used because no audio source devices were found.",
+      "voskLaunchError": "Cannot start engine.",
+      "voskError": "Engine error occurred.",
+      "modelLoadError": "Cannot load model."
     },
     "addSource": {
       "notActive": "To display automatically transcribed text, please add the source and enable automatic transcription in the settings."

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -771,7 +771,8 @@
       "downloading": "ダウンロード中",
       "installing": "インストール中...",
       "downloaded": "ダウンロード済み",
-      "download_error": "ダウンロードエラー"
+      "download_error": "ダウンロードエラー",
+      "load_error": "読み込みエラー"
     },
     "downloadVoskModel": "モデルをダウンロードする",
     "deleteVoskModel": "ダウンロードしたモデルを削除する",
@@ -857,7 +858,10 @@
       "disabled": "自動文字起こし機能が無効です。",
       "noVoskModel": "ダウンロードしたモデルを選択してください。",
       "noModelDownloaded": "モデルをダウンロードしてください。",
-      "noAudioDevice": "音声ソースデバイスが見つからないため、利用できません。"
+      "noAudioDevice": "音声ソースデバイスが見つからないため、利用できません。",
+      "voskLaunchError": "エンジンが起動できません。",
+      "voskError": "エンジンエラーが発生しました。",
+      "modelLoadError": "モデルが読み込めません。"
     },
     "addSource": {
       "notActive": "自動文字起こしされたテキストを表示するにはソース追加後、設定にて自動文字起こしを有効にしてください。"

--- a/app/services/transcription/VoskModelsManager.ts
+++ b/app/services/transcription/VoskModelsManager.ts
@@ -5,7 +5,7 @@ import { $t } from 'services/i18n';
 export const VOSK_MODEL_NAMES = ['vosk-model-small-ja-0.22', 'vosk-model-ja-0.22'] as const;
 
 export type VoskModelStatus = {
-  state: 'not_downloaded' | 'downloading' | 'installing' | 'downloaded' | 'download_error';
+  state: 'not_downloaded' | 'downloading' | 'installing' | 'downloaded' | 'download_error' | 'load_error';
   progress?: number; // percentage of download completion
   error_message?: string;
 };

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -15,6 +15,7 @@ import type {
 } from './VoskClient';
 
 const VOSK_MODEL_NAME = 'vosk-model-small-ja-0.22';
+const VOSK_MODEL_NAME_2 = 'vosk-model-ja-0.22';
 
 // Mock dependencies
 jest.mock('@electron/remote', () => ({
@@ -683,6 +684,69 @@ describe('TranscriptionService', () => {
         });
         expect(stopTranscription).toHaveBeenCalled();
         expect(require('node:fs').promises.rmdir).toHaveBeenCalled();
+      }),
+    );
+  });
+
+  describe('model switching', () => {
+    it(
+      'should deactivate and reactivate with new model when switching models',
+      withClock(async clock => {
+        const { instance, getVoskModelStatus, stopTranscription } = prepare();
+        const { CreateVoskCliClient: mockedCreateVoskCliClient } = require('./VoskClient');
+
+        // Mock two downloaded models
+        const downloadedStatus = { state: 'downloaded' as const };
+        const mockModelsManager = instance['modelsManager'];
+        jest.spyOn(mockModelsManager, 'getVoskModels').mockReturnValue([
+          { name: VOSK_MODEL_NAME, description: 'Small', status: downloadedStatus },
+          { name: VOSK_MODEL_NAME_2, description: 'Large', status: downloadedStatus },
+        ]);
+
+        // Set both models as downloaded
+        getVoskModelStatus.mockImplementation((modelName: string) => {
+          if (modelName === VOSK_MODEL_NAME || modelName === VOSK_MODEL_NAME_2) {
+            return downloadedStatus;
+          }
+          return { state: 'not_downloaded' };
+        });
+
+        instance['setModelStatus'](VOSK_MODEL_NAME, downloadedStatus);
+        instance['setModelStatus'](VOSK_MODEL_NAME_2, downloadedStatus);
+
+        // Set audio device and enable with first model
+        instance.setAudioDeviceId('test-device');
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+
+        // Verify first model was used
+        expect(mockedCreateVoskCliClient).toHaveBeenCalledTimes(1);
+        expect(mockedCreateVoskCliClient).toHaveBeenCalledWith({
+          voskCliPath: '/fake/vosk-cli',
+          modelPath: `/fake/path/vosk-model/${VOSK_MODEL_NAME}`,
+        });
+
+        // Clear mock to track new calls
+        mockedCreateVoskCliClient.mockClear();
+        stopTranscription.mockClear();
+
+        // Switch to second model
+        instance.setModelName(VOSK_MODEL_NAME_2);
+        await clock.tickAsync(0);
+
+        // Verify old client was stopped
+        expect(stopTranscription).toHaveBeenCalledTimes(1);
+
+        // Verify new client was created with second model
+        expect(mockedCreateVoskCliClient).toHaveBeenCalledTimes(1);
+        expect(mockedCreateVoskCliClient).toHaveBeenCalledWith({
+          voskCliPath: '/fake/vosk-cli',
+          modelPath: `/fake/path/vosk-model/${VOSK_MODEL_NAME_2}`,
+        });
+
+        // Verify new client's startTranscription was called
+        const newClient = mockedCreateVoskCliClient.mock.results[0].value;
+        expect(newClient.startTranscription).toHaveBeenCalled();
       }),
     );
   });

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -4,7 +4,10 @@ import { jest_fn } from 'util/jest_fn';
 import { createSetupFunction } from 'util/test-setup';
 import type { downloadAndUnzip as downloadAndUnzipType } from './downloadAndUnzip';
 import type { filterNoiseText as filterNoiseTextType } from './filterNoiseText';
-import type { ActiveStatus, TranscriptionService as TranscriptionServiceType } from './transcription';
+import type {
+  ActiveStatus,
+  TranscriptionService as TranscriptionServiceType,
+} from './transcription';
 import type {
   CreateVoskCliClient as CreateVoskCliClientType,
   TranscriptionMessage,
@@ -105,8 +108,14 @@ interface TestScenario {
 }
 
 // Test utilities
-const emptyDeviceList = { version: '1' as const, devices: [] as Array<{ id: string; name: string; index: number }> };
-const testDeviceList = { version: '1', devices: [{ id: 'test-device', name: 'Test Device', index: 0 }] };
+const emptyDeviceList = {
+  version: '1' as const,
+  devices: [] as Array<{ id: string; name: string; index: number }>,
+};
+const testDeviceList = {
+  version: '1',
+  devices: [{ id: 'test-device', name: 'Test Device', index: 0 }],
+};
 
 function withClock(testFn: (clock: FakeTimers.InstalledClock) => Promise<void>) {
   return async () => {
@@ -119,27 +128,31 @@ function withClock(testFn: (clock: FakeTimers.InstalledClock) => Promise<void>) 
   };
 }
 
-function setupTranscription(options: {
-  modelDownloaded?: boolean;
-  audioDeviceId?: string;
-  emptyDevices?: boolean;
-} = {}) {
+function setupTranscription(
+  options: {
+    modelDownloaded?: boolean;
+    audioDeviceId?: string;
+    emptyDevices?: boolean;
+  } = {},
+) {
   const downloadedStatus = { state: 'downloaded' as const };
   const notDownloadedStatus = { state: 'not_downloaded' as const };
-  
-  const prepareOptions = options.emptyDevices ? 
-    { mockOverrides: { 
-        listAudioDevices: emptyDeviceList,
-        voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus
-      } 
-    } : 
-    { mockOverrides: { 
-        voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus
-      } 
-    };
-    
+
+  const prepareOptions = options.emptyDevices
+    ? {
+        mockOverrides: {
+          listAudioDevices: emptyDeviceList,
+          voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
+        },
+      }
+    : {
+        mockOverrides: {
+          voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
+        },
+      };
+
   const { instance, ...rest } = prepare(prepareOptions);
-  
+
   if (options.modelDownloaded) {
     rest.getVoskModelStatus.mockReturnValue(downloadedStatus);
     // Also update the modelsStatusSubject$ to reflect the downloaded state
@@ -148,7 +161,7 @@ function setupTranscription(options: {
   if (options.audioDeviceId) {
     instance.setAudioDeviceId(options.audioDeviceId);
   }
-  
+
   return { instance, ...rest };
 }
 
@@ -195,9 +208,12 @@ function prepare(options: PrepareOptions = {}): {
     stopTranscription,
     audioDeviceIndex: -1,
   } as unknown as VoskClientType;
-  const { CreateVoskCliClient: mockedCreateVoskCliClient, VoskClient: mockedVoskClient } = require('./VoskClient');
+  const {
+    CreateVoskCliClient: mockedCreateVoskCliClient,
+    VoskClient: mockedVoskClient,
+  } = require('./VoskClient');
   mockedCreateVoskCliClient.mockReturnValue(client);
-  
+
   // Apply mock overrides for listAudioDevices
   if (options.mockOverrides?.listAudioDevices) {
     mockedVoskClient.listAudioDevices.mockReturnValue(options.mockOverrides.listAudioDevices);
@@ -236,261 +252,349 @@ describe('TranscriptionService', () => {
     const scenarios = [
       ['model not downloaded', { audioDeviceId: 'test-device' }, false],
       ['no devices available', { modelDownloaded: true, emptyDevices: true }, false],
-      ['model downloaded and device set', { modelDownloaded: true, audioDeviceId: 'test-device' }, true],
+      [
+        'model downloaded and device set',
+        { modelDownloaded: true, audioDeviceId: 'test-device' },
+        true,
+      ],
       ['auto-select device when available', { modelDownloaded: true }, true],
     ] as const;
 
     scenarios.forEach(([desc, setup, shouldStart]) => {
-      it(`should ${shouldStart ? '' : 'not '}activate when ${desc}`, withClock(async (clock) => {
-        const { instance, client } = setupTranscription(setup);
-        instance.setEnabled(true);
-        await clock.tickAsync(0);
-        if (shouldStart) {
-          expect(client.startTranscription).toHaveBeenCalled();
-        } else {
-          expect(client.startTranscription).not.toHaveBeenCalled();
-        }
-      }));
+      it(
+        `should ${shouldStart ? '' : 'not '}activate when ${desc}`,
+        withClock(async clock => {
+          const { instance, client } = setupTranscription(setup);
+          instance.setEnabled(true);
+          await clock.tickAsync(0);
+          if (shouldStart) {
+            expect(client.startTranscription).toHaveBeenCalled();
+          } else {
+            expect(client.startTranscription).not.toHaveBeenCalled();
+          }
+        }),
+      );
     });
 
-    it('should not activate if audio device manually cleared', withClock(async (clock) => {
-      const { instance, getVoskModelStatus, client } = prepare();
-      const { VoskClient: mockedVoskClient } = require('./VoskClient');
-      mockedVoskClient.listAudioDevices.mockReturnValue(emptyDeviceList);
-      
-      instance.updateAudioDevices();
-      instance.setAudioDeviceId(null);
-      getVoskModelStatus.mockReturnValue({ state: 'downloaded' });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(client.startTranscription).not.toHaveBeenCalled();
-    }));
+    it(
+      'should not activate if audio device manually cleared',
+      withClock(async clock => {
+        const { instance, getVoskModelStatus, client } = prepare();
+        const { VoskClient: mockedVoskClient } = require('./VoskClient');
+        mockedVoskClient.listAudioDevices.mockReturnValue(emptyDeviceList);
 
-    it('should deactivate when setEnabled(false)', withClock(async (clock) => {
-      const { instance, client, stopTranscription } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      instance.setEnabled(false);
-      await clock.tickAsync(0);
-      expect(stopTranscription).toHaveBeenCalled();
-    }));
+        instance.updateAudioDevices();
+        instance.setAudioDeviceId(null);
+        getVoskModelStatus.mockReturnValue({ state: 'downloaded' });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(client.startTranscription).not.toHaveBeenCalled();
+      }),
+    );
+
+    it(
+      'should deactivate when setEnabled(false)',
+      withClock(async clock => {
+        const { instance, client, stopTranscription } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        instance.setEnabled(false);
+        await clock.tickAsync(0);
+        expect(stopTranscription).toHaveBeenCalled();
+      }),
+    );
   });
 
   describe('activeStatus', () => {
-    it('should return "disabled" when service is not enabled', withClock(async (clock) => {
-      const { instance } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      expect(instance.activeStatus()).toBe('disabled');
-    }));
+    it(
+      'should return "disabled" when service is not enabled',
+      withClock(async clock => {
+        const { instance } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        expect(instance.activeStatus()).toBe('disabled');
+      }),
+    );
 
-    it('should return "noAudioDevice" when no audio devices available', withClock(async (clock) => {
-      const { instance } = setupTranscription({ modelDownloaded: true, emptyDevices: true });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noAudioDevice');
-    }));
+    it(
+      'should return "noAudioDevice" when no audio devices available',
+      withClock(async clock => {
+        const { instance } = setupTranscription({ modelDownloaded: true, emptyDevices: true });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noAudioDevice');
+      }),
+    );
 
-    it('should return "noModelDownloaded" when no models are downloaded', withClock(async (clock) => {
-      const { instance } = setupTranscription({ audioDeviceId: 'test-device' });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noModelDownloaded');
-    }));
+    it(
+      'should return "noModelDownloaded" when no models are downloaded',
+      withClock(async clock => {
+        const { instance } = setupTranscription({ audioDeviceId: 'test-device' });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noModelDownloaded');
+      }),
+    );
 
-    it('should return "noVoskModel" when voskModelName is null/undefined but has downloaded models', withClock(async (clock) => {
-      const { instance } = setupTranscription({ audioDeviceId: 'test-device' });
-      
-      // First set up a scenario where we have some downloaded models
-      const mockModelsManager = instance['modelsManager'];
-      jest.spyOn(mockModelsManager, 'getVoskModels').mockReturnValue([
-        { name: 'other-model', description: 'Other', status: { state: 'downloaded' } }
-      ]);
-      
-      // But set the selected model to null (which will be undefined)
-      jest.spyOn(mockModelsManager, 'getVoskModels').mockReturnValue([]);
-      instance.setModelName(null);
-      
-      // Now mock hasAnyDownloadedModel to return true
-      jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
-      
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noVoskModel');
-    }));
+    it(
+      'should return "noVoskModel" when voskModelName is null/undefined but has downloaded models',
+      withClock(async clock => {
+        const { instance } = setupTranscription({ audioDeviceId: 'test-device' });
 
-    it('should return "noVoskModel" when selected model is not downloaded but others are', withClock(async (clock) => {
-      const { instance } = setupTranscription({ audioDeviceId: 'test-device' });
-      
-      // Mock that we have some downloaded models, so hasAnyDownloadedModel returns true
-      jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
-      
-      // But the specific selected model is not downloaded
-      const mockModelsManager = instance['modelsManager'];
-      jest.spyOn(mockModelsManager, 'getVoskModelStatus').mockReturnValue({ state: 'not_downloaded' });
-      
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noVoskModel');
-    }));
+        // First set up a scenario where we have some downloaded models
+        const mockModelsManager = instance['modelsManager'];
+        jest
+          .spyOn(mockModelsManager, 'getVoskModels')
+          .mockReturnValue([
+            { name: 'other-model', description: 'Other', status: { state: 'downloaded' } },
+          ]);
 
-    it('should return "active" when all conditions are met', withClock(async (clock) => {
-      const { instance } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('active');
-    }));
+        // But set the selected model to null (which will be undefined)
+        jest.spyOn(mockModelsManager, 'getVoskModels').mockReturnValue([]);
+        instance.setModelName(null);
 
-    it('should emit activeStatus changes through observable', withClock(async (clock) => {
-      const { instance } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      const statusSpy = jest_fn().mockName('activeStatusSpy');
-      instance.activeStatus$.subscribe(statusSpy);
+        // Now mock hasAnyDownloadedModel to return true
+        jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
 
-      // Initial status should be 'disabled'
-      expect(statusSpy).toHaveBeenLastCalledWith('disabled');
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noVoskModel');
+      }),
+    );
 
-      // Enable should change to 'active'
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(statusSpy).toHaveBeenLastCalledWith('active');
+    it(
+      'should return "noVoskModel" when selected model is not downloaded but others are',
+      withClock(async clock => {
+        const { instance } = setupTranscription({ audioDeviceId: 'test-device' });
 
-      // Disable should change back to 'disabled'
-      instance.setEnabled(false);
-      await clock.tickAsync(0);
-      expect(statusSpy).toHaveBeenLastCalledWith('disabled');
-    }));
+        // Mock that we have some downloaded models, so hasAnyDownloadedModel returns true
+        jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
 
-    it('should transition through different states correctly', withClock(async (clock) => {
-      const { instance } = setupTranscription({ emptyDevices: true });
-      const statusSpy = jest_fn().mockName('activeStatusSpy');
-      instance.activeStatus$.subscribe(statusSpy);
+        // But the specific selected model is not downloaded
+        const mockModelsManager = instance['modelsManager'];
+        jest
+          .spyOn(mockModelsManager, 'getVoskModelStatus')
+          .mockReturnValue({ state: 'not_downloaded' });
 
-      // Start disabled
-      expect(instance.activeStatus()).toBe('disabled');
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noVoskModel');
+      }),
+    );
 
-      // Enable with no devices -> noAudioDevice
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noAudioDevice');
+    it(
+      'should return "active" when all conditions are met',
+      withClock(async clock => {
+        const { instance } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('active');
+      }),
+    );
 
-      // Add devices but no model -> noModelDownloaded
-      const { VoskClient: mockedVoskClient } = require('./VoskClient');
-      mockedVoskClient.listAudioDevices.mockReturnValue(testDeviceList);
-      instance.updateAudioDevices();
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noModelDownloaded');
+    it(
+      'should emit activeStatus changes through observable',
+      withClock(async clock => {
+        const { instance } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        const statusSpy = jest_fn().mockName('activeStatusSpy');
+        instance.activeStatus$.subscribe(statusSpy);
 
-      // Add downloaded model -> active
-      const mockModelsManager = instance['modelsManager'];
-      jest.spyOn(mockModelsManager, 'getVoskModels').mockReturnValue([
-        { name: VOSK_MODEL_NAME, description: 'Test', status: { state: 'downloaded' } }
-      ]);
-      jest.spyOn(mockModelsManager, 'getVoskModelStatus').mockReturnValue({ state: 'downloaded' });
-      jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
-      
-      instance['setModelStatus'](VOSK_MODEL_NAME, { state: 'downloaded' as const });
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('active');
+        // Initial status should be 'disabled'
+        expect(statusSpy).toHaveBeenLastCalledWith('disabled');
 
-      // Remove model -> noVoskModel
-      jest.spyOn(mockModelsManager, 'getVoskModelStatus').mockReturnValue({ state: 'not_downloaded' });
-      // Still has downloaded models in general, so hasAnyDownloadedModel returns true
-      jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
-      instance['setModelStatus'](VOSK_MODEL_NAME, { state: 'not_downloaded' as const });
-      await clock.tickAsync(0);
-      expect(instance.activeStatus()).toBe('noVoskModel');
-    }));
+        // Enable should change to 'active'
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(statusSpy).toHaveBeenLastCalledWith('active');
+
+        // Disable should change back to 'disabled'
+        instance.setEnabled(false);
+        await clock.tickAsync(0);
+        expect(statusSpy).toHaveBeenLastCalledWith('disabled');
+      }),
+    );
+
+    it(
+      'should transition through different states correctly',
+      withClock(async clock => {
+        const { instance } = setupTranscription({ emptyDevices: true });
+        const statusSpy = jest_fn().mockName('activeStatusSpy');
+        instance.activeStatus$.subscribe(statusSpy);
+
+        // Start disabled
+        expect(instance.activeStatus()).toBe('disabled');
+
+        // Enable with no devices -> noAudioDevice
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noAudioDevice');
+
+        // Add devices but no model -> noModelDownloaded
+        const { VoskClient: mockedVoskClient } = require('./VoskClient');
+        mockedVoskClient.listAudioDevices.mockReturnValue(testDeviceList);
+        instance.updateAudioDevices();
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noModelDownloaded');
+
+        // Add downloaded model -> active
+        const mockModelsManager = instance['modelsManager'];
+        jest
+          .spyOn(mockModelsManager, 'getVoskModels')
+          .mockReturnValue([
+            { name: VOSK_MODEL_NAME, description: 'Test', status: { state: 'downloaded' } },
+          ]);
+        jest
+          .spyOn(mockModelsManager, 'getVoskModelStatus')
+          .mockReturnValue({ state: 'downloaded' });
+        jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
+
+        instance['setModelStatus'](VOSK_MODEL_NAME, { state: 'downloaded' as const });
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('active');
+
+        // Remove model -> noVoskModel
+        jest
+          .spyOn(mockModelsManager, 'getVoskModelStatus')
+          .mockReturnValue({ state: 'not_downloaded' });
+        // Still has downloaded models in general, so hasAnyDownloadedModel returns true
+        jest.spyOn(instance, 'hasAnyDownloadedModel').mockReturnValue(true);
+        instance['setModelStatus'](VOSK_MODEL_NAME, { state: 'not_downloaded' as const });
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('noVoskModel');
+      }),
+    );
   });
 
   describe('text processing', () => {
+    it(
+      'should process partial and final text',
+      withClock(async clock => {
+        const { instance, transcriptionMessages$ } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
 
-    it('should process partial and final text', withClock(async (clock) => {
-      const { instance, transcriptionMessages$ } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
+        const textSpy = jest_fn().mockName('textSpy');
+        const partialSpy = jest_fn().mockName('partialSpy');
+        const linesSpy = jest_fn().mockName('linesSpy');
+        instance.text$.subscribe(textSpy);
+        instance.partial$.subscribe(partialSpy);
+        instance.lines$.subscribe(linesSpy);
 
-      const textSpy = jest_fn().mockName('textSpy');
-      const partialSpy = jest_fn().mockName('partialSpy');
-      const linesSpy = jest_fn().mockName('linesSpy');
-      instance.text$.subscribe(textSpy);
-      instance.partial$.subscribe(partialSpy);
-      instance.lines$.subscribe(linesSpy);
+        transcriptionMessages$.next({ partial: 'こんにちは' });
+        await clock.tickAsync(0);
+        expect(partialSpy).toHaveBeenLastCalledWith('こんにちは');
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: [], partial: 'こんにちは...' });
 
-      transcriptionMessages$.next({ partial: 'こんにちは' });
-      await clock.tickAsync(0);
-      expect(partialSpy).toHaveBeenLastCalledWith('こんにちは');
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: [], partial: 'こんにちは...' });
+        transcriptionMessages$.next({ text: 'こんにちは世界' });
+        await clock.tickAsync(0);
+        expect(textSpy).toHaveBeenCalledWith(expect.objectContaining({ text: 'こんにちは世界' }));
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['こんにちは世界'], partial: '' });
+      }),
+    );
 
-      transcriptionMessages$.next({ text: 'こんにちは世界' });
-      await clock.tickAsync(0);
-      expect(textSpy).toHaveBeenCalledWith(expect.objectContaining({ text: 'こんにちは世界' }));
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['こんにちは世界'], partial: '' });
-    }));
+    it(
+      'should handle text file line limit and time to live',
+      withClock(async clock => {
+        const { instance, transcriptionMessages$ } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
 
-    it('should handle text file line limit and time to live', withClock(async (clock) => {
-      const { instance, transcriptionMessages$ } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
+        instance.setTextFileMaxLine(2);
+        instance.setTextFileLineTimeToLive(1000);
 
-      instance.setTextFileMaxLine(2);
-      instance.setTextFileLineTimeToLive(1000);
+        const linesSpy = jest_fn().mockName('linesSpy');
+        instance.lines$.subscribe(linesSpy);
 
-      const linesSpy = jest_fn().mockName('linesSpy');
-      instance.lines$.subscribe(linesSpy);
+        transcriptionMessages$.next({ text: 'line 1' });
+        await clock.tickAsync(0);
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 1'], partial: '' });
 
-      transcriptionMessages$.next({ text: 'line 1' });
-      await clock.tickAsync(0);
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 1'], partial: '' });
+        transcriptionMessages$.next({ text: 'line 2' });
+        await clock.tickAsync(0);
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 1', 'line 2'], partial: '' });
 
-      transcriptionMessages$.next({ text: 'line 2' });
-      await clock.tickAsync(0);
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 1', 'line 2'], partial: '' });
+        transcriptionMessages$.next({ text: 'line 3' });
+        await clock.tickAsync(0);
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 2', 'line 3'], partial: '' });
 
-      transcriptionMessages$.next({ text: 'line 3' });
-      await clock.tickAsync(0);
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 2', 'line 3'], partial: '' });
+        await clock.tickAsync(1000);
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 3'], partial: '' });
 
-      await clock.tickAsync(1000);
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: ['line 3'], partial: '' });
+        await clock.tickAsync(1000);
+        expect(linesSpy).toHaveBeenLastCalledWith({ texts: [], partial: '' });
+      }),
+    );
 
-      await clock.tickAsync(1000);
-      expect(linesSpy).toHaveBeenLastCalledWith({ texts: [], partial: '' });
-    }));
+    it(
+      'should write to text file when enabled',
+      withClock(async clock => {
+        const { instance, transcriptionMessages$ } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        const { promises } = require('node:fs');
 
-    it('should write to text file when enabled', withClock(async (clock) => {
-      const { instance, transcriptionMessages$ } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      const { promises } = require('node:fs');
-      
-      instance.setEnabled(true);
-      instance.setTextFileEnabled(true);
-      instance.setTextFilePath('/fake/transcription.txt');
-      await clock.tickAsync(0);
+        instance.setEnabled(true);
+        instance.setTextFileEnabled(true);
+        instance.setTextFilePath('/fake/transcription.txt');
+        await clock.tickAsync(0);
 
-      transcriptionMessages$.next({ text: 'hello world' });
-      await clock.tickAsync(0);
+        transcriptionMessages$.next({ text: 'hello world' });
+        await clock.tickAsync(0);
 
-      expect(promises.writeFile).toHaveBeenCalledWith('/fake/transcription.txt', 'hello world', 'utf-8');
-    }));
+        expect(promises.writeFile).toHaveBeenCalledWith(
+          '/fake/transcription.txt',
+          'hello world',
+          'utf-8',
+        );
+      }),
+    );
 
-    it('should disable text file writing on error', withClock(async (clock) => {
-      const { instance, transcriptionMessages$ } = setupTranscription({ modelDownloaded: true, audioDeviceId: 'test-device' });
-      const { promises } = require('node:fs');
-      promises.writeFile.mockRejectedValue(new Error('Disk full'));
+    it(
+      'should disable text file writing on error',
+      withClock(async clock => {
+        const { instance, transcriptionMessages$ } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
+        const { promises } = require('node:fs');
+        promises.writeFile.mockRejectedValue(new Error('Disk full'));
 
-      instance.setEnabled(true);
-      instance.setTextFileEnabled(true);
-      instance.setTextFilePath('/fake/transcription.txt');
-      const spy = jest.spyOn(instance, 'setTextFileEnabled');
-      await clock.tickAsync(0);
+        instance.setEnabled(true);
+        instance.setTextFileEnabled(true);
+        instance.setTextFilePath('/fake/transcription.txt');
+        const spy = jest.spyOn(instance, 'setTextFileEnabled');
+        await clock.tickAsync(0);
 
-      transcriptionMessages$.next({ text: 'hello world' });
-      await clock.tickAsync(0);
+        transcriptionMessages$.next({ text: 'hello world' });
+        await clock.tickAsync(0);
 
-      expect(spy).toHaveBeenCalledWith(false);
-    }));
+        expect(spy).toHaveBeenCalledWith(false);
+      }),
+    );
   });
 
   describe('audio device management', () => {
     it('should get audio device list', () => {
-      expect(setupTranscription().instance.getAudioDeviceList()).toEqual([{ id: 'test-device', name: 'Test Device' }]);
+      expect(setupTranscription().instance.getAudioDeviceList()).toEqual([
+        { id: 'test-device', name: 'Test Device' },
+      ]);
       expect(setupTranscription({ emptyDevices: true }).instance.getAudioDeviceList()).toEqual([]);
     });
 
@@ -503,13 +607,13 @@ describe('TranscriptionService', () => {
 
     it('should set and correct audio device ID', () => {
       const { instance } = setupTranscription();
-      
+
       instance.setAudioDeviceId('test-device');
       expect(instance.state.audioDeviceId).toBe('test-device');
-      
+
       instance.setAudioDeviceId('invalid-device');
       expect(instance.state.audioDeviceId).toBe('test-device');
-      
+
       instance.setAudioDeviceId(null);
       expect(instance.state.audioDeviceId).toBe('test-device');
     });
@@ -517,22 +621,27 @@ describe('TranscriptionService', () => {
     it('should auto-select first available device', () => {
       // With devices available, should auto-select first
       expect(setupTranscription().instance.state.audioDeviceId).toBe('test-device');
-      
+
       // With empty device list, still gets auto-corrected to first available in mocked list
-      expect(setupTranscription({ emptyDevices: true }).instance.state.audioDeviceId).toBe('test-device');
+      expect(setupTranscription({ emptyDevices: true }).instance.state.audioDeviceId).toBe(
+        'test-device',
+      );
     });
 
     it('should handle updateAudioDevices error gracefully', () => {
       const { instance } = setupTranscription();
       const { VoskClient: mockedVoskClient } = require('./VoskClient');
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      
+
       mockedVoskClient.listAudioDevices.mockImplementation(() => {
         throw new Error('Audio device enumeration failed');
       });
-      
+
       expect(() => instance.updateAudioDevices()).not.toThrow();
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to create Vosk CLI client:', expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to create Vosk CLI client:',
+        expect.any(Error),
+      );
       consoleSpy.mockRestore();
     });
 
@@ -556,20 +665,25 @@ describe('TranscriptionService', () => {
       expect(downloadAndUnzip).toHaveBeenCalled();
     });
 
-    it('should delete a model and deactivate service', withClock(async (clock) => {
-      const { instance, stopTranscription, setVoskModelStatus } = setupTranscription({ 
-        modelDownloaded: true, 
-        audioDeviceId: 'test-device' 
-      });
-      
-      instance.setEnabled(true);
-      await clock.tickAsync(0);
+    it(
+      'should delete a model and deactivate service',
+      withClock(async clock => {
+        const { instance, stopTranscription, setVoskModelStatus } = setupTranscription({
+          modelDownloaded: true,
+          audioDeviceId: 'test-device',
+        });
 
-      await instance.deleteVoskModel(VOSK_MODEL_NAME);
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
 
-      expect(setVoskModelStatus).toHaveBeenLastCalledWith(VOSK_MODEL_NAME, { state: 'not_downloaded' });
-      expect(stopTranscription).toHaveBeenCalled();
-      expect(require('node:fs').promises.rmdir).toHaveBeenCalled();
-    }));
+        await instance.deleteVoskModel(VOSK_MODEL_NAME);
+
+        expect(setVoskModelStatus).toHaveBeenLastCalledWith(VOSK_MODEL_NAME, {
+          state: 'not_downloaded',
+        });
+        expect(stopTranscription).toHaveBeenCalled();
+        expect(require('node:fs').promises.rmdir).toHaveBeenCalled();
+      }),
+    );
   });
 });

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -85,9 +85,14 @@ export function defaultTextFilePath() {
 export type ActiveStatus =
   | 'active'
   | 'disabled'
+  | 'voskLaunchError'
+  | 'voskError'
   | 'noAudioDevice'
   | 'noModelDownloaded'
-  | 'noVoskModel';
+  | 'noVoskModel'
+  | 'modelLoadError';
+
+export type VoskError = 'launchError' | 'error';
 
 export class TranscriptionService extends PersistentStatefulService<ITranscriptionServiceState> {
   @Inject() transcriptionSourceUsageService: TranscriptionSourceUsageService;
@@ -122,6 +127,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
   });
   private modelsStatusSubject$ = new BehaviorSubject<Dictionary<VoskModelStatus>>({});
   private activeStatusSubject$ = new BehaviorSubject<ActiveStatus>('disabled');
+  private voskError$ = new BehaviorSubject<VoskError | null>(null);
   private updateActiveness$ = new Subject<void>();
 
   getModelPath(modelName: string): string {
@@ -213,19 +219,31 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     this.setTextFilePath(defaultTextFilePath());
 
     // enable 状態を監視して、状態が変わったら activate する
-    this.updateActiveness$
+    merge(this.updateActiveness$, this.voskError$)
       .pipe(
         map((): ActiveStatus => {
           if (!this.state.enabled) return 'disabled';
+
+          const voskError = this.voskError$.value;
+          if (voskError === 'launchError') return 'voskLaunchError';
+          if (voskError === 'error') return 'voskError';
+
           if (this.audioDevices$.value.length === 0) return 'noAudioDevice';
-          if (!this.hasAnyDownloadedModel()) return 'noModelDownloaded';
+
+          // 選択中のモデルの状態を先にチェック
           if (!this.state.voskModelName) return 'noVoskModel';
-          if (
-            this.modelsManager.getVoskModelStatus(this.state.voskModelName).state !== 'downloaded'
-          ) {
+
+          const modelStatus = this.modelsManager.getVoskModelStatus(this.state.voskModelName);
+          if (modelStatus.state === 'load_error') return 'modelLoadError';
+          if (modelStatus.state !== 'downloaded') {
+            // 選択中のモデルがダウンロードされていない場合のみ、他のモデルの存在をチェック
+            if (!this.hasAnyDownloadedModel()) return 'noModelDownloaded';
             return 'noVoskModel';
           }
           return 'active';
+        }),
+        tap(status => {
+          console.log('TranscriptionService activeStatus:', status);
         }),
       )
       .subscribe(this.activeStatusSubject$);
@@ -409,6 +427,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       });
       console.error('Failed to create Vosk CLI client:', err);
       this.client = null;
+      this.voskError$.next('launchError');
       return;
     }
 
@@ -421,10 +440,22 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
           this.partialSubject$.next(filterNoiseText(message.partial));
         } else if (isErrorTranscriptionMessage(message)) {
           console.error('Transcription error:', message.error);
+          if (message.error.startsWith('Failed to load model:')) {
+            this.deactivate();
+            this.setModelStatus(this.state.voskModelName, {
+              state: 'load_error',
+              error_message: message.error,
+            });
+          }
         } else if (isProcessExitedMessage(message)) {
           console.log('Vosk CLI process exited:', message.processExited);
-          this.deactivate();
-          this.updateActiveness$.next();
+          if (message.processExited.toLowerCase().includes('launch error')) {
+            this.deactivate();
+            this.voskError$.next('launchError');
+          } else {
+            this.deactivate();
+            this.voskError$.next('error');
+          }
         } else if (isInfoTranscriptionMessage(message) || isFormatTranscriptionMessage(message)) {
           // can safely be ignored
         } else {
@@ -456,6 +487,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       this.subscription.unsubscribe();
       this.subscription = null;
     }
+    // this.voskError$.next(null);
     this.updateActiveness$.next();
   }
 
@@ -468,6 +500,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       message: `TranscriptionService ${enabled ? 'enabled' : 'disabled'}`,
     });
     if (enabled) {
+      this.voskError$.next(null);
       this.updateAudioDevices();
     }
     this.setState({ enabled });

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -409,6 +409,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
         `Vosk model '${this.state.voskModelName}' is not downloaded. Please download it first.`,
       );
     }
+    console.log('Activating TranscriptionService with model:', this.state.voskModelName);
     try {
       this.client = CreateVoskCliClient({
         voskCliPath: this.voskCliPath,
@@ -487,8 +488,6 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       this.subscription.unsubscribe();
       this.subscription = null;
     }
-    // this.voskError$.next(null);
-    this.updateActiveness$.next();
   }
 
   setEnabled(enabled: boolean) {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "uuid": "^3.4.0",
     "v-tooltip": "~2.1.3",
     "vee-validate": "~2.2.15",
-    "vosk-cli": "github:n-air-app/vosk-cli#1.0.0",
+    "vosk-cli": "github:n-air-app/vosk-cli#1.0.1",
     "vue": "2.7.14",
     "vue-codemirror": "4.0.6",
     "vue-color": "2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13358,9 +13358,9 @@ verror@^1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vosk-cli@github:n-air-app/vosk-cli#1.0.0":
-  version "1.0.0"
-  resolved "https://codeload.github.com/n-air-app/vosk-cli/tar.gz/ac3ab6b7de192480a014b493a8cdd8b2556aff72"
+"vosk-cli@github:n-air-app/vosk-cli#1.0.1":
+  version "1.0.1"
+  resolved "https://codeload.github.com/n-air-app/vosk-cli/tar.gz/c408ffba4b37b749c734fe8549ff9384743de342"
 
 vue-class-component@^6.2.0:
   version "6.3.2"


### PR DESCRIPTION
# このpull requestが解決する内容
- [vosk-cli](https://github.com/n-air-app/vosk-cli) を 1.0.1に更新(JSON出力でエスケープ処理を追加)
- vosk-cliの起動エラーハンドリング
  - 起動エラー状態を保持
  - モデル読み込みエラーは場合分けをして、モデルステータスに反映し、その状態のモデルを選択しているときはプレビューに出すエラー文言も追加
- モデル変更で正しく指定したモデルで起動する

# 動作確認手順
- VoskClientのコンストラクターで `this._voskCliPath` や `this._modelPath` を設定しているところになにか適当な文字を追加するなりしてエラーが出るようにすると、それぞれエンジン起動エラー、モデル読み込みエラーになること
- 設定で両方のモデルを正常に読み込めている場合、選択を変更するとちゃんと切り替わること (console.log で表示確認するか、「こんにちは」が平仮名に確定するのがlarge, 「今日は」に確定するのがsmall)
