### PR TITLE
開発: 非推奨のnpm設定を.npmrcから削除

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,1 @@
-arch=x64
-runtime=electron
-target=2.0.8
-disturl=https://atom.io/download/electron
-build_from_source=true
 @n-air-app:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## 問題
npm コマンド実行時に以下の警告が表示されていました:

```
npm warn Unknown project config "arch". This will stop working in the next major version of npm.
npm warn Unknown project config "runtime". This will stop working in the next major version of npm.
npm warn Unknown project config "target". This will stop working in the next major version of npm.
npm warn Unknown project config "disturl". This will stop working in the next major version of npm.
npm warn Unknown project config "build_from_source". This will stop working in the next major version of npm.
```

## 変更内容
npm 12以降で削除される予定の以下の設定を `.npmrc` から削除しました:
- `arch`
- `runtime`
- `target`
- `disturl`
- `build_from_source`

これらはnative moduleをソースからビルドする際に使用されていた設定ですが、現在はGitHub Releasesからpre-builtバイナリを使用しているため不要です。

## 補足
このプロジェクトでは yarn v1 (`yarn@1.22.22`) をパッケージマネージャーとして使用しています。`.npmrc` は GitHub Packages (`@n-air-app` scope) の認証設定のためだけに使用しており、削除した設定項目は yarn では使用されていません。

GitHub Packagesの認証に必要な `@n-air-app:registry` 設定は維持しています。

## 確認事項
- [x] `npm --version` で警告が表示されなくなることを確認
- [x] GitHub Packages認証に必要な設定は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)