### PR TITLE
開発: E2EテストクリーンアップのflakyなEBUSYエラーを修正

### DIFF
--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -10,6 +10,7 @@ import {
   initializeTasks,
   killElectronInstances,
   testFn,
+  waitForCrashHandlerExit,
   waitForElectronInstancesExist,
 } from './runner-utils';
 export const test = testFn; // the overridden "test" function
@@ -277,9 +278,9 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     }
     await killElectronInstances();
 
-    // Wait for file handles to be released after killing processes
+    // Wait for crash-handler-process.exe to exit before attempting cleanup
     // This ensures crash-handler.log is closed before rimraf attempts deletion
-    await sleep(200);
+    await waitForCrashHandlerExit();
 
     appIsRunning = false;
 

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -276,6 +276,11 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
       console.error(e);
     }
     await killElectronInstances();
+
+    // Wait for file handles to be released after killing processes
+    // This ensures crash-handler.log is closed before rimraf attempts deletion
+    await sleep(200);
+
     appIsRunning = false;
 
     if (!clearCache) return;

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -158,6 +158,31 @@ export async function killElectronInstances() {
   tasks.forEach((task: any) => kill(task.pid));
 }
 
+export async function waitForCrashHandlerExit() {
+  const interval = 100;
+  const timeout = 5000;
+
+  let timeLeft = timeout;
+
+  do {
+    const tasks = await tasklist();
+    const crashHandlerTasks = tasks.filter(
+      (task: any) => task.imageName === 'crash-handler-process.exe',
+    );
+
+    if (crashHandlerTasks.length === 0) {
+      return;
+    }
+
+    await sleep(interval);
+    timeLeft -= interval;
+  } while (timeLeft > 0);
+
+  console.warn(
+    `Warning: crash-handler-process.exe still running after ${timeout}ms timeout`,
+  );
+}
+
 export async function waitForElectronInstancesExist() {
   const interval = 1000;
   const timeout = 10000;

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -137,7 +137,10 @@ export function saveTestStatsToFile(stats: Record<string, ITestStats>) {
 let ignoreTaskPIDs: number[] = [];
 async function getRawElectronTasks() {
   const tasks = await tasklist();
-  return tasks.filter((task: any) => task.imageName === 'electron.exe');
+  return tasks.filter(
+    (task: any) =>
+      task.imageName === 'electron.exe' || task.imageName === 'crash-handler-process.exe',
+  );
 }
 
 export async function initializeTasks() {


### PR DESCRIPTION
## Summary

rimraf v6更新後にE2Eテストのクリーンアップ時にEBUSYエラーが発生する問題を修正しました。

### 問題
- rimraf v6更新後、CI E2Eテストのクリーンアップ時に `crash-handler.log` の削除でEBUSYエラーが発生
- crash-handler-process.exeがdetached subprocessとして起動され、テスト終了時に終了されていなかった
- ファイルハンドルが開いたままでrimrafがディレクトリ削除に失敗

### 修正内容
1. **runner-utils.ts**: `getRawElectronTasks()` を更新し、`crash-handler-process.exe` もプロセス追跡対象に追加
2. **runner-utils.ts**: `waitForCrashHandlerExit()` 関数を追加し、プロセスが実際に終了するまで待機
   - 100msごとにtasklistをチェック
   - crash-handler-process.exeが見つからなければ即座にreturn
   - 最大5秒まで待機
3. **index.ts**: プロセス終了後に `waitForCrashHandlerExit()` を呼び出し、ファイルハンドルが確実に解放されるまで待機

### 実装の利点
- プロセスが実際に終了するまで確実に待つ（固定時間sleepではない）
- プロセスが早く終了すれば無駄な待機がない（最短100ms）
- テスト実行時間への影響を最小化

### ローカル検証
- `pnpm test test-dist/test/e2e/scene-collections.js` を数回実行して動作確認済み

## Test plan
- [x] CIでE2Eテストを複数回実行してEBUSYエラーが発生しないことを確認
- [x] 他のE2Eテストスイートでデグレがないことを確認
- [x] テスト実行時間が大きく増加していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)