### PR TITLE
開発: TypeScript ファイル保存時の import 自動整理が動作しない問題を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -156,17 +156,21 @@
     }
   ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.fixAll.stylelint": "explicit",
-    "source.organizeImports": "explicit"
-  },
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": [
+    "source.organizeImports",
+    "source.fixAll.eslint",
+    "source.fixAll.stylelint",
+    "source.formatDocument"
+  ],
   "css.validate": false,
   "less.validate": false,
   "stylelint.validate": ["css", "less", "vue"],
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "always"
+    }
   },
 
   "typescript.preferences.autoImportFileExcludePatterns": ["**/app-services.ts"],


### PR DESCRIPTION
## このpull requestが解決する内容

VS Code で TypeScript ファイル保存時の import 自動整理機能が正しく動作していなかった問題を修正しました。

### 経緯
- プロジェクト設定に `"source.organizeImports": "explicit"` が既に記述されていた
- 一部の開発者は個人の VS Code ユーザー設定で organize imports が動作していた
- しかし、環境によってはプロジェクト設定だけでは正しく動作しないケースがあった
- 設定の実行順序と形式を見直し、すべての開発者の環境で確実に動作するように改善した

### 問題の原因
- `editor.formatOnSave: true` と `editor.codeActionsOnSave` の実行順序が不明確だった
- Prettier のフォーマットが organize imports の結果を上書きしていた可能性
- TypeScript 専用の設定が不足していた

### 変更内容
- `editor.formatOnSave` を `false` に変更し、`editor.codeActionsOnSave` に統合
- `source.organizeImports` を code actions の最初に配置して、format より先に実行
- TypeScript 専用設定として `"source.organizeImports": "always"` を追加

### 保存時の実行順序
1. Organize Imports（import 文の整理・不要な import の削除）
2. ESLint 自動修正
3. Stylelint 自動修正
4. Document Format（Prettier）

### 効果
- すべての開発者の環境で、保存時に import 文が自動的に整理されるようになります
- 手動で Ctrl+Shift+O を実行する必要がなくなります
- import 文が常にアルファベット順に整理されます
- 未使用の import が自動的に削除されます
- コードレビュー時の import 順序に関する指摘が減ります

## 動作確認手順

1. TypeScript ファイルを開く
2. import 文の順序を乱す（例：最後の import を最初に移動）
3. 未使用の import を追加（例：`import { unused } from 'rxjs';`）
4. ファイルを保存（Ctrl+S）
5. import 文が自動的にアルファベット順に整理され、未使用の import が削除されることを確認

## 関連するIssue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)