### PR TITLE
開発: browserslist を Chrome 122 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "browserslist": [
-    "chrome >= 76"
+    "chrome >= 122"
   ],
   "ava": {
     "files": [


### PR DESCRIPTION
## 概要
Electron 29.3.3 が Chrome 122 を使用しているため、
browserslist を chrome >= 76 から chrome >= 122 に更新します。

## 変更内容
- package.json の browserslist を更新
- Autoprefixer が不要な -webkit- プリフィックスを削除

## 技術的背景
- **Babel**: .babelrc で Electron 29.3 をターゲットに指定しているため、JavaScript トランスパイルに browserslist は影響しない
- **CSS のみ**: Autoprefixer が browserslist を参照するため、CSS 出力のプリフィックス削減のみが対象

## 影響
- CSS 出力サイズが若干削減（2つの -webkit-appearance ルール削除）
- **JavaScript 出力への影響なし**（Babel は Electron 29.3 をベースに動作）
- ユーザー機能への影響なし

## 検証
実際の webpack ビルドで以下を確認：
- renderer.js の -webkit- プリフィックスが 283 → 281 に削減
- vendors~renderer.js（JS のみ）は変更なし
- Chrome 122 で問題なく動作