### PR TITLE
開発: dev server で node_modules/.cache 変更による不要なリロードを修正

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,9 @@ module.exports = function (env, argv) {
         static: {
           directory: __dirname,
           publicPath: '/',
+          watch: {
+            ignored: /node_modules/,
+          },
         },
         proxy: [
           {


### PR DESCRIPTION
## 概要

`pnpm run dev` で webpack-dev-server を使用した際、初回起動（cold cache）時にアプリケーションウィンドウが白画面のまま表示されない問題を修正します。

## 原因

webpack のビルドキャッシュは `node_modules/.cache/webpack/` に保存されます。
`devServer.static.directory` にプロジェクトルートが設定されており、webpack-dev-server がそのディレクトリ全体を監視していたため、webpack がキャッシュを書き込むたびにファイル変更を検知してページを強制リロードしていました。

初回起動時はキャッシュが一から生成されるため大量の書き込みが発生し、リロードループが起きてアプリが正常に表示されませんでした。

## 変更内容

- `webpack.config.js`: `devServer.static.watch.ignored` に `node_modules` を追加

```js
static: {
  directory: __dirname,
  publicPath: '/',
  watch: {
    ignored: /node_modules/,  // 追加
  },
},
```

## 動作確認手順

1. `node_modules/.cache` を削除してクリーンな状態にする
2. `pnpm run dev` を実行する
3. webpack ビルド完了後、アプリが正常に表示されることを確認
4. DevTools コンソールに `"from static directory was changed. Reloading..."` のループが出ないことを確認

## 関連

ホットリロード中の `Error: Render frame was disposed before WebFrameMain could be accessed` については後日別 PR で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)