### PR TITLE
開発: rimraf依存を削除しNode.js標準APIに移行

### DIFF
--- a/app/index.d.ts
+++ b/app/index.d.ts
@@ -45,7 +45,6 @@ declare module 'traverse';
 declare module 'vue-multiselect';
 // declare module 'unzip-stream';
 declare module 'node-fontinfo';
-declare module 'rimraf';
 declare module '@xkeshi/vue-qrcode';
 declare module 'vue-color';
 

--- a/main.js
+++ b/main.js
@@ -41,15 +41,15 @@ const osnVersion = getObsStudioNodeVersion();
 const electron = require('electron');
 const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell, crashReporter } =
   electron;
-const path = require('path');
-const { rimrafSync } = require('rimraf');
+const path = require('node:path');
+const fs = require('node:fs');
 const remote = require('@electron/remote/main');
 
-function rimrafWithRetry(rmPath) {
+function removePathWithRetry(rmPath) {
   const MAX_RETRIES = 3;
   for (let t = MAX_RETRIES; t > 0; t--) {
     try {
-      rimrafSync(rmPath);
+      fs.rmSync(rmPath, { recursive: true, force: true });
     } catch (e) {
       console.error(`failed to delete '${rmPath}: `, e);
       if (!t) {
@@ -71,7 +71,7 @@ if (process.env.NAIR_CACHE_DIR) {
 if (process.argv.includes('--clearCacheDir')) {
   const rmPath = app.getPath('userData');
   console.log('clear cache directory!: ', rmPath);
-  rimrafWithRetry(rmPath);
+  removePathWithRetry(rmPath);
 }
 
 function getCookieFiles() {
@@ -89,7 +89,7 @@ async function clearCookies() {
   console.log('clear cookies: ', files);
   for (const file of files) {
     try {
-      rimrafWithRetry(file);
+      removePathWithRetry(file);
     } catch (e) {
       console.error('failed to delete cookie file', file, e);
     }
@@ -227,13 +227,12 @@ try {
 remote.initialize();
 
 function initialize(crashHandler) {
-  const fs = require('node:fs');
   const { Updater } = require('./updater/Updater.js');
   const { randomUUID } = require('node:crypto');
   const windowStateKeeper = require('electron-window-state');
-  const { URL } = require('url');
+  const { URL } = require('node:url');
 
-  const pid = require('process').pid;
+  const pid = require('node:process').pid;
 
   app.commandLine.appendSwitch('force-ui-direction', 'ltr');
   process.env.IPC_UUID = `nair-${randomUUID()}`;
@@ -258,9 +257,9 @@ function initialize(crashHandler) {
   // 起動速度改善: 重い同期処理は app.on('ready') 後に実行
   // workaround for  https://github.com/electron/electron/issues/19468, https://github.com/electron/electron/issues/19978
   // (Electron 6 to 8 does not launch in Win10 dark mode with DevTool extensions installed)
-  // rimrafWithRetry(path.join(app.getPath('userData'), 'DevTools Extensions'));
+  // removePathWithRetry(path.join(app.getPath('userData'), 'DevTools Extensions'));
 
-  const util = require('util');
+  const util = require('node:util');
   const logFile = path.join(app.getPath('userData'), 'app.log');
   const maxLogBytes = 131072;
 
@@ -390,7 +389,7 @@ function initialize(crashHandler) {
     });
   }
 
-  const os = require('os');
+  const os = require('node:os');
   const cpus = os.cpus();
 
   ipcMain.on('get-cpu-model', e => {
@@ -846,7 +845,7 @@ function initialize(crashHandler) {
     // バックグラウンドで起動時のクリーンアップ処理を実行（非ブロッキング）
     setTimeout(() => {
       // DevTools Extensions削除
-      rimrafWithRetry(path.join(app.getPath('userData'), 'DevTools Extensions'));
+      removePathWithRetry(path.join(app.getPath('userData'), 'DevTools Extensions'));
 
       // ログファイル切り詰め
       if (fs.existsSync(logFile) && fs.statSync(logFile).size > maxLogBytes) {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "obs-studio-node": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz",
     "protobufjs": "^7.5.3",
     "reflect-metadata": "~0.2.2",
-    "rimraf": "~6.1.2",
     "rxjs": "^7.8.1",
     "semver": "^7.5.4",
     "socket.io": "4.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       reflect-metadata:
         specifier: ~0.2.2
         version: 0.2.2
-      rimraf:
-        specifier: ~6.1.2
-        version: 6.1.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -4152,10 +4149,6 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
-  glob@13.0.0:
-    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
-    engines: {node: 20 || >=22}
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -5126,10 +5119,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.4:
-    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
-    engines: {node: 20 || >=22}
-
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -5706,10 +5695,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
-
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
@@ -6204,11 +6189,6 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@6.1.2:
-    resolution: {integrity: sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==}
-    engines: {node: 20 || >=22}
     hasBin: true
 
   roarr@2.15.4:
@@ -12174,12 +12154,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@13.0.0:
-    dependencies:
-      minimatch: 10.1.1
-      minipass: 7.1.2
-      path-scurry: 2.0.1
-
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -13345,8 +13319,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.4: {}
-
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -13905,11 +13877,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-scurry@2.0.1:
-    dependencies:
-      lru-cache: 11.2.4
-      minipass: 7.1.2
-
   path-to-regexp@0.1.12: {}
 
   path-type@3.0.0:
@@ -14385,11 +14352,6 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
-
-  rimraf@6.1.2:
-    dependencies:
-      glob: 13.0.0
-      package-json-from-dist: 1.0.1
 
   roarr@2.15.4:
     dependencies:

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -26,7 +26,7 @@ class Application {
   client: WebdriverIO.Browser;
   process: ChildProcess.ChildProcess;
 
-  constructor(public options: RemoteOptions) {}
+  constructor(public options: RemoteOptions) { }
 
   async start(cacheDir: string, chromedriverLogging = false) {
     if (this.process) return;
@@ -88,14 +88,13 @@ class Application {
     try {
       const result = await fetch(statusUrl);
       return result.status === 200;
-    } catch (e: unknown) {}
+    } catch (e: unknown) { }
   }
 }
 
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const { rimraf } = require('rimraf');
 
 const afterStartCallbacks: ((t: TExecutionContext) => any)[] = [];
 export function afterAppStart(cb: (t: TExecutionContext) => any) {
@@ -279,13 +278,25 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     await killElectronInstances();
 
     // Wait for crash-handler-process.exe to exit before attempting cleanup
-    // This ensures crash-handler.log is closed before rimraf attempts deletion
+    // This ensures crash-handler.log is closed before fs.rmSync attempts deletion
     await waitForCrashHandlerExit();
 
     appIsRunning = false;
 
     if (!clearCache) return;
-    await rimraf(lastCacheDir, { maxRetries: 30, retryDelay: 100 });
+
+    // Retry logic for cleanup to handle locked files
+    const maxRetries = 30;
+    const retryDelay = 100;
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        fs.rmSync(lastCacheDir, { recursive: true, force: true });
+        break;
+      } catch (e) {
+        if (i === maxRetries - 1) throw e;
+        await sleep(retryDelay);
+      }
+    }
   };
 
   test.beforeEach(async t => {

--- a/test/screentest/runner.js
+++ b/test/screentest/runner.js
@@ -1,6 +1,5 @@
-const { rimrafSync } = require('rimraf');
 const { execSync } = require('child_process');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const CONFIG = JSON.parse(fs.readFileSync('test/screentest/config.json'));
 
@@ -10,7 +9,7 @@ const returnCode = (function main() {
   log('use branches', branches);
 
   const dir = CONFIG.dist;
-  rimrafSync(dir);
+  fs.rmSync(dir, { recursive: true, force: true });
 
   // create dir
   let currentPath = '';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,7 +153,6 @@ module.exports = function (env, argv) {
         'aws-sdk': 'require("aws-sdk")',
         asar: 'require("asar")',
         'node-fontinfo': 'require("node-fontinfo")',
-        rimraf: 'require("rimraf")',
 
         'utf-8-validate': 'require("utf-8-validate")',
         bufferutil: 'require("bufferutil")',


### PR DESCRIPTION
## 概要
外部依存のrimrafパッケージを削除し、Node.js標準のfs.rmSyncに移行しました。

## 変更内容
- rimrafSyncのみ使用していたため、標準APIで十分対応可能
- 全てのrimrafSync呼び出しをfs.rmSync({recursive: true, force: true})に置換
- リトライロジックをremovePathWithRetry関数として実装

## メリット
- rimraf削除により以下の依存関係も削減:
  - glob@13.0.0, lru-cache@11.2.4, path-scurry@2.0.1
- パッケージサイズの削減
- メンテナンス性の向上