### PR TITLE
開発: リリーススクリプトのyarn installに--frozen-lockfileオプションを追加

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -230,7 +230,7 @@ async function runScript({
     }
 
     info('Installing yarn packages...');
-    executeCmd('yarn install');
+    executeCmd('yarn install --frozen-lockfile');
 
     info('Compiling assets...');
     executeCmd('yarn compile:production');


### PR DESCRIPTION
## 概要
リリーススクリプトの`yarn install`に`--frozen-lockfile`オプションを追加し、開発者間のyarn.lock正規化ルールの違いによるリリース失敗を防止します。

## 背景
開発者間でyarn.lockの正規化ルールが異なる環境があり、リリース時に`yarn install`を実行するとlockファイルに差分が発生してリリースが失敗する問題がありました。

## 変更内容
- `bin/release/mini-release.js`の`yarn install`コマンドに`--frozen-lockfile`オプションを追加

## 効果
- lockファイルが変更されないことを保証
- 依存関係の不整合時はエラーで検出
- リリースビルドの再現性を確保

## 補足
この問題は古いyarn 1.xの既知の問題と思われます。将来的にyarn 4.xなど最新バージョンに更新することで根本的に解決できる可能性があります。

## テスト計画
- [ ] リリーススクリプトが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)