### PR TITLE
開発: パッチノートからPRブランチ内のsync mergeを除外

### DIFF
--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -203,6 +203,14 @@ async function collectNonPRMerges(previousVersion) {
 
     const [, hash, subject] = match;
 
+    // Skip merges into feature branches (these are PR internal syncs)
+    // Example: "Merge branch 'n-air_development' into feature/xyz"
+    // These are already captured by the PR merge that eventually happened
+    // NOTE: This only filters top-level merge commits, not commits within the merged branch
+    if (subject.match(/\sinto\s/)) {
+      continue;
+    }
+
     // Check if this is a real merge (has 2+ parents) to avoid fast-forward merges
     const parentsCmd = executeCmd(`git rev-list --parents -n 1 ${hash}`, { silent: true });
     const parentCount = parentsCmd.stdout.trim().split(/\s+/).length - 1;
@@ -215,7 +223,8 @@ async function collectNonPRMerges(previousVersion) {
     // Get commits added by this merge (from first parent to second parent)
     // Using ^1..^2 to get only the commits introduced by this specific merge
     // This avoids duplicates when the same branch is merged multiple times
-    const gitCmd = `git log --no-merges --format="%s (%h)" "${hash}^1..${hash}^2"`;
+    // NOTE: Include merge commits in the branch (e.g., sync merges) for direct merge branches
+    const gitCmd = `git log --format="%s (%h)" "${hash}^1..${hash}^2"`;
     const includedCommitsResult = sh.exec(gitCmd, { silent: true });
 
     // If git command failed, skip this merge

--- a/bin/release/scripts/patchNote.test.js
+++ b/bin/release/scripts/patchNote.test.js
@@ -315,7 +315,7 @@ describe('collectNonPRMerges', () => {
       .mockReturnValueOnce({
         // Same branch merged twice consecutively (git log: newest first)
         stdout:
-          'bbb2222 Merge branch \'feature/test\' into main\naaa1111 Merge branch \'feature/test\' into main',
+          'bbb2222 Merge branch \'feature/test\'\naaa1111 Merge branch \'feature/test\'',
       })
       .mockReturnValueOnce({ stdout: 'bbb2222 p1 p2' })
       .mockReturnValueOnce({ stdout: 'aaa1111 p1 p2' });
@@ -341,7 +341,7 @@ describe('collectNonPRMerges', () => {
       .mockReturnValueOnce({
         // Different branches: git log order (newest first): A, B, A
         stdout:
-          'aaa1111 Merge branch \'feature/A\' into main\nbbb2222 Merge branch \'feature/B\' into main\nccc3333 Merge branch \'feature/A\' into main',
+          'aaa1111 Merge branch \'feature/A\'\nbbb2222 Merge branch \'feature/B\'\nccc3333 Merge branch \'feature/A\'',
       })
       .mockReturnValueOnce({ stdout: 'aaa1111 p1 p2' })
       .mockReturnValueOnce({ stdout: 'bbb2222 p1 p2' })
@@ -453,5 +453,117 @@ describe('collectNonPRMerges', () => {
     const result = await collectNonPRMerges('1.0.20190826-2');
 
     expect(result).toBe('');
+  });
+
+  test('PRブランチ内のマージ(into付き)は除外される', async () => {
+    executeCmd.mockReturnValueOnce({
+      stdout: 'abc1234 Merge branch "n-air_development" into feature/test',
+    });
+    // into付きなので親チェックもsh.execも呼ばれない
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    expect(result).toBe('');
+    // into付きのマージは処理がスキップされるため、親チェック(executeCmd)もsh.execも呼ばれない
+    expect(executeCmd).toHaveBeenCalledTimes(1); // git logのみ
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  test('直接マージ(intoなし)は含まれる', async () => {
+    executeCmd
+      .mockReturnValueOnce({
+        stdout: 'abc1234 Merge branch "hotfix/urgent"',
+      })
+      .mockReturnValueOnce({
+        stdout: 'abc1234 parent1 parent2', // 2 parents
+      });
+    execSpy.mockReturnValue({
+      code: 0,
+      stdout: '修正: 緊急パッチ (def456)',
+    });
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    expect(result).toContain('Merge branch "hotfix/urgent" (abc1234)');
+    expect(result).toContain('修正: 緊急パッチ (def456)');
+  });
+
+  test('混在シナリオ: into付きは除外、intoなしは含む', async () => {
+    executeCmd
+      .mockReturnValueOnce({
+        // 3つのマージコミット: 1つ目と3つ目はinto付き(除外)、2つ目はintoなし(含む)
+        stdout:
+          'aaa1111 Merge branch "n-air_development" into feature/A\n' +
+          'bbb2222 Merge branch "hotfix/critical"\n' +
+          'ccc3333 Merge branch "main" into refactor/B',
+      })
+      // aaa1111はinto付きなので、親チェックの前にスキップされる
+      .mockReturnValueOnce({ stdout: 'bbb2222 parent1 parent2' });
+    // bbb2222のみ親チェックが実行される
+    // ccc3333もinto付きなので、親チェックの前にスキップされる
+
+    execSpy.mockReturnValue({
+      code: 0,
+      stdout: '修正: 重大なバグ修正 (xyz789)',
+    });
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    // bbb2222のみ含まれる
+    expect(result).toContain('Merge branch "hotfix/critical" (bbb2222)');
+    expect(result).toContain('修正: 重大なバグ修正 (xyz789)');
+    // aaa1111とccc3333は含まれない
+    expect(result).not.toContain('feature/A');
+    expect(result).not.toContain('refactor/B');
+    // sh.execは1回だけ呼ばれる(bbb2222のため)
+    expect(execSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('エッジケース: マージ内のコミットメッセージに"into"があっても影響しない', async () => {
+    executeCmd
+      .mockReturnValueOnce({
+        stdout: 'abc1234 Merge branch "feature/refactor"',
+      })
+      .mockReturnValueOnce({
+        stdout: 'abc1234 parent1 parent2',
+      });
+    execSpy.mockReturnValue({
+      code: 0,
+      stdout: '変更: Refactor code into modules (def456)', // コミットメッセージに"into"
+    });
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    // マージ件名に"into"がなければ含まれる
+    expect(result).toContain('Merge branch "feature/refactor" (abc1234)');
+    expect(result).toContain('変更: Refactor code into modules (def456)');
+  });
+
+  test('direct mergeブランチ内のsync merge (into付き)は掲載される', async () => {
+    executeCmd
+      .mockReturnValueOnce({
+        // hotfix/urgentを直接マージ（intoなし）
+        stdout: 'abc1234 Merge branch "hotfix/urgent"',
+      })
+      .mockReturnValueOnce({
+        stdout: 'abc1234 parent1 parent2',
+      });
+    execSpy.mockReturnValue({
+      code: 0,
+      // hotfix/urgentブランチ内のコミット（sync mergeを含む）
+      stdout:
+        '修正: 緊急バグ修正 (def456)\n' +
+        'Merge branch "n-air_development" into hotfix/urgent (ghi789)\n' +
+        '追加: 新機能追加 (jkl012)',
+    });
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    // direct mergeは含まれる
+    expect(result).toContain('Merge branch "hotfix/urgent" (abc1234)');
+    // 内訳コミットも全て含まれる（sync mergeも含む）
+    expect(result).toContain('修正: 緊急バグ修正 (def456)');
+    expect(result).toContain('Merge branch "n-air_development" into hotfix/urgent (ghi789)');
+    expect(result).toContain('追加: 新機能追加 (jkl012)');
   });
 });


### PR DESCRIPTION
## このpull requestが解決する内容
パッチノート生成時に、PRブランチ内のsync merge（"Merge branch 'n-air_development' into feature/xyz"）を不要な重複として除外します。

## 背景
PR #1075 で非PRマージコミットをパッチノートに含める機能を追加しましたが、v1.1.20260209-3 のリリースノートで約60以上の内部開発コミット（「開発:」接頭辞）がMerge Commits:セクションに含まれる問題が発生しました。

これらは、開発者がPRブランチで作業中にmainブランチと同期するための「sync merge」で、最終的なPRマージに既に含まれているため、別途表示する必要はありません。

## 変更内容

### 主な変更
1. **トップレベルのマージコミットフィルタリング**
   - マージコミットの件名に " into " が含まれる場合はスキップ
   - 例: `Merge branch 'n-air_development' into feature/xyz` → スキップ（PR内部のsync merge）
   - 例: `Merge branch 'hotfix/urgent'` → 含める（真のdirect merge）

2. **Direct mergeブランチ内のコミット詳細**
   - `--no-merges` フラグを削除し、ブランチ内のsync mergeも掲載
   - 理由: 開発ブランチは継続的にリリースされるため、何がマージされているかを知る必要がある
   - 例: `hotfix/urgent` ブランチ内の `Merge branch 'n-air_development' into hotfix/urgent` → 掲載

### ファイル変更
- `bin/release/scripts/patchNote.js`: 
  - " into " パターンチェックを追加（8行）
  - `--no-merges` フラグを削除（1行）
- `bin/release/scripts/patchNote.test.js`:
  - 既存テストのテストデータを修正（2箇所）
  - 新しいテストケースを5つ追加（112行）

### 動作の違い

**PRの場合:**
- PR merge: `Merge pull request #123` → パッチノートに含まれる（タイトルでサマライズ）
- PR内のsync merge: `Merge branch 'n-air_development' into feature/xyz` → **含まれない**（重複を避ける）

**Direct mergeの場合:**
- Direct merge: `Merge branch 'hotfix/urgent'` → パッチノートに含まれる
- ブランチ内のsync merge: `Merge branch 'n-air_development' into hotfix/urgent` → **含まれる**（詳細な履歴として必要）

## 影響範囲
- パッチノート生成処理のみ（`pnpm patch-note` コマンド）
- 既存のパッチノートには影響しない（次回リリースから適用）
- public/internal両方のリリースに適用

## テスト
- [x] 全51個のユニットテストが通過（5つの新規テスト含む）
- [ ] 実際のリポジトリで `pnpm patch-note` を実行してMerge Commits:セクションが空またはほぼ空であることを確認
- [ ] v1.1.20260209-3 相当のリリースで以前の約60個のエントリが除外されることを確認

## 補足
この修正により、パッチノートはより簡潔になり、ユーザーに見せるべき情報（PRの変更、真のdirect merge）のみが含まれるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)