### PR TITLE
開発: PR#1167 で発生したコメント接続のリグレッションを修正

### DIFF
--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -1,6 +1,7 @@
 import * as remote from '@electron/remote';
 import { Inject } from 'services/core/injector';
 import { $t } from 'services/i18n';
+import { NicoliveCommentViewerService } from 'services/nicolive-program/nicolive-comment-viewer';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
 import {
   NicoliveFailure,
@@ -17,6 +18,7 @@ import Popper from '../shared/Popper.vue';
 export default class ToolBar extends Vue {
   @Inject()
   nicoliveProgramService: NicoliveProgramService;
+  @Inject() nicoliveCommentViewerService: NicoliveCommentViewerService;
   @Inject() streamingService: StreamingService;
 
   // TODO: 後で言語ファイルに移動する
@@ -61,6 +63,8 @@ export default class ToolBar extends Vue {
     if (this.isFetching) throw new Error('fetchProgram is running');
     try {
       await this.nicoliveProgramService.fetchProgram();
+      // 番組情報取得時にコメント接続も更新する
+      await this.nicoliveCommentViewerService.refreshConnection();
     } catch (caught) {
       if (caught instanceof NicoliveFailure) {
         await openErrorDialogFromFailure(caught);

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -267,11 +267,13 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   nextConfigLoaded: Subject<void> = new Subject();
   private onNextConfig({ viewUri }: MessageServerConfig): void {
     this.unsubscribe();
-    this.clearList();
-    this.pinComment(null);
 
     // 予約番組は30分前にならないとURLが来ない
     if (!viewUri) return;
+
+    // 再接続時のみコメントリストをクリアする（番組終了で viewUri が空になる場合はクリアしない）
+    this.clearList();
+    this.pinComment(null);
 
     if (isFakeMode() && FakeModeConfig.dummyComment) {
       // pnpm dev 時はダミーでコメントを5秒ごとに出し続ける

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -508,6 +508,29 @@ test('refreshProgram:成功', async () => {
   `);
 });
 
+test('refreshProgram: viewUri が同じでも setState は1回のみ（viewUri リセットトリックなし）', async () => {
+  setup();
+  const { instance, setState } = setupInstance({ mockSetState: true });
+
+  // 初期状態として status と viewUri を設定（配信中で接続済みの状態）
+  (instance as any).state = {
+    ...(instance as any).state,
+    status: 'onAir',
+    viewUri: 'https://example.com/lv1',
+  };
+
+  instance.client.fetchProgram = jest
+    .fn()
+    .mockName('fetchProgram')
+    .mockResolvedValue({ ok: true, value: programs.onAir });
+
+  await expect(instance.refreshProgram()).resolves.toBeUndefined();
+  expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
+  // viewUri リセットトリックが削除されたため、viewUri が同じでも setState は1回のみ
+  expect(setState).toHaveBeenCalledTimes(1);
+  expect(setState.mock.calls[0][0]).not.toHaveProperty('viewUri', '');
+});
+
 test('refreshProgram:失敗', async () => {
   setup();
   const { instance, setState } = setupInstance({ mockSetState: true });

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -329,11 +329,6 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
         this.state.viewUri !== '' &&
         !this.state.showPlaceholder;
 
-      // viewUri が変わらない場合は一度空にしてコメント再接続をトリガーする
-      if (this.state.programID === nicoliveProgramId && this.state.viewUri === newViewUri && newViewUri !== '') {
-        this.setState({ viewUri: '' });
-      }
-
       this.setState({
         programID: nicoliveProgramId,
         status: program.status,
@@ -372,11 +367,6 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     const program = programResponse.value;
     const room = program.rooms.length > 0 ? program.rooms[0] : undefined;
     const newViewUri = room ? room.viewUri : '';
-
-    // viewUri が変わらない場合は一度空にしてコメント再接続をトリガーする
-    if (this.state.viewUri === newViewUri) {
-      this.setState({ viewUri: '' });
-    }
 
     this.setState({
       status: program.status,


### PR DESCRIPTION
## このpull requestが解決する内容

PR#1167「コメントサーバー再接続後にコメントが受信できない問題を修正」で発生した以下のリグレッションを修正します。

- 配信開始ボタンを押すとコメントリストがクリアされ再読み込みされる
- 番組終了時にコメントリストがクリアされる

## 背景

PR#1167 では通信エラーで切断後に「番組情報取得」「コメント更新」ボタンで再接続できるよう、以下の変更が行われた。

1. `fetchProgram()` / `refreshProgram()` に viewUri リセットトリック（同じ viewUri でも一度 `''` にしてから戻す）を追加
2. `onNextConfig()` の `clearList()` を viewUri ガードの前に移動

これらの変更が意図しないコードパスでも発動し、リグレッションが発生していた。

### 配信開始時の問題

`streaming.ts` が配信開始処理中に `fetchProgram()` を呼ぶため、viewUri リセットトリックが発動してコメントリストがクリア・再接続されていた。

### 番組終了時の問題

番組終了時、サーバーから `state='ended'` を受信して `refreshProgram()` が呼ばれると、API が rooms 空を返し `viewUri` が `''` に変化する。PR#1167 で `clearList()` がガード前に移動されたため、viewUri が空になる際にも必ずコメントリストがクリアされていた。

## 変更内容

- `fetchProgram()` / `refreshProgram()` から viewUri リセットトリックを削除
- `onNextConfig()` の `clearList()` を viewUri ガードの後に移動（`viewUri` が空の場合はコメントリストをクリアしない）
- ToolBar の「番組再取得」ボタンから `NicoliveCommentViewerService.refreshConnection()` を明示的に呼び出すことで、コメント再接続を明示的に行う（リセットトリック廃止後もボタンからの再接続機能を維持）

## テスト

- [x] 配信開始ボタンを押してもコメントリストがクリアされないこと
- [x] 番組終了時にコメントリストが維持され「番組が終了しました」メッセージが表示されること
- [x] 「番組再取得」ボタンでコメント再接続されること
- [x] 「コメント更新」ボタンでコメント再接続されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)