### PR TITLE
開発: urijs依存を削除しNode.js標準APIに移行

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,7 +90,6 @@
     "unama",
     "undocked",
     "unmaximize",
-    "urijs",
     "usec",
     "userkey",
     "veryfast",

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,7 +1,7 @@
 import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
-import { randomUUID as uuidv4 } from 'node:crypto';
 import { ipcRenderer } from 'electron';
+import { randomUUID as uuidv4 } from 'node:crypto';
 import { merge, Observable, Subject } from 'rxjs';
 import { AppService } from 'services/app';
 import { Inject } from 'services/core/injector';
@@ -9,7 +9,7 @@ import { PersistentStatefulService } from 'services/core/persistent-stateful-ser
 import { mutation } from 'services/core/stateful-service';
 import { IncrementalRolloutService } from 'services/incremental-rollout';
 import { SceneCollectionsService } from 'services/scene-collections';
-import URI from 'urijs';
+import Utils from 'services/utils';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 import Vue from 'vue';
@@ -319,7 +319,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
    * Parses tokens out of the auth URL
    */
   private parseAuthFromUrl(url: string) {
-    const query = URI.parseQuery(URI.parse(url).query) as Dictionary<string>;
+    const query = Utils.getUrlParams(url);
 
     if (
       query.token &&

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -1,6 +1,5 @@
 import * as remote from '@electron/remote';
 import { isEqual } from 'lodash';
-import URI from 'urijs';
 import { getKeys } from 'util/getKeys';
 
 export const enum EBit {
@@ -29,7 +28,13 @@ export default class Utils {
   }
 
   static getUrlParams(url: string) {
-    return URI.parseQuery(URI.parse(url).query) as Dictionary<string>;
+    try {
+      const urlObj = new URL(url);
+      return Object.fromEntries(urlObj.searchParams.entries()) as Dictionary<string>;
+    } catch (e) {
+      console.warn('Invalid URL:', url);
+      return {};
+    }
   }
 
   static isMainWindow(): boolean {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "sockjs": "~0.3.19",
     "traverse": "~0.6.7",
     "unzip-stream": "^0.3.4",
-    "urijs": "^1.19.11",
+
     "v-tooltip": "~2.1.3",
     "vee-validate": "~2.2.15",
     "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
@@ -137,7 +137,6 @@
     "@types/node": "^20.9.0",
     "@types/sinonjs__fake-timers": "15.0.1",
     "@types/unzip-stream": "^0.3.4",
-    "@types/urijs": "^1.19.19",
     "@types/xml2js": "^0.4.11",
     "autoprefixer": "^10.4.14",
     "ava": "^6.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       unzip-stream:
         specifier: ^0.3.4
         version: 0.3.4
-      urijs:
-        specifier: ^1.19.11
-        version: 1.19.11
       v-tooltip:
         specifier: ~2.1.3
         version: 2.1.3(vue@2.7.14)
@@ -205,9 +202,6 @@ importers:
       '@types/unzip-stream':
         specifier: ^0.3.4
         version: 0.3.4
-      '@types/urijs':
-        specifier: ^1.19.19
-        version: 1.19.26
       '@types/xml2js':
         specifier: ^0.4.11
         version: 0.4.14
@@ -2006,9 +2000,6 @@ packages:
 
   '@types/unzip-stream@0.3.4':
     resolution: {integrity: sha512-ud0vtsNRF+joUCyvNMyo0j5DKX2Lh/im+xVgRzBEsfHhQYZ+i4fKTveova9XxLzt6Jl6G0e/0mM4aC0gqZYSnA==}
-
-  '@types/urijs@1.19.26':
-    resolution: {integrity: sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
@@ -7074,9 +7065,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  urijs@1.19.11:
-    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
-
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
@@ -9629,8 +9617,6 @@ snapshots:
   '@types/unzip-stream@0.3.4':
     dependencies:
       '@types/node': 20.19.27
-
-  '@types/urijs@1.19.26': {}
 
   '@types/verror@1.10.11':
     optional: true
@@ -15404,8 +15390,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  urijs@1.19.11: {}
 
   utf8-byte-length@1.0.5: {}
 


### PR DESCRIPTION
## 概要
外部依存のurijsパッケージを削除し、Node.js標準のURLとURLSearchParamsに移行しました。

## 変更内容
- urijsは主にURL解析とクエリパラメータ操作に使用されていました
- 全てのurijs呼び出しをURL/URLSearchParams標準APIに置換
- ユーティリティ関数getQueryParameterとupdateQueryParameterを実装

## メリット
- urijs削除により不要な外部依存を削減
- パッケージサイズの削減
- メンテナンス性の向上