### PR TITLE
開発: GitHub Actionsをハッシュピンニング形式に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       bin: ${{ steps.filter.outputs.common == 'true' || steps.filter.outputs.bin == 'true' }}
     steps:
       - name: Checkout if push
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         if: ${{ github.event_name == 'push' }}
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -56,16 +56,16 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: cache node modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'additional/additional.json', 'additional/main.mjs') }}
@@ -84,16 +84,16 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: cache node modules(bin)
         id: cache-node-modules-bin
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: bin/node_modules
           key: ${{ runner.os }}-node-bin-${{ hashFiles('bin/yarn.lock') }}
@@ -110,16 +110,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: cache node modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'additional/additional.json', 'additional/main.mjs') }}
@@ -135,23 +135,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: cache node modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'additional/additional.json', 'additional/main.mjs') }}
 
       - name: cache node modules(bin)
         id: cache-node-modules-bin
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: bin/node_modules
           key: ${{ runner.os }}-node-bin-${{ hashFiles('bin/yarn.lock') }}
@@ -174,18 +174,18 @@ jobs:
     steps:
       - name: Checkout code
         if: ${{ needs.changes.outputs.app == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
         if: ${{ needs.changes.outputs.app == 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
       - name: cache node modules
         if: ${{ needs.changes.outputs.app == 'true' }}
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock', 'additional/additional.json', 'additional/main.mjs') }}


### PR DESCRIPTION
## 概要

`.github/workflows/test.yml` で使用しているGitHub Actionsをセキュリティ向上のためcommit hashによるピンニング形式に更新しました。

## 変更内容

以下のアクションをハッシュピンニング形式（`owner/repo@full-commit-hash # version`）に変更：

- `actions/checkout@v4` → `@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0`
- `dorny/paths-filter@v3` → `@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2`
- `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
- `actions/cache@v4` → `@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`

## 利点

- タグの書き換えによる攻撃を防止
- 使用しているアクションの正確なバージョンを明示
- セキュリティベストプラクティスに準拠

## テスト計画

- [x] CIワークフローが正常に実行されることを確認
- [x] すべてのジョブが期待通りに動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)