### PR TITLE
修正: コメントサーバー再接続後にコメントが受信できない問題を修正

### DIFF
--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -221,7 +221,7 @@ export default class ToolBar extends Vue {
 
   private async refreshProgram() {
     try {
-      return await this.nicoliveProgramService.refreshProgram();
+      await this.nicoliveProgramService.refreshProgram();
     } catch (caught) {
       if (caught instanceof NicoliveFailure) {
         await openErrorDialogFromFailure(caught);

--- a/app/services/nicolive-program/NdgrCommentReceiver.test.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.test.ts
@@ -1,10 +1,137 @@
 import { dwango } from '@n-air-app/nicolive-comment-protobuf';
+import { Subject } from 'rxjs';
 import { MessageResponse } from './ChatMessage';
 import { isChatMessage } from './ChatMessage/util';
 import {
+  NdgrCommentReceiver,
   convertChunkedResponseToMessageResponse,
   convertModifierToMail,
 } from './NdgrCommentReceiver';
+
+describe('NdgrCommentReceiver', () => {
+  // NdgrClient のモック: messages Subject と connect() の挙動を制御する
+  let mockMessages: Subject<dwango.nicolive.chat.service.edge.ChunkedMessage>;
+  let mockConnectImpl: () => Promise<void>;
+
+  // NdgrClient をモックし、NdgrCommentReceiver をロードして返す
+  function setupReceiverWithMock(): typeof NdgrCommentReceiver {
+    jest.resetModules();
+    jest.doMock('./NdgrClient', () => ({
+      // toNumber は NdgrCommentReceiver.ts から参照されるので実装を残す
+      toNumber: (n: number | { toNumber(): number }) =>
+        typeof n === 'number' ? n : n.toNumber(),
+      NdgrClient: jest.fn().mockImplementation(() => ({
+        messages: mockMessages,
+        connect: jest.fn().mockImplementation(() => mockConnectImpl()),
+        dispose: jest.fn().mockImplementation(() => {
+          mockMessages.complete();
+        }),
+      })),
+    }));
+    return (
+      require('./NdgrCommentReceiver') as { NdgrCommentReceiver: typeof NdgrCommentReceiver }
+    ).NdgrCommentReceiver;
+  }
+
+  beforeEach(() => {
+    mockMessages = new Subject();
+    mockConnectImpl = () => Promise.resolve();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('connect() でメッセージを受信できる', done => {
+    const Receiver = setupReceiverWithMock();
+    const receiver = new Receiver('https://example.com/view');
+    const received: MessageResponse[] = [];
+
+    receiver.connect().subscribe({
+      next: msg => received.push(msg),
+      error: done,
+    });
+
+    // チャットメッセージを送信
+    const chatMsg = new dwango.nicolive.chat.service.edge.ChunkedMessage({
+      meta: { at: { seconds: 1000, nanos: 0 } },
+      message: { chat: { content: 'hello' } },
+    });
+    mockMessages.next(chatMsg);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ chat: { content: 'hello' } });
+    done();
+  });
+
+  test('接続エラー後に close() → connect() で再接続できる', async () => {
+    const Receiver = setupReceiverWithMock();
+    const receiver = new Receiver('https://example.com/view');
+
+    // --- 1回目の接続: エラーを発生させる ---
+    const error = new Error('network error');
+    mockConnectImpl = () => Promise.reject(error);
+
+    const errors: unknown[] = [];
+    receiver.connect().subscribe({ error: e => errors.push(e) });
+
+    // connect() のエラーが Promise.reject で非同期に来るので待つ
+    await Promise.resolve();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBe(error);
+
+    // --- close() して再接続準備 ---
+    receiver.close();
+
+    // 2回目の接続用に新しい Subject とモックをセットアップ
+    mockMessages = new Subject();
+    mockConnectImpl = () => Promise.resolve();
+
+    // --- 2回目の接続: 正常に動作することを確認 ---
+    const received: MessageResponse[] = [];
+    const errors2: unknown[] = [];
+    receiver.connect().subscribe({
+      next: msg => received.push(msg),
+      error: e => errors2.push(e),
+    });
+
+    // メッセージを送信
+    const chatMsg = new dwango.nicolive.chat.service.edge.ChunkedMessage({
+      meta: { at: { seconds: 2000, nanos: 0 } },
+      message: { chat: { content: 'reconnected' } },
+    });
+    mockMessages.next(chatMsg);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ chat: { content: 'reconnected' } });
+    expect(errors2).toHaveLength(0);
+  });
+
+  test('エラー後の再接続で古いエラーが新しい購読者に伝播しない', async () => {
+    const Receiver = setupReceiverWithMock();
+    const receiver = new Receiver('https://example.com/view');
+
+    // 1回目: エラーで切断
+    const error = new Error('fetch error');
+    mockConnectImpl = () => Promise.reject(error);
+    receiver.connect().subscribe({ error: () => {} }); // エラーを捨てる
+
+    await Promise.resolve();
+    receiver.close();
+
+    // 2回目の接続用にリセット
+    mockMessages = new Subject();
+    mockConnectImpl = () => Promise.resolve();
+
+    // 2回目の接続: 新しい購読者がすぐにエラーにならないことを確認
+    let immediateError: unknown = null;
+    receiver.connect().subscribe({ error: e => (immediateError = e) });
+
+    // 同期的にはエラーが来ないはず
+    expect(immediateError).toBeNull();
+  });
+});
 
 // convertModifierToMail の test
 describe('convertModifierToMail', () => {

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -367,11 +367,12 @@ export function convertChunkedResponseToMessageResponse(
 export class NdgrCommentReceiver implements IMessageServerClient {
   private ndgrClient: NdgrClient;
   private ndgrSubscription: Subscription;
-  private messageSubject = new Subject<MessageResponse>();
+  private messageSubject: Subject<MessageResponse>;
 
   constructor(private uri: string, private label = 'comment') {}
 
   connect(): Observable<MessageResponse> {
+    this.messageSubject = new Subject<MessageResponse>();
     this.ndgrClient = new NdgrClient(this.uri, this.label);
     this.ndgrSubscription = this.ndgrClient.messages.subscribe({
       next: msg => {

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -267,12 +267,11 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   nextConfigLoaded: Subject<void> = new Subject();
   private onNextConfig({ viewUri }: MessageServerConfig): void {
     this.unsubscribe();
+    this.clearList();
+    this.pinComment(null);
 
     // 予約番組は30分前にならないとURLが来ない
     if (!viewUri) return;
-
-    this.clearList();
-    this.pinComment(null);
 
     if (isFakeMode() && FakeModeConfig.dummyComment) {
       // yarn dev 時はダミーでコメントを5秒ごとに出し続ける

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -320,6 +320,20 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
       const room = program.rooms.length > 0 ? program.rooms[0] : undefined;
 
+      const newViewUri = room ? room.viewUri : '';
+
+      // setState 前に「同じ番組をすでに接続済みでコメントを受信していたか」を保存
+      // viewUri != '' はコメント接続済みであることを示す
+      const isRefetchSameProgram =
+        this.state.programID === nicoliveProgramId &&
+        this.state.viewUri !== '' &&
+        !this.state.showPlaceholder;
+
+      // viewUri が変わらない場合は一度空にしてコメント再接続をトリガーする
+      if (this.state.programID === nicoliveProgramId && this.state.viewUri === newViewUri && newViewUri !== '') {
+        this.setState({ viewUri: '' });
+      }
+
       this.setState({
         programID: nicoliveProgramId,
         status: program.status,
@@ -329,14 +343,15 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
         vposBaseTime: program.vposBaseAt,
         endTime: program.endAt,
         isMemberOnly: program.isMemberOnly,
-        viewUri: room ? room.viewUri : '',
+        viewUri: newViewUri,
         ...(program.moderatorViewUri && !isFakeMode()
           ? { moderatorViewUri: program.moderatorViewUri }
           : {}),
         serverClockOffsetSec: calcServerClockOffsetSec(programResponse),
         ...(password ? { password } : {}),
       });
-      if (program.status === 'test') {
+      if (program.status === 'test' && !isRefetchSameProgram) {
+        // 同じ番組の再取得でコメント受信済みの場合は showPlaceholder を再セットしない
         this.showPlaceholder();
       }
     } finally {
@@ -356,6 +371,12 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
 
     const program = programResponse.value;
     const room = program.rooms.length > 0 ? program.rooms[0] : undefined;
+    const newViewUri = room ? room.viewUri : '';
+
+    // viewUri が変わらない場合は一度空にしてコメント再接続をトリガーする
+    if (this.state.viewUri === newViewUri) {
+      this.setState({ viewUri: '' });
+    }
 
     this.setState({
       status: program.status,
@@ -364,7 +385,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       startTime: program.beginAt,
       endTime: program.endAt,
       isMemberOnly: program.isMemberOnly,
-      viewUri: room ? room.viewUri : '',
+      viewUri: newViewUri,
       serverClockOffsetSec: calcServerClockOffsetSec(programResponse),
     });
   }


### PR DESCRIPTION
## このpull requestが解決する内容

コメントビューアーでコメントサーバーとの接続がエラー（ネットワーク障害、HTTPエラー等）で切断された後、番組再取得ボタンまたはコメント更新ボタンを押してもコメントが受信できない問題を修正します。

## 背景

### 根本原因: `NdgrCommentReceiver.messageSubject` の永続的なエラー状態

`NdgrCommentReceiver` の `messageSubject`（RxJS Subject）がクラス構築時に1回だけ作成され、再接続時に再作成されていなかった。

**エラー発生時の流れ:**
1. `NdgrClient.connect()` が失敗 → `.catch(err => { this.messageSubject.error(err) })` が呼ばれる
2. RxJSのSubjectは一度 `error()` が呼ばれると永久に「死んだ」状態になる（新しい値を受け付けない）
3. 再接続ボタン → `connect()` で同じ `NdgrCommentReceiver` インスタンスが再利用される
4. 新しい `NdgrClient` は作成されるが、死んだ `messageSubject` にパイプされる
5. 新しいサブスクライバーには即座にエラーが再送されるか、値が一切届かない → サイレントに再接続失敗

### 副次的な問題: 再接続時にコメント一覧がクリアされない

- `onNextConfig` の `clearList()` が `viewUri=''` のとき呼ばれない（if文の後ろにあった）
- `viewUri` が同じ値のままだと `distinctUntilChanged` によりイベントが発火しない

### 副次的な問題: 準備中画面が再表示される

- `fetchProgram()` は常に `showPlaceholder()` を呼んでいたため、同じ番組を再取得してもコメント受信済みの準備中画面が再表示される問題があった

## 変更内容

### `NdgrCommentReceiver.ts`
- `messageSubject` を `connect()` の先頭で毎回新規作成するよう変更

### `nicolive-comment-viewer.ts`
- `clearList()` と `pinComment(null)` を `if (!viewUri) return;` の前に移動し、`viewUri=''` のイベントでもコメント一覧がクリアされるようにした

### `nicolive-program.ts`
- `fetchProgram()`: `viewUri` が変わらない場合に一度 `viewUri=''` を emit して `onNextConfig` を強制トリガー
- `fetchProgram()`: 同じ番組を再取得かつコメント受信済みの場合は `showPlaceholder()` を呼ばないよう修正（`isRefetchSameProgram` フラグ）
- `refreshProgram()`: 同様に `viewUri=''` トリック追加

### `ToolBar.vue.ts`
- `refreshProgram()` の不要な `return` を削除

### `NdgrCommentReceiver.test.ts`
- `NdgrCommentReceiver` の再接続シナリオのユニットテストを追加:
  - `connect()` でメッセージを受信できる
  - 接続エラー後に `close()` → `connect()` で再接続できる
  - エラー後の再接続で古いエラーが新しい購読者に伝播しない

## テスト

- [x] `pnpm run test:unit:app` でユニットテストが全て通ることを確認
- [x] 強制切断後の再接続でコメントが再受信されることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)