### PR TITLE
開発: ローカルビルド時のコード署名を条件付きで無効化

### DIFF
--- a/electron-builder/local.config.js
+++ b/electron-builder/local.config.js
@@ -5,4 +5,11 @@ delete config.publish;
 delete config.upload;
 config.extraMetadata.buildProductName = config.productName;
 
+// ローカルビルドではコード署名をデフォルトで無効化
+// CERTIFICATE_SUBJECT_NAME が設定されている場合のみ有効化（署名確認用）
+if (!process.env.CERTIFICATE_SUBJECT_NAME && config.win) {
+  config.win.signAndEditExecutable = false;
+  delete config.win.signtoolOptions;
+}
+
 module.exports = config;


### PR DESCRIPTION
## このpull requestが解決する内容
`pnpm package:local` でのローカルビルド時に、アプリケーション本体のコード署名をデフォルトでスキップし、ビルド時間を短縮します。

## 背景
ローカル開発時のビルドでは、コード署名が不要な場合が多く、署名処理によってビルド時間が長くなっていました。一方で、署名動作の確認が必要な場合もあるため、環境変数で制御できるようにします。

## 変更内容

### ファイル変更
- `electron-builder/local.config.js`: 条件付き署名無効化ロジックを追加

### 動作
1. **デフォルト動作**: `pnpm package:local` 実行時、アプリケーション本体(`.exe`)の署名をスキップ
2. **署名を有効化**: `CERTIFICATE_SUBJECT_NAME` 環境変数を設定すると、通常通り署名を実行
3. **NSISインストーラー**: 常に署名を実行（Windows証明書ストアから自動検出されるため）

### 署名がスキップされるファイル（デフォルト時）
- `N Air(Local).exe` (アプリケーション本体)
- `vosk-cli.exe`, `mecab-dict-index.exe`, `n-voice-engine.exe` (内部実行ファイル)
- `app.asar.unpacked` 内の各種実行ファイル

### 署名が継続されるファイル
- `n-air-app-setup.*.exe` (NSISインストーラー)
- `n-air-app-setup.*.__uninstaller.exe` (アンインストーラー)

## 影響範囲
- ローカルビルド（`pnpm package:local`）のみ
- 他のビルドタイプ（`package:public-stable`, `package:public-unstable` など）は影響なし

## テスト
- [x] `pnpm package:local` でビルドが成功し、アプリケーション本体の署名がスキップされることを確認
- [x] `CERTIFICATE_SUBJECT_NAME` 環境変数を設定した場合に署名が有効化されることを確認

## 補足
- electron-builderの制約により、Windows証明書ストアに証明書が存在する場合、NSISインストーラーの署名を完全にスキップすることは困難です
- アプリケーション本体の署名がスキップされることで、ビルド時間は大幅に短縮されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)