### PR TITLE
開発: lodash-decorators を削除し lodash を直接使用するように変更

### DIFF
--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -1,5 +1,4 @@
-import _ from 'lodash';
-import { debounce } from 'lodash-decorators';
+import _, { debounce } from 'lodash';
 import VueColor from 'vue-color';
 import { Component, Prop } from 'vue-property-decorator';
 import Utils from '../../../services/utils';
@@ -28,16 +27,25 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
     this.pickerVisible = !this.pickerVisible;
   }
 
-  @debounce(500)
-  setValue(rgba: IColor) {
+  private setValueImpl(rgba: IColor) {
     if (!_.isEqual(rgba, this.obsColor)) {
       const intColor = Utils.rgbaToInt(rgba.r, rgba.g, rgba.b, Math.round(255 * rgba.a));
       this.emitInput({ ...this.value, value: intColor });
     }
   }
 
+  private debouncedSetValue = debounce(this.setValueImpl, 500);
+
+  setValue(rgba: IColor) {
+    this.debouncedSetValue(rgba);
+  }
+
   mounted() {
     this.setValue(this.obsColor);
+  }
+
+  beforeDestroy() {
+    this.debouncedSetValue.cancel();
   }
 
   get hexAlpha() {

--- a/app/components/obs/inputs/ObsSliderInput.vue.ts
+++ b/app/components/obs/inputs/ObsSliderInput.vue.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash-decorators';
+import { debounce } from 'lodash';
 import { Component, Prop } from 'vue-property-decorator';
 import Slider from '../../shared/Slider.vue';
 import { IObsSliderInputValue, ObsInput, TObsType } from './ObsInput';
@@ -16,14 +16,23 @@ class ObsSliderInput extends ObsInput<IObsSliderInputValue> {
   // moves the slider.  It makes the UI feel more responsive.
   localValue = this.value.value;
 
+  private emitValueImpl(value: number) {
+    this.emitInput({ ...this.value, value });
+  }
+
+  private debouncedEmitValue = debounce(this.emitValueImpl, 100);
+
   updateValue(value: number) {
     this.localValue = value;
     this.emitValue(value);
   }
 
-  @debounce(100)
   emitValue(value: number) {
-    this.emitInput({ ...this.value, value });
+    this.debouncedEmitValue(value);
+  }
+
+  beforeDestroy() {
+    this.debouncedEmitValue.cancel();
   }
 }
 

--- a/app/components/shared/inputs/SliderInput.vue.ts
+++ b/app/components/shared/inputs/SliderInput.vue.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash-decorators';
+import { throttle } from 'lodash';
 import { Component, Prop } from 'vue-property-decorator';
 import VueSlider from 'vue-slider-component';
 import { Inject } from '../../../services/core/injector';
@@ -33,15 +33,24 @@ export default class SliderInput extends BaseInput<number, ISliderMetadata> {
     }, 500);
   }
 
-  @throttle(500)
-  updateValue(value: number) {
+  private updateValueImpl(value: number) {
     if (!this.isFullyMounted) return;
     this.emitInput(this.roundNumber(value));
+  }
+
+  private throttledUpdateValue = throttle(this.updateValueImpl, 500);
+
+  updateValue(value: number) {
+    this.throttledUpdateValue(value);
   }
 
   handleKeydown(event: KeyboardEvent) {
     if (event.code === 'ArrowUp') this.updateValue(this.value + this.interval);
     if (event.code === 'ArrowDown') this.updateValue(this.value - this.interval);
+  }
+
+  beforeDestroy() {
+    this.throttledUpdateValue.cancel();
   }
 
   // Javascript precision is weird

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -248,13 +248,12 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     this.setVideoSetting('fpsDen', 1, display);
   }
 
-  private debouncedUpdateObsSettings = debounce(
-    (display: TDisplayType = 'horizontal') => {
-      this.contexts[display].video = this.state[display];
-      this.contexts[display].legacySettings = this.state[display];
-    },
-    200,
-  );
+  private updateObsSettingsImpl(display: TDisplayType = 'horizontal') {
+    this.contexts[display].video = this.state[display];
+    this.contexts[display].legacySettings = this.state[display];
+  }
+
+  private debouncedUpdateObsSettings = debounce(this.updateObsSettingsImpl, 200);
 
   updateObsSettings(display: TDisplayType = 'horizontal') {
     this.debouncedUpdateObsSettings(display);

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash-decorators';
+import { debounce } from 'lodash';
 import { Subject } from 'rxjs';
 import { Inject } from 'services/core/injector';
 import { SettingsService } from 'services/settings';
@@ -248,10 +248,16 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     this.setVideoSetting('fpsDen', 1, display);
   }
 
-  @debounce(200)
+  private debouncedUpdateObsSettings = debounce(
+    (display: TDisplayType = 'horizontal') => {
+      this.contexts[display].video = this.state[display];
+      this.contexts[display].legacySettings = this.state[display];
+    },
+    200,
+  );
+
   updateObsSettings(display: TDisplayType = 'horizontal') {
-    this.contexts[display].video = this.state[display];
-    this.contexts[display].legacySettings = this.state[display];
+    this.debouncedUpdateObsSettings(display);
   }
 
   setVideoSetting(key: string, value: unknown, display: TDisplayType = 'horizontal') {
@@ -267,7 +273,7 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     const legacySettings = this.contexts[display].legacySettings;
     this.contexts[display].video = legacySettings;
 
-    getKeys(legacySettings).forEach(key => {
+    getKeys(legacySettings).forEach((key) => {
       this.SET_VIDEO_SETTING(key, legacySettings[key], 'horizontal');
     });
   }
@@ -279,7 +285,9 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
    * Each context must be destroyed when shutting down the app to prevent errors
    */
   shutdown() {
-    displays.forEach(display => {
+    this.debouncedUpdateObsSettings.cancel();
+
+    displays.forEach((display) => {
       if (this.contexts[display]) {
         // save settings as legacy settings
         this.contexts[display].legacySettings = this.state[display];

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "game_overlay": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz",
     "iconv-lite": "^0.7.1",
     "lodash": "^4.17.21",
-    "lodash-decorators": "^4.5.0",
     "long": "^5.2.3",
     "luxon": "^3.5.0",
     "node-fontinfo": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/node-fontinfo-1.1.12-win64.tar.gz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      lodash-decorators:
-        specifier: ^4.5.0
-        version: 4.5.0(lodash@4.17.21)
       long:
         specifier: ^5.2.3
         version: 5.3.2
@@ -5026,12 +5023,6 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  lodash-decorators@4.5.0:
-    resolution: {integrity: sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==}
-    engines: {node: '>=0.12.0'}
-    peerDependencies:
-      lodash: 4.x
 
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
@@ -13219,11 +13210,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-decorators@4.5.0(lodash@4.17.21):
-    dependencies:
-      lodash: 4.17.21
-      tslib: 1.14.1
 
   lodash.clonedeep@4.5.0: {}
 


### PR DESCRIPTION
## このpull requestが解決する内容

lodash-decorators パッケージを削除し、既存の lodash パッケージの debounce/throttle 関数を直接使用する実装に置き換えます。

## lodash-decorators とは

[lodash-decorators](https://github.com/steelsojka/lodash-decorators) は、lodash の関数群を TypeScript/ES7 のデコレーター構文で使えるようにするラッパーライブラリです。例えば `@debounce(100)` のようにメソッドに注釈を付けるだけで debounce 処理を適用できます。

しかし、このライブラリは更新が止まっており（最終更新: 2017年）、現在では lodash を直接使用する方が標準的な実装パターンとなっています。

## 背景

lodash-decorators (v4.5.0) は更新が止まっており古くなっています。使用箇所は4ファイルのみで `@debounce` と `@throttle` デコレーターのみを使用しており、既に依存関係に含まれている lodash (v4.17.21) で代替可能です。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| lodash-decorators | 4.5.0 | (削除) | 古く更新が止まっている（最終更新: 2017年） |
| lodash | 4.17.21 | 4.17.21 | 既存パッケージを使用 |

### ファイル変更

- `app/services/settings-v2/video.ts`: `@debounce(200)` → debounce関数の直接呼び出し、`shutdown()`でクリーンアップ追加
- `app/components/obs/inputs/ObsSliderInput.vue.ts`: `@debounce(100)` → debounce関数の直接呼び出し、`beforeDestroy()`追加
- `app/components/obs/inputs/ObsColorInput.vue.ts`: `@debounce(500)` → debounce関数の直接呼び出し、`beforeDestroy()`追加
- `app/components/shared/inputs/SliderInput.vue.ts`: `@throttle(500)` → throttle関数の直接呼び出し、`beforeDestroy()`追加
- `package.json`: lodash-decorators 依存関係を削除
- `pnpm-lock.yaml`: 依存関係を更新

### 実装パターンの変更

デコレーター構文から通常のメソッド + debounce/throttle 関数の組み合わせに変更：

```typescript
// Before (デコレーター構文)
@debounce(100)
emitValue(value: number) {
  this.emitInput({ ...this.value, value });
}

// After (lodash を直接使用)
private emitValueImpl(value: number) {
  this.emitInput({ ...this.value, value });
}
private debouncedEmitValue = debounce(this.emitValueImpl, 100);

emitValue(value: number) {
  this.debouncedEmitValue(value);
}

beforeDestroy() {
  this.debouncedEmitValue.cancel();  // クリーンアップを追加
}
```

**Implメソッドパターンを採用した理由:**

アロー関数でインライン実装する方法も可能ですが、`this` バインディングの問題を避けるため、通常のメソッドとして定義してからdebounce/throttleに渡すパターンを採用しました：

```typescript
// ❌ インライン（thisバインディングが不安定になる可能性）
private debouncedEmitValue = debounce((value: number) => {
  this.emitInput({ ...this.value, value });
}, 100);

// ✅ Implメソッド（thisが確実にバインドされる）
private emitValueImpl(value: number) {
  this.emitInput({ ...this.value, value });
}
private debouncedEmitValue = debounce(this.emitValueImpl, 100);
```

メソッドとして定義することで、Vueのリアクティブシステムや TypeScript のクラスコンテキストが正しく `this` をバインドでき、実行時エラーを防ぐことができます。

### 主な改善点

- **メモリリーク防止の強化**: 既存実装では保留中の debounced/throttled 呼び出しがキャンセルされていませんでしたが、今回 `beforeDestroy()` と `shutdown()` でクリーンアップを追加
- **明示的な実装**: デコレーター構文よりコードの流れが理解しやすい
- **依存関係削減**: 古い lodash-decorators を削除
- **型安全性**: `@types/lodash` による完全な型サポート
- **遅延時間維持**: 全ての遅延時間（100ms, 200ms, 500ms）は元の値を維持
- **thisバインディングの安定性**: Implメソッドパターンにより実行時エラーを防止

## 影響範囲

- サービス層: 1ファイル (video.ts)
- Vueコンポーネント: 3ファイル (ObsSliderInput, ObsColorInput, SliderInput)
- 外部APIは変更なし（内部実装のみの変更）
- 破壊的変更なし

## テスト

- [x] TypeScript コンパイル成功
- [x] テキストソースのプロパティでカラーピッカーと透明度スライダーの動作確認
- [x] 500ms の debounce/throttle が正常に動作することを確認
- [x] エラーなし、アプリクラッシュなし

## 補足

- 既存の lodash-decorators 実装では、コンポーネント破棄時に保留中の呼び出しがキャンセルされていませんでした
- 今回の変更で適切なクリーンアップを追加し、メモリリーク防止を強化しています
- debounce/throttle の動作は完全に互換性があり、遅延時間も維持されています
- 4ファイルすべてで一貫した Implメソッドパターンを採用し、コードの統一性を確保しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)