### PR TITLE
追加: 文字起こしモデルのダウンロードキャンセル機能

### DIFF
--- a/app/components/TranscriptionSettings.vue
+++ b/app/components/TranscriptionSettings.vue
@@ -54,6 +54,18 @@
             data-variant="light"
             data-radius="sm"
             data-color="secondary"
+            v-tooltip="$t(cancelButtonText)"
+            @click="cancelDownloadVoskModel()"
+            v-if="isCancelButtonEnabled"
+          >
+            <i class="icon-close"></i>
+          </button>
+          <button
+            class="action-icon"
+            data-size="md"
+            data-variant="light"
+            data-radius="sm"
+            data-color="secondary"
             v-tooltip="$t(deleteButtonText)"
             @click="deleteVoskModel()"
             v-if="isDeleteButtonEnabled"

--- a/app/components/TranscriptionSettings.vue.ts
+++ b/app/components/TranscriptionSettings.vue.ts
@@ -216,12 +216,29 @@ export default class TranscriptionSettings extends Vue {
 
   get isDownloadButtonEnabled(): boolean {
     return (
-      this.modelStatus.state === 'not_downloaded' || this.modelStatus.state === 'download_error'
+      this.modelStatus.state === 'not_downloaded' ||
+      this.modelStatus.state === 'download_error' ||
+      this.modelStatus.state === 'cancelled'
     );
   }
 
   downloadVoskModel(): void {
     this.transcriptionService.startDownloadVoskModel(this.transcriptionService.state.voskModelName);
+  }
+
+  cancelButtonText = $t('settings.transcription.cancelVoskModel');
+
+  get isCancelButtonEnabled(): boolean {
+    return this.modelStatus.state === 'downloading';
+  }
+
+  cancelDownloadVoskModel(): void {
+    const wasCancelled = this.transcriptionService.cancelDownloadVoskModel(
+      this.transcriptionService.state.voskModelName,
+    );
+    if (wasCancelled) {
+      console.log('Cancelled download for model:', this.transcriptionService.state.voskModelName);
+    }
   }
 
   deleteButtonText = $t('settings.transcription.deleteVoskModel');

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -775,9 +775,11 @@
       "installing": "Installing...",
       "downloaded": "Downloaded",
       "download_error": "Download error",
-      "load_error": "Load error"
+      "load_error": "Load error",
+      "cancelled": "Cancelled"
     },
     "downloadVoskModel": "Download model",
+    "cancelVoskModel": "Cancel download",
     "deleteVoskModel": "Delete downloaded model",
     "audioSettings": "Audio Settings",
     "audioSource": "Audio Source",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -775,9 +775,11 @@
       "installing": "インストール中...",
       "downloaded": "ダウンロード済み",
       "download_error": "ダウンロードエラー",
-      "load_error": "読み込みエラー"
+      "load_error": "読み込みエラー",
+      "cancelled": "キャンセルされました"
     },
     "downloadVoskModel": "モデルをダウンロードする",
+    "cancelVoskModel": "ダウンロードをキャンセルする",
     "deleteVoskModel": "ダウンロードしたモデルを削除する",
     "audioSettings": "音声設定",
     "audioSource": "音声ソース",

--- a/app/services/transcription/VoskModelsManager.ts
+++ b/app/services/transcription/VoskModelsManager.ts
@@ -5,7 +5,7 @@ import { $t } from 'services/i18n';
 export const VOSK_MODEL_NAMES = ['vosk-model-small-ja-0.22', 'vosk-model-ja-0.22'] as const;
 
 export type VoskModelStatus = {
-  state: 'not_downloaded' | 'downloading' | 'installing' | 'downloaded' | 'download_error' | 'load_error';
+  state: 'not_downloaded' | 'downloading' | 'installing' | 'downloaded' | 'download_error' | 'load_error' | 'cancelled';
   progress?: number; // percentage of download completion
   error_message?: string;
 };

--- a/app/services/transcription/downloadAndUnzip.ts
+++ b/app/services/transcription/downloadAndUnzip.ts
@@ -36,16 +36,26 @@ export class ExtractError extends Error {
   }
 }
 
+export class CancelledError extends Error {
+  constructor() {
+    super('Download cancelled by user');
+
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 export async function downloadAndUnzip(
   url: string,
   zipPath: string,
   extractPath: string,
   onProgress: (status: { downloaded: number; total: number }) => void,
+  signal?: AbortSignal,
 ) {
   // 1. Download the zip file
   await (async () => {
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal });
       if (!response.ok || !response.body) {
         return Promise.reject(new DownloadError({ reason: 'response', response }));
       }
@@ -74,14 +84,42 @@ export async function downloadAndUnzip(
         },
       });
 
-      await pipeline(downloadStream, fileStream);
-      console.log('Download completed:', zipPath);
-      if (progressTimer) {
-        clearInterval(progressTimer);
-        progressTimer = null;
+      // Setup abort listener
+      const abortListener = () => {
+        if (progressTimer) {
+          clearInterval(progressTimer);
+          progressTimer = null;
+        }
+        reader.cancel();
+      };
+
+      if (signal) {
+        signal.addEventListener('abort', abortListener);
       }
-      onProgress(progress);
+
+      try {
+        await pipeline(downloadStream, fileStream);
+        console.log('Download completed:', zipPath);
+      } catch (error) {
+        if (signal?.aborted) {
+          throw new CancelledError();
+        }
+        throw error;
+      } finally {
+        if (progressTimer) {
+          clearInterval(progressTimer);
+          progressTimer = null;
+        }
+        if (signal) {
+          signal.removeEventListener('abort', abortListener);
+        }
+        onProgress(progress);
+      }
     } catch (error) {
+      // Re-throw CancelledError without wrapping
+      if (error instanceof CancelledError) {
+        throw error;
+      }
       return Promise.reject(
         new DownloadError({
           reason: 'fetch',
@@ -90,6 +128,11 @@ export async function downloadAndUnzip(
       );
     }
   })();
+
+  // Check if download was cancelled before attempting to unzip
+  if (signal?.aborted) {
+    throw new CancelledError();
+  }
 
   try {
     // 2. Unzip the downloaded file

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -39,9 +39,13 @@ jest.mock('services/i18n', () => ({
     .mockName('$t')
     .mockImplementation(key => key),
 }));
-jest.mock('./downloadAndUnzip', () => ({
-  downloadAndUnzip: jest_fn<typeof downloadAndUnzipType>().mockName('downloadAndUnzip'),
-}));
+jest.mock('./downloadAndUnzip', () => {
+  const actual = jest.requireActual('./downloadAndUnzip');
+  return {
+    ...actual,
+    downloadAndUnzip: jest_fn<typeof downloadAndUnzipType>().mockName('downloadAndUnzip'),
+  };
+});
 jest.mock('./filterNoiseText', () => ({
   filterNoiseText: jest_fn<typeof filterNoiseTextType>()
     .mockName('filterNoiseText')
@@ -875,6 +879,112 @@ describe('TranscriptionService', () => {
       expect(setVoskModelStatus).toHaveBeenCalledWith(VOSK_MODEL_NAME, { state: 'downloading' });
       expect(setVoskModelStatus).toHaveBeenLastCalledWith(VOSK_MODEL_NAME, { state: 'downloaded' });
       expect(downloadAndUnzip).toHaveBeenCalled();
+    });
+
+    it(
+      'should cancel download and set model status to cancelled',
+      withClock(async clock => {
+        const { instance, setVoskModelStatus } = setupTranscription();
+        const { downloadAndUnzip, CancelledError } = require('./downloadAndUnzip');
+
+        let rejectDownload: (error: Error) => void;
+
+        // Mock downloadAndUnzip to return a promise we can control
+        downloadAndUnzip.mockImplementation(() => {
+          return new Promise((resolve, reject) => {
+            rejectDownload = reject;
+          });
+        });
+
+        const downloadPromise = instance.startDownloadVoskModel(VOSK_MODEL_NAME);
+
+        // Verify download started
+        expect(setVoskModelStatus).toHaveBeenCalledWith(VOSK_MODEL_NAME, { state: 'downloading' });
+
+        // Cancel the download
+        const wasCancelled = instance.cancelDownloadVoskModel(VOSK_MODEL_NAME);
+        expect(wasCancelled).toBe(true);
+
+        // Simulate downloadAndUnzip throwing CancelledError
+        rejectDownload!(new CancelledError());
+
+        // Wait for download promise to complete
+        await downloadPromise;
+        await clock.tickAsync(0);
+
+        // Verify status was set to cancelled
+        expect(setVoskModelStatus).toHaveBeenCalledWith(VOSK_MODEL_NAME, { state: 'cancelled' });
+
+        // Advance time by 3 seconds to trigger auto-reset
+        await clock.tickAsync(3000);
+
+        // Verify status was reset to not_downloaded
+        expect(setVoskModelStatus).toHaveBeenCalledWith(VOSK_MODEL_NAME, {
+          state: 'not_downloaded',
+        });
+      }),
+    );
+
+    it('should return false when cancelling with no download in progress', () => {
+      const { instance } = setupTranscription();
+      const wasCancelled = instance.cancelDownloadVoskModel(VOSK_MODEL_NAME);
+      expect(wasCancelled).toBe(false);
+    });
+
+    it('should prevent downloading the same model multiple times', async () => {
+      const { instance } = setupTranscription();
+      const { downloadAndUnzip } = require('./downloadAndUnzip');
+
+      let resolveDownload: (value?: unknown) => void;
+
+      // Mock downloadAndUnzip to return a promise we can control
+      downloadAndUnzip.mockImplementation(
+        () =>
+          new Promise(resolve => {
+            resolveDownload = resolve;
+          }),
+      );
+
+      // Start first download
+      const firstDownload = instance.startDownloadVoskModel(VOSK_MODEL_NAME);
+
+      // Try to start the same model download again
+      await expect(instance.startDownloadVoskModel(VOSK_MODEL_NAME)).rejects.toThrow(
+        `Model ${VOSK_MODEL_NAME} is already being downloaded`,
+      );
+
+      // Complete first download
+      resolveDownload!();
+      await firstDownload;
+    });
+
+    it('should allow downloading different models simultaneously', async () => {
+      const { instance } = setupTranscription();
+      const { downloadAndUnzip } = require('./downloadAndUnzip');
+
+      const resolvers: ((value?: unknown) => void)[] = [];
+
+      // Mock downloadAndUnzip to return a promise we can control
+      downloadAndUnzip.mockImplementation(
+        () =>
+          new Promise(resolve => {
+            resolvers.push(resolve);
+          }),
+      );
+
+      // Start first download
+      const firstDownload = instance.startDownloadVoskModel(VOSK_MODEL_NAME);
+
+      // Start second download of different model - should succeed
+      const secondDownload = instance.startDownloadVoskModel(VOSK_MODEL_NAME_2);
+
+      // Complete both downloads
+      resolvers[0]!();
+      resolvers[1]!();
+      await firstDownload;
+      await secondDownload;
+
+      expect(downloadAndUnzip).toHaveBeenCalledTimes(2);
     });
 
     it(

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -23,7 +23,7 @@ import { NicoliveProgramService } from 'services/nicolive-program/nicolive-progr
 import { TranscriptionLog } from 'services/usage-statistics';
 import { Inject, mutation, PersistentStatefulService } from '../core';
 import { CommentColor, CommentFont, CommentPosition, CommentSize } from './CommentModifier';
-import { downloadAndUnzip, DownloadError, ExtractError } from './downloadAndUnzip';
+import { CancelledError, downloadAndUnzip, DownloadError, ExtractError } from './downloadAndUnzip';
 import { filterNoiseText } from './filterNoiseText';
 import { TranscriptionSourceUsageService } from './transcription-source-usage';
 import {
@@ -39,7 +39,7 @@ import {
   VoskClient,
 } from './VoskClient';
 import { VOSK_MODEL_NAMES, VoskModelsManager, VoskModelStatus } from './VoskModelsManager';
-export { VOSK_MODEL_NAMES, VoskModelStatus };
+export { CancelledError, VOSK_MODEL_NAMES, VoskModelStatus };
 
 // original site: https://alphacephei.com/vosk/models -> `https://alphacephei.com/vosk/models/${name}.zip`;
 const getVoskModelURL = (name: string): string =>
@@ -121,6 +121,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
   private modelBasePath: string;
   private modelsManager: VoskModelsManager;
   private client: ITranscriber;
+  private downloadControllers: Map<string, AbortController> = new Map();
   private state$ = new BehaviorSubject<ITranscriptionServiceState>(
     TranscriptionService.defaultState,
   );
@@ -688,6 +689,15 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       message: `Start downloading Vosk model: ${modelName}`,
     });
 
+    // Prevent downloading the same model multiple times
+    if (this.downloadControllers.has(modelName)) {
+      throw new Error(`Model ${modelName} is already being downloaded`);
+    }
+
+    // Create abort controller for this download
+    const controller = new AbortController();
+    this.downloadControllers.set(modelName, controller);
+
     const tmpDir = tmpdir();
     const tmpZipPath = join(tmpDir, `${modelName}.zip`);
 
@@ -713,7 +723,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
 
       const downloadUrl = getVoskModelURL(modelName);
 
-      await downloadAndUnzip(downloadUrl, tmpZipPath, this.modelBasePath, onProgress);
+      await downloadAndUnzip(downloadUrl, tmpZipPath, this.modelBasePath, onProgress, controller.signal);
 
       this.setModelStatus(modelName, { state: 'downloaded' });
       Sentry.captureEvent({
@@ -725,6 +735,19 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
         },
       });
     } catch (err) {
+      // Check for cancellation first
+      if (err instanceof CancelledError) {
+        console.log('Download cancelled:', modelName);
+        this.setModelStatus(modelName, { state: 'cancelled' });
+        // Reset to not_downloaded after 3 seconds
+        setTimeout(() => {
+          if (this.modelsManager.getVoskModelStatus(modelName).state === 'cancelled') {
+            this.setModelStatus(modelName, { state: 'not_downloaded' });
+          }
+        }, 3000);
+        return;
+      }
+
       let error_message: string;
       let error_type: string;
       if (err instanceof DownloadError) {
@@ -767,6 +790,9 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
         },
       });
     } finally {
+      // Clear download tracking for this model
+      this.downloadControllers.delete(modelName);
+
       // Delete the temporary zip file
       if (existsSync(tmpZipPath)) {
         try {
@@ -813,6 +839,28 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     } catch (err) {
       console.error('Failed to delete model directory:', err);
     }
+    return true;
+  }
+
+  /**
+   * Cancels the download of a specific model.
+   * @param modelName The name of the model to cancel
+   * @returns true if the download was cancelled, false if no download was in progress for this model
+   */
+  cancelDownloadVoskModel(modelName: string): boolean {
+    const controller = this.downloadControllers.get(modelName);
+    if (!controller) {
+      return false;
+    }
+
+    Sentry.addBreadcrumb({
+      category: 'transcription',
+      message: `Cancel downloading Vosk model: ${modelName}`,
+    });
+
+    console.log('Cancelling download:', modelName);
+    controller.abort();
+
     return true;
   }
 


### PR DESCRIPTION
## 概要

文字起こしモデルのダウンロード中にキャンセルボタンを表示し、ダウンロードを中断できるようにしました。

Closes #1034

## スクリーンショット

### ダウンロード中
<img width="822" height="161" alt="image" src="https://github.com/user-attachments/assets/04dfaa0c-9c3b-485a-9258-86dc0b4e6c90" />

### キャンセル後
<img width="799" height="122" alt="image" src="https://github.com/user-attachments/assets/08cce7a2-3037-4248-95af-23e1e0fe4a2d" />


## 変更内容

### 機能追加
- **ダウンロードキャンセル機能**: ダウンロード中(`downloading`状態)にキャンセルボタンを表示
- **キャンセルステート**: キャンセル後は`cancelled`状態を3秒間表示し、自動的に`not_downloaded`に戻る
- **複数モデル同時ダウンロード**: 異なるモデルを同時にダウンロード可能（同じモデルの重複は防止）

### 実装詳細
- `AbortController`を使用してfetchリクエストをキャンセル
- 各モデルのダウンロードを`Map<string, AbortController>`で管理
- `CancelledError`を追加し、キャンセル時のエラーハンドリングを実装
- UIにキャンセルボタンを追加（`icon-close`アイコン）

### i18n対応
- 日本語: "ダウンロードをキャンセルする", "キャンセルされました"
- 英語: "Cancel download", "Cancelled"

### テスト
- キャンセル機能のテスト
- 同じモデルの重複ダウンロード防止のテスト
- 異なるモデルの同時ダウンロード許可のテスト

全37テストがパス（3つのテストを追加）

## テスト方法
1. 設定画面で文字起こし機能を有効化
2. 大きいモデル（`vosk-model-ja-0.22`）のダウンロードを開始
3. ダウンロード中にキャンセルボタン(×)が表示されることを確認
4. キャンセルボタンをクリック
5. 「キャンセルされました」と表示され、3秒後に「未ダウンロード」に戻ることを確認
6. 異なる2つのモデルを同時にダウンロードできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)