### PR TITLE
開発: vue-svg-loaderを0.16.0に更新してセキュリティ脆弱性を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "typescript": "5.5.4",
     "typescript-eslint": "8.46.0",
     "vue-loader": "15.11.1",
-    "vue-svg-loader": "0.12.0",
+    "vue-svg-loader": "0.16.0",
     "vue-template-compiler": "2.7.14",
     "webdriverio": "7.30.2",
     "webpack": "^5.97.1",
@@ -216,7 +216,8 @@
   "packageManager": "pnpm@10.25.0",
   "pnpm": {
     "overrides": {
-      "tar-fs": "^2.1.4"
+      "tar-fs": "^2.1.4",
+      "nth-check": "^2.0.1"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   tar-fs: ^2.1.4
+  nth-check: ^2.0.1
 
 importers:
 
@@ -388,8 +389,8 @@ importers:
         specifier: 15.11.1
         version: 15.11.1(css-loader@2.1.1(webpack@5.103.0))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.14)(webpack@5.103.0)
       vue-svg-loader:
-        specifier: 0.12.0
-        version: 0.12.0(vue-template-compiler@2.7.14)
+        specifier: 0.16.0
+        version: 0.16.0(vue-template-compiler@2.7.14)
       vue-template-compiler:
         specifier: 2.7.14
         version: 2.7.14
@@ -5608,9 +5609,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  nth-check@1.0.2:
-    resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -6811,8 +6809,8 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
-  svg-to-vue@0.4.0:
-    resolution: {integrity: sha512-g/ZHtEFf4QDsDtTk9tuYX/MJ2HESTUBMTkuLoffQGQ3xMtlmD9Ec4YyTgmMkP1P8QJtWWu2FiGdOnlKaXc/X/Q==}
+  svg-to-vue@0.7.0:
+    resolution: {integrity: sha512-Tg2nMmf3BQorYCAjxbtTkYyWPVSeox5AZUFvfy4MoWK/5tuQlnA/h3LAlTjV3sEvOC5FtUNovRSj3p784l4KOA==}
     peerDependencies:
       vue-template-compiler: ^2.0.0
 
@@ -7308,8 +7306,10 @@ packages:
   vue-style-loader@4.1.3:
     resolution: {integrity: sha512-sFuh0xfbtpRlKfm39ss/ikqs9AbKCoXZBpHeVZ8Tx650o0k0q/YCM7FRvigtxpACezfq6af+a7JeqVTWvncqDg==}
 
-  vue-svg-loader@0.12.0:
-    resolution: {integrity: sha512-pg8H6iKCj+DAC7FZuxdfGJMHiFpJPv/YyoN1M7Iqlf+Hu4eU6Q/W/sEFx978syQA+aOx0NXrp+uQUAajqQvXbQ==}
+  vue-svg-loader@0.16.0:
+    resolution: {integrity: sha512-2RtFXlTCYWm8YAEO2qAOZ2SuIF2NvLutB5muc3KDYoZq5ZeCHf8ggzSan3ksbbca7CJ/Aw57ZnDF4B7W/AkGtw==}
+    peerDependencies:
+      vue-template-compiler: ^2.0.0
 
   vue-template-compiler@2.7.14:
     resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
@@ -11190,7 +11190,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 3.4.2
       domutils: 1.7.0
-      nth-check: 1.0.2
+      nth-check: 2.1.1
 
   css-shorthand-properties@1.1.2: {}
 
@@ -13911,10 +13911,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  nth-check@1.0.2:
-    dependencies:
-      boolbase: 1.0.0
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -15259,7 +15255,7 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svg-to-vue@0.4.0(vue-template-compiler@2.7.14):
+  svg-to-vue@0.7.0(vue-template-compiler@2.7.14):
     dependencies:
       svgo: 1.3.2
       vue-template-compiler: 2.7.14
@@ -15820,12 +15816,11 @@ snapshots:
       hash-sum: 1.0.2
       loader-utils: 1.4.2
 
-  vue-svg-loader@0.12.0(vue-template-compiler@2.7.14):
+  vue-svg-loader@0.16.0(vue-template-compiler@2.7.14):
     dependencies:
       loader-utils: 1.4.2
-      svg-to-vue: 0.4.0(vue-template-compiler@2.7.14)
-    transitivePeerDependencies:
-      - vue-template-compiler
+      svg-to-vue: 0.7.0(vue-template-compiler@2.7.14)
+      vue-template-compiler: 2.7.14
 
   vue-template-compiler@2.7.14:
     dependencies:


### PR DESCRIPTION
## このpull requestが解決する内容
Dependabotセキュリティアラート ([CVE-2021-3803](https://github.com/n-air-app/n-air-app/security/dependabot/100), severity: **high**, CVSS 7.5) を解決するため、vue-svg-loaderを0.16.0に更新しました。

## 変更内容

|package|before|after|備考|
|---|---|---|---|
|vue-svg-loader|0.12.0|[0.16.0](https://github.com/visualfanatic/vue-svg-loader/releases/tag/v0.16.0)|nth-check脆弱性対応 - [releases](https://github.com/visualfanatic/vue-svg-loader/releases)|
|nth-check|(間接依存 1.0.2)|2.1.1|pnpm.overridesで^2.0.1に固定|

- vue-svg-loaderを0.12.0から0.16.0に更新
- pnpm.overridesに `"nth-check": "^2.0.1"` を追加し、全ての依存で安全なバージョンを使用
- pnpm-lock.yamlを更新

## セキュリティ対応
- **脆弱性**: nth-check < 2.0.1 - Inefficient Regular Expression Complexity (ReDoS)
- **CVE**: CVE-2021-3803
- **深刻度**: High (CVSS 7.5)
- **影響**: vue-svg-loaderの依存するsvgo経由で古いnth-check 1.0.2が使われていた
- **対策**: vue-svg-loaderの更新 + pnpm.overridesでnth-checkを強制的に2.0.1以上に固定

## pnpm.overridesを使った理由
vue-svg-loaderは0.16.0が最新の安定版ですが、2021年3月以降メンテナンスされていません。このため、依存している`svgo@1.3.2`が古いバージョンのまま固定されており、それが脆弱な`nth-check@1.0.2`を引き込んでいます。

vue-svg-loaderのアップデートを待つことができないため、`pnpm.overrides`を使ってnth-checkを強制的に安全なバージョン（^2.0.1）に固定することで、脆弱性を解消しています。

## 影響範囲
- SVGアイコンのビルド処理のみ（開発時のみ使用）
- 本番コードへの影響なし

## テスト
- [x] `pnpm compile:ci` で TypeScript コンパイル成功
- [x] `pnpm compile` でフルビルド成功
- [x] `pnpm list nth-check` で全てのnth-checkが2.1.1に統一されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)