### PR TITLE
開発: game_overlay依存関係を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "electron-window-state": "5.0.3",
     "font-manager": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/font-manager-1.2.10-win64.tar.gz",
     "fuse.js": "~7.1.0",
-    "game_overlay": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz",
     "iconv-lite": "^0.7.1",
     "lodash": "^4.17.23",
     "long": "^5.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       fuse.js:
         specifier: ~7.1.0
         version: 7.1.0
-      game_overlay:
-        specifier: https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz
-        version: '@streamlabs/game_overlay@https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz'
       iconv-lite:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1823,11 +1820,6 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
-
-  '@streamlabs/game_overlay@https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz':
-    resolution: {tarball: https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz}
-    version: 0.0.63
-    engines: {node: '>= 14'}
 
   '@streamlabs/obs-studio-node@https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz':
     resolution: {tarball: https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz}
@@ -5103,6 +5095,9 @@ packages:
   lodash.zip@4.2.0:
     resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -5431,9 +5426,6 @@ packages:
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
-
-  node-addon-api@4.3.0:
-    resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -9414,10 +9406,6 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@streamlabs/game_overlay@https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/game-overlay-0.0.63-win64.tar.gz':
-    dependencies:
-      node-addon-api: 4.3.0
-
   '@streamlabs/obs-studio-node@https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz': {}
 
   '@szmarczak/http-timer@4.0.6':
@@ -11394,7 +11382,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.23
+      lodash: 4.17.21
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -13330,6 +13318,8 @@ snapshots:
 
   lodash.zip@4.2.0: {}
 
+  lodash@4.17.21: {}
+
   lodash@4.17.23: {}
 
   log-symbols@4.1.0:
@@ -13629,8 +13619,6 @@ snapshots:
 
   node-addon-api@1.7.2:
     optional: true
-
-  node-addon-api@4.3.0: {}
 
   node-addon-api@7.1.1: {}
 
@@ -15488,7 +15476,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.7.0
-      lodash: 4.17.23
+      lodash: 4.17.21
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION

## 未使用のgame_overlayを削除

未使用のgame_overlayをpackage.jsonから外します。
状況調査は以下

----------

## 概要

`game_overlay` は package.json に依存関係として記載されているが、N Air のコードベースでは**一切使用されていない**ネイティブモジュールです。

## game_overlay とは

### 機能

**Streamlabs Game Overlay** は、ゲーム画面内に配信用オーバーレイを直接表示するための機能です。

- プレイ中のゲーム画面に透過ウィンドウを重ねて表示
- チャットメッセージ、フォロー/サブスク通知、ドネーションアラートなどを表示
- 配信者がゲームを終了せずに配信情報を確認できる
- マウス/キーボードイベントのインタラクティブモードもサポート

### 技術的な仕組み

```typescript
// typings.d.ts より抜粋
export function addHWND(hwnd: HWND): OverlayId;
export function setPosition(id: OverlayId, x: number, y: number, width: number, height: number): void;
export function setTransparency(overlayId: OverlayId, transparency: number): void;
export function paintOverlay(overlayId: OverlayId, width: number, height: number, image: Buffer): number;
export function setMouseCallback(callback: Function): void;
export function switchInteractiveMode(active: Boolean): void;
```

- ゲームプロセスのウィンドウに対して透明なオーバーレイウィンドウを注入
- Electron の `BrowserWindow` から取得したゲームウィンドウのハンドル (HWND) を使用
- Electron で描画した画像をゲーム画面に転送

## game_capture との違い

### ❌ game_overlay（未使用）

**Streamlabs 独自のゲーム内オーバーレイ表示機能**

- **ゲーム画面内**にチャットやアラートを表示する（ゲーム → 配信者向け）
- N Air では**未実装・未使用**
- 配信者がゲーム中に配信情報を見るための機能
- Twitch/YouTube 配信に特化した機能

### ✅ game_capture（使用中）

**OBS 由来のゲーム画面キャプチャ機能**

- ゲームプロセスの映像を**配信ソース**として取り込む（ゲーム → 視聴者向け）
- N Air で**実装済み・使用中**
- [app/services/sources/properties-managers/default-manager.ts](../app/services/sources/properties-managers/default-manager.ts) で自動ゲームキャプチャ機能を実装
- [assets/gamecapture/game_capture_list.json](../assets/gamecapture/game_capture_list.json) で 1200 以上のゲームタイトルに対応
- ゲームウィンドウを自動認識してキャプチャ

## N Air での使用状況

### 調査結果

**使用状況: ❌ 未使用**

1. **コード内に使用箇所なし**
   - `require('game_overlay')` や import 文が存在しない
   - grep 検索で package.json と lockfile 以外にヒットなし

2. **サービスコードが存在しない**
   - Streamlabs 由来の `app/services/game-overlay/` ディレクトリは現在の HEAD に存在しない
   - git history では存在していたが、現在は削除済み

3. **最後の変更は 2022 年頃**
   - Streamlabs 側での更新履歴のみ（コミット: 32bf511a1, ceba9d9cd など）
   - N Air フォーク後、このモジュールに関する変更は皆無

4. **N Air 固有の変更なし**
   - git log で N Air 関連のコミットを検索しても game_overlay の変更なし

### なぜ package.json に残っているのか

- Streamlabs Desktop からフォークした際に依存関係がそのまま引き継がれた
- native-deps リポジトリのバイナリリリースに含まれているため、一括更新時に残り続けている
- 実害がないため削除されずに放置されている状態

## 結論

**`game_overlay` は削除可能な未使用依存関係です。**

- N Air ではゲーム画面内オーバーレイ機能は実装されていない
- 今後も実装する予定はない
- 削除してもゲームキャプチャー機能（game_capture）には一切影響しない
- package.json から削除することを推奨

## 参考情報

### Streamlabs での使用例

Git history より:
- `ceba9d9cd` - use version of game overlay what could collect users input for streaming analytics
- `b752ae180` - fix:(game-overlay): interaction controls weren't hiding for Twitch
- `32bf511a1` - game_overlay: update to v0.0.56


