### PR TITLE
開発: pnpm を 10.27.0 から 10.28.1 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "webpack-dev-server": "^5.1.0",
     "webpack-merge": "^6.0.1"
   },
-  "packageManager": "pnpm@10.27.0",
+  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
   "engines": {
     "node": ">=22.0.0",
     "npm": "please-use-pnpm",


### PR DESCRIPTION
## このpull requestが解決する内容
pnpm をマイナーバージョンアップ（10.27.0 → 10.28.1）します。

## 背景
pnpm 10.28.1 には3件のセキュリティ修正とバグフィックスが含まれており、10.27.0からの更新が推奨されます。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| pnpm | 10.27.0 | 10.28.1 | マイナーバージョンアップ |

### ファイル変更
- `package.json`: packageManager フィールドを更新

### 開発環境での対応
このPRをpull後、以下のいずれかの方法でpnpmバージョンを更新してください：

**推奨: Corepackによる自動更新**
```bash
corepack install
```

**または、pnpmコマンド実行時に自動更新**
- Corepackが有効な環境では、`pnpm`コマンド実行時に`package.json`の`packageManager`フィールドを参照し、自動的に10.28.1を使用します
- 初回実行時にダウンロードが発生する場合があります

### 主な改善点

#### セキュリティ修正（3件）
- ZIPファイル展開時のパストラバーサル脆弱性を修正
- Windowsでのtarball展開の脆弱性を修正（バックスラッシュシーケンス使用時）
- `@`で始まる名前のbinリンク脆弱性を修正

#### バグフィックス
- プライベートレジストリからの設定依存関係のインストール問題を修正
- `pnpm exec` のワーキングディレクトリ問題を修正
- `pnpm run -r` と `pnpm run --filter` がスクリプトが存在しない場合に非ゼロで終了するように変更（`--if-present` で従来の動作を維持可能）

#### その他の改善
- `.git`で終わるHTTP/HTTPS URLをGit依存として認識するように改善
- `--save-peer` で `jsr:` などのプロトコルベースのインストールに対して有効なsemver範囲を書き込むように修正

### 互換性
- **ブレイキングチェンジなし**: パッチバージョンアップのため破壊的変更はありません
- Node.js 22.x との互換性に問題なし

## 影響範囲
- パッケージマネージャーのみ（依存関係の解決とインストール動作）
- セキュリティ修正により、より安全な依存関係の取り扱いが可能になります

## 参考情報
- [pnpm 10.28.1 リリースノート](https://github.com/pnpm/pnpm/releases/tag/v10.28.1)
- [pnpm 10.28.0 リリースノート](https://github.com/pnpm/pnpm/releases/tag/v10.28.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)