### PR TITLE
開発: uuid パッケージ削除後に残っていた参照を修正

### DIFF
--- a/app/components/shared/Display.vue.ts
+++ b/app/components/shared/Display.vue.ts
@@ -1,5 +1,5 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { Inject } from 'services/core/injector';
+import { uuidv4 } from 'services/utils';
 import { Display as OBSDisplay, VideoService } from 'services/video';
 import { WindowsService } from 'services/windows';
 import Vue from 'vue';

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -1,5 +1,5 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { cloneDeep } from 'lodash';
+import { uuidv4 } from 'services/utils';
 import { getKeys } from 'util/getKeys';
 import Vue from 'vue';
 import { Prop } from 'vue-property-decorator';

--- a/app/components/shared/inputs/ValidatedForm.vue.ts
+++ b/app/components/shared/inputs/ValidatedForm.vue.ts
@@ -1,5 +1,5 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { Subject } from 'rxjs';
+import { uuidv4 } from 'services/utils';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 // @ts-expect-error

--- a/app/services/api/jsonrpc/jsonrpc.ts
+++ b/app/services/api/jsonrpc/jsonrpc.ts
@@ -1,5 +1,5 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { Service } from 'services/core/service';
+import { uuidv4 } from 'services/utils';
 import {
   E_JSON_RPC_ERROR,
   IJsonRpcEvent,

--- a/app/services/api/rpc-api.ts
+++ b/app/services/api/rpc-api.ts
@@ -1,4 +1,3 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import 'reflect-metadata';
 import { Observable, Subject, Subscription } from 'rxjs';
 import {
@@ -9,6 +8,7 @@ import {
   IMutation,
   JsonrpcService,
 } from 'services/api/jsonrpc';
+import { uuidv4 } from 'services/utils';
 import traverse from 'traverse';
 import { ServicesManager } from '../../services-manager';
 import { Service } from '../core/service';

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -1,5 +1,4 @@
 import * as remote from '@electron/remote';
-import { randomUUID as uuidv4 } from 'node:crypto';
 import electron from 'electron';
 import { Subscription } from 'rxjs';
 import { IpcServerService } from 'services/api/ipc-server';
@@ -24,7 +23,7 @@ import { TranscriptionService } from 'services/transcription/transcription';
 import { TransitionsService } from 'services/transitions';
 import { track } from 'services/usage-statistics';
 import { UserService } from 'services/user';
-import Utils from 'services/utils';
+import Utils, { uuidv4 } from 'services/utils';
 import { VideoService } from 'services/video';
 import { WindowsService } from 'services/windows';
 import { sleep } from 'util/sleep';

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -5,7 +5,6 @@ import {
   IObsNumberInputValue,
   TObsFormData,
 } from 'components/obs/inputs/ObsInput';
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { omit } from 'lodash';
 import { merge, Subject, Subscription } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
@@ -13,7 +12,7 @@ import { InitAfter, Inject, mutation, ServiceHelper, StatefulService } from 'ser
 import { $t } from 'services/i18n';
 import { ScenesService } from 'services/scenes';
 import { isNoAudioPropertiesManagerType, ISource, Source, SourcesService } from 'services/sources';
-import Utils from 'services/utils';
+import Utils, { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
 import Vue from 'vue';

--- a/app/services/nicolive-program/httpRelation.ts
+++ b/app/services/nicolive-program/httpRelation.ts
@@ -1,4 +1,4 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
+import { uuidv4 } from 'services/utils';
 import { ChatMessageType } from './ChatMessage/classifier';
 import { getDisplayText } from './ChatMessage/displaytext';
 import { sendLogGif } from './nicolive-logger';

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -16,6 +16,7 @@ import { SettingsService } from 'services/settings';
 import { SourcesService } from 'services/sources';
 import { TransitionsService } from 'services/transitions';
 import { UserService } from 'services/user';
+import { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import {
   ISceneCollectionCreateOptions,
@@ -34,8 +35,6 @@ import { ISourceInfo, SourcesNode } from './nodes/sources';
 import { TransitionsNode } from './nodes/transitions';
 import { parse } from './parse';
 import { SceneCollectionsStateService, ScenePresetId } from './state';
-
-const { v4: uuidv4 } = window['require']('uuid');
 
 export const NODE_TYPES = {
   RootNode,

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -1,4 +1,3 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import * as fs from 'fs';
 import { uniqBy } from 'lodash';
 import { filter } from 'rxjs/operators';
@@ -8,7 +7,7 @@ import { TSceneNodeInfo } from 'services/scene-collections/nodes/scene-items';
 import { Selection, SelectionService, TNodesList } from 'services/selection';
 import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
 import { Source, SourcesService, TSourceType } from 'services/sources';
-import Utils from 'services/utils';
+import Utils, { uuidv4 } from 'services/utils';
 import { assertIsDefined } from 'util/properties-type-guards';
 import * as obs from '../../../obs-api';
 import {

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -1,4 +1,3 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { without } from 'lodash';
 import { Subject } from 'rxjs';
 import { InitAfter } from 'services/core';
@@ -8,6 +7,7 @@ import { $t } from 'services/i18n';
 import { TDisplayType } from 'services/settings-v2/video';
 import { ISource, ISourceAddOptions, SourcesService } from 'services/sources';
 import { TransitionsService } from 'services/transitions';
+import { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import namingHelpers from 'util/NamingHelpers';
 import Vue from 'vue';

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/vue';
 import { TObsValue } from 'components/obs/inputs/ObsInput';
-import { randomUUID as uuidv4 } from 'node:crypto';
 import * as fs from 'fs';
 import cloneDeep from 'lodash/cloneDeep';
 import { Subject } from 'rxjs';
@@ -12,6 +11,7 @@ import { IPCWrapper } from 'services/ipc-wrapper';
 import { NVoiceCharacterTypes } from 'services/nvoice-character';
 import { ISceneItem, ScenesService } from 'services/scenes';
 import { UserService } from 'services/user';
+import { uuidv4 } from 'services/utils';
 import { IWindowOptions, WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
 import namingHelpers from 'util/NamingHelpers';

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -1,5 +1,4 @@
 import { IObsListOption, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { Subject } from 'rxjs';
 import { Inject } from 'services/core/injector';
 import { mutation, StatefulService } from 'services/core/stateful-service';
@@ -7,6 +6,7 @@ import { $t } from 'services/i18n';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { ScenesService } from 'services/scenes';
 import { DefaultManager } from 'services/sources/properties-managers/default-manager';
+import { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
 import * as obs from '../../obs-api';

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,6 +1,5 @@
 import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { ipcRenderer } from 'electron';
 import { merge, Observable, Subject } from 'rxjs';
 import { AppService } from 'services/app';
@@ -9,6 +8,7 @@ import { PersistentStatefulService } from 'services/core/persistent-stateful-ser
 import { mutation } from 'services/core/stateful-service';
 import { IncrementalRolloutService } from 'services/incremental-rollout';
 import { SceneCollectionsService } from 'services/scene-collections';
+import { uuidv4 } from 'services/utils';
 import URI from 'urijs';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import { FakeUserAuth, isFakeMode } from 'util/fakeMode';

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -1,7 +1,12 @@
 import * as remote from '@electron/remote';
 import { isEqual } from 'lodash';
+import { randomUUID } from 'node:crypto';
 import URI from 'urijs';
 import { getKeys } from 'util/getKeys';
+
+export function uuidv4(): string {
+  return randomUUID();
+}
 
 export const enum EBit {
   ZERO,

--- a/app/services/uuid.ts
+++ b/app/services/uuid.ts
@@ -1,4 +1,4 @@
-import { randomUUID as uuidv4 } from 'node:crypto';
+import { uuidv4 } from 'services/utils';
 import { StatefulService } from './core/stateful-service';
 
 interface IUuidServiceState { }
@@ -18,10 +18,6 @@ export class UuidService extends StatefulService<IUuidServiceState> {
     return this._uuid;
   }
 
-  private generateUuid(): string {
-    return uuidv4();
-  }
-
   private getUuid(): string {
     // もし uuid が生成済みで保存されていたらそれを返す
     const storageUuid = localStorage.getItem(this.localStorageKey);
@@ -29,7 +25,7 @@ export class UuidService extends StatefulService<IUuidServiceState> {
       return storageUuid;
     }
     // 無ければ生成して保存してから返す
-    const uuid = this.generateUuid();
+    const uuid = uuidv4();
     localStorage.setItem(this.localStorageKey, uuid);
     return uuid;
   }

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -34,12 +34,11 @@ import UserInfo from 'components/windows/UserInfo.vue';
 import electron from 'electron';
 import { Subject } from 'rxjs';
 import { mutation, StatefulService } from 'services/core/stateful-service';
-import Util from 'services/utils';
+import Util, { uuidv4 } from 'services/utils';
 import Vue from 'vue';
 
 const { ipcRenderer } = electron;
 const BrowserWindow = remote.BrowserWindow;
-const { v4: uuidv4 } = window['require']('uuid');
 
 // This is a list of components that are registered to be
 // top level components in new child windows.

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,4 @@ module.exports = {
     },
   },
   testMatch: ['**/app/**/*.test.ts'],
-  moduleNameMapper: {
-    '^uuid$': require.resolve('uuid'),
-  },
 };


### PR DESCRIPTION
## 概要

package.json から uuid パッケージを削除した後も、コード内に `window['require']('uuid')` の参照が残っていました。
これを Node.js 組み込みの crypto.randomUUID() に統一して修正しました。

## 問題

- `const { v4: uuidv4 } = window['require']('uuid');` がコード内に残っていた
- package.json から uuid パッケージは既に削除されていたため実行時に問題

## 変更内容

- services/utils に uuidv4() 関数を追加して UUID 生成を一元管理
- 15個のサービスファイル + 3個のコンポーネントで `randomUUID as uuidv4` からのインポートを `services/utils` に統一
- jest.config.js から uuid のモジュールマッピングを削除

## 影響範囲

- レンダラープロセス: services/utils の uuidv4() 経由で crypto.randomUUID() を使用
- メインプロセス (main.js): 既に crypto.randomUUID() を直接使用しており変更なし
- 既存の動作に影響なし（内部実装の変更のみ）

## 動作確認

- [x] ビルドが通ることを確認 (pnpm compile)
- [x] アプリケーションが正常に起動することを確認