### PR TITLE
開発: dependabot PRタイトルに「開発:」プレフィックスを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: 'weekly'
+    commit-message:
+      prefix: '開発'


### PR DESCRIPTION
## 背景
最近リポジトリをGitHubサポートにfork解除してもらい、dependabotが動作するようになった。
これによりdependabotのPRが生成されるようになったが、N AirのPRタイトルルール（開発関連の変更には「開発:」プレフィックスを付ける）に合わせた設定がされていなかった。

## Summary
- dependabot.ymlに`commit-message.prefix`設定を追加
- dependabotが作成するPRのタイトルとコミットメッセージに「開発:」プレフィックスが自動的に付与される
- リリースノート作成時に開発関連の変更として適切に分類されるようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)