### PR TITLE
追加: 配信経過時間表示にツールチップを追加

### DIFF
--- a/app/components/StreamingController.vue
+++ b/app/components/StreamingController.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="nav-container">
     <div class="nav-item elapsed-time">
-      <time>{{ streamingElapsedTime }}</time>
+      <time v-tooltip.left="elapsedTimeTooltip">{{ streamingElapsedTime }}</time>
     </div>
     <div class="nav-item">
       <button

--- a/app/components/StreamingController.vue.ts
+++ b/app/components/StreamingController.vue.ts
@@ -96,6 +96,7 @@ export default class StudioFooterComponent extends Vue {
     this.timeoutHandle = window.setTimeout(() => this.updateStreamingElapsedTime(), 200);
   }
 
+  elapsedTimeTooltip = $t('streaming.elapsedTimeTooltip');
   recordTooltip = $t('streaming.recordTooltip');
   startReplayBufferTooltip = $t('streaming.startReplayBuffer');
   stopReplayBufferTooltip = $t('streaming.stopReplayBuffer');

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -33,6 +33,7 @@
   "saveReplay": "Save Replay",
   "endStreamInStreamingConfirm": "Are you sure you want to exit while live?",
   "enableThePreviewStream": "Enable the preview stream",
+  "elapsedTimeTooltip": "Streaming Elapsed Time",
   "recordTooltip": "Set path in Settings > Output.",
   "notBroadcasting": "There is no program",
   "notBroadcastingMessage": "There is no program to start streaming on. Make a program on niconico live service.",

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -33,7 +33,7 @@
   "saveReplay": "Save Replay",
   "endStreamInStreamingConfirm": "Are you sure you want to exit while live?",
   "enableThePreviewStream": "Enable the preview stream",
-  "elapsedTimeTooltip": "Streaming Elapsed Time",
+  "elapsedTimeTooltip": "Time Elapsed Since Stream Started",
   "recordTooltip": "Set path in Settings > Output.",
   "notBroadcasting": "There is no program",
   "notBroadcastingMessage": "There is no program to start streaming on. Make a program on niconico live service.",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -33,6 +33,7 @@
   "saveReplay": "リプレイ保存",
   "endStreamInStreamingConfirm": "配信中ですが、N Airを終了してもよろしいですか？",
   "enableThePreviewStream": "配信プレビューを有効にする",
+  "elapsedTimeTooltip": "配信経過時間",
   "recordTooltip": "設定 > 出力で録画パスを指定できます",
   "notBroadcasting": "番組が作成されていません",
   "notBroadcastingMessage": "N Airでログインしているアカウントでは番組が作成されていないため、配信ができません。ニコニコ生放送にて番組を作成してください。",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -33,7 +33,7 @@
   "saveReplay": "リプレイ保存",
   "endStreamInStreamingConfirm": "配信中ですが、N Airを終了してもよろしいですか？",
   "enableThePreviewStream": "配信プレビューを有効にする",
-  "elapsedTimeTooltip": "配信経過時間",
+  "elapsedTimeTooltip": "配信開始からの経過時間",
   "recordTooltip": "設定 > 出力で録画パスを指定できます",
   "notBroadcasting": "番組が作成されていません",
   "notBroadcastingMessage": "N Airでログインしているアカウントでは番組が作成されていないため、配信ができません。ニコニコ生放送にて番組を作成してください。",


### PR DESCRIPTION
## 概要
配信開始からの経過時間の表示にツールチップを追加し、録画時間との混同を防ぎます。

## 背景
録画ボタンの隣に配信開始からの経過時間が表示されているため、録画時間と混同して数字が変わらないと戸惑うユーザーがいました。後日レイアウトの改善を検討しますが、現状のレイアウトで説明を追加することにしました。

## 変更内容
- StreamingController.vue: time要素にv-tooltip.leftディレクティブを追加
- StreamingController.vue.ts: elapsedTimeTooltipプロパティを追加  
- i18n: 日本語「配信開始からの経過時間」、英語「Time Elapsed Since Stream Started」を追加

## テスト
- [x] 配信開始からの経過時間の表示にマウスをホバーするとツールチップが表示されることを確認
- [x] 日本語環境で「配信開始からの経過時間」と表示されることを確認
  <img width="663" height="73" alt="image" src="https://github.com/user-attachments/assets/17a9a116-6954-41ad-adb2-8a6686f498e2" />
- [x] 英語環境で「Time Elapsed Since Stream Started」と表示されることを確認
  <img width="479" height="81" alt="image" src="https://github.com/user-attachments/assets/c86544e7-be4b-417f-b64f-1d4ac0e37198" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)