### PR TITLE
追加: 自動文字起こしソースのプロパティに、自動文字起こし機能が有効になっていない場合の警告表示を追加

### DIFF
--- a/app/components/source_properties/TextTranscriptionProperties.vue
+++ b/app/components/source_properties/TextTranscriptionProperties.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="text-transcription-properties">
+    <div v-if="!isTranscriptionEnabled" class="status-row">
+      <p class="disabled">{{ $t('source-props.text_transcription.properties.disabledMessage') }}</p>
+      <button class="button" @click="openSettings">
+        {{ $t('source-props.text_transcription.properties.openSettings') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" src="./TextTranscriptionProperties.vue.ts"></script>
+
+<style lang="less" scoped>
+@import url('../../styles/index');
+
+.text-transcription-properties {
+  padding: 16px;
+
+  .status-row {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+  }
+
+  p {
+    flex: 1;
+    margin: 0;
+  }
+
+  .disabled {
+    color: @red-light;
+  }
+}
+</style>

--- a/app/components/source_properties/TextTranscriptionProperties.vue.ts
+++ b/app/components/source_properties/TextTranscriptionProperties.vue.ts
@@ -10,6 +10,7 @@ export default class TextTranscriptionProperties extends Vue {
   @Inject() settingsService: SettingsService;
 
   get isTranscriptionEnabled(): boolean {
+    // 設定画面とこの画面はテレコなのでon/offタイミングでこの画面は出ていないため現状subscriptionまでは不要
     return this.transcriptionService.state.enabled ?? false;
   }
 

--- a/app/components/source_properties/TextTranscriptionProperties.vue.ts
+++ b/app/components/source_properties/TextTranscriptionProperties.vue.ts
@@ -1,0 +1,19 @@
+import { Inject } from 'services/core/injector';
+import { SettingsService } from 'services/settings';
+import { TranscriptionService } from 'services/transcription/transcription';
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+
+@Component({})
+export default class TextTranscriptionProperties extends Vue {
+  @Inject() transcriptionService: TranscriptionService;
+  @Inject() settingsService: SettingsService;
+
+  get isTranscriptionEnabled(): boolean {
+    return this.transcriptionService.state.enabled ?? false;
+  }
+
+  openSettings() {
+    this.settingsService.showSettings('Transcription');
+  }
+}

--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -3,6 +3,7 @@ import ModalLayout from 'components/ModalLayout.vue';
 import GenericForm from 'components/obs/inputs/GenericForm.vue';
 import { TObsFormData } from 'components/obs/inputs/ObsInput';
 import Display from 'components/shared/Display.vue';
+import TextTranscriptionProperties from 'components/source_properties/TextTranscriptionProperties.vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { Subscription } from 'rxjs';
 import { AppService } from 'services/app';
@@ -21,6 +22,7 @@ const PeriodicUpdateInterval = 5000; // in Milliseconds
     ModalLayout,
     Display,
     GenericForm,
+    TextTranscriptionProperties,
   },
 })
 export default class SourceProperties extends Vue {

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -214,7 +214,11 @@
   },
   "text_transcription": {
     "name": "Automatic Transcription Text",
-    "description": "Pre-configured text for automatic transcription"
+    "description": "Pre-configured text for automatic transcription",
+    "properties": {
+      "disabledMessage": "Automatic transcription is disabled, please enable it in settings",
+      "openSettings": "Open Settings"
+    }
   },
   "text (FreeType2)": {
     "name": "Text (FreeType 2)"

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -214,7 +214,11 @@
   },
   "text_transcription": {
     "name": "自動文字起こし",
-    "description": "自動文字起こしされたテキストを表示します"
+    "description": "自動文字起こしされたテキストを表示します",
+    "properties": {
+      "disabledMessage": "自動文字起こしが無効です、設定で有効にしてください",
+      "openSettings": "設定を開く"
+    }
   },
   "text (FreeType2)": {
     "name": "テキスト(FreeType 2)"

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -216,7 +216,7 @@
     "name": "自動文字起こし",
     "description": "自動文字起こしされたテキストを表示します",
     "properties": {
-      "disabledMessage": "自動文字起こしが無効です、設定で有効にしてください",
+      "disabledMessage": "自動文字起こしが無効です。設定で有効にしてください",
       "openSettings": "設定を開く"
     }
   },

--- a/app/services/sources/properties-managers/text-transcription-manager.ts
+++ b/app/services/sources/properties-managers/text-transcription-manager.ts
@@ -2,6 +2,7 @@ import { PropertiesManager } from './properties-manager';
 
 export class TextTranscriptionManager extends PropertiesManager {
   blacklist = ['read_from_file', 'file'];
+  customUIComponent = 'TextTranscriptionProperties';
 
   //   init() {
   //     // ここで初期値を入れたいが、起動毎でもここにくるのでスルー


### PR DESCRIPTION
## 概要
自動文字起こしソースのプロパティウィンドウに、カスタムUIコンポーネントを追加しました。自動文字起こし機能が無効な場合に、ユーザーに状態を通知し、設定画面へ誘導するUIを表示します。

## 機能説明

**自動文字起こしが無効な場合:**
- 「自動文字起こしが無効です、設定で有効にしてください」というメッセージを表示
- 「設定を開く」ボタンを表示し、クリックで文字起こし設定画面(`Transcription`)を開く

**自動文字起こしが有効な場合:**
- カスタムUIは非表示(デフォルトのプロパティフォームのみ表示)

## 技術詳細

- `TranscriptionService` の状態を監視して有効/無効を判定
- `SettingsService.showSettings('Transcription')` で設定画面を開く

## テスト確認項目
- [x] 自動文字起こしが無効な状態で、ソースプロパティを開くと警告メッセージが表示される
- [x] 「設定を開く」ボタンをクリックすると、文字起こし設定画面が開く
- [x] 自動文字起こしを有効にすると、カスタムUIが非表示になる

<img width="581" height="206" alt="Monosnap mogador 2025-11-06 11-13-19" src="https://github.com/user-attachments/assets/ffbce475-96cc-4b4b-897d-56d09b617124" />
