### PR TITLE
開発: 未使用の systeminformation パッケージを削除

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,7 +82,6 @@
     "Streamlabs",
     "stylelint",
     "superfast",
-    "systeminformation",
     "Telop",
     "toplevel",
     "typedoc",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "socket.io": "4.7.5",
     "sockjs": "~0.3.19",
     "sockjs-client": "~1.6.1",
-    "systeminformation": "~4.34.23",
     "traverse": "~0.6.7",
     "unzip-stream": "^0.3.4",
     "urijs": "^1.19.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11883,11 +11883,6 @@ svgo@^1.1.1:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-systeminformation@~4.34.23:
-  version "4.34.23"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.34.23.tgz#54c54ced5adc49c27cda953b73c0819ed56edd45"
-  integrity sha512-33+lQwlLxXoxy0o9WLOgw8OjbXeS3Jv+pSl+nxKc2AOClBI28HsdRPpH0u9Xa9OVjHLT9vonnOMw1ug7YXI0dA==
-
 table@^6.0.9, table@^6.8.1:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"


### PR DESCRIPTION
## このpull requestが解決する内容

Dependabot Alert（High severity）の対応：systeminformation パッケージのコマンドインジェクション脆弱性

調査の結果、systeminformationパッケージはコードベースで実際には使用されていないことが判明したため、package.jsonから削除しました。

### 変更内容
- `package.json`: systeminformationの依存関係を削除
- `.vscode/settings.json`: スペルチェック辞書からsysteminformationを削除
- `yarn.lock`: 依存関係を更新

### 理由
システム情報収集は既にNode.js標準の`os`モジュールで実装されています（main.js:386-421）。
systeminformationパッケージは不要な依存関係でした。

## 動作確認手順

1. 依存関係のインストール
```bash
yarn install
```

2. ビルド確認
```bash
yarn compile
```

3. アプリケーション起動確認
```bash
yarn start
```

4. Sentryエラーレポートでのcpu-model取得が正常に動作することを確認

## 関連するDependabot Alert

- https://github.com/n-air-app/n-air-app/security/dependabot/68

🤖 Generated with [Claude Code](https://claude.com/claude-code)