### PR TITLE
開発: pnpm を 10.28.1 から 10.28.2 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "webpack-dev-server": "^5.1.0",
     "webpack-merge": "^6.0.1"
   },
-  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "engines": {
     "node": ">=22.0.0",
     "npm": "please-use-pnpm",


### PR DESCRIPTION
## このpull requestが解決する内容
pnpm をパッチバージョンアップ（10.28.1 → 10.28.2）します。

## 背景
pnpm 10.28.2 には2件のセキュリティ修正とバグフィックスが含まれており、10.28.1からの更新が推奨されます。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| pnpm | 10.28.1 | 10.28.2 | パッチバージョンアップ |

### ファイル変更
- `package.json`: packageManager フィールドを更新

### 開発環境での対応
このPRをpull後、以下のいずれかの方法でpnpmバージョンを更新してください：

**推奨: Corepackによる自動更新**
```bash
corepack install
```

**または、pnpmコマンド実行時に自動更新**
- Corepackが有効な環境では、`pnpm`コマンド実行時に`package.json`の`packageManager`フィールドを参照し、自動的に10.28.2を使用します
- 初回実行時にダウンロードが発生する場合があります

### 主な改善点

#### セキュリティ修正（2件）
1. **`directories.bin`でのパストラバーサル防止**
   - `directories.bin`フィールド設定を通じたパストラバーサル攻撃を防ぐ脆弱性を修正

2. **file/git依存関係のシンボリックリンク検証**
   - `file:`または`git:`依存関係をインストールする際、シンボリックリンクを検証
   - パッケージルート外へのシンボリックリンクをスキップし、`/etc/passwd`やSSH鍵などの機密ファイルが`node_modules`に漏洩するのを防止
   - 注: レジストリパッケージは公開時にシンボリックリンクが削除されるため、file/git依存関係にのみ適用

#### バグフィックス
- **オプショナル依存関係のメタデータ解決**
  - オプショナル依存関係がレジストリから完全なメタデータを要求していなかった問題を修正
  - プラットフォーム互換性評価に必要な`libc`フィールドを正しく取得するように修正（[#9950](https://github.com/pnpm/pnpm/issues/9950)）

### 互換性
- **ブレイキングチェンジなし**: パッチバージョンアップのため破壊的変更はありません
- Node.js 22.x との互換性に問題なし

## 影響範囲
- パッケージマネージャーのみ（依存関係の解決とインストール動作）
- セキュリティ修正により、より安全な依存関係の取り扱いが可能になります

## 検証
- ✅ `pnpm install` 成功
- ✅ `pnpm run compile:ci` 成功
- ✅ `pnpm run test:unit:app` 全テストパス (41 suites, 646 tests passed)

## 参考情報
- [pnpm 10.28.2 リリースノート](https://github.com/pnpm/pnpm/releases/tag/v10.28.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)