### PR TITLE
修正: 設定ウィンドウが画面サイズに収まるように調整

### DIFF
--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -19,7 +19,6 @@ import { NicoliveProgramStateService } from 'services/nicolive-program/state';
 import { SourcesService } from 'services/sources';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
-import * as remote from '@electron/remote';
 import * as obs from '../../../obs-api';
 import { Inject } from '../core/injector';
 import { VideoSettingsService } from '../settings-v2';
@@ -97,8 +96,7 @@ type RecordingSettings = {
 
 export class SettingsService
   extends StatefulService<ISettingsState>
-  implements ISettingsServiceApi, ISettingsAccessor
-{
+  implements ISettingsServiceApi, ISettingsAccessor {
   static initialState = {};
 
   static convertFormDataToState(settingsFormData: TSettingsFormData): ISettingsState {
@@ -157,24 +155,13 @@ export class SettingsService
   }
 
   showSettings(categoryName?: SettingsCategory) {
-    // 画面サイズを考慮したウィンドウサイズを計算（画面からはみ出さないようにする）
-    const currentWindow = remote.getCurrentWindow();
-    const bounds = currentWindow.getBounds();
-    const currentDisplay = remote.screen.getDisplayMatching(bounds);
-    const { width: screenWidth, height: screenHeight } = currentDisplay.workArea;
-
-    // 希望サイズは800x800だが、画面サイズに収まらない場合は画面サイズ - 余白(100px)
-    const margin = 100;
-    const width = Math.min(800, screenWidth - margin);
-    const height = Math.min(800, screenHeight - margin);
-
     this.windowsService.showWindow({
       componentName: 'Settings',
       title: $t('common.settings'),
       queryParams: { categoryName },
       size: {
-        width,
-        height,
+        width: 800,
+        height: 800,
       },
     });
   }
@@ -471,10 +458,10 @@ export class SettingsService
       : (this.findSettingValue(output, 'Audio - Track 1', 'Track1Bitrate') as string);
     const rate_control = !isSimple
       ? (this.findSettingValue(output, 'Streaming', 'rate_control') as
-          | 'CBR'
-          | 'VBR'
-          | 'ABR'
-          | 'CRF')
+        | 'CBR'
+        | 'VBR'
+        | 'ABR'
+        | 'CRF')
       : null;
     const profile = !isSimple
       ? (this.findSettingValue(output, 'Streaming', 'profile') as 'high' | 'main' | 'baseline')

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -19,6 +19,7 @@ import { NicoliveProgramStateService } from 'services/nicolive-program/state';
 import { SourcesService } from 'services/sources';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
+import * as remote from '@electron/remote';
 import * as obs from '../../../obs-api';
 import { Inject } from '../core/injector';
 import { VideoSettingsService } from '../settings-v2';
@@ -156,13 +157,24 @@ export class SettingsService
   }
 
   showSettings(categoryName?: SettingsCategory) {
+    // 画面サイズを考慮したウィンドウサイズを計算（画面からはみ出さないようにする）
+    const currentWindow = remote.getCurrentWindow();
+    const bounds = currentWindow.getBounds();
+    const currentDisplay = remote.screen.getDisplayMatching(bounds);
+    const { width: screenWidth, height: screenHeight } = currentDisplay.workArea;
+
+    // 希望サイズは800x800だが、画面サイズに収まらない場合は画面サイズ - 余白(100px)
+    const margin = 100;
+    const width = Math.min(800, screenWidth - margin);
+    const height = Math.min(800, screenHeight - margin);
+
     this.windowsService.showWindow({
       componentName: 'Settings',
       title: $t('common.settings'),
       queryParams: { categoryName },
       size: {
-        width: 800,
-        height: 800,
+        width,
+        height,
       },
     });
   }

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -180,6 +180,25 @@ export class WindowsService extends StatefulService<IWindowsState> {
       message: options.componentName,
     });
 
+    // 画面サイズを考慮してウィンドウサイズを調整（画面からはみ出さないようにする）
+    if (options.size) {
+      const currentDisplay = remote.screen.getDisplayMatching(remote.getCurrentWindow().getBounds());
+      if (currentDisplay.workArea) {
+        // 画面サイズに収まらない場合は画面サイズ - 余白(100px)に調整、ただし最低サイズは100px
+        const margin = 100;
+        const minSize = 100;
+        const minWindow = margin + minSize + 50;
+        if (options.size.width && currentDisplay.workArea.width > minWindow) {
+          const maxWidth = currentDisplay.workArea.width - margin;
+          options.size.width = Math.min(Math.max(options.size.width, minSize), maxWidth);
+        }
+        if (options.size.height && currentDisplay.workArea.height > minWindow) {
+          const maxHeight = currentDisplay.workArea.height - margin;
+          options.size.height = Math.min(Math.max(options.size.height, minSize), maxHeight);
+        }
+      }
+    }
+
     // Don't center the window if it's the same component
     // This prevents "snapping" behavior when navigating settings
     if (options.componentName !== this.state.child.componentName) {


### PR DESCRIPTION
## 概要
設定ウィンドウを開く際に画面サイズを考慮し、小さい画面でもウィンドウが画面からはみ出さないようリサイズ処置を追加。
また、各種ウインドウも同様にリサイズ処理を追加。

## 変更内容
- 画面に余裕がある場合は従来と変わりません
- 画面に収まらない場合は自動的に縮小されます（画面サイズ - 100px の余白）
- 最低でも100pxのウインドウサイズを確保します
- これにより、小さい画面でもクローズボタンが確実に押せるようになります


<img width="836" height="560" alt="Monosnap work 2026-01-16 14-54-42" src="https://github.com/user-attachments/assets/3009da75-1ffc-4455-84d0-b9a943007ba2" />


## 影響範囲
影響するウインドウは以下となります

	1	Settings (800x800) - 設定ウィンドウ
	2	SceneTransitions (800x650) - シーン切り替え
	3	SourceFilters (800x800) - ソースフィルター
	4	SourceProperties (600x600) - ソースプロパティ
	5	RtvcSourceProperties (930x647) - RTVCソースプロパティ
	6	AdvancedAudio (840x500) - 高度なオーディオ設定
	7	AddSourceFilter (600x200) - ソースフィルター追加
	8	SourcesShowcase (680x600) - ソース一覧
	9	AddSource (640x715) - ソース追加
	10	RenameSource (400x250) - ソース名前変更
	11	BrowserSourceInteraction (800x600) - ブラウザソースインタラクション
	12	NameScene (400x250) - シーン名前変更
	13	NameFolder (400x250) - フォルダ名前変更
	14	NameSceneCollection (400x250) - シーンコレクション名前変更
	15	ManageSceneCollections (700x800) - シーンコレクション管理
	16	NicoliveProgramSelector (800x600) - ニコ生番組選択
	17	OptimizeForNiconico (600x500) - ニコニコ最適化
	18	Troubleshooter (500x600) - トラブルシューター
	19	Notifications (600x400) - 通知
	20	Informations (600x400) - お知らせ
	21	UserInfo (360x640) - ユーザー情報
	22	ModeratorConfirmDialog (480x220) - モデレーター確認ダイアログ
	23	AutoCompactConfirmDialog (500x240) - 自動コンパクトモード確認ダイアログ
	24	CroppingOverlay - クロッピングオーバーレイ（サイズ指定なし）
	25	Projector (640x360) - プロジェクター
