### PR TITLE
開発: ニコニコ生放送のmaxQualityパース処理で小数点値に対応

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -1,4 +1,5 @@
 import fetchMock from '@fetch-mock/jest';
+import type { MainProcessFetchResponse } from 'util/fetchViaMainProcess';
 
 jest.mock('services/i18n', () => ({
   $t: (x: any) => x,
@@ -7,7 +8,6 @@ jest.mock('util/menus/Menu', () => ({}));
 jest.mock('@electron/remote', () => ({
   BrowserWindow: jest.fn(),
 }));
-import type { MainProcessFetchResponse } from 'util/fetchViaMainProcess';
 const fetchViaMainProcess = jest
   .fn<Promise<MainProcessFetchResponse>, [string, RequestInit]>()
   .mockName('fetchViaMainProcess');
@@ -35,6 +35,9 @@ describe('parseMaxQuality', () => {
     ['384kbps288p', 384, 288, 30],
     ['192kbps288p', 192, 288, 30],
     ['8Mbps1080p60fps', 8000, 1080, 60],
+    ['1.5Mbps480p', 1500, 480, 30],
+    ['1500kbps480p', 1500, 480, 30],
+    ['1.5Mbps480p29.97fps', 1500, 480, 29.97],
     ['invalid', fallback.bitrate, fallback.height, fallback.fps],
   ])(`%s => %d kbps, %d x %d`, (maxQuality, bitrate, height, fps) => {
     expect(parseMaxQuality(maxQuality, fallback)).toEqual({
@@ -235,7 +238,7 @@ function setupMock() {
     loadURL(url: string) {
       this.url = url;
       for (const cb of this.webContentsCallbacks) {
-        cb({ preventDefault() {} }, url);
+        cb({ preventDefault() { } }, url);
       }
     }
     close = jest.fn().mockImplementation(() => {
@@ -268,7 +271,7 @@ function setupMock() {
   }));
   jest.doMock('electron', () => ({
     ipcRenderer: {
-      send() {},
+      send() { },
     },
   }));
 
@@ -442,11 +445,11 @@ describe('NicoliveClient.wrapResult', () => {
             expect,
             viaMainProcess
               ? {
-                  ok,
-                  headers,
-                  status,
-                  text,
-                }
+                ok,
+                headers,
+                status,
+                text,
+              }
               : new Response(text, { status, headers }),
           ];
         },

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -72,7 +72,7 @@ export function isOk<T>(result: WrappedResult<T>): result is SucceededResult<T> 
   return result.ok === true;
 }
 
-export class NotLoggedInError {}
+export class NotLoggedInError { }
 
 type Quality = {
   bitrate: number;
@@ -82,12 +82,12 @@ type Quality = {
 
 export function parseMaxQuality(maxQuality: string, fallback: Quality): Quality {
   try {
-    const match = maxQuality.match(/(\d+)([Mk])bps(\d+)p((\d+)fps)?/);
+    const match = maxQuality.match(/(\d+([.]\d+)?)([Mk])bps(\d+)p((\d+([.]\d+)?)fps)?/);
 
     return {
-      bitrate: parseInt(match[1], 10) * (match[2] === 'M' ? 1000 : 1),
-      height: parseInt(match[3], 10),
-      fps: parseInt(match[5], 10) || 30,
+      bitrate: parseFloat(match[1]) * (match[3] === 'M' ? 1000 : 1),
+      height: parseInt(match[4], 10),
+      fps: parseFloat(match[6]) || 30,
     };
   } catch (e) {
     console.warn('Failed to parse max quality', maxQuality, e);
@@ -173,7 +173,7 @@ export class NicoliveClient {
     private options: {
       niconicoSession?: string;
     } = {},
-  ) {}
+  ) { }
 
   static isProgramPage(url: string): boolean {
     return /^https?:\/\/live2?\.nicovideo\.jp\/watch\/lv\d+/.test(url);
@@ -813,8 +813,7 @@ export class NicoliveClient {
 
     return this.requestAPI<void>(
       'DELETE',
-      `${
-        NicoliveClient.live2BaseURL
+      `${NicoliveClient.live2BaseURL
       }/unama/api/v4/programs/${programId}/comments?${params.toString()}`,
       {
         headers: NicoliveClient.v4ApiHeaders(programId),


### PR DESCRIPTION
## Summary
- 番組情報APIの`maxQuality`フィールドに小数点を含むビットレート・フレームレートが含まれる可能性があるため、`parseMaxQuality`関数を更新
- 正規表現パターンを小数点対応に修正 (`\d+` → `\d+([.]\d+)?`)
- `parseInt`から`parseFloat`に変更してビットレートとfpsをパース
- テストケースに小数点を含むパターンを追加 (`1.5Mbps480p`, `29.97fps`等)

## Test plan
- [x] 既存のユニットテストが全て通過することを確認
- [x] 小数点を含むmaxQuality値のテストケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)