### PR TITLE
開発: build_checkジョブでパブリッシュを無効化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,7 +268,7 @@ jobs:
         run: pnpm run compile:production
 
       - name: Package local
-        run: pnpm run package:local
+        run: pnpm run package:local -- --publish never
 
   test-summary:
     # 注意: needs に setupも入れないと、setupで失敗すると後段のresultが `skipped` になってしまい、すりぬけてしまう


### PR DESCRIPTION
## このpull requestが解決する内容
#1143 でマージした `build_check` ジョブで発生しているGH_TOKENエラーを修正します。

## 問題
`package:local` を実行すると、electron-builderが暗黙的にパブリッシングを試みるため、CIで以下のエラーが発生していました:

```
⨯ GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
```

参考: https://github.com/n-air-app/n-air-app/actions/runs/21695684310/job/62565392646

## 根本原因
`local.config.js` では `delete config.publish;` でpublish設定を削除していますが、electron-builder 26.4.1 には以下の仕様があります:

> **CI環境を検出すると、publish設定がない場合でも暗黙的にパブリッシングを有効化する**

実際のログ:
```
• Implicit publishing triggered by CI detection. This behavior will be disabled in electron-builder v27. Please use --publish explicitly.
```

つまり:
- **ローカル環境**: `delete config.publish;` で問題なくパブリッシュなし
- **CI環境**: CI検出により自動的にパブリッシングが有効化 → GH_TOKENが必要になる

## 解決方法
`package:local` に `--publish never` オプションを追加し、パブリッシングを明示的に無効化します。

```yaml
- name: Package local
  run: pnpm run package:local -- --publish never
```

これにより、CI環境でもパブリッシングが確実に無効化されます。

## 影響範囲
- CIの `build_check` ジョブのみ
- パッケージングの確認は引き続き実行される

## テスト
- [x] CIの `build_check` ジョブが正常に完了する（4分14秒）
- [x] GH_TOKENエラーが発生しない
- [x] 全てのCIチェックが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)