### PR TITLE
改善: 設定画面で文字起こしの行数を変更すると、アクティブなシーンの文字起こしソースに自動反映する

### DIFF
--- a/app/services/sources/properties-managers/text-transcription-manager.ts
+++ b/app/services/sources/properties-managers/text-transcription-manager.ts
@@ -1,7 +1,7 @@
 import { PropertiesManager } from './properties-manager';
 
 export class TextTranscriptionManager extends PropertiesManager {
-  blacklist = ['read_from_file', 'file'];
+  blacklist = ['read_from_file', 'file', 'chatlog', 'chatlog_lines'];
   customUIComponent = 'TextTranscriptionProperties';
 
   //   init() {

--- a/app/services/transcription/transcription-source-usage.ts
+++ b/app/services/transcription/transcription-source-usage.ts
@@ -2,15 +2,15 @@ import { BehaviorSubject, merge } from 'rxjs';
 import { mutation, StatefulService } from 'services/core';
 import { Inject } from 'services/core/injector';
 import { ScenesService } from 'services/scenes';
-import { SourcesService } from 'services/sources';
+import { TranscriptionSourceService } from './transcription-source';
 
 interface ITranscriptionSourceUsageState {
   existsInActiveScene: boolean;
 }
 
 export class TranscriptionSourceUsageService extends StatefulService<ITranscriptionSourceUsageState> {
-  @Inject() private sourcesService: SourcesService;
   @Inject() private scenesService: ScenesService;
+  @Inject() private transcriptionSourceService: TranscriptionSourceService;
 
   static initialState: ITranscriptionSourceUsageState = {
     existsInActiveScene: false,
@@ -33,7 +33,7 @@ export class TranscriptionSourceUsageService extends StatefulService<ITranscript
   }
 
   updateTranscriptionUsage() {
-    if (this.containsTranscriptionInActiveScene()) {
+    if (this.transcriptionSourceService.containsTranscriptionInActiveScene()) {
       this.markTranscriptionUsed();
     } else {
       this.reset();
@@ -50,23 +50,9 @@ export class TranscriptionSourceUsageService extends StatefulService<ITranscript
     this.setState({ existsInActiveScene: false });
   }
 
-  isTranscriptionSourceId(sourceId: string): boolean {
-    const sourceDetails = this.sourcesService.getSource(sourceId).getComparisonDetails();
-    return sourceDetails.propertiesManager === 'text_transcription';
-  }
-
-  containsTranscriptionInActiveScene(): boolean {
-    for (const item of this.scenesService.activeScene.getItems()) {
-      if (this.isTranscriptionSourceId(item.sourceId)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   startStreaming() {
     this.reset();
-    if (this.containsTranscriptionInActiveScene()) {
+    if (this.transcriptionSourceService.containsTranscriptionInActiveScene()) {
       this.markTranscriptionUsed();
     }
   }

--- a/app/services/transcription/transcription-source.ts
+++ b/app/services/transcription/transcription-source.ts
@@ -12,17 +12,50 @@ export class TranscriptionSourceService extends Service {
   @Inject() private transcriptionService: TranscriptionService;
   @Inject() private scenesService: ScenesService;
 
+  /**
+   * 行数から表示に必要な各種パラメータを計算
+   * @param lines 表示する行数（不正な値の場合はデフォルト値2を使用）
+   * @returns 正規化された行数と表示パラメータ
+   */
+  private calculateTranscriptionParams(lines: number) {
+    // 行数のバリデーションと正規化
+    const normalizedLines = typeof lines === 'number' && lines > 0 ? lines : 2;
+
+    const lineHeight = 64;
+    const width = 1600;
+    const height = lineHeight * Math.min(normalizedLines + 2, 15); // 折り返しに備えて+2
+    const scale = this.videoService.baseWidth / 1920;
+
+    return {
+      normalizedLines,
+      fontSize: lineHeight,
+      width,
+      height,
+      scale,
+      position: {
+        x: (this.videoService.baseWidth - width * scale) / 2,
+        y: this.videoService.baseHeight - (height + 40) * scale,
+      },
+    };
+  }
+
+  /**
+   * 文字起こしソースとその初期設定を生成
+   * @param name ソース名
+   * @param sourceAddOptions ソース追加オプション
+   * @param lines 表示する行数（デフォルト: 2）
+   * @returns ソース、配置オプション、プロパティスキップフラグ
+   */
   createTextTranscriptionSourceAndOption(
     name: string,
     sourceAddOptions: ISourceAddOptions,
+    lines: number = 2,
   ): {
     source: ISourceApi;
     options: ISourceAddOptions;
     forceSkipProperties?: boolean;
   } {
-    const width = 1600;
-    const height = 260;
-    const scale = this.videoService.baseWidth / 1920;
+    const params = this.calculateTranscriptionParams(lines);
 
     // これらの値は画面で弄った後、OBSが保存するjson(....\AppData\Roaming\n-air-app-unstable\SceneCollections)を参照で
     return {
@@ -41,7 +74,7 @@ export class TranscriptionSourceService extends Service {
           font: {
             face: 'Arial',
             style: '',
-            size: 64,
+            size: params.fontSize,
             flags: 0,
           },
           align: 'center',
@@ -56,10 +89,10 @@ export class TranscriptionSourceService extends Service {
           outline_size: 2,
           outline_color: 0x5052c,
           outline_opacity: 100,
-          chatlog_lines: 3,
+          chatlog_lines: params.normalizedLines,
           extents_wrap: true,
-          extents_cx: width,
-          extents_cy: height,
+          extents_cx: params.width,
+          extents_cy: params.height,
           transform: 0,
           antialiasing: true,
         },
@@ -70,12 +103,8 @@ export class TranscriptionSourceService extends Service {
       ),
       options: {
         initialTransform: {
-          position: {
-            // bottom-center
-            x: (this.videoService.baseWidth - width * scale) / 2,
-            y: this.videoService.baseHeight - (height + 40) * scale,
-          },
-          scale: { x: scale, y: scale },
+          position: params.position,
+          scale: { x: params.scale, y: params.scale },
         },
       },
       forceSkipProperties: true,
@@ -85,6 +114,7 @@ export class TranscriptionSourceService extends Service {
   /**
    * text_transcription ソースをデフォルト設定でアクティブシーンに追加する
    * @param name ソース名（省略時は自動生成）
+   * @param lines 表示する行数（省略時は現在の設定値を使用）
    * @returns 作成されたソース
    */
   addTextTranscriptionSourceToActiveScene(name?: string): ISourceApi {
@@ -94,13 +124,53 @@ export class TranscriptionSourceService extends Service {
     }
 
     // ソースを作成
-    const { source, options } = this.createTextTranscriptionSourceAndOption(name, {
-      propertiesManagerSettings: {},
-    });
+    const { source, options } = this.createTextTranscriptionSourceAndOption(
+      name,
+      { propertiesManagerSettings: {} },
+      this.transcriptionService.state.textFileMaxLine,
+    );
 
     // アクティブシーンに追加
     this.scenesService.activeScene.addSource(source.sourceId, options);
 
     return source;
+  }
+
+  /**
+   * アクティブシーンから文字起こしソースのアイテムを取得
+   * @returns 文字起こしソースのアイテム配列
+   */
+  getTranscriptionItemsInActiveScene() {
+    return this.scenesService.activeScene.getItems().filter(item => {
+      const sourceDetails = this.sourcesService.getSource(item.sourceId).getComparisonDetails();
+      return sourceDetails.propertiesManager === 'text_transcription';
+    });
+  }
+
+  /**
+   * アクティブシーンに文字起こしソースが含まれているかチェック
+   * @returns 含まれている場合true
+   */
+  containsTranscriptionInActiveScene(): boolean {
+    return this.getTranscriptionItemsInActiveScene().length > 0;
+  }
+
+  /**
+   * アクティブシーン内の全ての文字起こしソースの行数設定を更新
+   */
+  updateTranscriptionLines(): void {
+    const params = this.calculateTranscriptionParams(
+      this.transcriptionService.state.textFileMaxLine,
+    );
+
+    const items = this.getTranscriptionItemsInActiveScene();
+    for (const item of items) {
+      // ソースの設定を更新
+      const source = this.sourcesService.getSource(item.sourceId);
+      source.updateSettings({ chatlog_lines: params.normalizedLines, extents_cy: params.height });
+
+      // アイテムの位置を更新
+      item.setSettings({ transform: { position: params.position } });
+    }
   }
 }

--- a/app/services/transcription/transcription-source.ts
+++ b/app/services/transcription/transcription-source.ts
@@ -114,7 +114,6 @@ export class TranscriptionSourceService extends Service {
   /**
    * text_transcription ソースをデフォルト設定でアクティブシーンに追加する
    * @param name ソース名（省略時は自動生成）
-   * @param lines 表示する行数（省略時は現在の設定値を使用）
    * @returns 作成されたソース
    */
   addTextTranscriptionSourceToActiveScene(name?: string): ISourceApi {

--- a/app/services/transcription/transcription-source.ts
+++ b/app/services/transcription/transcription-source.ts
@@ -1,6 +1,6 @@
 import { InitAfter, Inject, Service } from '../core';
 import { $t } from '../i18n';
-import { ScenesService } from '../scenes';
+import { SceneItem, ScenesService } from '../scenes';
 import { ISourceAddOptions, ISourceApi, SourcesService } from '../sources';
 import { VideoService } from '../video';
 import { TranscriptionService } from './transcription';
@@ -137,10 +137,10 @@ export class TranscriptionSourceService extends Service {
   }
 
   /**
-   * アクティブシーンから文字起こしソースのアイテムを取得
-   * @returns 文字起こしソースのアイテム配列
+   * アクティブシーンから文字起こしソース(text_transcription)のアイテムを取得
+   * @returns 文字起こしソースのSceneItem配列
    */
-  getTranscriptionItemsInActiveScene() {
+  getTranscriptionItemsInActiveScene(): SceneItem[] {
     return this.scenesService.activeScene.getItems().filter(item => {
       const sourceDetails = this.sourcesService.getSource(item.sourceId).getComparisonDetails();
       return sourceDetails.propertiesManager === 'text_transcription';
@@ -148,8 +148,8 @@ export class TranscriptionSourceService extends Service {
   }
 
   /**
-   * アクティブシーンに文字起こしソースが含まれているかチェック
-   * @returns 含まれている場合true
+   * アクティブシーンに文字起こしソース(text_transcription)が含まれているかチェック
+   * @returns 文字起こしソースが1つでも含まれている場合true、それ以外false
    */
   containsTranscriptionInActiveScene(): boolean {
     return this.getTranscriptionItemsInActiveScene().length > 0;
@@ -157,6 +157,7 @@ export class TranscriptionSourceService extends Service {
 
   /**
    * アクティブシーン内の全ての文字起こしソースの行数設定を更新
+   * 現在の設定値(textFileMaxLine)に基づいて、ソースの行数・高さ・位置を自動調整する
    */
   updateTranscriptionLines(): void {
     const params = this.calculateTranscriptionParams(

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -78,6 +78,9 @@ const setup = createSetupFunction({
       getSourceByDeviceId: jest_fn().mockName('getSourceByDeviceId').mockReturnValue(undefined),
       audioSourceUpdated: new Subject(),
     },
+    TranscriptionSourceService: {
+      updateTranscriptionLines: jest_fn().mockName('updateTranscriptionLines'),
+    },
   },
 });
 
@@ -1070,5 +1073,39 @@ describe('TranscriptionService', () => {
         expect(newClient.startTranscription).toHaveBeenCalled();
       }),
     );
+  });
+
+  describe('setTextFileMaxLine integration', () => {
+    it('should call updateTranscriptionLines when setting new value', () => {
+      const { instance } = prepare();
+      
+      // TranscriptionSourceServiceのupdateTranscriptionLinesをモック
+      const mockUpdateTranscriptionLines = jest_fn().mockName('updateTranscriptionLines');
+      instance.transcriptionSourceService.updateTranscriptionLines = mockUpdateTranscriptionLines;
+
+      // 行数を変更
+      instance.setTextFileMaxLine(5);
+
+      // updateTranscriptionLinesが呼ばれたことを確認
+      expect(mockUpdateTranscriptionLines).toHaveBeenCalledTimes(1);
+      expect(instance.state.textFileMaxLine).toBe(5);
+    });
+
+    it('should update transcription sources when value changes', () => {
+      const { instance } = prepare();
+      
+      // モックを準備
+      const mockUpdateTranscriptionLines = jest_fn().mockName('updateTranscriptionLines');
+      instance.transcriptionSourceService.updateTranscriptionLines = mockUpdateTranscriptionLines;
+
+      // 複数回変更
+      instance.setTextFileMaxLine(3);
+      instance.setTextFileMaxLine(7);
+      instance.setTextFileMaxLine(2);
+
+      // 3回呼ばれたことを確認
+      expect(mockUpdateTranscriptionLines).toHaveBeenCalledTimes(3);
+      expect(instance.state.textFileMaxLine).toBe(2);
+    });
   });
 });

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -6,7 +6,6 @@ import { join } from 'node:path';
 import {
   BehaviorSubject,
   distinctUntilChanged,
-  EMPTY,
   filter,
   map,
   merge,
@@ -25,6 +24,7 @@ import { Inject, mutation, PersistentStatefulService } from '../core';
 import { CommentColor, CommentFont, CommentPosition, CommentSize } from './CommentModifier';
 import { CancelledError, downloadAndUnzip, DownloadError, ExtractError } from './downloadAndUnzip';
 import { filterNoiseText } from './filterNoiseText';
+import { TranscriptionSourceService } from './transcription-source';
 import { TranscriptionSourceUsageService } from './transcription-source-usage';
 import {
   CreateVoskCliClient,
@@ -100,6 +100,7 @@ export type VoskError = 'launchError' | 'error';
 
 export class TranscriptionService extends PersistentStatefulService<ITranscriptionServiceState> {
   @Inject() transcriptionSourceUsageService: TranscriptionSourceUsageService;
+  @Inject() transcriptionSourceService: TranscriptionSourceService;
   @Inject() audioService: AudioService;
   @Inject() nicoliveProgramService: NicoliveProgramService;
 
@@ -674,6 +675,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
   }
   setTextFileMaxLine(textFileMaxLine: number) {
     this.setState({ textFileMaxLine });
+    this.transcriptionSourceService.updateTranscriptionLines();
   }
   setTextFileLineTimeToLive(textFileLineTimeToLive: number) {
     if (textFileLineTimeToLive < 0) {


### PR DESCRIPTION
## 概要
設定画面で文字起こしの行数を変更したときに、既にアクティブなシーンに配置済みの文字起こしソースの表示設定を自動的に更新する機能を追加しました。

## 変更内容

### TranscriptionSourceServiceの機能拡張
- `containsTranscriptionInActiveScene()`: アクティブシーンに文字起こしソースが含まれているかを判定
- `getTranscriptionItemsInActiveScene()`: アクティブシーンから文字起こしソースのアイテムを取得
- `updateTranscriptionLines()`: 既存の全文字起こしソースの行数設定を動的に更新（高さ・位置を自動調整）
- `calculateTranscriptionParams()`: 行数からパラメータを計算（共通化し、バリデーションも統合）

### TranscriptionServiceの統合
- `setTextFileMaxLine()`から`TranscriptionSourceService.updateTranscriptionLines()`を自動呼び出し
- 設定変更時に既存ソースへの反映が即座に行われる

### TranscriptionSourceUsageServiceのリファクタリング
- 重複していた`containsTranscriptionInActiveScene()`などを削除
- `TranscriptionSourceService`に処理を委譲
- 不要な`SourcesService`の依存を削除

### その他
- `text-transcription-manager.ts`: プロパティブラックリストに`chatlog`と`chatlog_lines`を追加

## 動作
1. 設定画面で「文字起こしの最大行数」を変更
2. 既にシーンに配置されている文字起こしソースの表示が即座に更新される
   - 行数設定が変更される
   - 高さ（`extents_cy`）が再計算される
   - 位置（bottom-center）が調整される

## テスト
- 既存のテストはすべてPASS
- `TranscriptionService.setTextFileMaxLine()`の統合テストを追加

## 補足
- `calculateTranscriptionParams()`でundefined/null/負の数も適切に処理（デフォルト値2を使用）
- 戻り値を変数で受け取る形に統一（`params.normalizedLines`等）