### PR TITLE
開発: pnpm移行後にリリーススクリプトが「Git working directory not clean」エラーで失敗する問題を修正

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -217,8 +217,13 @@ async function runScript({
   eslintFix(noteFilename);
   info(`generated patch-note file: ${noteFilename}.`);
 
-  // update package.json with newVersion and git tag
-  executeCmd(`pnpm version ${newVersion}`);
+  // update package.json with newVersion (without git operations)
+  executeCmd(`pnpm version ${newVersion} --no-git-tag-version`);
+
+  // commit both notes.ts and package.json together, then create tag
+  executeCmd(`git add ${noteFilename} package.json`);
+  executeCmd(`git commit -m "${newVersion}"`);
+  executeCmd(`git tag v${newVersion}`);
 
   if (skipBuild) {
     info('SKIP build process since skipBuild is set...');


### PR DESCRIPTION
## 概要
pnpmでリリーススクリプトを実行すると、`pnpm version`実行時に`notes.ts`が未コミットのまま残り、「Git working directory not clean」エラーが発生する問題を修正。

## 背景
リリーススクリプトは、`notes.ts`（パッチノート）と`package.json`（バージョン情報）を**同じコミットに含める**設計になっている。これにより、バージョンコミットを見るだけでそのバージョンのパッチノート内容も確認できる。

過去のリリースコミット（例: v1.1.20251217-unstable.1）を確認すると、実際に`notes.ts`と`package.json`が同じコミットに含まれている。

## 問題
#1064 でyarn v1からpnpm v10に移行したことで、`version`コマンドの動作が変わり、リリーススクリプトが動作しなくなった。

yarn使用時は、`notes.ts`を更新後に`yarn version`を実行すると、staging areaにある`notes.ts`も自動的に同じコミットに含まれていた。

しかし、`pnpm version`コマンドは実行前にworking directoryが**完全にclean**であることを要求するため、`notes.ts`をステージングエリアに追加してから実行してもエラーになる。

## 修正内容
- `pnpm version`に`--no-git-tag-version`オプションを追加し、gitコミット・タグ作成を抑制
- `notes.ts`と`package.json`を手動でステージング
- 手動でコミットとタグを作成

これにより、yarn使用時と同様に`notes.ts`と`package.json`が同じコミットに含まれるようになる。

## テスト
- [x] 公開ではないブランチでのリリーステストで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)