### PR TITLE
開発: tsconfig.jsonの設定を調整してエディタ警告を解消

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -170,6 +170,8 @@
   },
 
   "typescript.preferences.autoImportFileExcludePatterns": ["**/app-services.ts"],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
 
   "github.copilot.chat.commitMessageGeneration.instructions": [
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "removeComments": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "outDir": "bundles/ts",
+    "outDir": "dist/tsc-out",
     "sourceMap": true,
     "sourceRoot": "/",
     "allowJs": false,
@@ -18,6 +18,7 @@
     "downlevelIteration": true,
     "baseUrl": "./app",
     "jsx": "preserve",
+    "skipLibCheck": true,
 
     "alwaysStrict": true,
     "noImplicitAny": true,
@@ -28,6 +29,6 @@
     "strictPropertyInitialization": false,
     "useUnknownInCatchVariables": true
   },
-  "exclude": ["node_modules"],
-  "include": ["./app/**/*"]
+  "exclude": ["node_modules", "**/*.vue"],
+  "include": ["./app/**/*.ts", "./app/**/*.tsx", "./app/**/*.d.ts"]
 }


### PR DESCRIPTION
## このpull requestが解決する内容

VSCodeエディタ上で表示されていたTypeScriptの"Cannot write file because it would be overwritten"警告を解消します。

### 問題
- `.vue`ファイルと`.vue.ts`ファイルが同じ出力ファイル名(`.vue.js`)にコンパイルされようとして、エディタ上で警告が表示されていた
- 実際のビルド(webpack)には影響がなかったが、エディタ上でノイズとなっていた

### 解決方法
- `tsconfig.json`の`include`パターンを具体的に指定(`.ts`, `.tsx`, `.d.ts`のみ)
- `.vue`関連ファイルはWebpackが処理するため、TypeScriptコンパイラの対象から除外
- ワークスペースのTypeScriptバージョンを使用するよう`.vscode/settings.json`を設定

### 変更内容
- `tsconfig.json`: includeパターンの具体化、outDir変更、skipLibCheck追加
- `.vscode/settings.json`: TypeScript SDK設定の追加

## 動作確認手順

1. ブランチをチェックアウト
2. `yarn compile`を実行して正常にビルドできることを確認
3. VSCodeで`tsconfig.json`を開いて警告が表示されないことを確認

## 関連するIssue

なし(開発環境の改善)
