### PR TITLE
修正: 文字起こしでノイズ除去後の空文字列が結果に追加される問題を修正

### DIFF
--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -485,9 +485,15 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       next: message => {
         console.log('Transcribe message:', message);
         if (isTextTranscriptionMessage(message)) {
-          this.rawTextSubject$.next(filterNoiseText(message.text));
+          const text = filterNoiseText(message.text);
+          if (text) {
+            this.rawTextSubject$.next(text);
+          }
         } else if (isPartialTranscriptionMessage(message)) {
-          this.partialSubject$.next(filterNoiseText(message.partial));
+          const partial = filterNoiseText(message.partial);
+          if (partial) {
+            this.partialSubject$.next(partial);
+          }
         } else if (isErrorTranscriptionMessage(message)) {
           console.error('Transcription error:', message.error);
           if (message.error.startsWith('Failed to load model:')) {


### PR DESCRIPTION
## 概要
音声認識結果に対して `filterNoiseText()` でノイズ除去を行った結果、空文字列になった場合に、その空文字列が認識結果として文字起こし結果に追加されていた問題を修正しました。

## 変更内容
`app/services/transcription/transcription.ts` の488-497行目で、`filterNoiseText()` の結果をチェックし、空文字列でない場合のみ Subject に流すように変更しました。

## テスト計画
- [x] 文字起こし機能を有効化
- [x] ノイズパターン（「えーと」、「ん」など）のみの音声を認識させる
- [x] 空文字列が文字起こし結果に追加されないことを確認
- [x] 通常の音声認識が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)