### PR TITLE
修正: Visual C++ Redistributableのダウンロードリンクを更新

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -39,7 +39,7 @@ LangString failed_download 1041 "警告: Microsoft から最新の Visual C++ �
   
   ; vc_redistのインストール処理
   DetailPrint "Visual C++ Redistributable not found. Downloading and installing..."
-  NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  
+  NSISdl::download https://aka.ms/vc14/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  
 
   ${If} ${FileExists} `$INSTDIR\vc_redist.x64.exe`
     ExecWait '$INSTDIR\vc_redist.x64.exe /passive /norestart' $1

--- a/main.js
+++ b/main.js
@@ -111,11 +111,11 @@ async function showRequiredSystemComponentInstallGuideDialog() {
   });
   switch (result.response) {
     case 0:
-      await shell.openExternal('https://aka.ms/vs/17/release/vc_redist.x64.exe');
+      await shell.openExternal('https://aka.ms/vc14/vc_redist.x64.exe');
       break;
     case 1:
       await shell.openExternal(
-        'https://support.microsoft.com/ja-jp/help/2977003/the-latest-supported-visual-c-downloads',
+        'https://learn.microsoft.com/ja-jp/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version',
       );
       break;
     case 2:


### PR DESCRIPTION
## 概要

Visual C++ Redistributable のダウンロードリンクを `https://aka.ms/vs/17/release/vc_redist.x64.exe` から `https://aka.ms/vc14/vc_redist.x64.exe` に変更します。

## 背景

Microsoft の[公式案内ページ](https://learn.microsoft.com/ja-jp/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version)は変わっていませんが、いつからか `vs/17/release` のリンク先が変更されていました：

- 旧リンク (`vs/17/release`): バージョン 14.44.35211
- 新リンク (`vc14`): バージョン 14.50.35719

## 問題

14.50 が既にインストールされている環境で N Air をインストールすると、より古い 14.44 をインストールしようとするためインストーラーで警告が表示されます。

## 解決策

14.44 に 14.50 はアップデートとして正常にインストールできるため、より新しいバージョン (14.50) がダウンロードされる `https://aka.ms/vc14/vc_redist.x64.exe` にリンクを変更します。

## 変更内容


- installer.nsh のダウンロードURLを変更
- main.js の VC Redistributable ダウンロードリンクと説明ページのリンクを更新


#### 14.50がインストールされている状況で14.44をインストールしようとした時のダイアログ

<img width="398" height="110" alt="image" src="https://github.com/user-attachments/assets/f1dc71c3-bdff-4150-97a7-8300b2dbb551" />
