### PR TITLE
開発: dev server HMR リロードで背景だけになる問題と関連エラーを修正

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -52,7 +52,15 @@ plugins.push((store: Store<any>) => {
   // Only the main window should ever receive this
   ipcRenderer.on('vuex-sendState', (event: Electron.Event, windowId: number) => {
     const win = remote.BrowserWindow.fromId(windowId);
-    win.webContents.send('vuex-loadState', store.state);
+    if (!win || win.isDestroyed()) return;
+    try {
+      win.webContents.send('vuex-loadState', store.state);
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message?.includes('Render frame was disposed')) {
+        return;
+      }
+      throw e;
+    }
   });
 
   // Only child windows should ever receive this

--- a/main.js
+++ b/main.js
@@ -463,6 +463,19 @@ function initialize(crashHandler) {
 
   global.indexUrl = process.env.DEV_SERVER || `file://${__dirname}/index.html`;
 
+  if (process.env.DEV_SERVER) {
+    // During dev server hot reload, Electron's WebFrameMain.prototype.send() catches
+    // "Render frame was disposed" internally and calls console.error() without re-throwing.
+    // try-catch cannot suppress this, so we filter the console output directly.
+    const originalConsoleError = console.error;
+    console.error = function (...args) {
+      if (typeof args[0] === 'string' && args[0].startsWith('Error sending from webFrameMain')) {
+        return;
+      }
+      return originalConsoleError.apply(this, args);
+    };
+  }
+
   // eslint-disable-next-line no-inner-declarations
   function openDevTools() {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -525,6 +538,24 @@ function initialize(crashHandler) {
 
   // Import splash window functions
   const { createSplashWindow, closeSplashWindow } = require('./splash/splash-window');
+
+  // Safely send IPC messages to a BrowserWindow or WebContents.
+  // During dev hot reload, the render frame may be disposed while the window is still alive.
+  // BrowserWindow.isDestroyed() does not catch this — only the frame is replaced, not the window.
+  // eslint-disable-next-line no-inner-declarations
+  function safeSend(target, channel, ...args) {
+    try {
+      if (target.isDestroyed()) return false;
+      const wc = target.webContents || target;
+      wc.send(channel, ...args);
+      return true;
+    } catch (e) {
+      if (e.message && e.message.includes('Render frame was disposed')) {
+        return false;
+      }
+      throw e;
+    }
+  }
 
   // eslint-disable-next-line no-inner-declarations
   async function startApp() {
@@ -637,7 +668,7 @@ function initialize(crashHandler) {
       if (!shutdownStarted) {
         console.log('[EXIT] Starting shutdown sequence');
         shutdownStarted = true;
-        mainWindow.send('shutdown');
+        safeSend(mainWindow, 'shutdown');
 
         // We give the main window 10 seconds to acknowledge a request
         // to shut down.  Otherwise, we just close it.
@@ -737,7 +768,7 @@ function initialize(crashHandler) {
     // background until it is needed.
     childWindow.on('close', e => {
       if (!shutdownStarted) {
-        childWindow.send('closeWindow');
+        safeSend(childWindow, 'closeWindow');
 
         // Prevent the window from actually closing
         e.preventDefault();
@@ -752,7 +783,7 @@ function initialize(crashHandler) {
     const requests = {};
 
     function sendRequest(request, event = null) {
-      mainWindow.webContents.send('services-request', request);
+      if (!safeSend(mainWindow, 'services-request', request)) return;
       if (!event) return;
       requests[request.id] = Object.assign({}, request, { event });
     }
@@ -771,7 +802,14 @@ function initialize(crashHandler) {
 
     ipcMain.on('services-ready', () => {
       if (!childWindow.isDestroyed()) {
-        childWindow.loadURL(`${global.indexUrl}?windowId=child`);
+        // Only load the URL if the child window hasn't been initialized yet.
+        // During HMR hot reload, the child window reloads itself independently,
+        // so calling loadURL again would interrupt its own reload and break the
+        // vuex state sync chain.
+        const currentUrl = childWindow.webContents.getURL();
+        if (!currentUrl || currentUrl === 'about:blank') {
+          childWindow.loadURL(`${global.indexUrl}?windowId=child`);
+        }
       }
     });
 
@@ -789,7 +827,7 @@ function initialize(crashHandler) {
       const windows = BrowserWindow.getAllWindows();
       windows.forEach(window => {
         if (window.id === mainWindow.id || window.isDestroyed()) return;
-        window.webContents.send('services-message', payload);
+        safeSend(window, 'services-message', payload);
       });
     });
 
@@ -824,7 +862,7 @@ function initialize(crashHandler) {
     // Check for protocol links in the argv of the other process
     argv.forEach(arg => {
       if (arg.match(/^n-air-app:\/\//)) {
-        mainWindow.send('protocolLink', arg);
+        safeSend(mainWindow, 'protocolLink', arg);
       }
     });
 
@@ -1034,7 +1072,7 @@ function initialize(crashHandler) {
       // Tell the mainWindow to send its current store state
       // to the newly registered window
 
-      mainWindow.webContents.send('vuex-sendState', windowId);
+      safeSend(mainWindow, 'vuex-sendState', windowId);
     }
   });
 
@@ -1049,7 +1087,7 @@ function initialize(crashHandler) {
         .filter(id => id !== windowId.toString())
         .forEach(id => {
           const win = registeredStores[id];
-          if (!win.isDestroyed()) win.webContents.send('vuex-mutation', mutation);
+          safeSend(win, 'vuex-mutation', mutation);
         });
     }
   });
@@ -1088,14 +1126,11 @@ function initialize(crashHandler) {
 
   ipcMain.on('requestPerformanceStats', e => {
     const stats = app.getAppMetrics();
-    e.sender.send('performanceStatsResponse', stats);
+    safeSend(e.sender, 'performanceStatsResponse', stats);
   });
 
   ipcMain.on('showErrorAlert', () => {
-    if (!mainWindow.isDestroyed()) {
-      // main window may be destroyed on shutdown
-      mainWindow.send('showErrorAlert');
-    }
+    safeSend(mainWindow, 'showErrorAlert');
   });
 
   ipcMain.on('webContents-enableRemote', (e, id) => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compile:ci": "pnpm clear && webpack-cli --mode development",
     "compile:production": "pnpm clear && webpack-cli --progress --mode production",
     "compile-tests": "tsc -p test",
-    "dev": "run-p dev:*",
+    "dev": "run-p --race dev:*",
     "dev:server": "webpack-cli serve --progress --hot --mode development",
     "dev:start": "cross-env NAIR_UNSTABLE=1 DEV_SERVER=\"http://localhost:8080/index.dev.html\" electron . && echo 'electron exited.'",
     "format": "eslint --fix {app,test,nvoice}/**/*.{ts,js,vue} && stylelint --fix app/**/*.{vue,css,less} && npx sort-package-json",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,7 +107,9 @@ module.exports = function (env, argv) {
           directory: __dirname,
           publicPath: '/',
           watch: {
-            ignored: /node_modules/,
+            // Ignore source directories compiled by webpack — they should trigger
+            // webpack HMR, not a static-file live reload before recompilation.
+            ignored: [/node_modules/, /[/\\]app[/\\]/, /[/\\]nvoice[/\\]/],
           },
         },
         proxy: [


### PR DESCRIPTION
## このpull requestが解決する内容

`pnpm run dev` でソースファイルを編集したとき、以下の問題を修正します。

1. **メインウィンドウが背景だけになる**: ソース変更後のリロードでアプリが正常に表示されなくなる
2. **"Error sending from webFrameMain" エラー**: HMR リロード時に IPC フレームが破棄されたことで出力されるエラー
3. **プロセス残留**: Ctrl+C で停止後、webpack-dev-server が終了せずポート 8080 を占有する

## 根本原因

`webpack.config.js` の `devServer.static.directory` がプロジェクトルート（`__dirname`）に設定されており、static ファイルウォッチャーが `app/` 以下のソースファイルも監視していた。ファイルを変更すると **webpack がコンパイルする前に** live reload (`window.location.reload()`) が走り、旧コードでリロードされた後にメインウィンドウの初期化が失敗していた。

関連: #1171（static ウォッチャーから node_modules を除外）でも同様の問題に対処しており、本 PR はその続きとしてソースディレクトリ（`app/`, `nvoice/`）も除外対象に追加する。

## 変更内容

### `webpack.config.js`
- static ウォッチャーの `ignored` に `app/` と `nvoice/` を追加
- これらは webpack がコンパイルするソースファイルであり、webpack HMR 経由で変更を適用すべき
- これにより、ソース変更 → webpack コンパイル → HMR 適用 という正しい順序になる

### `main.js`
- `safeSend()` ヘルパーを追加し、IPC 送信箇所に適用
  - HMR リロード中にウィンドウが存在してもフレームが破棄されている場合のクラッシュを防ぐ
- dev server 実行時に `"Error sending from webFrameMain"` の `console.error` を抑制
  - Electron 29 の `WebFrameMain.prototype.send()` は "Render frame was disposed" を内部でキャッチして `console.error()` 出力するため、try-catch では捕捉できない
- `services-ready` 受信時、child window が既に URL を持っている場合は `loadURL()` を再実行しない
  - HMR リロード時に child window が自律的に再初期化するのを妨げないようにする

### `app/store/index.ts`
- `vuex-sendState` ハンドラに null チェックと try-catch を追加
- `@electron/remote` 経由の `win.webContents.send()` が例外をスローするケースに対応

### `package.json`
- `run-p --race dev:*` に変更
- electron 終了時（ウィンドウを閉じる・Ctrl+C）に webpack-dev-server も自動的に kill され、プロセスが残留しなくなる

## テスト

- [x] `pnpm run dev` でアプリが正常に起動することを確認
- [x] `app/components/nicolive-area/NicoliveArea.vue` を変更するとウィンドウが背景だけにならず正常に表示されることを確認
- [x] "Error sending from webFrameMain" エラーが出ないことを確認
- [x] アプリを閉じると webpack-dev-server プロセスも終了することを確認

## 関連PR
- #1171 

🤖 Generated with [Claude Code](https://claude.com/claude-code)