### PR TITLE
改善: ミキサーの音量メーターの負荷軽減

### DIFF
--- a/app/components/MixerVolmeter.vue.ts
+++ b/app/components/MixerVolmeter.vue.ts
@@ -1,7 +1,5 @@
 import { Subscription } from 'rxjs';
 import { AudioSource } from 'services/audio';
-import { Inject } from 'services/core/injector';
-import { CustomizationService } from 'services/customization';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 
@@ -24,61 +22,85 @@ const ADVANCED_BG = '#050e18';
 
 @Component({})
 export default class MixerVolmeter extends Vue {
-  @Prop() audioSource: AudioSource;
+  @Prop() audioSource!: AudioSource;
 
-  @Inject() customizationService: CustomizationService;
+  private volmeterSubscription?: Subscription;
 
-  volmeterSubscription: Subscription;
-
-  $refs: {
+  $refs!: {
     canvas: HTMLCanvasElement;
     spacer: HTMLDivElement;
   };
 
-  ctx: CanvasRenderingContext2D;
+  private ctx!: CanvasRenderingContext2D;
 
-  peakHoldCounters: number[];
-  peakHolds: number[];
-  canvasWidth: number;
-  canvasWidthInterval: number;
-  channelCount: number;
-  canvasHeight: number;
+  private peakHoldCounters: number[] = [];
+  private peakHolds: number[] = [];
+  private canvasWidth = 0;
+  private channelCount = 0;
+  private canvasHeight = 0;
 
-  mounted() {
-    this.subscribeVolmeter();
-    this.peakHoldCounters = [];
-    this.peakHolds = [];
+  private previousPeaks: number[] = [];
+  private previousPeakHolds: number[] = [];
+  private hasDrawn = false;
+
+  private resizeObserver?: ResizeObserver;
+
+  mounted(): void {
+    this.ctx = this.$refs.canvas.getContext('2d')!;
     this.setChannelCount(1);
-    this.ctx = this.$refs.canvas.getContext('2d');
-    this.canvasWidthInterval = window.setInterval(() => this.setCanvasWidth(), 500);
+    this.updateCanvasWidth();
+    this.subscribeVolmeter();
+
+    // ResizeObserverでサイズ変更を監視
+    this.resizeObserver = new ResizeObserver(() => this.updateCanvasWidth());
+
+    const parentElement = this.$refs.canvas.parentElement;
+    if (parentElement) this.resizeObserver.observe(parentElement);
   }
 
-  destroyed() {
-    clearInterval(this.canvasWidthInterval);
+  destroyed(): void {
+    // ResizeObserverの監視を停止
+    if (this.resizeObserver) this.resizeObserver.disconnect();
     this.unsubscribeVolmeter();
   }
 
-  setChannelCount(channels: number) {
-    if (channels !== this.channelCount) {
-      this.channelCount = channels;
-      this.canvasHeight = channels * (CHANNEL_HEIGHT + PADDING_HEIGHT) - PADDING_HEIGHT;
-      this.$refs.canvas.height = this.canvasHeight;
-      this.$refs.canvas.style.height = `${this.canvasHeight}px`;
-      this.$refs.spacer.style.height = `${this.canvasHeight}px`;
-    }
+  private setChannelCount(channels: number): void {
+    if (channels === this.channelCount) return;
+
+    this.channelCount = channels;
+    this.canvasHeight = channels * (CHANNEL_HEIGHT + PADDING_HEIGHT) - PADDING_HEIGHT;
+    this.$refs.canvas.height = this.canvasHeight;
+    this.$refs.canvas.style.height = `${this.canvasHeight}px`;
+    this.$refs.spacer.style.height = `${this.canvasHeight}px`;
+
+    this.peakHoldCounters = new Array(channels).fill(0);
+    this.peakHolds = new Array(channels).fill(-65535);
+    this.previousPeaks = new Array(channels).fill(-65535);
+    this.previousPeakHolds = new Array(channels).fill(-65535);
   }
 
-  setCanvasWidth() {
-    const width = Math.floor(this.$refs.canvas.parentElement.offsetWidth);
+  private updateCanvasWidth(): void {
+    const parentElement = this.$refs.canvas.parentElement;
+    if (!parentElement) return;
 
-    if (width !== this.canvasWidth) {
-      this.canvasWidth = width;
-      this.$refs.canvas.width = width;
-      this.$refs.canvas.style.width = `${width}px`;
-    }
+    const width = Math.floor(parentElement.offsetWidth);
+    if (width === this.canvasWidth) return;
+
+    this.canvasWidth = width;
+    this.$refs.canvas.width = width;
+    this.$refs.canvas.style.width = `${width}px`;
+    this.hasDrawn = false;
+
+    // キャッシュを更新
+    this.recalculatePixelCache();
   }
 
-  drawVolmeter(peaks: number[]) {
+  private recalculatePixelCache(): void {
+    this.warningPx = this.convertDbToPixels(WARNING_LEVEL);
+    this.dangerPx = this.convertDbToPixels(DANGER_LEVEL);
+  }
+
+  private drawVolmeter(peaks: number[]): void {
     this.ctx.fillStyle = ADVANCED_BG;
     this.ctx.fillRect(0, 0, this.canvasWidth, this.canvasHeight);
 
@@ -87,70 +109,124 @@ export default class MixerVolmeter extends Vue {
     });
   }
 
-  drawVolmeterChannel(peak: number, channel: number) {
-    this.updatePeakHold(peak, channel);
+  // キャッシュ用プロパティ
+  private warningPx = 0;
+  private dangerPx = 0;
 
+  private drawVolmeterChannel(peak: number, channel: number): void {
     const heightOffset = channel * (CHANNEL_HEIGHT + PADDING_HEIGHT);
-    const warningPx = this.dbToPx(WARNING_LEVEL);
-    const dangerPx = this.dbToPx(DANGER_LEVEL);
+    const peakPx = this.convertDbToPixels(peak);
 
+    // 背景描画
+    this.drawChannelBackground(heightOffset);
+
+    // ピークレベル描画
+    this.drawPeakLevel(peak, peakPx, heightOffset);
+
+    // ピークホールド描画
+    this.drawPeakHold(channel, heightOffset);
+  }
+
+  private drawChannelBackground(heightOffset: number): void {
     this.ctx.fillStyle = GREEN_BG;
-    this.ctx.fillRect(0, heightOffset, warningPx, CHANNEL_HEIGHT);
+    this.ctx.fillRect(0, heightOffset, this.warningPx, CHANNEL_HEIGHT);
     this.ctx.fillStyle = YELLOW_BG;
-    this.ctx.fillRect(warningPx, heightOffset, dangerPx - warningPx, CHANNEL_HEIGHT);
+    this.ctx.fillRect(this.warningPx, heightOffset, this.dangerPx - this.warningPx, CHANNEL_HEIGHT);
     this.ctx.fillStyle = RED_BG;
-    this.ctx.fillRect(dangerPx, heightOffset, this.canvasWidth - dangerPx, CHANNEL_HEIGHT);
+    this.ctx.fillRect(
+      this.dangerPx,
+      heightOffset,
+      this.canvasWidth - this.dangerPx,
+      CHANNEL_HEIGHT,
+    );
+  }
 
-    const peakPx = this.dbToPx(peak);
+  private drawPeakLevel(peak: number, peakPx: number, heightOffset: number): void {
+    // Green level
+    const greenLevel = Math.min(peakPx, this.warningPx);
+    if (greenLevel <= 0) return;
 
-    const greenLevel = Math.min(peakPx, warningPx);
     this.ctx.fillStyle = GREEN;
     this.ctx.fillRect(0, heightOffset, greenLevel, CHANNEL_HEIGHT);
 
-    if (peak > WARNING_LEVEL) {
-      const yellowLevel = Math.min(peakPx, dangerPx);
-      this.ctx.fillStyle = YELLOW;
-      this.ctx.fillRect(warningPx, heightOffset, yellowLevel - warningPx, CHANNEL_HEIGHT);
-    }
+    // Yellow level
+    if (peak <= WARNING_LEVEL) return;
 
-    if (peak > DANGER_LEVEL) {
-      this.ctx.fillStyle = RED;
-      this.ctx.fillRect(dangerPx, heightOffset, peakPx - dangerPx, CHANNEL_HEIGHT);
-    }
+    const yellowLevel = Math.min(peakPx, this.dangerPx);
+    this.ctx.fillStyle = YELLOW;
+    this.ctx.fillRect(this.warningPx, heightOffset, yellowLevel - this.warningPx, CHANNEL_HEIGHT);
 
-    this.ctx.fillStyle = GREEN;
-    if (this.peakHolds[channel] > WARNING_LEVEL) this.ctx.fillStyle = YELLOW;
-    if (this.peakHolds[channel] > DANGER_LEVEL) this.ctx.fillStyle = RED;
+    // Red level
+    if (peak <= DANGER_LEVEL) return;
+
+    this.ctx.fillStyle = RED;
+    this.ctx.fillRect(this.dangerPx, heightOffset, peakPx - this.dangerPx, CHANNEL_HEIGHT);
+  }
+
+  private drawPeakHold(channel: number, heightOffset: number): void {
+    const peakHold = this.peakHolds[channel];
+
+    let color = GREEN;
+    if (peakHold > DANGER_LEVEL) color = RED;
+    else if (peakHold > WARNING_LEVEL) color = YELLOW;
+
+    this.ctx.fillStyle = color;
     this.ctx.fillRect(
-      this.dbToPx(this.peakHolds[channel]) - PEAK_WIDTH / 2,
+      this.convertDbToPixels(peakHold) - PEAK_WIDTH / 2,
       heightOffset,
       PEAK_WIDTH,
       CHANNEL_HEIGHT,
     );
   }
 
-  dbToPx(db: number) {
+  private convertDbToPixels(db: number): number {
     return Math.round((db + 60) * (this.canvasWidth / 60));
   }
 
-  updatePeakHold(peak: number, channel: number) {
-    if (!this.peakHoldCounters[channel] || peak > this.peakHolds[channel]) {
+  private updatePeakHold(peak: number, channel: number): void {
+    if (this.peakHoldCounters[channel] === 0 || peak > this.peakHolds[channel]) {
       this.peakHolds[channel] = peak;
       this.peakHoldCounters[channel] = PEAK_HOLD_CYCLES;
       return;
     }
 
-    this.peakHoldCounters[channel] -= 1;
+    this.peakHoldCounters[channel] = Math.max(0, this.peakHoldCounters[channel] - 1);
   }
 
-  subscribeVolmeter() {
+  private checkPeaks(peaks: number[]): boolean {
+    if (peaks.length !== this.channelCount) {
+      this.hasDrawn = false;
+      return false;
+    }
+
+    let changed = false;
+    peaks.forEach((peak, channel) => {
+      this.updatePeakHold(peak, channel);
+
+      // 変化がなければ再描画しない
+      if (
+        peak !== this.previousPeaks[channel] ||
+        this.peakHolds[channel] !== this.previousPeakHolds[channel]
+      )
+        changed = true;
+
+      this.previousPeaks[channel] = peak;
+      this.previousPeakHolds[channel] = this.peakHolds[channel];
+    });
+
+    return !changed && this.hasDrawn;
+  }
+
+  private subscribeVolmeter(): void {
     this.volmeterSubscription = this.audioSource.subscribeVolmeter(volmeter => {
+      if (this.checkPeaks(volmeter.peak)) return;
       this.setChannelCount(volmeter.peak.length);
       this.drawVolmeter(volmeter.peak);
+      this.hasDrawn = true;
     });
   }
 
-  unsubscribeVolmeter() {
-    this.volmeterSubscription && this.volmeterSubscription.unsubscribe();
+  private unsubscribeVolmeter(): void {
+    if (this.volmeterSubscription) this.volmeterSubscription.unsubscribe();
   }
 }

--- a/app/components/shared/Slider.vue.ts
+++ b/app/components/shared/Slider.vue.ts
@@ -1,5 +1,3 @@
-import ResizeSensor from 'css-element-queries/src/ResizeSensor';
-import { debounce } from 'lodash-decorators';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import VueSlider from 'vue-slider-component';
@@ -21,16 +19,17 @@ export default class SliderInput extends Vue {
 
   $refs: { slider: any };
 
-  mounted() {
-    // Hack to prevent transitions from messing up slider width
-    setTimeout(() => {
-      this.onResizeHandler();
-    }, 500);
+  private resizeObserver?: ResizeObserver;
 
-    // eslint-disable-next-line no-new
-    new ResizeSensor(this.$el, () => {
-      this.onResizeHandler();
-    });
+  mounted() {
+    // ResizeObserverでサイズ変更を監視
+    this.resizeObserver = new ResizeObserver(() => this.onResizeHandler());
+    if (this.$el) this.resizeObserver.observe(this.$el);
+  }
+
+  destroyed() {
+    // ResizeObserverの監視を停止
+    if (this.resizeObserver) this.resizeObserver.disconnect();
   }
 
   updateValue(value: number) {
@@ -53,7 +52,6 @@ export default class SliderInput extends Vue {
     return formattedValue;
   }
 
-  @debounce(500)
   private onResizeHandler() {
     if (this.$refs.slider) this.$refs.slider.refresh();
   }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "base64-js": "^1.5.1",
     "color-picker": "https://github.com/n-air-app/native-deps/releases/download/osn0.24.38/color-picker-1.3.10-win64.tar.gz",
     "crash-handler": "https://github.com/n-air-app/native-deps/releases/download/osn0.24.38/crash-handler-1.2.21-win64.tar.gz",
-    "css-element-queries": "~1.2.1",
     "electron-log": "3.0.4",
     "electron-updater": "4.3.8",
     "electron-window-state": "5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5220,11 +5220,6 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-css-element-queries@~1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/css-element-queries/-/css-element-queries-1.2.3.tgz#e14940b1fcd4bf0da60ea4145d05742d7172e516"
-  integrity sha512-QK9uovYmKTsV2GXWQiMOByVNrLn2qz6m3P7vWpOR4IdD6I3iXoDw5qtgJEN3Xq7gIbdHVKvzHjdAtcl+4Arc4Q==
-
 css-functions-list@^3.1.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.2.tgz#9a54c6dd8416ed25c1079cd88234e927526c1922"


### PR DESCRIPTION
# このpull requestが解決する内容

ボリュームメータは100msec毎に再描画を行い、かつ常時画面上にあるためCPU負荷が懸念されるので処理低減の改修を行います。

MixerVolmeter.vue.ts

- 値の変化がない場合(muted含む)は再描画を行わない
- リサイズ監視のタイマーフェッチを廃止しResizeObserverに変更
- 描画時の再計算などを低減

Slider.vue.ts

- リサイズ監視をResizeServerと補助タイマーフェッチからResizeObserverに変更
- 伴ってここでしか使っていなかったライブラリcss-element-queriesの排除



# 動作確認手順

従来と変わらない動作（ボリュームの描画・リサイズの追従など）であればOK


# 関連するIssue（あれば）
