### PR TITLE
開発: void 0 をundefinedに置き換え

### DIFF
--- a/app/components/Selector.vue.ts
+++ b/app/components/Selector.vue.ts
@@ -41,7 +41,7 @@ export default class Selector extends Vue {
   }
 
   handleContextMenu(ev: MouseEvent, index?: number) {
-    if (index !== void 0) {
+    if (index !== undefined) {
       const value = this.normalizedItems[index].value;
       this.handleSelect(ev, index);
       this.$emit('contextmenu', value);

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -231,12 +231,12 @@ export function obsValuesToInputValues(
       }
 
       for (const listOption of listOptions) {
-        if (listOption.description === void 0) {
+        if (listOption.description === undefined) {
           listOption.description = listOption['name'];
         }
       }
 
-      const needToSetDefaultValue = listOptions.length && prop.value === void 0;
+      const needToSetDefaultValue = listOptions.length && prop.value === undefined;
       if (needToSetDefaultValue) prop.value = listOptions[0].value;
 
       (<any>prop).options = listOptions;

--- a/app/components/obs/inputs/ObsIntInput.vue.ts
+++ b/app/components/obs/inputs/ObsIntInput.vue.ts
@@ -19,11 +19,11 @@ class ObsIntInput extends ObsInput<IObsNumberInputValue> {
       formattedValue = '0';
     }
 
-    if (this.value.minVal !== void 0 && Number(value) < this.value.minVal) {
+    if (this.value.minVal !== undefined && Number(value) < this.value.minVal) {
       formattedValue = String(this.value.minVal);
     }
 
-    if (this.value.maxVal !== void 0 && Number(value) > this.value.maxVal) {
+    if (this.value.maxVal !== undefined && Number(value) > this.value.maxVal) {
       formattedValue = String(this.value.maxVal);
     }
 

--- a/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
@@ -119,9 +119,9 @@ export default class ObsSystemFontSelector extends ObsInput<IObsInput<IObsFont>>
     fontObj.path = '';
 
     // Apply current values for parameters that were not passed
-    if (fontObj.face === void 0) fontObj.face = this.$refs.font.value.family;
-    if (fontObj.size === void 0) fontObj.size = this.value.value.size;
-    if (fontObj.flags === void 0) fontObj.flags = this.getFlagsFromFont(this.$refs.font.value);
+    if (fontObj.face === undefined) fontObj.face = this.$refs.font.value.family;
+    if (fontObj.size === undefined) fontObj.size = this.value.value.size;
+    if (fontObj.flags === undefined) fontObj.flags = this.getFlagsFromFont(this.$refs.font.value);
 
     this.emitInput({ ...this.value, value: fontObj });
   }

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -39,7 +39,7 @@ export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends
     getKeys(validations).forEach(key => {
       // VeeValidate recognizes undefined values as valid constraints
       // so just remove it
-      if (validations[key] === void 0) delete validations[key];
+      if (validations[key] === undefined) delete validations[key];
     });
     return validations;
   }

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -102,7 +102,7 @@ export class ServicesManager extends Service {
 
     const helperName = resourceId.split('[')[0];
     const constructorArgsStr = resourceId.substr(helperName.length);
-    const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : void 0;
+    const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : undefined;
     return this.getHelper(helperName, constructorArgs);
   }
 

--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -90,7 +90,7 @@ export class ExternalApiService extends RpcApi {
     // take serialized constructor arguments from `resourceId` string and construct a new instance
     const helperName = resourceId.split('[')[0];
     const constructorArgsStr = resourceId.substr(helperName.length);
-    const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : void 0;
+    const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : undefined;
     const Helper = this.resources[helperName];
     if (Helper) {
       return this.applyFallbackProxy(new (Helper as any)(...constructorArgs));

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -135,7 +135,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
   }
 
   getSource(sourceId: string): AudioSource {
-    return this.state.audioSources[sourceId] ? new AudioSource(sourceId) : void 0;
+    return this.state.audioSources[sourceId] ? new AudioSource(sourceId) : undefined;
   }
 
   getSources(): AudioSource[] {
@@ -199,7 +199,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
 
     const globalSources = this.sourcesService
       .getSources()
-      .filter(source => source.channel !== void 0);
+      .filter(source => source.channel !== undefined);
     return globalSources
       .concat(sceneSources)
       .map((sceneSource: ISource) => this.getSource(sceneSource.sourceId))
@@ -290,7 +290,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     const newPatch = omit(patch, 'fader');
 
     getKeys(newPatch).forEach(name => {
-      if (newPatch[name] === void 0) return;
+      if (newPatch[name] === undefined) return;
 
       if (name === 'syncOffset') {
         const value = newPatch[name];

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -214,7 +214,7 @@ export class ObsImporterService extends Service {
               sourceJSON.settings,
               {
                 propertiesManager,
-                channel: sourceJSON.channel !== 0 ? sourceJSON.channel : void 0,
+                channel: sourceJSON.channel !== 0 ? sourceJSON.channel : undefined,
               },
             );
 

--- a/app/services/scene-collections/nodes/overlays/slots.ts
+++ b/app/services/scene-collections/nodes/overlays/slots.ts
@@ -172,7 +172,7 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
       await obj.content.load({
         sceneItem,
         assetsPath: context.assetsPath,
-        existing: existingWebcam !== void 0,
+        existing: existingWebcam !== undefined,
       });
 
       return;

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -234,7 +234,7 @@ export class SourcesNode extends Node<ISchema, {}> {
             name: filter.name,
             type: filter.type,
             settings: filter.settings,
-            enabled: filter.enabled === void 0 ? true : filter.enabled,
+            enabled: filter.enabled === undefined ? true : filter.enabled,
           };
         }),
         syncOffset: { sec: 0, nsec: 0 },
@@ -261,10 +261,10 @@ export class SourcesNode extends Node<ISchema, {}> {
 
       const newSource = this.sourcesService.getSource(sourceInfo.id);
       if (newSource.async && newSource.video) {
-        if (sourceInfo.deinterlaceMode !== void 0) {
+        if (sourceInfo.deinterlaceMode !== undefined) {
           newSource.setDeinterlaceMode(sourceInfo.deinterlaceMode);
         }
-        if (sourceInfo.deinterlaceFieldOrder !== void 0) {
+        if (sourceInfo.deinterlaceFieldOrder !== undefined) {
           newSource.setDeinterlaceFieldOrder(sourceInfo.deinterlaceFieldOrder);
         }
       }

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -166,7 +166,7 @@ export class SceneItem extends SceneItemNode {
         obsSceneItem.crop = cropModel;
       }
 
-      if (changedTransform.rotation !== void 0) {
+      if (changedTransform.rotation !== undefined) {
         // Adjusts any positve or negative rotation value into a normalized
         // value between 0 and 360.
         const effectiveRotation = ((newSettings.transform.rotation % 360) + 360) % 360;
@@ -176,29 +176,29 @@ export class SceneItem extends SceneItemNode {
       }
     }
 
-    if (changed.locked !== void 0) {
+    if (changed.locked !== undefined) {
       if (changed.locked && this.selectionService.isSelected(this.sceneItemId)) {
         this.selectionService.deselect(this.sceneItemId);
       }
     }
 
-    if (changed.visible !== void 0) {
+    if (changed.visible !== undefined) {
       this.getObsSceneItem().visible = newSettings.visible;
     }
 
-    if (changed.scaleFilter !== void 0) {
+    if (changed.scaleFilter !== undefined) {
       this.getObsSceneItem().scaleFilter = newSettings.scaleFilter;
     }
 
-    if (changed.blendingMode !== void 0) {
+    if (changed.blendingMode !== undefined) {
       this.getObsSceneItem().blendingMode = newSettings.blendingMode;
     }
 
-    if (changed.blendingMethod !== void 0) {
+    if (changed.blendingMethod !== undefined) {
       this.getObsSceneItem().blendingMethod = newSettings.blendingMethod;
     }
 
-    if (changed.output !== void 0 || patch.hasOwnProperty('output')) {
+    if (changed.output !== undefined || patch.hasOwnProperty('output')) {
       this.getObsSceneItem().video = newSettings.output as obs.IVideo;
     }
 

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -232,7 +232,7 @@ export class OutputSettingsService extends Service {
       preset = [
         this.settingsService.findValidListValue(output, 'Streaming', 'QualityPreset'),
         this.settingsService.findValidListValue(output, 'Streaming', 'AMDPreset'),
-      ].find(item => item !== void 0);
+      ].find(item => item !== undefined);
     } else {
       preset = [
         this.settingsService.findValidListValue(output, 'Streaming', 'preset'),
@@ -240,7 +240,7 @@ export class OutputSettingsService extends Service {
         this.settingsService.findValidListValue(output, 'Streaming', 'NVENCPreset'),
         this.settingsService.findValidListValue(output, 'Streaming', 'QSVPreset'),
         this.settingsService.findValidListValue(output, 'Streaming', 'target_usage'),
-      ].find(item => item !== void 0);
+      ].find(item => item !== undefined);
     }
 
     const bitrate: number =
@@ -406,7 +406,7 @@ export class OutputSettingsService extends Service {
       );
     }
 
-    if (settingsPatch.encoderOptions !== void 0 && encoder === 'x264') {
+    if (settingsPatch.encoderOptions !== undefined && encoder === 'x264') {
       this.settingsService.setSettingValue(
         'Output',
         encoderFieldsMap[encoder].encoderOptions,
@@ -414,11 +414,11 @@ export class OutputSettingsService extends Service {
       );
     }
 
-    if (settingsPatch.rescaleOutput !== void 0) {
+    if (settingsPatch.rescaleOutput !== undefined) {
       this.settingsService.setSettingValue('Output', 'Rescale', settingsPatch.rescaleOutput);
     }
 
-    if (settingsPatch.bitrate !== void 0) {
+    if (settingsPatch.bitrate !== undefined) {
       if (currentSettings.mode === 'Advanced') {
         this.settingsService.setSettingValue('Output', 'bitrate', settingsPatch.bitrate);
       } else {

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -691,7 +691,7 @@ export class SettingsService
     const audioDevices = this.audioService.getDevices();
     const sourcesInChannels = this.sourcesService
       .getSources()
-      .filter(source => source.channel !== void 0);
+      .filter(source => source.channel !== undefined);
 
     const parameters: TObsFormData = [];
 

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -171,7 +171,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   addSource(obsInput: obs.IInput, name: string, options: ISourceAddOptions = {}) {
-    if (options.channel !== void 0) {
+    if (options.channel !== undefined) {
       obs.Global.setOutputSource(options.channel, obsInput);
     }
     const id = obsInput.name;
@@ -221,7 +221,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
      * sure we reset the channel it's set to,
      * otherwise OBS thinks it's still attached
      * and won't release it. */
-    if (source.channel !== void 0) {
+    if (source.channel !== undefined) {
       obs.Global.setOutputSource(source.channel, null);
     }
 
@@ -320,7 +320,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     });
 
     if (type === 'dshow_input') {
-      if (resolvedSettings.video_device_id === void 0) {
+      if (resolvedSettings.video_device_id === undefined) {
         const devices = obs.NodeObs.OBS_settings_getVideoDevices();
         if (devices.length > 0) {
           resolvedSettings.video_device_id = devices[0].id;
@@ -342,14 +342,14 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
     // setup default settings
     if (type === 'browser_source') {
-      if (resolvedSettings.shutdown === void 0) resolvedSettings.shutdown = true;
-      if (resolvedSettings.url === void 0) {
+      if (resolvedSettings.shutdown === undefined) resolvedSettings.shutdown = true;
+      if (resolvedSettings.url === undefined) {
         resolvedSettings.url = 'https://n-air-app.nicovideo.jp/browser-source/';
       }
     }
 
     if (type === 'text_gdiplus') {
-      if (resolvedSettings.text === void 0) resolvedSettings.text = name;
+      if (resolvedSettings.text === undefined) resolvedSettings.text = name;
     }
     return resolvedSettings;
   }
@@ -588,7 +588,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   getSource(id: string): Source {
-    return this.state.sources[id] || this.state.temporarySources[id] ? new Source(id) : void 0;
+    return this.state.sources[id] || this.state.temporarySources[id] ? new Source(id) : undefined;
   }
 
   getSources() {

--- a/test/api/scenes.ts
+++ b/test/api/scenes.ts
@@ -86,12 +86,12 @@ test('Scenes events', async t => {
   const scenesService = client.getResource<ScenesService>('ScenesService');
   let event: Dictionary<any>;
 
-  scenesService.sceneSwitched.subscribe(() => void 0);
-  scenesService.sceneAdded.subscribe(() => void 0);
-  scenesService.sceneRemoved.subscribe(() => void 0);
-  scenesService.itemAdded.subscribe(() => void 0);
-  scenesService.itemRemoved.subscribe(() => void 0);
-  scenesService.itemUpdated.subscribe(() => void 0);
+  scenesService.sceneSwitched.subscribe(() => undefined);
+  scenesService.sceneAdded.subscribe(() => undefined);
+  scenesService.sceneRemoved.subscribe(() => undefined);
+  scenesService.itemAdded.subscribe(() => undefined);
+  scenesService.itemRemoved.subscribe(() => undefined);
+  scenesService.itemUpdated.subscribe(() => undefined);
 
   const scene2 = scenesService.createScene('Scene2');
   event = await client.fetchNextEvent();

--- a/test/api/sources.ts
+++ b/test/api/sources.ts
@@ -45,9 +45,9 @@ test('Source events', async t => {
   const sourcesService = client.getResource<ISourcesServiceApi>('SourcesService');
   let event: Dictionary<any>;
 
-  sourcesService.sourceAdded.subscribe(() => void 0);
-  sourcesService.sourceRemoved.subscribe(() => void 0);
-  sourcesService.sourceUpdated.subscribe(() => void 0);
+  sourcesService.sourceAdded.subscribe(() => undefined);
+  sourcesService.sourceRemoved.subscribe(() => undefined);
+  sourcesService.sourceUpdated.subscribe(() => undefined);
 
   const source1 = sourcesService.createSource('audio1', 'wasapi_output_capture');
   event = await client.fetchNextEvent();

--- a/test/api/streaming.ts
+++ b/test/api/streaming.ts
@@ -38,7 +38,7 @@ test('Streaming to server via API', async t => {
 
   let streamingStatus = streamingService.getModel().streamingStatus;
 
-  streamingService.streamingStatusChange.subscribe(() => void 0);
+  streamingService.streamingStatusChange.subscribe(() => undefined);
 
   t.is(streamingStatus, EStreamingState.Offline);
 
@@ -74,7 +74,7 @@ test('Recording via API', async (t: TExecutionContext) => {
 
   let recordingStatus = streamingService.getModel().recordingStatus;
 
-  streamingService.recordingStatusChange.subscribe(() => void 0);
+  streamingService.recordingStatusChange.subscribe(() => undefined);
 
   t.is(recordingStatus, ERecordingState.Offline);
 

--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -281,7 +281,7 @@ export class ApiClient {
 
     return new Proxy(resourceModel, {
       get: (target, property: string, receiver) => {
-        if (resourceModel[property] !== void 0) return resourceModel[property];
+        if (resourceModel[property] !== undefined) return resourceModel[property];
 
         const resourceScheme = this.getResourceScheme(resourceId);
 
@@ -350,7 +350,7 @@ class ApiEventWatcher {
     this.subscriptions = this.eventNames.map(eventName => {
       const [resourceId, prop] = eventName.split('.');
       const observable = this.apiClient.getResource<Dictionary<Observable<any>>>(resourceId)[prop];
-      return observable.subscribe(() => void 0);
+      return observable.subscribe(() => undefined);
     });
 
     this.apiClient.eventReceived.subscribe(event => this.onEventHandler(event));

--- a/test/helpers/cmd-client.ts
+++ b/test/helpers/cmd-client.ts
@@ -29,7 +29,7 @@ console.log = () => {};
     .request(resource, method, ...args)
     .then(response => {
       let responseStr = '';
-      if (response === void 0) {
+      if (response === undefined) {
         responseStr = 'true';
       } else {
         responseStr = JSON.stringify(response);


### PR DESCRIPTION
## 概要
この PR はコードベース内で意図的に使用されていた void 0 を undefined に置き換える変更です。型および実行時値として undefined を明示することで、型推論の一貫性と実行時の振る舞いの明確化を図ります。

## 背景と目的
	•	一部の箇所で戻り値や値として void 0 が用いられていましたが、void は TypeScript の型表現であり、値としては undefined と等価であるものの混用による曖昧さ・誤解を招く可能性がありました。
	•	今回の置換は挙動を変更する意図はなく、型と実装の整合性を高める安全なリファクタです。
