### PR TITLE
修正: NDI RuntimeのダウンロードURLをv6に更新

### DIFF
--- a/app/components/windows/SourcesShowcase.vue.ts
+++ b/app/components/windows/SourcesShowcase.vue.ts
@@ -148,7 +148,7 @@ export default class SourcesShowcase extends Vue {
   }
 
   downloadNdiRuntime() {
-    remote.shell.openExternal('http://ndi.link/NDIRedistV5');
+    remote.shell.openExternal('https://downloads.ndi.tv/SDK/NDI_SDK/NDI%206%20Runtime.exe');
   }
 
   get readyToAdd() {


### PR DESCRIPTION
## Summary
- NDI Runtime v5のダウンロードURLが変更されたため、v6の新しいURLに更新
- `http://ndi.link/NDIRedistV5` → `https://downloads.ndi.tv/SDK/NDI_SDK/NDI%206%20Runtime.exe`
- Closes #1047

## Changes
- `app/components/windows/SourcesShowcase.vue.ts`: `downloadNdiRuntime()`メソッドのURL更新

## Test Plan
- [x] 後方互換性を確認: 古いソースからの受信を確認済み
- [x] UI動作確認: SourcesShowcase画面でNDIソース追加時のダウンロードボタンが正しく動作するか
- [x] ダウンロード確認: 新しいURLからダウンロード・インストール・OS再起動後、NDIソースがソース追加画面に現れることを確認。それをシーンに追加し、LAN内のNDIソースの映像を受信することまで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)