### PR TITLE
開発: i18n辞書のnullエントリによる警告を抑制

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -1,4 +1,5 @@
 import { I18nService } from 'services/i18n';
+import { get } from 'lodash';
 
 // eslint-disable-next-line
 window['eval'] = global.eval = () => {
@@ -227,6 +228,19 @@ document.addEventListener('DOMContentLoaded', () => {
       messages: i18nService.getLoadedDictionaries(),
       missing: ((locale: VueI18n.Locale, key: VueI18n.Path, vm: Vue, values: any[]): string => {
         if (values[0] && typeof values[0].fallback === 'string') {
+          // Check if the key exists in the dictionary with a null value
+          // If so, don't warn - null means "use the fallback value from OBS"
+          const dictionaries = i18nService.getLoadedDictionaries();
+          // Convert key path like "settings.Output['Streaming']['Preset']['ultrafast']"
+          // to lodash-compatible path like "settings.Output.Streaming.Preset.ultrafast"
+          const lodashPath = key.replace(/\['([^']+)'\]/g, '.$1');
+          const value = get(dictionaries[locale], lodashPath);
+
+          if (value === null) {
+            // Key exists with null value - this is intentional, use fallback without warning
+            return values[0].fallback;
+          }
+
           if (!isProduction) {
             // beware: enable following line only when investigating around i18n keys!
             // this adds huge amount of lines to console.


### PR DESCRIPTION
## 概要

OBS設定値の翻訳処理において、i18n辞書に`null`エントリが存在する場合に不要な警告が出力されていた問題を修正しました。

## 問題

- i18n辞書に`null`エントリが存在する場合、「翻訳せずOBSの文字列を使用する」という意図だった
- しかしVue I18n 7.xが`null`を「翻訳が見つからない」と判断し、`missing`ハンドラで警告を出力
- 特に日本語ロケールでx264エンコーダーのプリセット選択時に大量の警告が発生
- これらの警告がSentryに送信されていた

警告例：
```
[warn] i18n missing key - settings.Output['Streaming']['Preset']['ultrafast']: (フォールバックなし)
[warn] i18n missing key - settings.Output['Streaming']['Preset']['superfast']: (フォールバックなし)
```

## 修正内容

**app/app.ts の`missing`ハンドラを修正:**
- `lodash.get`を使用して辞書内の値を安全に参照
- 辞書に`null`エントリが存在する場合は警告を出さず、`fallback`値（OBSから取得した文字列）を返す
- `null`エントリが存在しない場合は従来通り警告を出力

## Test plan

- [x] コンパイルが成功することを確認
- [x] アプリケーションを起動し、日本語ロケールで動作確認
- [x] 設定 > 出力 > 配信でエンコーダーを「ソフトウェア(x264)」に変更
- [x] プリセットのドロップダウンが正しく表示されることを確認
- [x] コンソールにi18n警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)