### PR TITLE
開発: v-tooltipをカスタムディレクティブに置き換え、ツールチップ機能を実装

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -13,12 +13,12 @@ import * as Sentry from '@sentry/electron/renderer';
 import { init as sentryVueInit } from '@sentry/vue';
 import ChildWindow from 'components/windows/ChildWindow.vue';
 import OneOffWindow from 'components/windows/OneOffWindow.vue';
+import tooltipDirective from 'directives/tooltip';
 import electron from 'electron';
 import { Settings } from 'luxon';
 import path from 'path';
 import util from 'util';
 import { setupGlobalContextMenuForEditableElement } from 'util/menus/GlobalMenu';
-import VTooltip from 'v-tooltip';
 import VueI18n from 'vue-i18n';
 import * as obs from '../obs-api';
 import { AppService } from './services/app';
@@ -109,9 +109,8 @@ require('./app.less');
 require('./theme.less');
 require('./theme2.less');
 
-// Initiates tooltips and sets their parent wrapper
-Vue.use(VTooltip);
-VTooltip.options.defaultContainer = '#mainWrapper';
+// Initiates tooltips
+Vue.directive('tooltip', tooltipDirective);
 
 // Disable chrome default drag/drop behavior
 document.addEventListener('dragover', event => event.preventDefault());

--- a/app/directives/tooltip.test.ts
+++ b/app/directives/tooltip.test.ts
@@ -1,0 +1,78 @@
+import directive from './tooltip';
+
+describe('v-tooltip directive', () => {
+    let targetEl: HTMLElement;
+    let containerEl: HTMLElement;
+
+    beforeEach(() => {
+        // コンテナを作成
+        containerEl = document.createElement('div');
+        containerEl.id = 'mainWrapper';
+        document.body.appendChild(containerEl);
+
+        // ターゲット要素を作成
+        targetEl = document.createElement('button');
+        targetEl.textContent = 'Test Button';
+        document.body.appendChild(targetEl);
+
+        // getBoundingClientRectをモック
+        targetEl.getBoundingClientRect = jest.fn(() => ({
+            top: 100,
+            left: 100,
+            bottom: 130,
+            right: 200,
+            width: 100,
+            height: 30,
+            x: 100,
+            y: 100,
+            toJSON: () => { },
+        }));
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('マウスホバーでツールチップが表示される', async () => {
+        const vnode = {} as any;
+        const oldVnode = {} as any;
+
+        // ディレクティブをバインド
+        directive.bind?.(targetEl, {
+            name: 'tooltip',
+            value: 'テストツールチップ',
+            modifiers: { bottom: true },
+            oldValue: undefined,
+            arg: undefined,
+        }, vnode, oldVnode);
+
+        // ツールチップ要素はまだ存在しない
+        expect(containerEl.querySelector('.tooltip')).toBeNull();
+
+        // マウスエンターイベントを発火
+        targetEl.dispatchEvent(new MouseEvent('mouseenter'));
+
+        // requestAnimationFrameを待つ
+        await new Promise(resolve => {
+            requestAnimationFrame(() => resolve(undefined));
+        });
+        await new Promise(resolve => {
+            setTimeout(() => resolve(undefined), 10);
+        });
+
+        // ツールチップ要素が生成されている
+        const tooltipEl = containerEl.querySelector('.tooltip');
+        expect(tooltipEl).not.toBeNull();
+        expect(tooltipEl?.classList.contains('show')).toBe(true);
+
+        // コンテンツが正しい
+        const innerEl = tooltipEl?.querySelector('.tooltip-inner');
+        expect(innerEl?.textContent).toBe('テストツールチップ');
+
+        // x-placement属性が設定されている
+        expect(tooltipEl?.getAttribute('x-placement')).toBe('bottom');
+
+        // クリーンアップ
+        directive.unbind?.(targetEl, {} as any, vnode, oldVnode);
+    });
+});

--- a/app/directives/tooltip.ts
+++ b/app/directives/tooltip.ts
@@ -1,0 +1,457 @@
+/**
+ * v-tooltip ディレクティブ 
+ * 
+ * 使用方法:
+ *   v-tooltip="'テキスト'"
+ *   v-tooltip.top="'テキスト'"
+ *   v-tooltip.bottom="'テキスト'"
+ *   v-tooltip.left="'テキスト'"
+ *   v-tooltip.right="'テキスト'"
+ * 
+ * 
+ * 使用箇所一覧:チェック時点のことなので増減あり
+ * 
+ * [Mixer.vue]
+ *   - タイトル (bottom): 音声ミキサー説明
+ *   - 歯車アイコン (bottom): 高度な音声設定を開く
+ * 
+ * [SourceSelector.vue]
+ *   - タイトル (bottom): ソース説明
+ *   - フォルダアイコン (bottom): グループを追加
+ *   - +アイコン (bottom): ソースを追加
+ *   - 鍵アイコン (bottom): ロック
+ *   - 目アイコン (bottom): 表示/非表示
+ *   - ゴミ箱アイコン (bottom): ソースを削除
+ *   - 歯車アイコン (bottom): プロパティ
+ * 
+ * [StreamingController.vue]
+ *   - 経過時間 (left): 配信開始からの経過時間
+ *   - 録画ボタン (left): 録画パス設定
+ *   - リプレイ開始/停止/保存 (left): リプレイ録画機能
+ * 
+ * [StartStreamingButton.vue]
+ *   - 大ボタン (left): 配信開始/終了
+ * 
+ * [SceneSelector.vue]
+ *   - +アイコン (bottom): シーンを追加
+ *   - 切替アイコン (bottom): シーン切り替え
+ *   - ゴミ箱アイコン (bottom): シーンを削除
+ * 
+ * [nicolive-area/ToolBar.vue]
+ *   - 延長ボタン (bottom): 延長設定
+ *   - 番組再取得 (bottom): 番組再取得
+ *   - ▼ボタン (bottom): 配信開始/終了ボタンを選択
+ * 
+ * [nicolive-area/ProgramStatistics.vue]
+ *   - 来場者数/コメント数/広告ポイント/ギフトポイント (bottom)
+ * 
+ * [nicolive-area/ProgramInfo.vue]
+ *   - 番組タイトル (bottom): 番組タイトル文字列
+ * 
+ * [nicolive-area/CommentViewer.vue]
+ *   - 更新/フィルター/モデレーター/設定アイコン (bottom)
+ * 
+ * [nicolive-area/CommentFilter.vue]
+ *   - 絞り込みアイコン (bottom): 登録者で絞り込み
+ * 
+ * [nicolive-area/comment/CommonComment.vue]
+ *   - モデレーター/サポーターバッジ (bottom)
+ * 
+ * [windows/UserInfo.vue]
+ *   - モデレーター/サポーターバッジ/その他メニュー (bottom)
+ * 
+ * [windows/RtvcSourceProperties.vue]
+ *   - 音声設定/共通設定/サンプル再生等 (bottom/top)
+ * 
+ * [windows/SceneTransitions.vue]
+ *   - 警告アイコン (default): 冗長なコネクション警告
+ * 
+ * [TranscriptionSettings.vue]
+ *   - 文字起こし機能説明/ダウンロード/キャンセル/削除 (bottom/default)
+ * 
+ * [NotificationsArea.vue]
+ *   - 通知/未読通知アイコン (default)
+ */
+
+import { ObjectDirective } from 'vue';
+
+// ========================================
+// 型定義
+// ========================================
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+interface Position {
+    top: number;
+    left: number;
+    placement: TooltipPlacement;
+}
+
+interface TooltipOptions {
+    content: string;
+    placement: TooltipPlacement;
+    container: string;
+    delay: number;
+}
+
+interface TooltipElement extends Element {
+    _tooltipManager?: TooltipManager;
+    _tooltipHandlers?: Record<string, () => void>;
+}
+
+// ========================================
+// 定数
+// ========================================
+
+const DEFAULT_OPTIONS: TooltipOptions = {
+    content: '',
+    placement: 'top',
+    container: '#mainWrapper',
+    delay: 0,
+};
+
+const TOOLTIP_OFFSET = 10; // ツールチップとターゲット要素の間隔(px)
+const VIEWPORT_PADDING = 10; // ビューポート端からの余白(px)
+const DISPOSE_TIMEOUT = 5000; // ツールチップDOM要素の自動破棄までの時間(ms)
+
+// ========================================
+// 位置計算
+// ========================================
+
+/**
+ * ツールチップの位置を計算
+ * @param targetEl ターゲット要素
+ * @param tooltipEl ツールチップ要素
+ * @param placement 希望する配置位置
+ * @returns 計算された位置と最終的な配置位置
+ */
+function calculatePosition(
+    targetEl: Element,
+    tooltipEl: HTMLElement,
+    placement: TooltipPlacement,
+): Position {
+    const targetRect = targetEl.getBoundingClientRect();
+    const tooltipRect = tooltipEl.getBoundingClientRect();
+    const viewport = {
+        width: window.innerWidth,
+        height: window.innerHeight,
+    };
+
+    let top = 0;
+    let left = 0;
+    let finalPlacement = placement;
+
+    // 基本位置を計算
+    switch (placement) {
+        case 'top':
+            top = targetRect.top - tooltipRect.height - TOOLTIP_OFFSET;
+            left = targetRect.left + (targetRect.width - tooltipRect.width) / 2;
+            break;
+
+        case 'bottom':
+            top = targetRect.bottom + TOOLTIP_OFFSET;
+            left = targetRect.left + (targetRect.width - tooltipRect.width) / 2;
+            break;
+
+        case 'left':
+            top = targetRect.top + (targetRect.height - tooltipRect.height) / 2;
+            left = targetRect.left - tooltipRect.width - TOOLTIP_OFFSET;
+            break;
+
+        case 'right':
+            top = targetRect.top + (targetRect.height - tooltipRect.height) / 2;
+            left = targetRect.right + TOOLTIP_OFFSET;
+            break;
+    }
+
+    // 画面外にはみ出す場合は反対側にフリップ
+    if (placement === 'top' && top < VIEWPORT_PADDING) {
+        // 上にはみ出す場合は下に配置
+        finalPlacement = 'bottom';
+        top = targetRect.bottom + TOOLTIP_OFFSET;
+    } else if (placement === 'bottom' && top + tooltipRect.height > viewport.height - VIEWPORT_PADDING) {
+        // 下にはみ出す場合は上に配置
+        finalPlacement = 'top';
+        top = targetRect.top - tooltipRect.height - TOOLTIP_OFFSET;
+    } else if (placement === 'left' && left < VIEWPORT_PADDING) {
+        // 左にはみ出す場合は右に配置
+        finalPlacement = 'right';
+        left = targetRect.right + TOOLTIP_OFFSET;
+    } else if (placement === 'right' && left + tooltipRect.width > viewport.width - VIEWPORT_PADDING) {
+        // 右にはみ出す場合は左に配置
+        finalPlacement = 'left';
+        left = targetRect.left - tooltipRect.width - TOOLTIP_OFFSET;
+    }
+
+    // 左右のはみ出しを調整（中央寄せの場合）
+    if (placement === 'top' || placement === 'bottom') {
+        if (left < VIEWPORT_PADDING) {
+            left = VIEWPORT_PADDING;
+        } else if (left + tooltipRect.width > viewport.width - VIEWPORT_PADDING) {
+            left = viewport.width - tooltipRect.width - VIEWPORT_PADDING;
+        }
+    }
+
+    // 上下のはみ出しを調整（中央寄せの場合）
+    if (placement === 'left' || placement === 'right') {
+        if (top < VIEWPORT_PADDING) {
+            top = VIEWPORT_PADDING;
+        } else if (top + tooltipRect.height > viewport.height - VIEWPORT_PADDING) {
+            top = viewport.height - tooltipRect.height - VIEWPORT_PADDING;
+        }
+    }
+
+    return { top, left, placement: finalPlacement };
+}
+
+// ========================================
+// TooltipManager クラス
+// ========================================
+
+/**
+ * ツールチップDOM管理とライフサイクル制御
+ */
+class TooltipManager {
+    private targetEl: Element;
+    private tooltipEl: HTMLElement | null = null;
+    private options: TooltipOptions;
+    private showTimer: number | null = null;
+    private disposeTimer: number | null = null;
+    private isVisible = false;
+
+    constructor(targetEl: Element, options: Partial<TooltipOptions>) {
+        this.targetEl = targetEl;
+        this.options = { ...DEFAULT_OPTIONS, ...options };
+    }
+
+    /**
+     * コンテンツを更新
+     */
+    setContent(content: string): void {
+        this.options.content = content;
+        if (this.tooltipEl && this.isVisible) {
+            const inner = this.tooltipEl.querySelector('.tooltip-inner');
+            if (inner) {
+                inner.textContent = content;
+            }
+        }
+    }
+
+    /**
+     * 配置位置を更新
+     */
+    setPlacement(placement: TooltipPlacement): void {
+        this.options.placement = placement;
+    }
+
+    /**
+     * ツールチップを表示
+     */
+    show(): void {
+        this.clearTimer();
+        this.scheduleAction(this.doShow.bind(this));
+    }
+
+    /**
+     * ツールチップを非表示
+     */
+    hide(): void {
+        this.clearTimer();
+        this.scheduleAction(this.doHide.bind(this));
+    }
+
+    /**
+     * ツールチップを破棄
+     */
+    dispose(): void {
+        this.clearTimer();
+        this.destroyTooltip();
+    }
+
+    /**
+     * 遅延付きでアクションをスケジュール
+     */
+    private scheduleAction(action: () => void): void {
+        if (this.options.delay > 0) {
+            this.showTimer = window.setTimeout(action, this.options.delay);
+        } else {
+            action();
+        }
+    }
+
+    /**
+     * 実際に表示する処理
+     */
+    private doShow(): void {
+        if (this.isVisible || !this.options.content) return;
+
+        this.clearTimer('dispose');
+        this.createTooltip();
+        this.updatePosition();
+        this.isVisible = true;
+
+        requestAnimationFrame(() => this.tooltipEl?.classList.add('show'));
+    }
+
+    /**
+     * 実際に非表示にする処理
+     */
+    private doHide(): void {
+        if (!this.isVisible || !this.tooltipEl) return;
+
+        this.isVisible = false;
+        this.tooltipEl.classList.remove('show');
+        this.disposeTimer = window.setTimeout(() => this.destroyTooltip(), DISPOSE_TIMEOUT);
+    }
+
+    /**
+     * ツールチップDOM要素を作成
+     */
+    private createTooltip(): void {
+        if (this.tooltipEl) return;
+
+        this.tooltipEl = document.createElement('div');
+        this.tooltipEl.className = 'tooltip';
+        this.tooltipEl.setAttribute('role', 'tooltip');
+        this.tooltipEl.innerHTML = `<div class="tooltip-inner">${this.options.content}</div>`;
+
+        const container = document.querySelector(this.options.container) || document.body;
+        container.appendChild(this.tooltipEl);
+    }
+
+    /**
+     * ツールチップDOM要素を破棄
+     */
+    private destroyTooltip(): void {
+        this.tooltipEl?.parentNode?.removeChild(this.tooltipEl);
+        this.tooltipEl = null;
+    }
+
+    /**
+     * ツールチップの位置を更新
+     */
+    private updatePosition(): void {
+        if (!this.tooltipEl) return;
+
+        const { top, left, placement } = calculatePosition(
+            this.targetEl,
+            this.tooltipEl,
+            this.options.placement,
+        );
+
+        Object.assign(this.tooltipEl.style, {
+            position: 'fixed',
+            top: `${top}px`,
+            left: `${left}px`,
+        });
+        this.tooltipEl.setAttribute('x-placement', placement);
+    }
+
+    /**
+     * 指定したタイマーまたは全タイマーをクリア
+     */
+    private clearTimer(type?: 'show' | 'dispose'): void {
+        if (!type || type === 'show') {
+            if (this.showTimer !== null) {
+                clearTimeout(this.showTimer);
+                this.showTimer = null;
+            }
+        }
+        if (!type || type === 'dispose') {
+            if (this.disposeTimer !== null) {
+                clearTimeout(this.disposeTimer);
+                this.disposeTimer = null;
+            }
+        }
+    }
+}
+
+// ========================================
+// Vue ディレクティブ
+// ========================================
+
+/**
+ * modifiersから配置位置を取得
+ */
+function getPlacement(modifiers: Record<string, boolean>): TooltipPlacement {
+    if (modifiers.top) return 'top';
+    if (modifiers.bottom) return 'bottom';
+    if (modifiers.left) return 'left';
+    if (modifiers.right) return 'right';
+    return 'top'; // デフォルト
+}
+
+/**
+ * ツールチップのコンテンツを取得
+ */
+function getContent(value: any): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (value && typeof value === 'object' && 'content' in value) {
+        return String(value.content);
+    }
+    return String(value || '');
+}
+
+const directive: ObjectDirective = {
+    bind(el: TooltipElement, binding) {
+        const content = getContent(binding.value);
+        if (!content) return;
+
+        const manager = new TooltipManager(el, {
+            content,
+            placement: getPlacement(binding.modifiers),
+            container: '#mainWrapper',
+            delay: 0,
+        });
+
+        el._tooltipManager = manager;
+
+        // イベントハンドラーを設定
+        el._tooltipHandlers = {
+            mouseenter: () => manager.show(),
+            mouseleave: () => manager.hide(),
+            focus: () => manager.show(),
+            blur: () => manager.hide(),
+        };
+
+        Object.entries(el._tooltipHandlers).forEach(([event, handler]) => {
+            el.addEventListener(event, handler);
+        });
+
+        el.classList.add('has-tooltip');
+    },
+
+    update(el: TooltipElement, binding) {
+        const manager = el._tooltipManager;
+        if (!manager) return;
+
+        const content = getContent(binding.value);
+        if (!content) {
+            manager.dispose();
+            return;
+        }
+
+        manager.setContent(content);
+        manager.setPlacement(getPlacement(binding.modifiers));
+    },
+
+    unbind(el: TooltipElement) {
+        if (el._tooltipHandlers) {
+            Object.entries(el._tooltipHandlers).forEach(([event, handler]) => {
+                el.removeEventListener(event, handler);
+            });
+            delete el._tooltipHandlers;
+        }
+
+        if (el._tooltipManager) {
+            el._tooltipManager.dispose();
+            delete el._tooltipManager;
+        }
+
+        el.classList.remove('has-tooltip');
+    },
+};
+
+export default directive;

--- a/app/index.d.ts
+++ b/app/index.d.ts
@@ -40,7 +40,6 @@ interface IResource {
 
 // list of modules without type definitions
 declare module 'raven-js/*';
-declare module 'v-tooltip';
 declare module 'traverse';
 declare module 'vue-multiselect';
 // declare module 'unzip-stream';

--- a/app/styles/classes.less
+++ b/app/styles/classes.less
@@ -125,3 +125,18 @@
 .noselect {
   user-select: none;
 }
+
+// ツールチップを表示するアイコンのスタイル
+.icon-tooltip {
+  margin-left: 8px;
+  color: var(--color-button-primary);
+
+  &:hover {
+    color: var(--color-text-active);
+  }
+
+  &.icon-help-border {
+    font-size: var(--font-size-md);
+    color: var(--color-object-emphasis-medium);
+  }
+}

--- a/app/styles/tooltips.less
+++ b/app/styles/tooltips.less
@@ -1,20 +1,24 @@
 // TOOLTIPS
 
-.tooltip-trigger {
-  margin: 0 10px;
-  color: var(--color-text);
-  opacity: 0.6;
-}
-
 .tooltip {
+  position: fixed;
   z-index: @z-index-tooltip;
   display: block !important;
+  visibility: hidden;
   padding: 0;
   background: transparent;
   border: 0;
+  opacity: 0;
+  transition: opacity 0.15s, visibility 0.15s;
 
+  &.show {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  // Foundation CSSの矢印を無効化
   &::before {
-    border: 0;
+    display: none !important;
   }
 }
 
@@ -28,99 +32,21 @@
   word-wrap: break-word;
   background-color: var(--color-tooltip-bg);
   border: 1px solid var(--color-tooltip-border);
-
-  &.wide {
-    width: max-content;
-    max-width: 300px;
-  }
-}
-
-.tooltip .tooltip-arrow {
-  display: none;
 }
 
 .tooltip[x-placement^='top'] {
   margin-bottom: 10px;
 }
 
-.tooltip[x-placement^='top'] .tooltip-arrow {
-  bottom: -5px;
-  left: calc(50% - 5px);
-  margin-top: 0;
-  margin-bottom: 0;
-  border-width: 5px 5px 0;
-  border-right-color: transparent !important;
-  border-bottom-color: transparent !important;
-  border-left-color: transparent !important;
-}
-
 .tooltip[x-placement^='bottom'] {
   margin-top: 10px;
-}
-
-.tooltip[x-placement^='bottom'] .tooltip-arrow {
-  top: -5px;
-  left: calc(50% - 5px);
-  margin-top: 0;
-  margin-bottom: 0;
-  border-width: 0 5px 5px;
-  border-top-color: transparent !important;
-  border-right-color: transparent !important;
-  border-left-color: transparent !important;
 }
 
 .tooltip[x-placement^='right'] {
   margin-left: 10px;
 }
 
-.tooltip[x-placement^='right'] .tooltip-arrow {
-  top: calc(50% - 5px);
-  left: -5px;
-  margin-right: 0;
-  margin-left: 0;
-  border-width: 5px 5px 5px 0;
-  border-top-color: transparent !important;
-  border-bottom-color: transparent !important;
-  border-left-color: transparent !important;
-}
-
 .tooltip[x-placement^='left'] {
   margin-right: 10px;
 }
 
-.tooltip[x-placement^='left'] .tooltip-arrow {
-  top: calc(50% - 5px);
-  right: -5px;
-  margin-right: 0;
-  margin-left: 0;
-  border-width: 5px 0 5px 5px;
-  border-top-color: transparent !important;
-  border-right-color: transparent !important;
-  border-bottom-color: transparent !important;
-}
-
-.tooltip[aria-hidden='true'] {
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity 0.15s, visibility 0.15s;
-}
-
-.tooltip[aria-hidden='false'] {
-  visibility: visible;
-  opacity: 1;
-  transition: opacity 0.15s;
-}
-
-.icon-tooltip {
-  margin-left: 8px;
-  color: var(--color-button-primary);
-
-  &:hover {
-    color: var(--color-text-active);
-  }
-
-  &.icon-help-border {
-    font-size: var(--font-size-md);
-    color: var(--color-object-emphasis-medium);
-  }
-}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "sockjs": "~0.3.19",
     "traverse": "~0.6.7",
     "unzip-stream": "^0.3.4",
-    "v-tooltip": "~2.1.3",
     "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
     "vue": "2.7.14",
     "vue-color": "2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       unzip-stream:
         specifier: ^0.3.4
         version: 0.3.4
-      v-tooltip:
-        specifier: ~2.1.3
-        version: 2.1.3(vue@2.7.14)
       vosk-cli:
         specifier: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz
         version: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz
@@ -998,10 +995,6 @@ packages:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -7047,9 +7040,6 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  v-tooltip@2.1.3:
-    resolution: {integrity: sha512-xXngyxLQTOx/yUEy50thb8te7Qo4XU6h4LZB6cvEfVd9mnysUxLEoYwGWDdqR+l69liKsy3IPkdYff3J1gAJ5w==}
-
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -7118,11 +7108,6 @@ packages:
 
   vue-property-decorator@7.3.0:
     resolution: {integrity: sha512-HarXfTQ/Nxm4s/APpAaGIGHq5ZzslApImQy8ZrtkfGamw8rUFAVgMS5C50/AQ80+wfw3Wpnf4bNzbmj75m/k2Q==}
-
-  vue-resize@1.0.1:
-    resolution: {integrity: sha512-z5M7lJs0QluJnaoMFTIeGx6dIkYxOwHThlZDeQnWZBizKblb99GSejPnK37ZbNE/rVwDcYcHY+Io+AxdpY952w==}
-    peerDependencies:
-      vue: ^2.6.0
 
   vue-slider-component@2.8.16:
     resolution: {integrity: sha512-06gDoheKMU8TdqjoofIJaYfXw3uuWOXF2I14d/F5yW/8iOxnoI4Ks9WSXy8RWY+gs62GBE6tQXHDSX/H6IOaAw==}
@@ -8226,8 +8211,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.28.5
       esutils: 2.0.3
-
-  '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -15304,15 +15287,6 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  v-tooltip@2.1.3(vue@2.7.14):
-    dependencies:
-      '@babel/runtime': 7.28.4
-      lodash: 4.17.23
-      popper.js: 1.16.1
-      vue-resize: 1.0.1(vue@2.7.14)
-    transitivePeerDependencies:
-      - vue
-
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -15439,11 +15413,6 @@ snapshots:
   vue-property-decorator@7.3.0:
     dependencies:
       vue-class-component: 6.3.2
-
-  vue-resize@1.0.1(vue@2.7.14):
-    dependencies:
-      '@babel/runtime': 7.28.4
-      vue: 2.7.14
 
   vue-slider-component@2.8.16: {}
 


### PR DESCRIPTION
### 概要

外部ライブラリ `v-tooltip` を削除し、カスタムVueディレクティブとして実装しました。Popper.js不使用のシンプルな実装により、依存関係を削減し、アプリケーション固有のニーズに最適化しました。

**以前のtooltipから挙動・使用方法に変更はありません。** 既存のコードはそのまま動作します。

### 変更内容

#### 追加
- `app/directives/tooltip.ts` - カスタムツールチップディレクティブ実装
  - 4方向配置対応（top/bottom/left/right）
  - 画面外はみ出し時の自動フリップ
  - TooltipManagerクラスによるライフサイクル管理
  - 遅延表示・自動破棄機能
- `app/directives/tooltip.test.ts` - ユニットテスト
- `app/styles/classes.less` - ツールチップスタイル追加

#### 変更
- `app/app.ts` - カスタムディレクティブの登録
- `app/styles/tooltips.less` - 不要なスタイルを削減

#### 削除
- `package.json` - v-tooltipパッケージ依存関係を削除
- `app/index.d.ts` - v-tooltip型定義を削除

### 使用箇所

アプリケーション全体で使用（`tooltip.ts` ヘッダーコメントに詳細一覧あり）：
- Mixer.vue
- SourceSelector.vue
- StreamingController.vue
- nicolive-area配下の各種コンポーネント
- その他

### テスト

- ユニットテスト追加（TooltipManagerクラスの基本動作）
- 既存の全使用箇所で動作確認が必要

### 影響範囲

- **破壊的変更なし** - 既存のv-tooltip構文（`v-tooltip.bottom="text"` など）をそのまま維持
- 依存関係が1つ減少（バンドルサイズ削減）
- 内部実装のみの変更のため、ユーザーへの影響なし