### PR TITLE
開発: socket.io経由のws脆弱性を解消（Alert 102の一部）

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3561,8 +3561,8 @@ packages:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
 
-  engine.io@6.6.4:
-    resolution: {integrity: sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==}
+  engine.io@6.6.5:
+    resolution: {integrity: sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==}
     engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.18.4:
@@ -6450,8 +6450,8 @@ packages:
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
 
-  socket.io-adapter@2.5.5:
-    resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
   socket.io-client@4.8.3:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
@@ -11404,7 +11404,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.4:
+  engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 20.19.27
@@ -11412,9 +11412,9 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.5
-      debug: 4.3.7
+      debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.17.1
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14651,10 +14651,10 @@ snapshots:
 
   smob@1.5.0: {}
 
-  socket.io-adapter@2.5.5:
+  socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.3.7
-      ws: 8.17.1
+      debug: 4.4.3
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14684,8 +14684,8 @@ snapshots:
       base64id: 2.0.0
       cors: 2.8.5
       debug: 4.4.3
-      engine.io: 6.6.4
-      socket.io-adapter: 2.5.5
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## このpull requestが解決する内容
socket.io 経由の ws 脆弱性（Alert 102 の一部）を解消します。

## 背景
Dependabot Alert 102 (CVE-2024-37890) により、ws < 8.18.0 に DoS 脆弱性が存在します。この脆弱性は WebSocket サーバーが大量のヘッダーを持つリクエストでクラッシュする問題です。

N Air では socket.io を通じて ws を使用しており、サーバー側（engine.io）とクライアント側（socket.io-client）の両方で脆弱なバージョンが使用されていました。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| engine.io | 6.6.4 | 6.6.5 | ws@8.18.3 を使用（脆弱性解消） |
| socket.io-adapter | 2.5.5 | 2.5.6 | ws@8.18.3 を使用（脆弱性解消） |

### ファイル変更
- `pnpm-lock.yaml`: socket.io 関連パッケージの依存関係を更新
  - **package.json は変更なし**（既存の依存範囲内での更新）

### 更新コマンド
```bash
pnpm update socket.io engine.io socket.io-adapter engine.io-client
```

このコマンドにより、package.json の依存範囲内で利用可能な最新版に更新されます。

### pnpm-lock.yaml のみの更新でリグレッションの心配がない理由

1. **依存範囲内の更新**
   - socket.io@4.8.3 は `engine.io@~6.6.0` に依存
   - チルダ範囲 `~6.6.0` は 6.6.x の最新版を許容
   - 6.6.4 → 6.6.5 はパッチバージョンアップのみ

2. **将来も安定**
   - pnpm の依存解決は「その時点で利用可能な範囲内の最新版」を選択
   - 将来 pnpm-lock.yaml を再生成しても、6.6.5（または 6.6.x の最新版）が選ばれる
   - package.json に変更がないため、依存範囲は維持される

3. **セマンティックバージョニング準拠**
   - パッチバージョンアップはバグ修正のみで破壊的変更なし
   - engine.io 6.6.5 のリリースノートでも後方互換性が保証されている

### 脆弱性の影響範囲

**CVE-2024-37890 の詳細:**
- 攻撃対象: WebSocket **サーバー**
- 攻撃方法: 大量のヘッダーを持つリクエストで DoS
- CVSS 3.1: 7.5 (High)

**更新状況:**
- ✅ **サーバー側（解消済み）**: engine.io@6.6.5 → ws@8.18.3
- ✅ **サーバー側（解消済み）**: socket.io-adapter@2.5.6 → ws@8.18.3
- ℹ️ **クライアント側（影響なし）**: socket.io-client → engine.io-client@6.6.3 → ws@8.17.1
  - クライアント用途のため、サーバー攻撃の脆弱性は該当せず
  - 琴詠ニアのアバター表示（browser source）で使用


## 影響範囲
- プロダクション環境: socket.io サーバー側の DoS 脆弱性を解消
- 開発環境: webdriverio 経由の ws@8.5.0 は依然として残存（electron 更新待ち、devDependency のみ）

## テスト
- [x] 琴詠ニアのアバター表示が正常に動作すること（socket.io を使用）

## 補足
- この修正により Alert 102 (ws/socket.io) のサーバー側リスクが解消されます
- webdriverio 経由の ws は devDependency のみで実質リスクが低いため、electron 更新時に対応予定
- 関連 issue: #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)