### PR TITLE
開発: xmldom 0.6.0 の脆弱性を修正

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -24,5 +24,8 @@
     "semver": "^7.6.3",
     "shelljs": "^0.8.5",
     "webfont": "^11.2.26"
+  },
+  "resolutions": {
+    "svg2ttf": "6.0.3"
   }
 }

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -1373,6 +1373,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@xmldom/xmldom@^0.7.2":
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.13.tgz#ff34942667a4e19a9f4a0996a76814daac364cf3"
+  integrity sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==
+
 a-sync-waterfall@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz#75b6b6aa72598b497a125e7a2770f14f4c8a1fa7"
@@ -2418,17 +2423,17 @@ svg-pathdata@^6.0.0:
   resolved "https://registry.yarnpkg.com/svg-pathdata/-/svg-pathdata-6.0.0.tgz#53fc61dcdbd2cb51359f2484e890c63371f1e977"
   integrity sha512-8XoCZjKbP0fvJbDsm6KFxVau2N3SkWkMj8OniADm87q4OiFXk/gSgri5Uyr8hE1fQ9npI+9XzRlTUObgWmBBNw==
 
-svg2ttf@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/svg2ttf/-/svg2ttf-6.0.2.tgz#7eec850c3dc2c81f813ce5fa518c8a15b1292d43"
-  integrity sha512-QiDMuvYMHVPm543Pg99QpUsw6QXm7totYLeF23JJCS6g+0+xUgnapzCFFSKEKPwT7kfQHzR+S/JqP6vptJucyA==
+svg2ttf@6.0.3, svg2ttf@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/svg2ttf/-/svg2ttf-6.0.3.tgz#7b92978ff124b2a583d21e1208b9675e245e56d1"
+  integrity sha512-CgqMyZrbOPpc+WqH7aga4JWkDPso23EgypLsbQ6gN3uoPWwwiLjXvzgrwGADBExvCRJrWFzAeK1bSoSpE7ixSQ==
   dependencies:
+    "@xmldom/xmldom" "^0.7.2"
     argparse "^2.0.1"
     cubic2quad "^1.2.1"
     lodash "^4.17.10"
     microbuffer "^1.0.0"
     svgpath "^2.1.5"
-    xmldom "~0.6.0"
 
 svgicons2svgfont@^10.0.3:
   version "10.0.3"
@@ -2592,11 +2597,6 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
-
-xmldom@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
- bin/package.json に resolutions フィールドを追加して svg2ttf を 6.0.3 に更新
- 脆弱性のある xmldom 0.6.0 を安全な @xmldom/xmldom 0.7.13 に置き換え
- webfont の動作確認済み（フォント生成が正常に完了）

## 背景: resolutions を使用する理由

webfont パッケージは **2021年8月7日以降メンテナンスされていない** ため、依存関係が古いままです：
- webfont 11.2.26（最終リリース: 2021-08-07）が svg2ttf 6.0.2 を要求
- svg2ttf 6.0.2 は脆弱な xmldom 0.6.0 に依存
- svg2ttf 6.0.3（リリース: 2021-08-21）は既に安全な @xmldom/xmldom 0.7.2 に更新済み

webfont 本体の更新が期待できないため、Yarn の resolutions 機能を使用して svg2ttf のみを 6.0.3 に強制更新することで、最小限の変更で脆弱性を解決します。

## 解決された脆弱性

### 1. Multiple root elements in DOM tree (Critical)
- **CVE**: GHSA-crh6-fp67-6883
- **URL**: https://github.com/xmldom/xmldom/security/advisories/GHSA-crh6-fp67-6883
- XMLの不正な形式を受け入れ、複数のルート要素を許可してしまう問題

### 2. Prototype Pollution (Low)
- **CVE**: GHSA-9pgh-qqpf-7wqj
- **URL**: https://github.com/xmldom/xmldom/security/advisories/GHSA-9pgh-qqpf-7wqj
- dom.jsのcopy関数におけるプロトタイプ汚染の脆弱性

### 3. Misinterpretation of malicious XML input (Moderate)
- **CVE**: CVE-2021-32796 / GHSA-5fg8-2547-mr8q
- **URL**: https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q
- 特殊文字のエスケープが不適切で、悪意のあるXML入力の誤解釈を招く問題（≤ 0.6.0）

### 4. Misinterpretation of malicious XML input (Moderate)
- **CVE**: CVE-2021-21366 / GHSA-h6q6-9hqw-rwfv
- **URL**: https://github.com/xmldom/xmldom/security/advisories/GHSA-h6q6-9hqw-rwfv
- システム識別子や名前空間の維持が不適切な問題（≤ 0.4.0）

## 依存関係チェーン
```
webfont 11.2.26 → svg2ttf 6.0.2 → xmldom 0.6.0 (脆弱)
                              ↓
webfont 11.2.26 → svg2ttf 6.0.3 → @xmldom/xmldom 0.7.13 (安全)
```

## Test plan
- [x] `cd bin && yarn install` で依存関係を更新
- [x] `yarn why svg2ttf` で 6.0.3 に更新されたことを確認
- [x] `yarn why xmldom` で古い xmldom が削除されたことを確認
- [x] `yarn webfont` でフォント生成が正常に完了することを確認
- [x] 生成ファイル（app/fonts/n-air.woff、app/styles/custom-icons.less）に差分がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)