### PR TITLE
開発: CODEOWNERS のデザイナーアカウントを更新

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,9 @@ replace_rules.json @takuhiro-koyama
 /.github/CODEOWNERS @takuhiro-koyama
 
 # designers
-*.vue @yusukess @kechino
-*.html @yusukess @kechino
-*.less @yusukess @kechino
-*.css @yusukess @kechino
-/app/styles/ @yusukess @kechino
-/media/images/ @yusukess @kechino
+*.vue @yusuke-shibakiri @Keiichi-Ichino
+*.html @yusuke-shibakiri @Keiichi-Ichino
+*.less @yusuke-shibakiri @Keiichi-Ichino
+*.css @yusuke-shibakiri @Keiichi-Ichino
+/app/styles/ @yusuke-shibakiri @Keiichi-Ichino
+/media/images/ @yusuke-shibakiri @Keiichi-Ichino


### PR DESCRIPTION
## Summary
デザイナーの GitHub アカウントを更新しました。

## 変更内容
- `@yusukess` → `@yusuke-shibakiri`
- `@kechino` → `@Keiichi-Ichino`

## 影響
- UI関連ファイル（`.vue`, `.html`, `.less`, `.css`, `/app/styles/`, `/media/images/`）の変更時に、新しいアカウントがコードオーナーとして通知されます
- 両アカウントともリポジトリのコラボレーター（admin権限）として登録済みです

🤖 Generated with [Claude Code](https://claude.com/claude-code)