### PR TITLE
開発: ニコニコのユーザーID取得を新しいAPIに移行

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -11,6 +11,9 @@ export class HostsService extends Service {
       if (url.startsWith(this.niconicoAccount)) {
         return url.replace(this.niconicoAccount, 'http://localhost:8080/account');
       }
+      if (url.startsWith(this.niconicoId)) {
+        return url.replace(this.niconicoId, 'http://localhost:8080/id');
+      }
       if (url.startsWith(this.niconicoOAuth)) {
         return url.replace(this.niconicoOAuth, 'http://localhost:8080/oauth');
       }

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -23,6 +23,9 @@ export class HostsService extends Service {
   get niconicoAccount() {
     return 'https://account.nicovideo.jp';
   }
+  get niconicoId() {
+    return 'https://api.id.nicovideo.jp';
+  }
   get niconicoOAuth() {
     return 'https://oauth.nicovideo.jp';
   }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/vue';
 import { ipcRenderer } from 'electron';
+import { FrontendIdHeader } from 'services/platforms/niconicoDefs';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import { fetchViaMainProcess, MainProcessFetchResponse } from 'util/fetchViaMainProcess';
 import { handleErrors } from 'util/requests';
@@ -143,10 +144,6 @@ export class NicoliveClient {
   static nicoadBaseURL = 'https://api.nicoad.nicovideo.jp' as const;
   static userFollowBaseURL = 'https://user-follow-api.nicovideo.jp' as const;
   static userIconBaseURL = 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/' as const;
-
-  private static FrontendIdHeader = {
-    'x-frontend-id': '134',
-  } as const;
 
   private static OpenWindows: { [key: string]: Electron.BrowserWindow | null } = {};
 
@@ -379,7 +376,7 @@ export class NicoliveClient {
     return this.requestAPI<void>(
       'POST',
       `${NicoliveClient.live2BaseURL}/unama/tool/v2/programs/${programID}/comments`,
-      NicoliveClient.jsonBody({ text, vpos, modifier }, NicoliveClient.FrontendIdHeader),
+      NicoliveClient.jsonBody({ text, vpos, modifier }, FrontendIdHeader),
     );
   }
 
@@ -695,7 +692,7 @@ export class NicoliveClient {
     const res = await fetch(
       NicoliveClient.userFollowEndpoint(userId),
       NicoliveClient.createRequest('GET', {
-        headers: NicoliveClient.FrontendIdHeader,
+        headers: FrontendIdHeader,
       }),
     );
     if (res.ok) {
@@ -728,7 +725,7 @@ export class NicoliveClient {
       NicoliveClient.userFollowEndpoint(userId),
       NicoliveClient.createRequest('POST', {
         headers: {
-          ...NicoliveClient.FrontendIdHeader,
+          ...FrontendIdHeader,
           'X-Request-With': 'N Air',
         },
       }),
@@ -748,7 +745,7 @@ export class NicoliveClient {
       NicoliveClient.userFollowEndpoint(userId),
       NicoliveClient.createRequest('DELETE', {
         headers: {
-          ...NicoliveClient.FrontendIdHeader,
+          ...FrontendIdHeader,
           'X-Request-With': 'N Air',
         },
       }),
@@ -775,7 +772,7 @@ export class NicoliveClient {
     return this.requestAPI<AddModerator>(
       'POST',
       `${NicoliveClient.live2BaseURL}/unama/api/v2/broadcasters/moderators`,
-      NicoliveClient.jsonBody({ userId: parseInt(userId, 10) }, NicoliveClient.FrontendIdHeader),
+      NicoliveClient.jsonBody({ userId: parseInt(userId, 10) }, FrontendIdHeader),
     );
   }
   async removeModerator(userId: string): Promise<WrappedResult<void>> {
@@ -783,7 +780,7 @@ export class NicoliveClient {
       'DELETE',
       `${NicoliveClient.live2BaseURL}/unama/api/v2/broadcasters/moderators?userId=${userId}`,
       {
-        headers: NicoliveClient.FrontendIdHeader,
+        headers: FrontendIdHeader,
       },
     );
   }

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -9,44 +9,33 @@ import { WindowsService } from 'services/windows';
 import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 import { authorizedHeaders, handleErrors } from 'util/requests';
 import { sleep } from 'util/sleep';
-import { parseString } from 'xml2js';
 import { IPlatformService, IStreamingSetting } from '.';
+import { FrontendIdHeader } from './niconicoDefs';
 
-export type INiconicoProgramSelection = {
-  info: LiveProgramInfo;
-  selectedId: string;
-};
+// /v1/sessions/me のレスポンス型
+type NiconicoSessionsMeResponse =
+  | {
+      user: {
+        id: number;
+      };
+    }
+  | {
+      error: {
+        status: number;
+        code: string;
+        message?: string;
+        debug?: string;
+      };
+    };
 
-function parseXml(xml: String): Promise<object> {
-  return new Promise((resolve, reject) => {
-    parseString(xml, (err, result) => {
-      if (err) {
-        // sentryに送る
-        console.error(err, xml);
-        reject(err);
-      } else {
-        resolve(result);
-      }
-    });
-  });
+function isSessionsMeResponse(obj: any): obj is NiconicoSessionsMeResponse {
+  if ('user' in obj) {
+    return typeof obj.user.id === 'number';
+  } else if ('error' in obj) {
+    return typeof obj.error.status === 'number' && typeof obj.error.code === 'string';
+  }
+  return false;
 }
-
-type Program = {
-  id: string;
-};
-
-type SocialGroup = {
-  tfakeype: 'community' | 'channel';
-  id: string;
-  name: string;
-  thumbnailUrl: string;
-  broadcastablePrograms: Program[];
-};
-
-export type LiveProgramInfo = {
-  community?: SocialGroup;
-  channels?: SocialGroup[];
-};
 
 export class NiconicoService extends Service implements IPlatformService {
   @Inject() hostsService: HostsService;
@@ -66,8 +55,11 @@ export class NiconicoService extends Service implements IPlatformService {
     if (isFakeMode()) {
       return FakeUserAuth.platform.id; // dummy user ID
     }
-    const url = `${this.hostsService.niconicoAccount}/api/public/v1/user/id.json`;
-    const request = new Request(url, { credentials: 'same-origin' });
+    const url = `${this.hostsService.niconicoId}/v1/sessions/me`;
+    const request = new Request(url, {
+      credentials: 'same-origin',
+      headers: FrontendIdHeader,
+    });
 
     const response = await fetch(request);
     if (response.status === 400 || response.status === 401) {
@@ -75,8 +67,12 @@ export class NiconicoService extends Service implements IPlatformService {
     }
     const response_1 = await handleErrors(response); // !response.ok を例外にする
     const json = await response_1.json();
-    if (json.data && json.data.userId) {
-      return json.data.userId;
+    if (isSessionsMeResponse(json)) {
+      if ('user' in json) {
+        return json.user.id.toString();
+      }
+    } else {
+      console.error('NiconicoService.getUserId: invalid response', json);
     }
     return '';
   }

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -56,7 +56,7 @@ export class NiconicoService extends Service implements IPlatformService {
       return FakeUserAuth.platform.id; // dummy user ID
     }
     const url = `${this.hostsService.niconicoId}/v1/sessions/me`;
-    const request = new Request(url, {
+    const request = new Request(this.hostsService.replaceHost(url), {
       credentials: 'same-origin',
       headers: FrontendIdHeader,
     });

--- a/app/services/platforms/niconicoDefs.ts
+++ b/app/services/platforms/niconicoDefs.ts
@@ -1,0 +1,4 @@
+// N Air Frontend ID Header
+export const FrontendIdHeader = {
+  'x-frontend-id': '134',
+} as const;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,6 +115,12 @@ module.exports = function (env, argv) {
             pathRewrite: { '^/account': '' },
           },
           {
+            context: ['/id'],
+            target: 'https://api.id.nicovideo.jp',
+            changeOrigin: true,
+            pathRewrite: { '^/id': '' },
+          },
+          {
             context: ['/oauth'],
             target: 'https://oauth.nicovideo.jp',
             changeOrigin: true,


### PR DESCRIPTION
## 概要

- ニコニコのセッションのユーザーID取得に使うAPIを新しい物に移行します。

## 変更内容

- `{アカウントサーバー}/api/public/v1/user/id.json` -> `{IDサーバー}/v1/sessions/me`
- ついでに niconicoモジュールにあった今は使っていない型宣言を掃除し、`frontendIdHeader` 定義を NicoliveClientから独立させて niconicoモジュールからも利用するようにしました

## 動作確認手順

- N Airでニコニコにログインした状態で起動して自分のユーザーIDが取得できている(ニコ生パネルに自分のアカウントが表示されている)こと
