### PR TITLE
開発: pnpmを10.27.0にアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "webpack-dev-server": "^5.1.0",
     "webpack-merge": "^6.0.1"
   },
-  "packageManager": "pnpm@10.25.0",
+  "packageManager": "pnpm@10.27.0",
   "pnpm": {
     "overrides": {
       "tar-fs": "^2.1.4",


### PR DESCRIPTION
## このpull requestが解決する内容
pnpmを10.25.0から10.27.0にアップデートします。

## 背景
2026年1月7日に公開された3件の重大な脆弱性（High severity）を修正するため、pnpmの緊急アップデートが必要です。

## 脆弱性情報

### 1. コマンドインジェクション (CVE-2025-69262)
- **CVSS**: 7.6 (High)
- **影響バージョン**: 6.25.0 ～ 10.26.x
- **修正バージョン**: 10.27.0
- **内容**: `.npmrc`の`tokenHelper`設定で環境変数置換を使用する際に、任意のコマンドを実行できる脆弱性
- **影響**: CI/CD、Docker、Kubernetesなどで環境変数を制御できる攻撃者が任意コードを実行可能

### 2. Git依存関係のライフサイクルスクリプトバイパス (CVE-2025-69264)
- **CVSS**: 8.8 (High)
- **影響バージョン**: 10.0.0 ～ 10.25.0
- **修正バージョン**: 10.26.0
- **内容**: pnpm v10でスクリプト実行がデフォルト無効化されたはずが、Git依存関係が`prepare`/`prepublish`/`prepack`スクリプトを実行できてしまう
- **影響**: リモートコード実行、秘密情報の窃取、バックドア注入

### 3. ロックファイル整合性バイパス (CVE-2025-69263)
- **CVSS**: 7.5 (High)
- **影響バージョン**: 10.26.0未満
- **修正バージョン**: 10.26.0
- **内容**: HTTP tarballやGit依存関係のハッシュがロックファイルに記録されず、サーバーが毎回異なる内容を提供できる
- **影響**: サプライチェーン攻撃、標的型マルウェア配布

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| pnpm | 10.25.0 | 10.27.0 | セキュリティアップデート（3件のHigh severity脆弱性を修正） |

### ファイル変更
- `package.json`: `packageManager`フィールドを`pnpm@10.27.0`に更新

### 10.27.0の主な変更点
- **セキュリティ**: CVE-2025-69262の修正（コマンドインジェクション）
- **信頼ポリシー**: `trustPolicyIgnoreAfter`追加（指定時間以前に公開されたパッケージの信頼ポリシーチェックをスキップ）
- **グローバルストア管理**: プロジェクトを`{storeDir}/v10/projects/`のシンボリックリンクで登録
- **ガベージコレクション**: `pnpm store prune`がmark-and-sweepアルゴリズムで未使用パッケージを削除（monorepo対応）
- **バグ修正**: `pnpm add`がcatalogエントリを誤って正確なバージョンに変更する問題を修正

### 10.26.0で追加されたセキュリティ機能
- **`blockExoticSubdeps`**: 推移的依存関係で非標準プロトコルをブロック（サプライチェーン保護）
- **HTTP tarball整合性ハッシュ**: HTTP tarball依存関係の整合性ハッシュをロックファイルに記録し、検証

## 開発者向け: pnpmバージョンの更新方法

このPRをマージした後、開発者は以下の方法でpnpmを更新できます。

### Corepackを使用している場合（推奨）

1. **package.jsonの指定に従って自動更新:**
   ```bash
   # プロジェクトディレクトリで任意のpnpmコマンドを実行すると自動的に更新されます
   pnpm --version
   # または
   pnpm install
   ```

2. **明示的に更新する場合:**
   ```bash
   corepack install
   ```

### Voltaを使用している場合

Voltaとcorepackが競合する場合は、まずcorepackを無効化してからVoltaでインストールします。
```bash
# 管理者権限で実行
corepack disable pnpm

# Voltaでインストール
volta install pnpm@10.27.0
```

### 手動でグローバルインストールしている場合

```bash
npm install -g pnpm@10.27.0
```

**注意**: このプロジェクトでは `package.json` の `packageManager` フィールドでバージョンを管理しているため、Corepackの使用を推奨します。Corepackを有効化すると、プロジェクトごとに適切なバージョンが自動的に使用されます。

## 影響範囲
- パッケージマネージャーのみ（package.jsonの1行のみ変更）
- 依存関係のインストール・管理プロセスに影響
- ランタイムには影響なし

## テスト
- [x] ビルドが正常に完了することを確認
- [x] 依存関係のインストールが正常に動作することを確認

## 参考リンク
- [pnpm v10.27.0 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v10.27.0)
- [pnpm v10.26.0 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v10.26.0)
- [GHSA-2phv-j68v-wwqx - Command Injection](https://github.com/pnpm/pnpm/security/advisories/GHSA-2phv-j68v-wwqx)
- [GHSA-379q-355j-w6rj - Lifecycle Scripts Bypass](https://github.com/pnpm/pnpm/security/advisories/GHSA-379q-355j-w6rj)
- [GHSA-7vhp-vf5g-r2fw - Lockfile Integrity Bypass](https://github.com/pnpm/pnpm/security/advisories/GHSA-7vhp-vf5g-r2fw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)