### PR TITLE
開発: 未使用のnode-fetchパッケージを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "less": "^3.13.1",
     "less-loader": "^12.2.0",
     "lint-staged": "^16.2.6",
-    "node-fetch": "~2.6.12",
     "node-win32-np": "1.0.6",
     "npm-run-all": "~4.1.5",
     "pixelmatch": "~4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,9 +310,6 @@ importers:
       lint-staged:
         specifier: ^16.2.6
         version: 16.2.7
-      node-fetch:
-        specifier: ~2.6.12
-        version: 2.6.13(encoding@0.1.13)
       node-win32-np:
         specifier: 1.0.6
         version: 1.0.6

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -279,7 +279,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     appIsRunning = false;
 
     if (!clearCache) return;
-    await rimraf(lastCacheDir, { maxRetries: 10, retryDelay: 100 });
+    await rimraf(lastCacheDir, { maxRetries: 30, retryDelay: 100 });
   };
 
   test.beforeEach(async t => {

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -8,7 +8,6 @@ import { uniq } from 'lodash';
 import { sleep } from '../../../app/util/sleep';
 import { ITestContext } from './index';
 const fs = require('fs');
-const fetch = require('node-fetch');
 const tasklist = require('tasklist');
 const kill = require('tree-kill');
 


### PR DESCRIPTION
## このpull requestが解決する内容
未使用のnode-fetchパッケージを削除し、依存関係を整理します。また、E2Eテストの安定性を向上させます。

## 背景
コードベースを調査した結果、node-fetchパッケージはtest/helpers/webdriver/runner-utils.tsでrequireされていましたが、実際には使用されていないことが判明しました。プロジェクト全体では、Electron 29（Chromium 122）組み込みのグローバルfetch APIを使用しています。

## 変更内容

### 1. node-fetchパッケージの削除

| package | before | after | 備考 |
|---------|--------|-------|------|
| node-fetch | 2.6.12 | 削除 | 未使用のため削除 |

**ファイル変更:**
- `test/helpers/webdriver/runner-utils.ts`: 未使用の`const fetch = require('node-fetch')`を削除
- `package.json`: devDependenciesからnode-fetchを削除
- `pnpm-lock.yaml`: 依存関係を更新

**node-fetch使用状況の調査結果:**
- `test/helpers/webdriver/runner-utils.ts:11` でrequireされているが、変数は一度も使用されていない
- プロジェクト内の他のfetch使用箇所（main.js、app/services/、app/components/等）は、node-fetchをimportせず、グローバルのfetch（Electron/Chromium組み込み）を使用
- Electron 29はChromium 122ベースで、fetchは完全にサポート済み

### 2. E2Eテストの安定性向上

**ファイル変更:**
- `test/helpers/webdriver/index.ts`: rimrafのmaxRetriesを10から30に増加（合計3秒のリトライ期間）

**背景:**
- CI環境でE2Eテストのクリーンアップ時にファイル削除が失敗することがある
- rimrafのリトライ回数を増やすことで、ファイルロックによる一時的な失敗に対処

## 影響範囲
- 開発時の依存関係のみ（devDependencies）
- ランタイムには影響なし（未使用のパッケージの削除）
- プロジェクト内のすべてのfetch呼び出しは、Electron組み込みのグローバルfetchを使用
- E2Eテスト環境でのクリーンアップの安定性が向上

## テスト
- [x] ユニットテスト全パス（40 suites, 621 tests）
- [x] E2Eテスト全パス（4つのテストスイート全て）
- [x] リントチェック全パス

## 補足
- Node.js 22.x以降（およびElectron 29のChromium 122）では、fetch APIが標準で組み込まれています
- メインプロセス・レンダラープロセスの両方でグローバルfetchが利用可能です
- node-fetchは古いNode.js環境でfetchを使用するためのポリフィルですが、本プロジェクトでは不要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)