### PR TITLE
修正: 「この番組で収入を得る」から収益化申請ページにアクセスできない問題を修正

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -70,7 +70,7 @@ export class HostsService extends Service {
   }
 
   getCreatorsProgramURL(programID: string): string {
-    return `https://commons.nicovideo.jp/cpp/application/?site_id=nicolive&creation_id=${programID}`;
+    return `https://commons.nicovideo.jp/cpp-applications/${programID}/new?site_id=nicolive`;
   }
 
   getModeratorSettingsURL(): string {


### PR DESCRIPTION
## 問題
ニコニコ生放送の配信中に、右上のメニューから「この番組で収入を得る」を選択すると「ページが見つかりません」というエラーページが表示される問題がありました。

## 原因
ニコニコのクリエイター奨励プログラム(収益化申請)ページのURLが変更されており、旧URLへのリンクが使用されていたため。

## 修正内容
`app/services/hosts.ts`の`getCreatorsProgramURL`メソッドで使用しているURLを新しいものに更新しました。

**変更前:**
```
https://commons.nicovideo.jp/cpp/application/?site_id=nicolive&creation_id={programID}
```

**変更後:**
```
https://commons.nicovideo.jp/cpp-applications/{programID}/new?site_id=nicolive
```

## 影響範囲
「この番組で収入を得る」メニューから正しく収益化申請ページにアクセスできるようになります。
(注: 実際の収益化申請は番組終了後に行えます)

🤖 Generated with [Claude Code](https://claude.com/claude-code)