### PR TITLE
開発: ビルドスクリプトの承認設定を onlyBuiltDependencies に移行

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -7,11 +7,6 @@ git-shallow-hosts=github.com
 node-linker=hoisted
 shamefully-hoist=true
 
-# ビルドスクリプトの承認
-# pnpm v10のセキュリティ機能で、postinstall等のスクリプト実行を制限
-# 開発環境では信頼できるパッケージのみなので承認チェックをスキップ
-enable-pre-post-scripts=true
-
 # パッケージリリース後の安全期間
 # 新規リリースから7日間（10080分）経過するまでインストールを待機
 # セキュリティリスク軽減のため

--- a/package.json
+++ b/package.json
@@ -197,6 +197,16 @@
     "yarn": "please-use-pnpm"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@sentry/cli",
+      "electron",
+      "electron-chromedriver",
+      "electron-winstaller",
+      "husky",
+      "less",
+      "protobufjs",
+      "vue-popperjs"
+    ],
     "overrides": {
       "nth-check": "^2.0.1",
       "tar-fs": "^2.1.4"


### PR DESCRIPTION
## このpull requestが解決する内容
pnpm v10.1.0 以降のビルドスクリプト承認機能に対応し、CI で表示されていた警告を解消します。

## 背景
PR #1130 で less を 4.5.1 に更新した際、CI で以下の警告が表示されるようになりました：

```
Ignored build scripts: less@4.5.1.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm v10.1.0 以降、セキュリティ強化のためビルドスクリプトの実行には明示的な承認が必要になりました。

### なぜ less だけ警告が出たのか

- **electron などの主要パッケージ**: pnpm の compatibility database（互換性データベース）に含まれており、デフォルトで承認済み
- **less@4.5.1**: 新しいバージョンのため compatibility database に未登録で、承認が必要

従来の `.npmrc` の `enable-pre-post-scripts=true` は全てのスクリプトを無条件で実行する設定でしたが、pnpm v10.1.0 以降は非推奨となり、`package.json` の `pnpm.onlyBuiltDependencies` でパッケージ単位で管理する方式に移行しています。

### 参考リンク

- [pnpm approve-builds コマンド](https://pnpm.io/cli/approve-builds)
- [Supply chain security (公式ブログ)](https://pnpm.io/blog/2025/01/05/supply-chain-security)
- [package.json の pnpm 設定](https://pnpm.io/package_json#pnpm)

## 変更内容

### package.json
```json
{
  "pnpm": {
    "onlyBuiltDependencies": [
      "@sentry/cli",
      "electron",
      "electron-chromedriver",
      "electron-winstaller",
      "husky",
      "less",
      "protobufjs",
      "vue-popperjs"
    ]
  }
}
```

このプロジェクトで postinstall スクリプトを持つ全てのパッケージを明示的に承認リストに追加しました。

### .npmrc
- `enable-pre-post-scripts=true` を削除
  - pnpm v10.1.0 以降は `onlyBuiltDependencies` で管理するため不要
  - 非推奨設定のため削除

### 承認されたパッケージの postinstall スクリプト

| パッケージ | postinstall の内容 | 必要性 |
|-----------|------------------|--------|
| @sentry/cli | CLI バイナリのダウンロード | Sentry 連携に必要 |
| electron | Electron バイナリのダウンロード | アプリケーション実行に必須 |
| electron-chromedriver | ChromeDriver のダウンロード | E2E テストに必要 |
| electron-winstaller | Windows インストーラー作成ツール | パッケージングに必要 |
| husky | Git hooks のセットアップ | pre-commit hooks に必要 |
| less | Playwright のインストール（開発環境のみ） | 実際には実行されないが承認 |
| protobufjs | CLI ツールのビルド | protobuf 処理に必要 |
| vue-popperjs | Popper.js のビルド | ツールチップ表示に必要 |

## onlyBuiltDependencies の動作

`onlyBuiltDependencies` は**ホワイトリスト**として機能：
- リストに含まれるパッケージ → postinstall 実行
- リストに含まれないパッケージ → postinstall 無視
- 空配列 `[]` → 全てのパッケージを無視

従来の `enable-pre-post-scripts=true` は全てのパッケージを無条件で許可していましたが、`onlyBuiltDependencies` により明示的な承認リストで管理できるようになり、セキュリティが向上しました。

## enable-pre-post-scripts との関係

検証の結果、以下のことが判明しました：

1. **`enable-pre-post-scripts=true` があっても、pnpm v10.1.0 以降は `onlyBuiltDependencies` による承認が優先される**
2. **`onlyBuiltDependencies` を指定すれば、`enable-pre-post-scripts` は不要**
3. **compatibility database に含まれるパッケージ（electron など）も、`onlyBuiltDependencies` を指定した場合は明示的にリストに追加する必要がある**

つまり、`onlyBuiltDependencies` を指定すると完全にホワイトリスト方式になります。

## 影響範囲
- ローカル開発環境と CI 環境の両方で警告が解消
- 承認されたパッケージのみビルドスクリプトが実行される
- セキュリティが向上（悪意のあるパッケージの postinstall を防止）
- 既存の動作に変更なし（全ての必要なスクリプトは実行される）

## テスト
- [x] ローカル: クリーンインストールで全パッケージの postinstall が正常に実行されることを確認
  - electron のバイナリがダウンロードされた
  - obs-studio-node の postinstall が実行された（このプロジェクト独自の postinstall）
  - 警告が表示されない
- [x] CI: キャッシュをクリアして再実行し、警告が表示されないことを確認
  - GitHub Actions の pnpm-store と node_modules のキャッシュを削除
  - ワークフローを再実行して実際に `pnpm install` を実行
  - setup(app) のログで "Ignored build scripts" 警告が出ないことを確認
  - less と obs-studio-node の postinstall が正常に実行されたことを確認

## 補足
- pnpm v10.1.0 の新機能のため、既存の CI/CD 環境でも互換性あり
- `enable-pre-post-scripts` は非推奨だが後方互換性のため動作していた
- `onlyBuiltDependencies` による明示的な管理が推奨される方式
- less の postinstall は開発環境でのみ Playwright をインストールするため、このプロジェクトでは実際には何も実行されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)