### PR TITLE
開発: xml2js の脆弱性を修正（0.4.23 → 0.6.2）

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "vue-toasted": "1.1.24",
     "vuedraggable": "2.24.3",
     "vuex": "3.1.1",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.22.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,9 +1048,9 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/node-gyp@git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2":
+"@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+  resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
@@ -12808,10 +12808,10 @@ xml-name-validator@^4.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
-xml2js@^0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"


### PR DESCRIPTION
## 概要
xml2js 0.4.23 にプロトタイプ汚染（Prototype Pollution）の脆弱性があるため、0.6.2 にアップデートします。

## 変更内容
- **xml2js**: 0.4.23 → 0.6.2

## セキュリティへの影響
### 脆弱性
- **種類**: プロトタイプ汚染（Prototype Pollution）
- **深刻度**: MODERATE（中）
- **CVE**: https://www.npmjs.com/advisories/1096693

### 影響範囲
本アプリでは以下の箇所で xml2js を使用しています：
- app/services/platforms/niconico.ts - ニコニコ生放送の番組情報XML解析
- app/services/informations/informations.ts - お知らせRSSフィード解析

これらは外部からのXMLを処理するため、脆弱性の影響を受ける可能性がありました。

## 互換性
APIに破壊的変更はなく、既存コードの修正は不要です。
- parseString 関数のシグネチャは変更なし
- コールバックパターンも同じ