### PR TITLE
開発: webpack の ESLint プラグインで Flat Config 形式を明示的に指定

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = function (env, argv) {
     }),
   );
   plugins.push(new VueLoaderPlugin());
-  plugins.push(new ESLintPlugin({ extensions: ['js', 'ts'] }));
+  plugins.push(new ESLintPlugin({ extensions: ['js', 'ts'], configType: 'flat' }));
 
   /** @type import('webpack').Configuration */
   const common = {


### PR DESCRIPTION
## 概要

PR #1017 で ESLint v9 と typescript-eslint v8 に更新した際、webpack.config.js の ESLintPlugin 設定に更新漏れがあり、間欠的にビルドエラーが発生していた問題を修正しました。

## 問題

- ESLint v9 では Flat Config 形式（`eslint.config.mjs`）が推奨
- PR #1017 で `.eslintrc.js` を削除し `eslint.config.mjs` に移行済み
- しかし `webpack.config.js` の ESLintPlugin に `configType: 'flat'` が指定されていなかった
- eslint-webpack-plugin は `configType` 未指定の場合、旧形式（`.eslintrc.js`）を探そうとする
- 結果として、設定ファイルが見つからず間欠的にエラーが発生

## 修正内容

`webpack.config.js:63` の ESLintPlugin に `configType: 'flat'` パラメータを追加：

```javascript
plugins.push(new ESLintPlugin({ extensions: ['js', 'ts'], configType: 'flat' }));
```

## 動作確認

- ✅ `yarn compile` でビルド成功
- ✅ ESLint がエラーなく実行
- ✅ Flat Config 形式（`eslint.config.mjs`）を正しく認識

## 関連

- 元のPR: #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)