### PR TITLE
開発: リリーススクリプトのSlack投稿エラーを修正

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -77,25 +77,18 @@ async function postReleaseToSlack({ version, environment, channel, link, notes }
         },
       },
       {
-        type: 'section',
+        type: 'header',
         text: {
-          type: 'mrkdwn',
+          type: 'plain_text',
           text: 'Patch Note',
         },
       },
-    ],
-    attachments: [
       {
-        color: '#36a64f',
-        blocks: [
-          {
-            type: 'section',
-            text: {
-              type: 'plain_text',
-              text: notes,
-            },
-          },
-        ],
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: notes,
+        },
       },
     ],
   });


### PR DESCRIPTION
## このpull requestが解決する内容
`pnpm release` 実行時にGitHubリリースは成功するものの、最後のSlack投稿で400 Bad Requestエラーが発生する問題を修正します。

## 背景
リリーススクリプト実行時に以下のエラーが発生していました:
```
ERROR: Error: failed to post to slack: 400 Bad Request
```

調査の結果、`postReleaseToSlack()` 関数のSlack Block Kit構造に問題があることが判明しました。具体的には、`attachments` 内で `blocks` を使用する構造がSlackの現在の仕様では非推奨となっており、400エラーの原因となっていました。

## 変更内容

### ファイル変更
- `bin/release/mini-release.js:62-95` - `postReleaseToSlack()` 関数の構造を変更

### 主な修正内容
1. **`attachments` の削除**: 非推奨の `attachments` 内の `blocks` 構造を完全に削除
2. **`header` タイプの使用**: 「Patch Note」見出しに適切な `header` タイプを使用
3. **パッチノート内容の表示**: `notes` を `mrkdwn` タイプの `section` で表示し、Markdown形式でレンダリング

### 修正前の構造（問題あり）
```javascript
blocks: [
  { type: 'section', ... },  // Released
  { type: 'section', ... },  // バージョン情報
  { type: 'section', text: { type: 'mrkdwn', text: 'Patch Note' } }
],
attachments: [
  {
    color: '#36a64f',
    blocks: [  // ← 非推奨の構造
      { type: 'section', text: { type: 'plain_text', text: notes } }
    ]
  }
]
```

### 修正後の構造（現代的）
```javascript
blocks: [
  { type: 'section', ... },  // Released
  { type: 'section', ... },  // バージョン情報
  { type: 'header', text: { type: 'plain_text', text: 'Patch Note' } },
  { type: 'section', text: { type: 'mrkdwn', text: notes } }
]
```

## 影響範囲
- リリーススクリプト実行時のSlack通知のみに影響
- アプリケーション本体の動作には影響なし
- Slack Block Kitの現代的な仕様に準拠した形式に変更

## テスト
- [x] `SLACK_TEST = true` に設定してSlack投稿のテストを実施
- [x] 実際のリリース時にSlack投稿が正常に完了することを確認

## 補足
- `bin/release/mini-release.js:28` の `SLACK_TEST` フラグを `true` に設定することで、実際のリリースプロセスを実行せずにSlack投稿機能のみをテストできます

🤖 Generated with [Claude Code](https://claude.com/claude-code)