### PR TITLE
開発: VS Code の import 自動整理設定を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -156,12 +156,11 @@
     }
   ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": [
     "source.organizeImports",
     "source.fixAll.eslint",
-    "source.fixAll.stylelint",
-    "source.formatDocument"
+    "source.fixAll.stylelint"
   ],
   "css.validate": false,
   "less.validate": false,


### PR DESCRIPTION
## このpull requestが解決する内容

#1059 で実装した import 自動整理機能が、`formatOnSave: false` の設定では正しく動作しないことが判明したため、設定を修正しました。

### 問題
- 前回の PR で `editor.formatOnSave` を `false` に変更し、`editor.codeActionsOnSave` に `source.formatDocument` を追加した
- しかしこの設定では、環境によって organize imports が動作しなかった
- `formatOnSave: true` に戻すと正しく動作することを確認

### 原因
VS Code のドキュメントによると：
- `formatOnSave: true` の場合、`codeActionsOnSave` が先に実行され、その後にフォーマットが実行される
- この順序により、organize imports → ESLint/Stylelint → format の実行順序が保証される
- `formatOnSave: false` + `source.formatDocument` の組み合わせでは、実行順序が不安定

### 変更内容
- `editor.formatOnSave` を `true` に戻す
- `source.formatDocument` を削除（`formatOnSave` で自動実行されるため冗長）

### 保存時の実行順序（修正後）
1. Organize Imports（import 文の整理・不要な import の削除）
2. ESLint 自動修正
3. Stylelint 自動修正
4. Document Format（Prettier、formatOnSave により実行）

## 動作確認手順

1. TypeScript ファイルを開く
2. import 文の順序を乱す（例：最後の import を最初に移動）
3. 未使用の import を追加（例：`import { unused } from 'rxjs';`）
4. ファイルを保存（Ctrl+S）
5. import 文が自動的にアルファベット順に整理され、未使用の import が削除されることを確認

## 関連するIssue

#1059 のフォローアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)