### PR TITLE
開発: build_checkジョブのsetup-bin依存を削除してスキップ問題を解消

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
             common:
               - 'package.json'
               - 'pnpm-lock.yaml'
+              - '.github/workflows/test.yml'
             app:
               - 'installer.nsh'
               - 'tsconfig.json'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
 
   build_check:
     name: build check
-    needs: [changes, setup-app, setup-bin]
+    needs: [changes, setup-app]
     if: ${{ needs.changes.outputs.app == 'true' }}
     runs-on: windows-2022
 
@@ -258,6 +258,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'additional/additional.json', 'additional/main.mjs') }}
 
       - name: cache node modules(bin)
+        if: ${{ needs.changes.outputs.bin == 'true' }}
         id: cache-node-modules-bin
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
             common:
               - 'package.json'
               - 'pnpm-lock.yaml'
-              - '.github/workflows/test.yml'
             app:
               - 'installer.nsh'
               - 'tsconfig.json'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const DefinePlugin = require('webpack').DefinePlugin;
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 const path = require('node:path');
-// Test: verify build_check runs without setup-bin dependency
 
 const package = require('./package.json');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const DefinePlugin = require('webpack').DefinePlugin;
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 const path = require('node:path');
+// Test: verify build_check runs without setup-bin dependency
 
 const package = require('./package.json');
 


### PR DESCRIPTION
## このpull requestが解決する内容
webpack.config.js のみを変更したPR（例: #1134）で build_check ジョブがスキップされてしまう問題を修正します。

## 背景
現在の test.yml では、build_check ジョブが setup-bin に依存しているため、bin/ ディレクトリに関係ない変更（webpack.config.js のみの更新など）で setup-bin がスキップされると、build_check もスキップされてしまいます。

**問題の原因:**
- `build_check` ジョブは `needs: [changes, setup-app, setup-bin]` で setup-bin に依存
- `setup-bin` ジョブは `if: ${{ needs.changes.outputs.bin == 'true' }}` の条件で実行
- webpack.config.js の変更は bin フィルターに該当しないため、bin=false となる
- そのため setup-bin がスキップされ、setup-bin に依存している build_check もスキップされる

## 変更内容

### ファイル変更
- `.github/workflows/test.yml`:
  - build_check の needs から setup-bin を削除
  - bin/node_modules キャッシュステップに条件を追加（bin 変更時のみキャッシュを使用）

### 技術的な根拠
- `build_check` が実行する `pnpm run package:local` コマンドは内部で `pnpm install --dir bin --ignore-workspace` を実行
- このコマンドにより bin/node_modules が自動的にインストールされる（convert-to-shiftjis.js に必要な iconv-lite のため）
- setup-bin ジョブは**パフォーマンス最適化のためのキャッシュ**であり、機能的には必須ではない

### 期待される効果
- webpack.config.js のみの変更でも build_check が正常に実行される
- bin/ 関連の変更があった場合はキャッシュを利用してパフォーマンスを維持
- bin/ 関連の変更がない場合でも package:local 内の pnpm install で依存関係が確実にインストールされる

## 影響範囲
- CI/CD パイプラインのみ（GitHub Actions のジョブ依存関係）
- ビルドプロセスの機能には影響なし（package:local が依存関係を自動インストール）

## テスト

このPRでは、修正が意図通りに機能することを検証するため、以下のテストを実施しました：

### 検証方法
1. 一時的に common フィルターから test.yml を除外（コミット 140046e）
2. webpack.config.js に変更を追加
3. CI で setup-bin が skip され、build_check が正常に実行されることを確認
4. 検証後、変更を revert（コミット 01c203d）

### 検証結果
- ✅ setup-bin が正常に **skipping** になることを確認
- ✅ setup-bin が skip された状態で **build_check が pass**（6m13s で成功）
- ✅ 全てのテストが正常に通過

この検証により、webpack.config.js のみの変更でも build_check が正常に実行され、setup-bin への依存がなくても問題なく動作することが証明されました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)