### PR TITLE
開発: lint-staged でのメモリ不足による SIGKILL を解決

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,22 @@
+// lint-staged configuration
+// 大量のファイルがある場合のメモリ不足対策
+
+// Node.js のメモリ制限を増やす
+process.env.NODE_OPTIONS = '--max-old-space-size=4096';
+
+module.exports = {
+  // TypeScript, JavaScript, Vue ファイル
+  '*.{ts,js,vue}': ['eslint'],
+
+  // CSS, Less, Vue スタイル
+  '*.{css,less,vue}': ['stylelint'],
+
+  // 国際化ファイル
+  'app/i18n/*/*.json': ['node ./bin/i18n-early-check.js'],
+
+  // フォントグリフ
+  '{app/fonts/glyphs/*.svg,app/styles/custom-icons.less.njk}': [
+    'pnpm run webfont',
+    'git add app/fonts/n-air.woff app/styles/custom-icons.less',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -45,21 +45,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "lint-staged": {
-    "*.{ts,js,vue}": [
-      "eslint"
-    ],
-    "*.{css,less,vue}": [
-      "stylelint"
-    ],
-    "app/i18n/*/*.json": [
-      "node ./bin/i18n-early-check.js"
-    ],
-    "{app/fonts/glyphs/*.svg,app/styles/custom-icons.less.njk}": [
-      "pnpm run webfont",
-      "git add app/fonts/n-air.woff app/styles/custom-icons.less"
-    ]
-  },
   "browserslist": [
     "chrome >= 122"
   ],


### PR DESCRIPTION
## Summary
大量のファイルが staged されている場合に `lint-staged` が Node.js のデフォルトメモリ制限を超えて SIGKILL で終了する問題を解決しました。

## 問題
- 複数の大きなファイルや多数のファイルを staged してコミットすると、pre-commit フック（lint-staged）が SIGKILL で終了
- Node.js のデフォルトメモリ制限（約 512MB）が原因
- 特に SVG ファイルの変更時に `webfont` 生成が走ると、メモリ不足が顕著に

## 解決方法
`.lintstagedrc.js` を新規作成し、`NODE_OPTIONS` で `max-old-space-size` を 4GB に設定しました。これにより、lint-staged のプロセスが十分なメモリを使用できるようになります。

## 変更内容
- `.lintstagedrc.js` を追加
  - `NODE_OPTIONS='--max-old-space-size=4096'` を設定
  - `package.json` の lint-staged 設定を移行
- `package.json` から `lint-staged` セクションを削除
  - `.lintstagedrc.js` が優先されるため、package.json の設定は不要
  - 設定の二重管理による混乱を回避

## Test plan
- [x] 大量のファイルを staged してコミットが成功することを確認
- [x] 通常の少数ファイルのコミットも正常に動作することを確認
- [x] package.json から設定を削除しても lint-staged が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)