### PR TITLE
開発: avaテストがローカル環境で無限ループする問題を修正

### DIFF
--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -160,12 +160,21 @@ export async function waitForElectronInstancesExist() {
   const timeout = 10000;
 
   let timeLeft = timeout;
-  return new Promise(async resolve => {
-    let tasks: any[] = [];
-    do {
-      tasks = await getElectronInstances();
+  let tasks: any[] = [];
+
+  do {
+    tasks = await getElectronInstances();
+    if (tasks.length > 0) {
+      await new Promise(r => {
+        setTimeout(r, interval);
+      });
       timeLeft -= interval;
-    } while (tasks.length || timeLeft < 0);
-    resolve(null);
-  });
+    }
+  } while (tasks.length > 0 && timeLeft > 0);
+
+  if (tasks.length > 0) {
+    console.warn(
+      `Warning: ${tasks.length} electron instances still running after ${timeout}ms timeout`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

`test/helpers/webdriver/runner-utils.ts` の `waitForElectronInstancesExist()` 関数に論理エラーがあり、ローカル環境でテストが途中で止まりタイムアウトしていた問題を修正しました。
fixes #1002

### 修正内容

- **while条件の論理エラー修正**: `tasks.length || timeLeft < 0` → `tasks.length > 0 && timeLeft > 0`
  - 修正前は OR 条件だったため、タイムアウト後も永遠にループが継続していた
  - AND 条件に変更することで、プロセスが存在しない、またはタイムアウトしたら正常に終了するように修正
- **待機処理の追加**: ループ内に `setTimeout` による実際の待機処理を追加（以前は待機なしで高速ループしていた）
- **タイムアウト警告の追加**: タイムアウト時に残っているプロセス数を警告表示
- **コード品質改善**: 不要な Promise ラッパーを削除し、async/await で直接記述

### 動作確認

- CI では動作していたが、ローカル環境では止まっていた理由:
  - CI: テストを4グループに分割して並列実行するため、各グループの負荷が軽い
  - ローカル: 全テストを順次実行（`ava -v -s`）するため、リソース消耗が激しく Electron プロセスが終了しづらい
- 修正後、ローカル環境でも `yarn test` が正常に完走することを確認済み

## Test plan

- [x] ローカル環境で `yarn test` が完走することを確認
- [x] TypeScript コンパイルエラーがないことを確認
- [x] ESLint チェックをパス
- [ ] CI でのテスト実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)