### PR TITLE
開発: pnpm start実行時のcolorsパッケージ依存問題を解決

### DIFF
--- a/bin/release/scripts/log.js
+++ b/bin/release/scripts/log.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const sh = require('shelljs');
-const colors = require('colors/safe');
+let colors; // Lazy load to avoid requiring 'colors' when not needed
 
 /**
  * @param {string[]} msg
@@ -14,6 +14,7 @@ function log(...msg) {
  * @param {string} msg
  */
 function info(msg) {
+  if (!colors) colors = require('colors/safe');
   sh.echo(colors.magenta(msg));
 }
 
@@ -21,6 +22,7 @@ function info(msg) {
  * @param {string} msg
  */
 function error(msg) {
+  if (!colors) colors = require('colors/safe');
   sh.echo(colors.red(`ERROR: ${msg}`));
 }
 


### PR DESCRIPTION
## このpull requestが解決する内容
`pnpm start`実行時に`colors`パッケージが見つからずエラーになる問題を解決します。

## 背景
yarnからpnpmへの移行時、`bin/`ディレクトリの依存関係を自動インストールする仕組みが`start`スクリプトに追加されていませんでした。

`pnpm start`実行時、`bin/start-with-auto-env.js` → `patchNote.js` → `log.js`と読み込まれますが、`log.js`がトップレベルで`colors/safe`をrequireするため、`bin/node_modules`未インストールでエラーが発生していました。

しかし、**`start`で実際に使われる`getVersionContext()`は色付き出力を行わない**ため、`colors`パッケージは本来不要です。

## 変更内容
`bin/release/scripts/log.js`で`colors`パッケージを遅延読み込みに変更しました。

### 効果
- `log.js`をrequireしても、`info()`や`error()`を**呼ばなければ**`colors`パッケージは読み込まれない
- `start`で使う`getVersionContext()`は`info()`/`error()`を呼ばないため、`colors`なしで動作
- `bin/node_modules`が未インストールの状態でも`pnpm start`が実行可能に
- 開発サイクルでの起動時に追加の待ち時間なし

## 影響範囲
- `release`、`patch-note`など色付き出力が必要なスクリプトは従来通り動作
  - これらは既に`pnpm install --dir bin --ignore-workspace`を実行するため、`colors`パッケージがインストールされた状態で実行される

## テスト
- [x] `bin/node_modules`削除後、`pnpm start`が正常に起動することを確認
- [x] `bin`の依存関係インストール後、`info()`と`error()`の色付き出力が正常に機能することを確認

## 関連
- #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)