### PR TITLE
改善: 琴詠ニアが時々微笑み顔になる

### DIFF
--- a/nvoice/near/index.js
+++ b/nvoice/near/index.js
@@ -37,6 +37,7 @@ addEventListener('visibilitychange', () => {
 
 const IMAGE_FILENAMES = {
   default: 'default.png',
+  smile: 'smile.png',
 
   a: 'a.png',
 
@@ -54,15 +55,19 @@ const IMAGE_FILENAMES = {
   m: 'm.png',
   p: 'm.png',
   b: 'm.png',
-  'silE': 'm.png',
+  silE: 'm.png',
 };
 const DEFAULT_COOL_TIME_MS = 1000;
+
+// デフォルト状態に戻る際にdefault.pngとsmile.pngをランダムで選択
+const DEFAULT_IMAGES = [IMAGE_FILENAMES.default, IMAGE_FILENAMES.smile];
 
 let t;
 function timer_set() {
   timer_reset();
   t = setTimeout(() => {
-    image.src = IMAGE_FILENAMES.default;
+    const randomImage = DEFAULT_IMAGES[Math.floor(Math.random() * DEFAULT_IMAGES.length)];
+    image.src = randomImage;
     t = undefined;
   }, DEFAULT_COOL_TIME_MS);
 }
@@ -74,7 +79,7 @@ function timer_reset() {
 }
 
 if (socket) {
-  socket.on('phoneme', (phoneme) => {
+  socket.on('phoneme', phoneme => {
     if (!active) {
       return;
     }
@@ -94,10 +99,11 @@ const BLINK_INTERVAL_MS = 5000;
 setInterval(() => {
   if (active) {
     const blink = () => {
-      const isDefault = image.src.endsWith('default.png');
+      // default.pngまたはsmile.pngの場合はSD_default_*.pngを使用
+      const isDefaultOrSmile = image.src.endsWith('default.png') || image.src.endsWith('smile.png');
       ++blinkIndex;
       if (blinkIndex < blinkSequence.length) {
-        eyes.src = `SD_${isDefault ? 'default' : 'read'}_${blinkSequence[blinkIndex]}.png`;
+        eyes.src = `SD_${isDefaultOrSmile ? 'default' : 'read'}_${blinkSequence[blinkIndex]}.png`;
         eyes.hidden = false;
         setTimeout(blink, BLINK_FRAME_MS);
       } else {


### PR DESCRIPTION
## Summary
- 読み上げ終了後に`default.png`に戻る際、`smile.png`もランダムで選択されるように変更
- 琴詠ニアが時々微笑み顔を見せるようになります

Closes #606

## 変更内容
- `IMAGE_FILENAMES`に`smile.png`を追加
- `DEFAULT_IMAGES`配列を追加して`default.png`と`smile.png`をランダム選択
- `timer_set()`関数で`Math.random()`を使用してランダム表示を実装
- まばたきロジックで`smile.png`表示時も`SD_default_*.png`を使用するように修正

## Test plan
- [x] N Airを起動して琴詠ニアを表示
- [x] 読み上げ機能を使用して、読み上げ終了後に時々`smile.png`が表示されることを確認
- [x] まばたきアニメーションが`smile.png`表示時も正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)