### PR TITLE
開発: cross-env を 7.0.3 から 10.1.0 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "sockjs": "~0.3.19",
     "traverse": "~0.6.7",
     "unzip-stream": "^0.3.4",
-
     "v-tooltip": "~2.1.3",
     "vee-validate": "~2.2.15",
     "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
@@ -140,7 +139,7 @@
     "autoprefixer": "^10.4.14",
     "ava": "^6.4.1",
     "babel-loader": "~10.0.0",
-    "cross-env": "~7.0.3",
+    "cross-env": "~10.1.0",
     "css-loader": "^7.1.2",
     "electron": "29.3.3",
     "electron-builder": "26.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
         specifier: ~10.0.0
         version: 10.0.0(@babel/core@7.28.6)(webpack@5.104.1)
       cross-env:
-        specifier: ~7.0.3
-        version: 7.0.3
+        specifier: ~10.1.0
+        version: 10.1.0
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(webpack@5.104.1)
@@ -1128,6 +1128,9 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -3165,9 +3168,9 @@ packages:
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
-  cross-env@7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   cross-fetch@3.1.5:
@@ -5078,9 +5081,6 @@ packages:
 
   lodash.zip@4.2.0:
     resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -8459,6 +8459,8 @@ snapshots:
       - supports-color
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -10959,8 +10961,9 @@ snapshots:
   cross-dirname@0.1.0:
     optional: true
 
-  cross-env@7.0.3:
+  cross-env@10.1.0:
     dependencies:
+      '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
 
   cross-fetch@3.1.5(encoding@0.1.13):
@@ -11348,7 +11351,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -13277,8 +13280,6 @@ snapshots:
   lodash.union@4.6.0: {}
 
   lodash.zip@4.2.0: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.17.23: {}
 
@@ -15422,7 +15423,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.7.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## このpull requestが解決する内容
cross-env をメジャーバージョンアップ（7.0.3 → 10.1.0）します。

## 背景
cross-env 7.x は古く、v10.0.0 で ESM への完全移行と Node.js 20+ のサポートが追加されています。このプロジェクトは Node.js 22.x を使用しているため、最新版への更新が適切です。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| cross-env | 7.0.3 | 10.1.0 | メジャーバージョンアップ |

### ファイル変更
- `package.json`: devDependencies の cross-env を更新
- `pnpm-lock.yaml`: 依存関係を更新

### Breaking Changes の影響分析

#### v10.0.0 の主な変更
- CommonJS から ESM-only に変更
  - 影響なし（CLI として使用しているため透過的）
- Node.js >=20 が必須
  - 影響なし（このプロジェクトは Node.js 22.x を使用）
- TypeScript への完全移行
  - 影響なし（利用側の変更は不要）

**結論**: このプロジェクトでは `dev:start` と `start:unstable` スクリプトで cross-env を CLI として使用しているため、すべて互換性あり

### 主な改善点
- ESM サポートによる現代的なモジュール形式
- TypeScript による型安全性の向上
- Node.js 20+ での最適化
- 3年分のバグフィックスとパフォーマンス改善

## 影響範囲
- 開発環境のみ（cross-env は開発時の環境変数設定ツール）
- CLI として使用しているため、コード変更は不要

## テスト
- [x] `pnpm exec cross-env NODE_ENV=test echo "test"` で動作確認済み

## 補足
- cross-env はクロスプラットフォームで環境変数を設定するための開発ツールです
- package.json の scripts でのみ使用されており、アプリケーションコードからは参照されていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)