### PR TITLE
開発: nicolive-comment-protobuf を v2025.1117.170000 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@electron/remote": "2.1.2",
     "@n-air-app/n-voice-package": "^1.0.2",
-    "@n-air-app/nicolive-comment-protobuf": "2025.602.163750",
+    "@n-air-app/nicolive-comment-protobuf": "2025.1117.170000",
     "@sentry/electron": "7.2.0",
     "@sentry/vue": "10.17.0",
     "@types/unzip-stream": "^0.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,12 +1561,12 @@
     rollup-plugin-typescript2 "^0.34.1"
     typescript "^4.9.5"
 
-"@n-air-app/nicolive-comment-protobuf@2025.602.163750":
-  version "2025.602.163750"
-  resolved "https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2025.602.163750/275fa685d0bf4f3c1b30a8d3d2e1357036fbf025#275fa685d0bf4f3c1b30a8d3d2e1357036fbf025"
-  integrity sha512-cuvpxDmO6Fm1pjcchLtlBaqVLGEZo2Eszi6IKbQpTh1+b8kXD5JBMPc7sHtLIdj7JljICAa9RZFR8YRl8/URtg==
+"@n-air-app/nicolive-comment-protobuf@2025.1117.170000":
+  version "2025.1117.170000"
+  resolved "https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2025.1117.170000/73b1c2f30f2df49ea6912dda6775236d059304da#73b1c2f30f2df49ea6912dda6775236d059304da"
+  integrity sha512-DYhbJ8n1LoyCBDbt7ZKGzBl0qBmNZDFkprLmnq7GsYOH2W5SfNe7hQhHs6ys9rTj1HjSHiGWDaahLRSlVVwOgA==
   dependencies:
-    protobufjs "^7.5.3"
+    protobufjs "^7.5.4"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -10178,7 +10178,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@^7.5.3:
+protobufjs@^7.5.3, protobufjs@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
   integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==


### PR DESCRIPTION
## Summary
- nicolive-comment-protobuf を v2025.602.163750 から v2025.1117.170000 に更新
- 新しい protobuf メッセージタイプが追加されたが、N Air では未処理のため影響なし

## 追加された新しいメッセージタイプ
### message.proto
- `akashic_message_event` (field 24) - Akashicゲーム関連のメッセージイベント

### state.proto
- `ichiba_launcher` (field 11) - ニコニ広告ランチャーのアイテムセット
- `stream_state_change` (field 12) - 配信状態の変更
- `akashic_state` (field 13) - Akashic状態ルーティング

### notifications.proto
- `USER_FOLLOW` (enum 9) - ユーザーフォロー通知

## 動作確認
- これらの新しいメッセージタイプは `NdgrCommentReceiver.convertChunkedResponseToMessageResponse` で未処理のため、受信しても `undefined` を返す
- `undefined` のメッセージは `if (result)` チェックで除外され、`messageSubject` に送信されない
- 結果として、コメント欄には何も表示されず、既存の動作に影響なし

## Test plan
- [x] コンパイルが通ることを確認
- [x] 既存のテストが通ることを確認
- [x] 新しいメッセージタイプの処理フローを追跡し、コメント欄に影響しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)