### PR TITLE
開発: GitHub ActionsのNode.jsバージョンを22に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: cache node modules
         id: cache-node-modules
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: cache node modules(bin)
         id: cache-node-modules-bin
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: cache node modules
         id: cache-node-modules
@@ -140,7 +140,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: cache node modules
         id: cache-node-modules
@@ -180,7 +180,7 @@ jobs:
         if: ${{ needs.changes.outputs.app == 'true' }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: cache node modules
         if: ${{ needs.changes.outputs.app == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,4 +161,4 @@ test('service behavior', () => {
 
 **Native Modules:** Several native dependencies hosted on GitHub releases (obs-studio-node, font-manager, etc.)
 **Package Manager:** Must use Yarn (npm blocked), lockfile committed
-**Node Version:** Requires Node.js 20.x LTS
+**Node Version:** Requires Node.js 22.x LTS

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ N Air は Streamlabs OBS をベースにした、生放送に便利な機能が�
 
 npm パッケージをインストールし、さまざまなスクリプトを実行するには Node が必要です。
 
-現在の LTS リリース 20.x.x を推奨します：<https://nodejs.org/>
+現在の LTS リリース 22.x.x を推奨します：<https://nodejs.org/>
 
 ### Yarn
 

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "engines": {
+    "node": ">=20.0.0",
     "npm": "please-use-yarn"
   },
   "buildProductName": "N Air"


### PR DESCRIPTION
## 概要
GitHub ActionsのワークフローおよびドキュメントでNode.jsバージョンを20から22に更新し、package.jsonにNode.jsの最小バージョン要件を設定しました。

## 変更内容
- `.github/workflows/test.yml`: すべてのジョブでNode.jsバージョンを22に変更
  - setup-app
  - setup-bin  
  - unit_test-app
  - unit_test-bin
  - e2e_test
- `README.md`: Node.js推奨バージョンを20.x.xから22.x.xに更新
- `CLAUDE.md`: Node.js必須バージョンを20.x LTSから22.x LTSに更新
- `package.json`: engines フィールドに `node >= 20.0.0` を追加（Node.js 20は現在もLTSサポート中のため下限として設定）

## テスト計画
- [ ] GitHub Actionsのワークフローが正常に実行されることを確認
- [ ] すべてのジョブがNode.js 22で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)