### PR TITLE
開発: dependabot PRタイトルのコロンを修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: 'weekly'
     commit-message:
-      prefix: '開発'
+      prefix: '開発:'


### PR DESCRIPTION
## 背景
PR #1061でdependabotのprefix設定を追加したが、日本語プレフィックスの場合はdependabotが自動的にコロンを追加しないことが判明。
実際に作成されたPR #1062のタイトルが「開発 Bump...」となり、コロンが無かった。

## 修正内容
- dependabot.ymlの`commit-message.prefix`を`'開発'`から`'開発:'`に変更
- これにより今後のdependabot PRで正しく「開発:」プレフィックスが付与される

## 後始末
- PR #1062のタイトルは手動で「開発: Bump actions/cache from 4.3.0 to 5.0.1」に修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)