### PR TITLE
開発: 自動文字起こしのコメント投稿OFFスイッチを一時的に非表示

### DIFF
--- a/app/components/TranscriptionSettings.vue
+++ b/app/components/TranscriptionSettings.vue
@@ -78,6 +78,7 @@
         ></label>
       </div>
       <p class="section-notice-text">{{ commentSectionNotice2 }}</p>
+      <!---
       <div class="input-container">
         <div class="input-wrapper">
           <div class="row">
@@ -88,6 +89,7 @@
           </div>
         </div>
       </div>
+    -->
       <div v-if="commentEnabled">
         <ObsListInput v-model="commentSizeModel" />
         <ObsListInput v-model="commentPositionModel" />


### PR DESCRIPTION
# このpull requestが解決する内容
スイッチをオフにしたときにユーザーが迷子になぱないようにずるケアを追加してからリリースしたいので、一旦スイッチを非表示にして、準備状態にしておきます

# 動作確認手順
設定で自動文字起こしのコメント部分に投稿スイッチがないこと

# 関連するPR
#988 
