### PR TITLE
開発: tar-fs を 2.1.4 に更新して脆弱性を解決

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,6 +236,9 @@
     "webpack-merge": "^6.0.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "resolutions": {
+    "tar-fs": "^2.1.4"
+  },
   "engines": {
     "node": ">=22.0.0",
     "npm": "please-use-yarn"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11736,10 +11736,10 @@ tapable@^2.0.0, tapable@^2.2.0, tapable@^2.3.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.0.tgz#7e3ea6d5ca31ba8e078b560f0d83ce9a14aa8be6"
   integrity sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==
 
-tar-fs@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+tar-fs@2.1.1, tar-fs@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.4.tgz#800824dbf4ef06ded9afea4acafe71c67c76b930"
+  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"


### PR DESCRIPTION
## Summary
- yarn resolutions を使用して tar-fs を 2.1.1 から 2.1.4 に更新
- 3個のDependabotセキュリティアラート（すべて High severity）を解決

## 解決される脆弱性
- Alert [#78](https://github.com/n-air-app/n-air-app/security/dependabot/78): CVE-2025-59343 - Symlink validation bypass (High)
- Alert [#6](https://github.com/n-air-app/n-air-app/security/dependabot/6): Path traversal vulnerability (High)
- Alert [#1](https://github.com/n-air-app/n-air-app/security/dependabot/1): Path traversal vulnerability (High)

## 影響範囲

### 開発環境のみ（E2Eテスト）
- **tar-fs 2.1.4** (今回更新対象)
  - 依存パス: `webdriverio` (devDependencies) → `puppeteer-core` → `tar-fs`
  - 使用箇所: E2Eテスト（test/e2e/）で使用する webdriverio のみ
  - **ビルドしたアプリには含まれない**

### 更新方法
- webdriverio が依存する puppeteer-core が tar-fs 2.1.1 を固定で指定
- yarn の `resolutions` 機能を使用して tar-fs を 2.1.4 に強制更新

## Test plan
- [x] TypeScript compilation check
  ```bash
  yarn tsc -p test --noEmit
  ```
- [x] i18n integrity check
  ```bash
  node bin/i18n-early-check.js
  ```
- [x] Lint check
  ```bash
  yarn lint
  ```
- [x] Build
  ```bash
  yarn compile
  ```
- [x] E2E tests (CI で確認)
  ```bash
  yarn test
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)