### PR TITLE
開発: rimrafをv6に更新してdeprecated警告を解消

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,14 +42,14 @@ const electron = require('electron');
 const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell, crashReporter } =
   electron;
 const path = require('path');
-const rimraf = require('rimraf');
+const { rimrafSync } = require('rimraf');
 const remote = require('@electron/remote/main');
 
 function rimrafWithRetry(rmPath) {
   const MAX_RETRIES = 3;
   for (let t = MAX_RETRIES; t > 0; t--) {
     try {
-      rimraf.sync(rmPath);
+      rimrafSync(rmPath);
     } catch (e) {
       console.error(`failed to delete '${rmPath}: `, e);
       if (!t) {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "protobufjs": "^7.5.3",
     "recursive-readdir": "~2.2.3",
     "reflect-metadata": "~0.2.2",
-    "rimraf": "~2.7.1",
+    "rimraf": "~6.1.2",
     "rxjs": "^7.8.1",
     "semver": "^7.5.4",
     "sl-vue-tree": "https://github.com/stream-labs/sl-vue-tree",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: ~0.2.2
         version: 0.2.2
       rimraf:
-        specifier: ~2.7.1
-        version: 2.7.1
+        specifier: ~6.1.2
+        version: 6.1.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -4130,6 +4130,10 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
+  glob@13.0.0:
+    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
+    engines: {node: 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -5106,6 +5110,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.2.4:
+    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -5702,6 +5710,10 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.1:
+    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
+    engines: {node: 20 || >=22}
+
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
@@ -6187,14 +6199,14 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@6.1.2:
+    resolution: {integrity: sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   roarr@2.15.4:
@@ -12123,6 +12135,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.0:
+    dependencies:
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      path-scurry: 2.0.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -13289,6 +13307,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.2.4: {}
+
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -13879,6 +13899,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.1:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.2
+
   path-to-regexp@0.1.12: {}
 
   path-type@3.0.0:
@@ -14357,13 +14382,14 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@6.1.2:
+    dependencies:
+      glob: 13.0.0
+      package-json-from-dist: 1.0.1
 
   roarr@2.15.4:
     dependencies:

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -94,7 +94,7 @@ class Application {
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const rimraf = require('rimraf');
+const { rimraf } = require('rimraf');
 
 const afterStartCallbacks: ((t: TExecutionContext) => any)[] = [];
 export function afterAppStart(cb: (t: TExecutionContext) => any) {
@@ -279,9 +279,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     appIsRunning = false;
 
     if (!clearCache) return;
-    await new Promise(resolve => {
-      rimraf(lastCacheDir, resolve);
-    });
+    await rimraf(lastCacheDir);
   };
 
   test.beforeEach(async t => {

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -279,7 +279,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     appIsRunning = false;
 
     if (!clearCache) return;
-    await rimraf(lastCacheDir);
+    await rimraf(lastCacheDir, { maxRetries: 10, retryDelay: 100 });
   };
 
   test.beforeEach(async t => {

--- a/test/screentest/runner.js
+++ b/test/screentest/runner.js
@@ -1,4 +1,4 @@
-const rimraf = require('rimraf');
+const { rimrafSync } = require('rimraf');
 const { execSync } = require('child_process');
 const fs = require('fs');
 
@@ -10,7 +10,7 @@ const returnCode = (function main() {
   log('use branches', branches);
 
   const dir = CONFIG.dist;
-  rimraf.sync(dir);
+  rimrafSync(dir);
 
   // create dir
   let currentPath = '';


### PR DESCRIPTION
## 概要

rimraf v2.7.1の非推奨警告を解消するため、v6.1.2に更新します。

## 変更内容

- **rimraf: 2.7.1 → 6.1.2** (major update)
- API変更対応:
  - `rimraf.sync()` → `rimrafSync()`
  - コールバック形式 → Promise形式

## 影響箇所

1. **main.js** - メインプロセスのキャッシュ削除処理
2. **test/screentest/runner.js** - スクリーンテストのディレクトリ削除
3. **test/helpers/webdriver/index.ts** - E2Eテストのキャッシュクリーンアップ

## 検証

- ✅ TypeScript compilation (`pnpm run compile`)
- ✅ Lint checks (`pnpm lint`)
- ✅ Unit tests (`pnpm run test:unit`): 40 suites, 621 tests passed

## 補足

- rimraf v6はNode 20+が必要ですが、本プロジェクトはNode 22.xを使用しているため問題ありません
- v6では`fs/promises`ベースの最適化が行われており、パフォーマンスも改善されています

🤖 Generated with [Claude Code](https://claude.com/claude-code)