### PR TITLE
修正: 音声ソースのトラック設定が不正な値の場合に自動修復

### DIFF
--- a/app/services/audio/audio-api.ts
+++ b/app/services/audio/audio-api.ts
@@ -3,6 +3,12 @@ import { Observable, Subscription } from 'rxjs';
 import * as obs from '../../../obs-api';
 import { ISource } from '../sources/sources-api';
 
+/**
+ * audioMixersのデフォルト値（全トラックON）
+ * 8ビット = 0b11111111 = 255
+ */
+export const DEFAULT_AUDIO_MIXERS = 255;
+
 export interface IAudioSourcesState {
   audioSources: Dictionary<IAudioSource>;
 }

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -2,7 +2,7 @@ import * as remote from '@electron/remote';
 import fs from 'fs';
 import defaultTo from 'lodash/defaultTo';
 import path from 'path';
-import { AudioService } from 'services/audio';
+import { AudioService, DEFAULT_AUDIO_MIXERS } from 'services/audio';
 import { Inject } from 'services/core/injector';
 import { Service } from 'services/core/service';
 import { SceneCollectionsService } from 'services/scene-collections';
@@ -227,7 +227,7 @@ export class ObsImporterService extends Service {
               this.audioService.getSource(source.sourceId).setMuted(sourceJSON.muted);
               this.audioService.getSource(source.sourceId).setMul(sourceJSON.volume);
               this.audioService.getSource(source.sourceId).setSettings({
-                audioMixers: defaultTo(sourceJSON.mixers, 255),
+                audioMixers: defaultTo(sourceJSON.mixers, DEFAULT_AUDIO_MIXERS),
                 monitoringType: defaultTo(sourceJSON.monitoring_type, defaultMonitoring),
                 syncOffset: defaultTo(sourceJSON.sync / 1000000, 0),
                 forceMono: !!(sourceJSON.flags & obs.ESourceFlags.ForceMono),

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -351,7 +351,7 @@ export class SourcesNode extends Node<ISchema, {}> {
                     sourceType: sourceInfo.type,
                     migration: 'audioMixers',
                   },
-                  fingerprint: ['audioMixers-migration', sourceInfo.type],
+                  fingerprint: ['audioMixers-migration'],
                   extra: {
                     sourceName: sourceInfo.name,
                     oldAudioMixers: 0,

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/vue';
 import * as fi from 'node-fontinfo';
-import { AudioService } from 'services/audio';
+import { AudioService, DEFAULT_AUDIO_MIXERS } from 'services/audio';
 import { FontLibraryService } from 'services/font-library';
 import { $t } from 'services/i18n';
 import { ScenesService } from 'services/scenes';
@@ -10,12 +10,12 @@ import {
   TSourceType,
   isNoAudioPropertiesManagerType,
 } from 'services/sources';
+import Utils from 'services/utils';
 import * as obs from '../../../../obs-api';
 import { Inject } from '../../core/injector';
 import { HotkeysNode } from './hotkeys';
 import { Node } from './node';
 import { applyPathConvertForPreset, unapplyPathConvertForPreset } from './sources-util';
-import Utils from 'services/utils';
 
 interface ISchema {
   items: ISourceInfo[];
@@ -326,12 +326,48 @@ export class SourcesNode extends Node<ISchema, {}> {
               });
             } else {
               audioSource.setMul(sourceInfo.volume != null ? sourceInfo.volume : 1);
+
+              // マイグレーション: 音声を持つべきソースでaudioMixers=0の場合、デフォルト値に修正
+              // 注: 内部的には8ビットだがUIでは6トラック（ビット0-5）しか操作できないため、
+              //     手動で全トラックOFFにしても0（全ビットOFF）にはならない（ビット6-7は変更されない）
+              //     audioMixers=0は過去のバグや初期化ミスによる異常値であり、マイグレーション対象とする
+              let audioMixers = sourceInfo.audioMixers;
+              const sourceTypesWithAudio = [
+                'nair-rtvc-source',
+                'game_capture',
+                'wasapi_input_capture',
+                'wasapi_output_capture',
+              ];
+
+              if (audioMixers === 0 && sourceTypesWithAudio.includes(sourceInfo.type)) {
+                const message = `Migrating audioMixers for source "${sourceInfo.name}" (${sourceInfo.type}) from 0 to ${DEFAULT_AUDIO_MIXERS}`;
+                console.warn(message);
+
+                // Sentryに警告を送信（タグとfingerprintを付けて同一イベントとして集計）
+                Sentry.captureEvent({
+                  message,
+                  level: 'warning',
+                  tags: {
+                    sourceType: sourceInfo.type,
+                    migration: 'audioMixers',
+                  },
+                  fingerprint: ['audioMixers-migration', sourceInfo.type],
+                  extra: {
+                    sourceName: sourceInfo.name,
+                    oldAudioMixers: 0,
+                    newAudioMixers: DEFAULT_AUDIO_MIXERS,
+                  },
+                });
+
+                audioMixers = DEFAULT_AUDIO_MIXERS; // 全トラックON
+              }
+
               audioSource.setSettings({
                 forceMono: sourceInfo.forceMono,
                 syncOffset: sourceInfo.syncOffset
                   ? AudioService.timeSpecToMs(sourceInfo.syncOffset)
                   : 0,
-                audioMixers: sourceInfo.audioMixers,
+                audioMixers,
                 monitoringType: sourceInfo.monitoringType,
               });
               audioSource.setHidden(!!sourceInfo.mixerHidden);


### PR DESCRIPTION
## この修正で解決される問題

以下のような症状が出ている場合、この修正で自動的に解決される可能性があります：

**症状：**
- Rtvc（ボイスチェンジャー）、ゲームキャプチャ、音声入力/出力キャプチャの音声が配信や録画に出力されない
- **ミキサーの高度な設定で「配信音声あり」になっているのに、実際には音声が出力されない**
- 新規作成したソースは正常だが、古いシーンコレクションのソースだけ問題が発生する

**実際の原因（気づきにくい）：**
- 高度な設定ダイアログを横スクロールすると表示される「トラック」の一覧が全てOFFになっている
- シーンコレクションファイル内の音声トラック設定が不正な値（0 = 全トラックOFF）になっている

**この修正の効果：**
起動時に不正な値を自動検出して正常値へ修復し、配信・録画に音声が出力されるようになります

---

## 概要

古いバージョンで作成されたシーンコレクションに含まれる音声ソース（Rtvc、ゲームキャプチャ等）で、トラック設定が不正な値（0 = 全トラックOFF）になっている場合、起動時に自動的に正常値へ修復する機能を追加しました。

## 背景

**注意：これは開発者環境で発生した問題であり、一般ユーザーへの影響範囲は不明です。**

開発者の環境で、古いシーンコレクションを読み込んだ際に以下のソースでトラック設定が0（全トラックOFF）になっており、**配信や録画に音声が出力されない**状態が確認されました：

- Rtvc（ボイスチェンジャー）
- PCゲームキャプチャ
- 音声入力/出力キャプチャ

### audioMixers=0（不正な値）の時に起きる現象

- 音声ミキサーの高度な設定で「配信音声あり」となっているのに音声が出ない
- 配信トラック、録画トラックのいずれにも音声が送られない
- **結果：配信や録画を開始しても、該当ソースの音声が全く出力されない**
- ユーザーが気づかずに配信を続けてしまうリスクがある
- トラック一覧（横スクロールで表示）を見ると全てOFFになっているが、この画面は通常見ないため気づきにくい

### 検証結果

- ✅ 新規作成時はトラックが全てON（正常）
- ✅ 複製やコピー&ペーストでもトラック設定は正しく複製される（正常）
- ✅ プロパティ変更してもトラック設定は維持される（正常）
- ❌ 古いシーンコレクション読み込み時のみ問題が発生

**重要：** UIでは6トラック（ビット0-5）しか操作できないため、手動で全トラックOFFにしてもaudioMixers=0にはなりません（ビット6-7は変更されない）。つまり、audioMixers=0は過去のバグや初期化ミスによる異常値と考えられます。

## 解決方法（仮説に基づく修正）

この修正は、問題の根本原因が完全に特定できていない状態での**仮説に基づく対応**です：

**仮説：** 過去のN Airバージョンで、特定の条件下でaudioMixersが0で保存される不具合があった可能性

**対応：** シーンコレクション読み込み時に以下の処理を追加：

1. 対象ソースタイプでaudioMixers=0を検出
2. 自動的にデフォルト値（255 = 全トラックON）へ修正
3. **Sentryにwarningレベルで記録**（タグ、fingerprint付き）

**Sentryでの追跡目的：**
- 実際に一般ユーザー環境でも発生しているかどうかを確認
- 影響を受けたユーザー数の把握
- ソースタイプ別の発生頻度の分析
- 今後の根本原因調査のためのデータ収集

## 変更内容

### 修正ファイル

- `app/services/audio/audio-api.ts`
  - `DEFAULT_AUDIO_MIXERS = 255` 定数を追加
- `app/services/scene-collections/nodes/sources.ts`
  - マイグレーション処理を実装
  - Sentryへの記録（タグ、fingerprint、extra情報付き）
- `app/services/obs-importer.ts`
  - マジックナンバー255を定数に置き換え

### 対象ソースタイプ

- `nair-rtvc-source`
- `game_capture`
- `wasapi_input_capture`
- `wasapi_output_capture`

### Sentryイベント情報

マイグレーション実行時に以下の情報を記録：
- **level**: `warning`
- **tags**: 
  - `sourceType`: ソースタイプ（Rtvc、game_capture等）
  - `migration`: `audioMixers`
- **fingerprint**: `['audioMixers-migration']` - 全てのソースタイプを単一イベントとして集計
  - これにより、Sentry上でタグ（sourceType）による分布を確認可能
- **extra**: ソース名、変更前後の値

## テスト

- [x] シーンコレクションファイルのaudioMixersを0に書き換えてテスト
- [x] 起動時に0→255へ正しく補正されることを確認
- [x] Sentryへのイベント送信を確認
- [x] 新規作成時のデフォルト値（255）を確認
- [x] 正常なシーンコレクションが影響を受けないことを確認

## 影響範囲

- **低リスク**: audioMixers=0の異常値のみ修正
- 正常なデータには影響なし
- 既存の動作（新規作成、保存、複製等）は変更なし
- 意図的にトラックをカスタマイズしている場合（audioMixers≠0）は変更されない

## 今後の対応

Sentryログを監視し、以下を確認：
1. 一般ユーザー環境での発生状況
2. 影響を受けたユーザー数
3. 特定のソースタイプでの発生傾向（タグ分布から確認）

データが蓄積されたら、根本原因の特定と恒久対策を検討します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)