### PR TITLE
修正: 自動文字起こしコメントをなふだコーチング対象から除外

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -545,8 +545,13 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
       }
 
       if (this.nicoliveProgramStateService.state.nameplateHint === undefined) {
+        // なふだヒントをまだ表示したことがない場合、最初のなふだ付きコメントにヒントをつける
         const firstCommentWithName = values.find(
-          c => isWrappedChat(c) && !!c.value.name && c.value.no,
+          c =>
+            isWrappedChat(c) &&
+            !!c.value.name &&
+            c.value.no &&
+            !(c.value.user_id && this.nicoliveProgramService.isBroadcaster(c.value.user_id)), // 放送者の通常コメントは除外
         );
         if (firstCommentWithName && isWrappedChat(firstCommentWithName)) {
           this.nicoliveProgramService.checkNameplateHint(firstCommentWithName.value.no);

--- a/app/services/nicolive-program/state.ts
+++ b/app/services/nicolive-program/state.ts
@@ -20,6 +20,9 @@ type SpeechSynthesizerSettingsState = {
   };
 };
 
+/** なふだコーチングを表示した記録。
+ * undefined なら初回表示判定を行い、設定済みなら同一番組中はそのコメントに表示し、他の番組では表示しない
+ */
 type NameplateHintState = {
   programID: string;
   commentNo: number;

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -15,6 +15,7 @@ import { AudioService, E_AUDIO_CHANNELS } from 'services/audio';
 import { StatefulService, mutation } from 'services/core/stateful-service';
 import { DismissablesService, EDismissable } from 'services/dismissables';
 import { $t } from 'services/i18n';
+import { NicoliveProgramStateService } from 'services/nicolive-program/state';
 import { SourcesService } from 'services/sources';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
@@ -125,6 +126,7 @@ export class SettingsService
 
   @Inject() videoSettingsService: VideoSettingsService;
   @Inject() private dismissablesService: DismissablesService;
+  @Inject() private nicoliveProgramStateService: NicoliveProgramStateService;
 
   init() {
     this.loadSettingsIntoStore();
@@ -836,20 +838,43 @@ export class SettingsService
             },
         ),
       },
+      {
+        nameSubCategory: 'NicoliveProgramState',
+        codeSubCategory: 'NicoliveProgramState',
+        parameters: [
+          <IObsInput<boolean>>{
+            value: this.nicoliveProgramStateService.state.nameplateHint !== undefined,
+            name: 'ResetNameplateHint',
+            description: 'なふだコーチングをリセットする',
+            type: 'OBS_PROPERTY_BOOL',
+            visible: true,
+            enabled: this.nicoliveProgramStateService.state.nameplateHint !== undefined,
+          },
+        ],
+      },
     ];
   }
 
   private setDeveloperSettings(settingsData: ISettingsSubCategory[]) {
     for (const setting of settingsData) {
-      if (setting.nameSubCategory === 'Dismissables') {
-        for (const item of setting.parameters) {
-          const name = item.name as EDismissable;
-          if (item.value) {
-            this.dismissablesService.reset(name);
-          } else {
-            this.dismissablesService.dismiss(name);
+      switch (setting.nameSubCategory) {
+        case 'Dismissables':
+          for (const item of setting.parameters) {
+            const name = item.name as EDismissable;
+            if (item.value) {
+              this.dismissablesService.reset(name);
+            } else {
+              this.dismissablesService.dismiss(name);
+            }
           }
-        }
+          break;
+        case 'NicoliveProgramState':
+          for (const item of setting.parameters) {
+            if (item.name === 'ResetNameplateHint') {
+              this.nicoliveProgramStateService.updateNameplateHint(undefined);
+            }
+          }
+          break;
       }
     }
     return;


### PR DESCRIPTION
## 概要
Issue #1022 を修正しました。

自動文字起こしコメント（放送者の通常コメント）が「なふだコーチング」（匿名でない通常コメントの初回表示時の説明）の対象になっていた問題を修正しました。

## 変更内容

### 主な修正
- **nicolive-comment-viewer.ts:545-554** - なふだヒント表示対象の選定ロジックを修正
  - 放送者の通常コメント（`isBroadcaster()`が`true`のコメント）を除外する条件を追加

### 補助的な変更
- **state.ts:23-25** - `NameplateHintState`型にJSDocコメントを追加して仕様を明確化
- **settings.ts** - 開発モード時に設定画面のDeveloper tabに「なふだコーチングをリセットする」ボタンを追加
  - 動作確認を容易にするための開発者向け機能

## テスト手順
1. 開発モードで起動
2. ニコニコ生放送を開始
3. 自動文字起こし機能を有効にする
4. 放送者が発言して自動文字起こしコメントが表示されることを確認
5. なふだコーチングが表示されないことを確認
6. （必要に応じて）Settings → Developer → NicoliveProgramState → 「なふだコーチングをリセットする」でリセット

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)