### PR TITLE
開発: vosk-cli の依存関係をビルド済みアセットへ変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "uuid": "^3.4.0",
     "v-tooltip": "~2.1.3",
     "vee-validate": "~2.2.15",
-    "vosk-cli": "github:n-air-app/vosk-cli#1.0.2",
+    "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
     "vue": "2.7.14",
     "vue-codemirror": "4.0.6",
     "vue-color": "2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13437,9 +13437,9 @@ verror@^1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vosk-cli@github:n-air-app/vosk-cli#1.0.2":
+"vosk-cli@https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz":
   version "1.0.2"
-  resolved "https://codeload.github.com/n-air-app/vosk-cli/tar.gz/d77363a7a92a8ee2a432c40e0831b6cd2c47f7b4"
+  resolved "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz#c606feb8a139267cfdccc7b89ef19ff008978706"
 
 vue-class-component@^6.2.0:
   version "6.3.2"


### PR DESCRIPTION
## 説明

### 変更の背景

従来の指定では、yarn install 時にリポジトリ全体がコピーされ、不要なファイルも含めて展開されていました。これにより、以下の問題が発生していました：

- node_modules のサイズ増加
- インストール時間の増加
- 不要なソースコードや開発用ファイルの混入

### 変更内容
- vosk-cli を必要最小限のファイルのみを含む tar.gz パッケージとして配布
- package.json の依存関係を GitHub リリースアセット（tar.gz）への直接参照に変更

### 変更による効果
1. **依存関係サイズの削減**: リポジトリ全体ではなく、必要なファイルのみを含む tar.gz を使用
2. **インストール速度の向上**: 不要なファイルのコピーが不要になる
3. **依存関係パターンの統一**: 他のネイティブモジュールと同じ管理方法に揃える

### 影響範囲
- 依存関係のインストール方法のみの変更で、機能的な変更なし
- バージョンは  1.0.2  で変更なし
- 音声認識機能（VOSK）の動作に影響なし
- パッケージ内容は必要最小限のファイルのみに削減

### テスト項目
- [x] yarn install が正常に完了する
- [x] アプリケーションが正常に起動する
- [x] 音声認識機能（VOSK）が正常に動作する

### レビューポイント
- package.json と yarn.lock の変更内容が正しいこと
- 他のネイティブ依存関係と同じパターンになっていることの確認
- リリースアセットの URL が正しいこと