### PR TITLE
追加: コンパクトモード解除ボタンにヘルプTipを追加

### DIFF
--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -5,6 +5,14 @@
         <a @click="toggleCompactMode" class="link">
           <i v-if="isCompactMode" class="icon-full-mode" :title="$t('common.fullMode')" />
           <i v-if="!isCompactMode" class="icon-compact-mode" :title="$t('common.compactMode')" />
+          <help-tip
+            v-if="isCompactMode"
+            :dismissable-key="CompactModeToggleHelpTipDismissable"
+            mode="compact-mode-toggle"
+          >
+            <div slot="title" v-text="$t('common.compactModeToggleHelpTipTitle')"></div>
+            <div slot="content" v-text="$t('common.compactModeToggleHelpTipContent')"></div>
+          </help-tip>
         </a>
       </div>
       <template v-if="isCompactMode && isUserLoggedIn">

--- a/app/components/SideNav.vue.ts
+++ b/app/components/SideNav.vue.ts
@@ -94,6 +94,10 @@ export default class SideNav extends Vue {
     return EDismissable.InitialHelpTip;
   }
 
+  get CompactModeToggleHelpTipDismissable() {
+    return EDismissable.CompactModeToggleHelpTip;
+  }
+
   openHelp() {
     remote.shell.openExternal('https://qa.nicovideo.jp/faq/show/11857?site_domain=default');
   }

--- a/app/components/shared/HelpTip.vue
+++ b/app/components/shared/HelpTip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="help-tip" v-if="shouldShow && !isCompactMode" :data-mode="mode">
+  <div class="help-tip" v-if="shouldShow && (mode === 'compact-mode-toggle' || !isCompactMode)" :data-mode="mode">
     <div class="help-tip__arrow"></div>
     <div class="help-tip__inner">
       <div class="help-tip__title">
@@ -43,6 +43,12 @@
     left: 44px;
   }
 
+  &[data-mode='compact-mode-toggle'] {
+    top: 0;
+    left: 48px;
+    max-width: 280px;
+  }
+
   &[data-mode='streaming'] {
     right: -12px;
     bottom: 62px;
@@ -66,6 +72,10 @@
 
   .help-tip[data-mode='login'] & {
     bottom: 8px;
+  }
+
+  .help-tip[data-mode='compact-mode-toggle'] & {
+    top: 20px;
   }
 
   .help-tip[data-mode='streaming'] & {

--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -76,6 +76,8 @@
   "loginHelpTipContent": "Click here to log in to niconico",
   "endStreamHelpTipTitle": "Stream Not Started",
   "endStreamHelpTipContent": "The program is live, but video and audio are not being sent.\nClick [GO LIVE] to begin.",
+  "compactModeToggleHelpTipTitle": "Switch to Full Mode",
+  "compactModeToggleHelpTipContent": "Click this button to exit compact mode",
   "fieldIsRequired": "The field is required",
   "fieldMustBeLarger": "The field value must be %{value} or larger",
   "fieldMustBeLess": "The field value must be %{value} or less",

--- a/app/i18n/ja-JP/common.json
+++ b/app/i18n/ja-JP/common.json
@@ -76,6 +76,8 @@
   "loginHelpTipContent": "ニコニコへのログインはこちら",
   "endStreamHelpTipTitle": "配信が開始されていません",
   "endStreamHelpTipContent": "番組は視聴者に公開されていますが、映像・音声が届いていません。\n［配信開始］ボタンを押して、配信を開始してください。",
+  "compactModeToggleHelpTipTitle": "フルモードへの切り替え",
+  "compactModeToggleHelpTipContent": "このボタンをクリックするとコンパクトモードを解除できます",
   "fieldIsRequired": "このフィールドは必須です",
   "fieldMustBeLarger": "%{value} 以上を指定してください",
   "fieldMustBeLess": "%{value} 以上を指定してください",

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -8,6 +8,7 @@ export enum EDismissable {
   LoginHelpTip = 'login_help_tip',
   EndStreamHelpTip = 'end_stream_help_tip',
   InitialHelpTip = 'initial_help_tip',
+  CompactModeToggleHelpTip = 'compact_mode_toggle_help_tip',
 }
 
 const InitiallyDismissed = new Set<EDismissable>([]);


### PR DESCRIPTION
## Summary
- コンパクトモード時にフルモードボタンの横にヘルプTipを追加
- ユーザーがこのボタンでコンパクトモードを解除できることを分かりやすくした
- EDismissable.CompactModeToggleHelpTip キーを追加
- i18n文言（日本語/英語）を追加
- HelpTipコンポーネントのスタイルと表示条件を更新

<img width="515" height="474" alt="image" src="https://github.com/user-attachments/assets/e40733d5-a645-4906-987c-58dd51e88312" />
<img width="454" height="165" alt="image" src="https://github.com/user-attachments/assets/f9a9dc76-6d6b-4660-a926-b2ec1dcc4498" />


## Test plan
- [x] コンパクトモードに切り替える
- [x] フルモードボタンの横にヘルプTipが表示されることを確認
- [x] ヘルプTipの内容が正しく表示されることを確認（日本語/英語）
- [x] ヘルプTipの閉じるボタンが機能することを確認
- [x] ヘルプTipを閉じた後、再度表示されないことを確認
- [x] フルモードに切り替えた後、ヘルプTipが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)