### PR TITLE
開発: lodash を 4.17.21 から 4.17.23 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "fuse.js": "~7.1.0",
     "game_overlay": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz",
     "iconv-lite": "^0.7.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "long": "^5.2.3",
     "luxon": "^3.5.0",
     "node-fontinfo": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/node-fontinfo-1.1.12-win64.tar.gz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+        specifier: ^4.17.23
+        version: 4.17.23
       long:
         specifier: ^5.2.3
         version: 5.3.2
@@ -360,7 +360,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vue-loader:
         specifier: 15.11.1
-        version: 15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.7.14)(webpack@5.104.1)
+        version: 15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.23)(vue-template-compiler@2.7.14)(webpack@5.104.1)
       vue-svg-loader:
         specifier: 0.16.0
         version: 0.16.0(vue-template-compiler@2.7.14)
@@ -5070,8 +5070,8 @@ packages:
   lodash.zip@4.2.0:
     resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -8765,7 +8765,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fs-extra: 9.1.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
@@ -9746,9 +9746,9 @@ snapshots:
       postcss: 8.5.6
       source-map: 0.6.1
 
-  '@vue/component-compiler-utils@3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)':
+  '@vue/component-compiler-utils@3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.23)':
     dependencies:
-      consolidate: 0.15.1(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)
+      consolidate: 0.15.1(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.23)
       hash-sum: 1.0.2
       lru-cache: 4.1.5
       merge-source-map: 1.1.0
@@ -10804,7 +10804,7 @@ snapshots:
       esutils: 2.0.3
       fast-diff: 1.3.0
       js-string-escape: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       md5-hex: 3.0.1
       semver: 7.7.3
       well-known-symbols: 2.0.0
@@ -10820,13 +10820,13 @@ snapshots:
 
   consola@3.4.2: {}
 
-  consolidate@0.15.1(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21):
+  consolidate@0.15.1(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.23):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
       ejs: 3.1.10
       handlebars: 4.7.8
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   content-disposition@0.5.4:
     dependencies:
@@ -11305,7 +11305,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -13241,7 +13241,7 @@ snapshots:
 
   lodash.zip@4.2.0: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -15356,7 +15356,7 @@ snapshots:
   v-tooltip@2.1.3(vue@2.7.14):
     dependencies:
       '@babel/runtime': 7.28.4
-      lodash: 4.17.21
+      lodash: 4.17.23
       popper.js: 1.16.1
       vue-resize: 1.0.1(vue@2.7.14)
     transitivePeerDependencies:
@@ -15403,7 +15403,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.7.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -15414,9 +15414,9 @@ snapshots:
     dependencies:
       vue: 2.7.14
 
-  vue-loader@15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.7.14)(webpack@5.104.1):
+  vue-loader@15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.23)(vue-template-compiler@2.7.14)(webpack@5.104.1):
     dependencies:
-      '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)
+      '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.23)
       css-loader: 7.1.2(webpack@5.104.1)
       hash-sum: 1.0.2
       loader-utils: 1.4.2


### PR DESCRIPTION
## このpull requestが解決する内容
lodash をパッチバージョンアップ（4.17.21 → 4.17.23）し、Dependabot Alert 111, 110 (CVE-2025-13465) のPrototype Pollution脆弱性を解消します。

## 背景
lodash 4.17.22以前に `_.unset` と `_.omit` 関数におけるPrototype Pollution脆弱性が発見されました。攻撃者が細工されたパスを使用すると、グローバルプロトタイプからメソッドを削除できる可能性があります。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| lodash | 4.17.21 | 4.17.23 | パッチバージョンアップ |

### ファイル変更
- `package.json`: dependencies の lodash を更新
- `pnpm-lock.yaml`: 依存関係を更新

### セキュリティ修正
- CVE-2025-13465: `_.unset` と `_.omit` 関数のPrototype Pollution脆弱性を修正
- CVSS 3.1スコア: 6.5 (Medium)
- CVSS 4.0スコア: 6.9 (Medium)

### 影響分析
- パッチバージョンアップのため、破壊的変更なし
- N Airでlodashは広く使用されているが、ユーザー入力を直接 `_.unset`/`_.omit` に渡していない限り影響は限定的
- 本修正により、将来的な攻撃リスクを予防

## 影響範囲
- 本番環境のlodash依存全体（直接依存 + 間接依存）
- パッチバージョンアップのため、既存コードへの影響はなし

## テスト
- [x] ユニットテスト全てパス (40 test suites, 626 tests)
- [x] 起動テスト（手動確認済み）

## 参考
- GitHub Security Advisory: [GHSA-xxjr-mmjv-4gpg](https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg)
- Dependabot Alert 111: https://github.com/n-air-app/n-air-app/security/dependabot/111
- Dependabot Alert 110: https://github.com/n-air-app/n-air-app/security/dependabot/110
- Issue #1073: セキュリティアラート追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)