### PR TITLE
開発: actions/checkout を v5.0.0 から v6.0.0 にアップデート

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       bin: ${{ steps.filter.outputs.common == 'true' || steps.filter.outputs.bin == 'true' }}
     steps:
       - name: Checkout if push
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         if: ${{ github.event_name == 'push' }}
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -56,7 +56,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
@@ -84,7 +84,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
@@ -174,7 +174,7 @@ jobs:
     steps:
       - name: Checkout code
         if: ${{ needs.changes.outputs.app == 'true' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Node.js
         if: ${{ needs.changes.outputs.app == 'true' }}


### PR DESCRIPTION
GitHub Actions の actions/checkout を v5.0.0 から v6.0.0 にアップデートします。

## 変更内容

- `.github/workflows/test.yml` 内のすべての `actions/checkout` を v6.0.0 に更新

## v6.0.0 の主な変更点

- 認証情報を `$RUNNER_TEMP` 配下の別ファイルに保存（セキュリティ向上）
- Node.js 24 サポート
- Docker container action シナリオでは Actions Runner v2.329.0 以上が必要

## リンク

- [actions/checkout リリースノート v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)
- [Full Changelog](https://github.com/actions/checkout/compare/v5.0.0...v6.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)