### PR TITLE
開発: 未使用のVeeValidate依存関係を削除

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -19,7 +19,6 @@ import path from 'path';
 import util from 'util';
 import { setupGlobalContextMenuForEditableElement } from 'util/menus/GlobalMenu';
 import VTooltip from 'v-tooltip';
-import VeeValidate from 'vee-validate';
 import VueI18n from 'vue-i18n';
 import * as obs from '../obs-api';
 import { AppService } from './services/app';
@@ -113,7 +112,6 @@ require('./theme2.less');
 // Initiates tooltips and sets their parent wrapper
 Vue.use(VTooltip);
 VTooltip.options.defaultContainer = '#mainWrapper';
-Vue.use(VeeValidate); // form validations
 
 // Disable chrome default drag/drop behavior
 document.addEventListener('dragover', event => event.preventDefault());

--- a/app/vue-augmentations.d.ts
+++ b/app/vue-augmentations.d.ts
@@ -3,14 +3,7 @@ import { Store } from 'vuex';
 
 // Vue instance type augmentations
 declare module 'vue/types/vue' {
-  interface Vue {
-    $validator: {
-      validateAll(scope?: string): Promise<boolean>;
-      errors: {
-        items: unknown[];
-      };
-    };
-  }
+  interface Vue { }
 }
 
 // Vue component options augmentations

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "traverse": "~0.6.7",
     "unzip-stream": "^0.3.4",
     "v-tooltip": "~2.1.3",
-    "vee-validate": "~2.2.15",
     "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
     "vue": "2.7.14",
     "vue-color": "2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       v-tooltip:
         specifier: ~2.1.3
         version: 2.1.3(vue@2.7.14)
-      vee-validate:
-        specifier: ~2.2.15
-        version: 2.2.15
       vosk-cli:
         specifier: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz
         version: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz
@@ -7064,9 +7061,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vee-validate@2.2.15:
-    resolution: {integrity: sha512-4TOsI8XwVkKVLkg8Nhmy+jyoJrR6XcTRDyxBarzcCvYzU61zamipS1WsB6FlDze8eJQpgglS4NXAS6o4NDPs1g==}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -15337,8 +15331,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   vary@1.1.2: {}
-
-  vee-validate@2.2.15: {}
 
   verror@1.10.1:
     dependencies:


### PR DESCRIPTION
## 概要
#1133 で `shared/inputs` コンポーネント（ValidatedFormなど）を削除した際に不要になった VeeValidate パッケージを削除しました。

## 変更内容
- `vee-validate` パッケージを package.json から削除
- `app.ts` から VeeValidate のインポートと初期化処理（`Vue.use(VeeValidate)`）を削除
- `vue-augmentations.d.ts` から型定義を削除

## 確認事項
- [x] コードベース全体で VeeValidate の使用がないことを確認
- [x] コンパイルが正常に完了することを確認