### PR TITLE
修正: 文字起こしモデルのダウンロード中に重複したダウンロード案内が表示される問題を修正

### DIFF
--- a/app/components/TranscriptionSettings.vue.ts
+++ b/app/components/TranscriptionSettings.vue.ts
@@ -116,8 +116,8 @@ export default class TranscriptionSettings extends Vue {
     const lastEnabled = this.transcriptionService.state.enabled ?? false;
     this.transcriptionService.setEnabled(enable);
     if (!lastEnabled && enable) {
-      // もし、有効化したときにモデルをひとつもダウンロードしていない場合、ダウンロードすることを確認してモデル(small)をだダウンロード開始する
-      if (!this.hasAtLeastOneVoskModelDownloaded) {
+      // もし、有効化したときにモデルをひとつもダウンロードしていない場合、ダウンロードすることを確認してモデル(small)をダウンロード開始する
+      if (!this.hasAtLeastOneVoskModelDownloaded && !this.hasModelDownloadInProgress) {
         if (
           remote.dialog.showMessageBoxSync(remote.getCurrentWindow(), {
             type: 'question',
@@ -186,6 +186,13 @@ export default class TranscriptionSettings extends Vue {
   // vosk model をひとつでもダウンロードしているならtrue
   get hasAtLeastOneVoskModelDownloaded(): boolean {
     return Object.values(this.modelsStatus).some(status => status.state === 'downloaded');
+  }
+
+  // vosk model をダウンロード中またはインストール中ならtrue
+  get hasModelDownloadInProgress(): boolean {
+    return Object.values(this.modelsStatus).some(
+      status => status.state === 'downloading' || status.state === 'installing',
+    );
   }
 
   get voskModelModel(): IObsListInput<string> {

--- a/app/components/TranscriptionSettings.vue.ts
+++ b/app/components/TranscriptionSettings.vue.ts
@@ -117,7 +117,7 @@ export default class TranscriptionSettings extends Vue {
     this.transcriptionService.setEnabled(enable);
     if (!lastEnabled && enable) {
       // もし、有効化したときにモデルをひとつもダウンロードしていない場合、ダウンロードすることを確認してモデル(small)をダウンロード開始する
-      if (!this.hasAtLeastOneVoskModelDownloaded && !this.hasModelDownloadInProgress) {
+      if (!this.hasVoskModelDownloadedOrInProgress) {
         if (
           remote.dialog.showMessageBoxSync(remote.getCurrentWindow(), {
             type: 'question',
@@ -183,15 +183,13 @@ export default class TranscriptionSettings extends Vue {
     this.transcriptionSourceService.addTextTranscriptionSourceToActiveScene();
   }
 
-  // vosk model をひとつでもダウンロードしているならtrue
-  get hasAtLeastOneVoskModelDownloaded(): boolean {
-    return Object.values(this.modelsStatus).some(status => status.state === 'downloaded');
-  }
-
-  // vosk model をダウンロード中またはインストール中ならtrue
-  get hasModelDownloadInProgress(): boolean {
+  // vosk model がひとつでもダウンロード済み、ダウンロード中、またはインストール中ならtrue
+  get hasVoskModelDownloadedOrInProgress(): boolean {
     return Object.values(this.modelsStatus).some(
-      status => status.state === 'downloading' || status.state === 'installing',
+      status =>
+        status.state === 'downloaded' ||
+        status.state === 'downloading' ||
+        status.state === 'installing',
     );
   }
 


### PR DESCRIPTION
## 概要

文字起こし機能を有効化する際、モデルがダウンロード中またはインストール中であっても、ダウンロード確認ダイアログが重複して表示されていた問題を修正しました。

## 修正した問題

`app/components/TranscriptionSettings.vue.ts`の`set enabled()`メソッド内で、モデルがダウンロード済み（`downloaded`）かどうかのみをチェックしていたため、ダウンロード中（`downloading`）やインストール中（`installing`）の状態が考慮されていませんでした。

## 変更内容

- `hasAtLeastOneVoskModelDownloaded`を`hasVoskModelDownloadedOrInProgress`に変更し、`downloaded`、`downloading`、`installing`の3つの状態をチェックするように拡張
- コメントの誤字修正（「だダウンロード」→「ダウンロード」）

## テスト項目

- [x] モデルが一つもダウンロードされていない状態で文字起こしを有効化 → ダイアログが表示されること
- [x] モデルがダウンロード中の状態で文字起こしを有効化 → ダイアログが表示されないこと
- [x] モデルがインストール中の状態で文字起こしを有効化 → ダイアログが表示されないこと
- [x] モデルがダウンロード済みの状態で文字起こしを有効化 → ダイアログが表示されないこと
- [x] ダウンロードエラー後に文字起こしを有効化 → ダイアログが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)