### PR TITLE
開発: bin/package.json の js-yaml を 4.1.1 にアップデート

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -19,7 +19,7 @@
     "@inquirer/prompts": "^7.3.2",
     "colors": "^1.4.0",
     "iconv-lite": "^0.6.3",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "progress": "^2.0.0",
     "semver": "^7.6.3",
     "shelljs": "^0.8.5",

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -1912,10 +1912,10 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+js-yaml@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## このpull requestが解決する内容

Dependabot Alert（Medium severity）の対応：js-yamlのPrototype Pollution脆弱性

bin配下のjs-yamlパッケージを4.1.0から4.1.1にアップデートしました。

### 変更内容
- `bin/package.json`: js-yamlを`^4.1.0` → `^4.1.1`に更新
- `bin/yarn.lock`: 依存関係を更新

### 注記
- メインの`package.json`のjs-yamlは既に3.14.2で安全なバージョンを使用しています
- bin配下のツール（patch-note生成、webfont生成など）で使用されているjs-yamlのみの更新です

## 動作確認手順

1. bin依存関係のインストール
```bash
yarn install --cwd bin
```

2. 正常にインストールされることを確認

## 関連するDependabot Alert

- https://github.com/n-air-app/n-air-app/security/dependabot/85
- https://github.com/n-air-app/n-air-app/security/dependabot/86
- https://github.com/n-air-app/n-air-app/security/dependabot/87
- https://github.com/n-air-app/n-air-app/security/dependabot/88

🤖 Generated with [Claude Code](https://claude.com/claude-code)