### PR TITLE
修正: 音声デバイス設定の選択値が反映されない問題を修正

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -668,17 +668,28 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * Creates the default audio sources
    */
   private setupDefaultAudio() {
+    // 実際には以下のようにデバイス一覧を取得してからデフォルトデバイスを探すべきですが、
+    // 既存が強制だったのでそのままの形にしておきます
+    // 参考:
+    // const audioDevices = this.audioService.getDevices();
+    // // デフォルトの出力デバイスがあれば作成
+    // const defaultOutput = audioDevices.find(device => device.type === 'output' && device.id === 'default');
+    // if (defaultOutput) {...}
+    // // デフォルトの入力デバイスがあれば作成
+    // const defaultInput = audioDevices.find(device => device.type === 'input' && device.id === 'default');
+    // if (defaultInput) {...}
+
     this.sourcesService.createSource(
       $t('sources.desktopAudio'),
       'wasapi_output_capture',
-      {},
+      { device_id: 'default' },
       { channel: E_AUDIO_CHANNELS.OUTPUT_1 },
     );
 
     this.sourcesService.createSource(
       $t('sources.micAux'),
       'wasapi_input_capture',
-      {},
+      { device_id: 'default' },
       { channel: E_AUDIO_CHANNELS.INPUT_1 },
     );
   }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -808,7 +808,7 @@ export class SettingsService
           this.sourcesService.createSource(
             displayName,
             isOutput ? 'wasapi_output_capture' : 'wasapi_input_capture',
-            {},
+            { device_id: deviceForm.value },
             { channel },
           );
         } else {


### PR DESCRIPTION
## 修正内容

音声設定でマイク・デスクトップ音声のデバイスを変更しても、設定が保存されずに表示が反映されない問題を修正しました。

### 問題
- 設定画面で音声デバイス（マイク/デスクトップ音声）を「無効」から「既定」などに変更しても、保存後も画面上は「無効」のままになっていた
- 初期起動時に利用可能なデバイスが存在するにもかかわらず「無効」と表示されていた

### 原因
- ソース作成時に device_id を設定していなかったため、実際にはデバイスの状態が更新されない時があった
- 初期セットアップ時も空の settings で音声ソースを作成していた

### 修正
- setAudioSettings() でソース新規作成時(無効から有効にした場合)に、選択されたデバイスの ID を正しく device_id として設定するよう修正
- setupDefaultAudio() で初期セットアップ時にデフォルトデバイスで音声ソースを作成するよう修正