### PR TITLE
追加: ショートカットキーを追加（シーンアイテムの一時表示/非表示、リプレイバッファー開始/停止、パフォーマンスモード切替、コンパクトモード切替）

### DIFF
--- a/app/i18n/en-US/hotkeys.json
+++ b/app/i18n/en-US/hotkeys.json
@@ -13,5 +13,11 @@
   "enableStudioMode": "Enable Studio Mode",
   "disableStudioMode": "Disable Studio Mode",
   "studioModeTransition": "Transition (Studio Mode)",
-  "saveReplay": "Save Replay"
+  "saveReplay": "Save Replay",
+  "startReplayBuffer": "Start Replay Buffer",
+  "stopReplayBuffer": "Stop Replay Buffer",
+  "togglePerformanceMode": "Toggle Performance Mode",
+  "toggleCompactMode": "Toggle Compact Mode",
+  "pushToSourceShow": "Show %{sourcename} (while key held)",
+  "pushToSourceHide": "Hide %{sourcename} (while key held)"
 }

--- a/app/i18n/ja-JP/hotkeys.json
+++ b/app/i18n/ja-JP/hotkeys.json
@@ -13,5 +13,11 @@
   "enableStudioMode": "スタジオモードを有効にする",
   "disableStudioMode": "スタジオモードを無効にする",
   "studioModeTransition": "プレビュー画面の内容をライブ画面に反映する（スタジオモード時）",
-  "saveReplay": "リプレイを保存する"
+  "saveReplay": "リプレイを保存する",
+  "startReplayBuffer": "リプレイバッファーを開始する",
+  "stopReplayBuffer": "リプレイバッファーを停止する",
+  "togglePerformanceMode": "パフォーマンス優先モードを切り替える",
+  "toggleCompactMode": "コンパクトモードを切り替える",
+  "pushToSourceShow": "%{sourcename} を表示する（押している間）",
+  "pushToSourceHide": "%{sourcename} を非表示にする（押している間）"
 }

--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -6,8 +6,8 @@ import { isNoAudioPropertiesManagerType, SourcesService } from 'services/sources
 import { StreamingService } from 'services/streaming';
 import { TransitionsService } from 'services/transitions';
 import { Inject, mutation, ServiceHelper, StatefulService } from './core';
-import { NicoliveProgramService } from './nicolive-program/nicolive-program';
 import { CustomizationService } from './customization';
+import { NicoliveProgramService } from './nicolive-program/nicolive-program';
 
 function getScenesService(): ScenesService {
   return ScenesService.instance;

--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -7,6 +7,7 @@ import { StreamingService } from 'services/streaming';
 import { TransitionsService } from 'services/transitions';
 import { Inject, mutation, ServiceHelper, StatefulService } from './core';
 import { NicoliveProgramService } from './nicolive-program/nicolive-program';
+import { CustomizationService } from './customization';
 
 function getScenesService(): ScenesService {
   return ScenesService.instance;
@@ -26,6 +27,10 @@ function getNicoliveProgramService(): NicoliveProgramService {
 
 function getTransitionsService(): TransitionsService {
   return TransitionsService.instance;
+}
+
+function getCustomizationService(): CustomizationService {
+  return CustomizationService.instance;
 }
 
 type THotkeyType = 'GENERAL' | 'SCENE' | 'SCENE_ITEM' | 'SOURCE';
@@ -126,6 +131,37 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
       down: () => getStreamingService().saveReplay(),
     },
     {
+      name: 'START_REPLAY_BUFFER',
+      description: () => $t('hotkeys.startReplayBuffer'),
+      down: () => getStreamingService().startReplayBuffer(),
+      isActive: () => {
+        const streamingService = getStreamingService();
+        return streamingService.state.replayBufferStatus !== 'offline';
+      },
+    },
+    {
+      name: 'STOP_REPLAY_BUFFER',
+      description: () => $t('hotkeys.stopReplayBuffer'),
+      down: () => getStreamingService().stopReplayBuffer(),
+      isActive: () => {
+        const streamingService = getStreamingService();
+        return streamingService.state.replayBufferStatus === 'offline';
+      },
+    },
+    {
+      name: 'TOGGLE_PERFORMANCE_MODE',
+      description: () => $t('hotkeys.togglePerformanceMode'),
+      down: () => {
+        const customization = getCustomizationService();
+        customization.setSettings({ performanceMode: !customization.state.performanceMode });
+      },
+    },
+    {
+      name: 'TOGGLE_COMPACT_MODE',
+      description: () => $t('hotkeys.toggleCompactMode'),
+      down: () => getCustomizationService().toggleCompactMode(),
+    },
+    {
       name: 'START_PROGRAM',
       description: () => '番組開始',
       down: () => getNicoliveProgramService().startProgram(),
@@ -174,6 +210,28 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
       shouldApply: sceneItemId => getScenesService().getSceneItem(sceneItemId).video,
       isActive: sceneItemId => !getScenesService().getSceneItem(sceneItemId).visible,
       down: sceneItemId => getScenesService().getSceneItem(sceneItemId).setVisibility(false),
+    },
+
+    {
+      name: 'PUSH_TO_SOURCE_SHOW',
+      description: sceneItemId => {
+        const sceneItem = getScenesService().getSceneItem(sceneItemId);
+        return $t('hotkeys.pushToSourceShow', { sourcename: sceneItem.source.name });
+      },
+      shouldApply: sceneItemId => getScenesService().getSceneItem(sceneItemId).video,
+      down: sceneItemId => getScenesService().getSceneItem(sceneItemId).setVisibility(true),
+      up: sceneItemId => getScenesService().getSceneItem(sceneItemId).setVisibility(false),
+    },
+
+    {
+      name: 'PUSH_TO_SOURCE_HIDE',
+      description: sceneItemId => {
+        const sceneItem = getScenesService().getSceneItem(sceneItemId);
+        return $t('hotkeys.pushToSourceHide', { sourcename: sceneItem.source.name });
+      },
+      shouldApply: sceneItemId => getScenesService().getSceneItem(sceneItemId).video,
+      down: sceneItemId => getScenesService().getSceneItem(sceneItemId).setVisibility(false),
+      up: sceneItemId => getScenesService().getSceneItem(sceneItemId).setVisibility(true),
     },
   ],
 


### PR DESCRIPTION
## 概要

Streamlabs Desktop の upstream から OBS ネイティブ機能のショートカットキーを移植し、N Air にも実装されている Streamlabs 由来機能と N Air 独自機能のショートカットキーも追加しました。

Closes #1055

## 追加したショートカットキー（6個）

### 1. Streamlabs upstream から移植（OBS ネイティブ機能）

- **PUSH_TO_SOURCE_SHOW**: キーを押している間だけシーンアイテムを表示
- **PUSH_TO_SOURCE_HIDE**: キーを押している間だけシーンアイテムを非表示
  - 既存の PUSH_TO_MUTE/PUSH_TO_TALK と同じパターンで実装
  - 一時的にソースを表示/非表示にする用途に便利

### 2. OBS ネイティブ機能

- **START_REPLAY_BUFFER**: リプレイバッファーを開始
- **STOP_REPLAY_BUFFER**: リプレイバッファーを停止
  - 既存の SAVE_REPLAY を補完する機能
  - 誤動作防止のため isActive を実装（開始済み/停止済みの状態で再実行を防止）

### 3. Streamlabs 由来機能

- **TOGGLE_PERFORMANCE_MODE**: パフォーマンス優先モードを切り替え
  - Streamlabs にもある機能で、N Air にも実装済み
  - 純粋なトグル動作（isActive なし）

### 4. N Air 独自機能

- **TOGGLE_COMPACT_MODE**: コンパクトモードを切り替え
  - N Air 独自のコンパクトモードをショートカットキーで素早く切り替え可能に
  - 純粋なトグル動作（isActive なし）

## 変更内容

### app/services/hotkeys.ts
- `CustomizationService` を import
- `getCustomizationService()` 関数を追加
- GENERAL カテゴリに4個のショートカットキー定義を追加
- SCENE_ITEM カテゴリに2個のショートカットキー定義を追加

### app/i18n/en-US/hotkeys.json
- 6個の英語翻訳を追加

### app/i18n/ja-JP/hotkeys.json  
- 6個の日本語翻訳を追加

## テスト

- ✅ TypeScript コンパイル成功
- ✅ ESLint + Stylelint チェック成功
- ✅ i18n 整合性チェック成功
- ✅ 手動動作確認（TOGGLE_PERFORMANCE_MODE, TOGGLE_COMPACT_MODE で動作確認済み）

## ショートカットキー総数の変化

- **変更前**: 17個
- **変更後**: 23個（+6個）

## 備考

- Streamlabs upstream には他にもショートカットキーがありますが、以下の理由で今回は含めていません：
  - スライドショー操作系: `obs.NodeObs.OBS_API_ProcessHotkeyStatus()` API が必要（現在コメントアウト中）
  - FFMPEG_SOURCE_RESTART: 同上
  - オーバーレイ系: Streamlabs 固有機能
  - 仮想カメラ系: N Air の obs-studio-node バージョンでは未サポート
- これらは将来的に OBS API が有効化されれば追加可能です

🤖 Generated with [Claude Code](https://claude.com/claude-code)