### PR TITLE
開発: 消し忘れていたaudio.ts のデバイス検索デバッグ表示を削除

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -155,12 +155,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
 
     // Find AudioSource with matching device_id
     const audioSources = this.getSources();
-    console.log('Looking for device ID:', deviceId); // DEBUG
     for (const audioSource of audioSources) {
-      if (audioSource.name === 'マイク') {
-        console.log('- ', JSON.stringify(audioSource, null, 2)); // DEBUG
-        console.log('- settings: ', audioSource.source.getObsInput()?.settings); // DEBUG)
-      }
       try {
         const obsInput = audioSource.source.getObsInput();
         const obsDeviceId = obsInput?.settings?.device_id;


### PR DESCRIPTION
## 概要

開発起動したときに audio device id検索のconsole log が沢山出ているので消します ( #981 の開発中に付けていたものの消し忘れ)

## 影響範囲

- ユーザー影響なし

## 動作確認手順

- `yarn start`
