### PR TITLE
開発: Popper の初回クリックでメニューが開かない問題と位置ずれを修正

### DIFF
--- a/app/components/shared/Popper.vue
+++ b/app/components/shared/Popper.vue
@@ -1,11 +1,11 @@
 <template>
   <span>
     <transition>
-      <span v-show="showPopper">
+      <span v-show="showPopper" ref="popperWrapper">
         <slot />
       </span>
     </transition>
-    <slot name="reference" />
+    <span ref="referenceWrapper"><slot name="reference" /></span>
   </span>
 </template>
 

--- a/app/components/shared/Popper.vue.ts
+++ b/app/components/shared/Popper.vue.ts
@@ -193,18 +193,28 @@ export default defineComponent({
         const showPopper = ref(false);
         const referenceEl = ref<Element | null>(null);
         const popperEl = ref<HTMLElement | null>(null);
+        // テンプレート ref: slot コンテンツのラッパー要素
+        const referenceWrapper = ref<HTMLElement | null>(null);
+        const popperWrapper = ref<HTMLElement | null>(null);
 
         const updatePosition = () => {
             if (!referenceEl.value || !popperEl.value) return;
 
             const placement = props.placement;
+
+            // width を先に設定してから寸法を測定する
+            // 未設定のまま getBoundingClientRect を呼ぶと viewport 端に追い込まれて
+            // 幅が圧縮され、高さが異常に大きくなって位置計算がおかしくなる
+            if (props.width !== undefined) {
+                popperEl.value.style.width = props.width;
+            }
+
             const { top, left } = calculatePosition(referenceEl.value, popperEl.value, placement);
 
             Object.assign(popperEl.value.style, {
                 position: 'fixed',
                 top: `${top}px`,
                 left: `${left}px`,
-                ...(props.width !== undefined ? { width: props.width } : {}),
             });
 
             popperEl.value.setAttribute('x-placement', placement);
@@ -267,21 +277,20 @@ export default defineComponent({
         });
 
         onMounted(() => {
-            nextTick(() => {
-                const referenceSlot = slots.reference?.();
-                const defaultSlot = slots.default?.();
+            // テンプレート ref 経由で slot コンテンツの DOM 要素を取得する。
+            // slots.xxx()[0].elm は setup() 呼び出し時に新しい VNode が生成されるため
+            // .elm が未設定になる場合があり使用できない。
+            // ラッパー span の firstElementChild が実際のコンテンツ要素となる。
+            if (referenceWrapper.value?.firstElementChild) {
+                referenceEl.value = referenceWrapper.value.firstElementChild;
+            }
+            if (popperWrapper.value?.firstElementChild) {
+                popperEl.value = popperWrapper.value.firstElementChild as HTMLElement;
+            }
 
-                if (referenceSlot?.[0]?.elm) {
-                    referenceEl.value = referenceSlot[0].elm as Element;
-                }
-                if (defaultSlot?.[0]?.elm) {
-                    popperEl.value = defaultSlot[0].elm as HTMLElement;
-                }
-
-                referenceEl.value?.addEventListener('click', onReferenceClick);
-                popperEl.value?.addEventListener('click', onPopperClick);
-                document.addEventListener('click', onDocumentClick);
-            });
+            referenceEl.value?.addEventListener('click', onReferenceClick);
+            popperEl.value?.addEventListener('click', onPopperClick);
+            document.addEventListener('click', onDocumentClick);
         });
 
         onBeforeUnmount(() => {
@@ -293,6 +302,8 @@ export default defineComponent({
         return {
             showPopper,
             doClose,
+            referenceWrapper,
+            popperWrapper,
         };
     },
 });

--- a/app/components/shared/Popper.vue.ts
+++ b/app/components/shared/Popper.vue.ts
@@ -189,7 +189,7 @@ export default defineComponent({
             default: true,
         },
     },
-    setup(props, { emit, slots }) {
+    setup(props, { emit }) {
         const showPopper = ref(false);
         const referenceEl = ref<Element | null>(null);
         const popperEl = ref<HTMLElement | null>(null);


### PR DESCRIPTION
## このpull requestが解決する内容

PR #1155 で `vue-popperjs` を軽量なカスタム Popper 実装に置き換えた際に生じた2つの問題を修正します：

1. **初回クリックでメニューが開かない**: 番組取得後など `v-if` でコンポーネントが新たにマウントされた直後のクリックをイベントリスナーが取り逃す
2. **初回表示時にポップアップが画面上端に飛ぶ**: `top: -1322px` などの異常な座標になり、メニューが見えない位置に表示される

## 原因

### 問題1: `nextTick` による遅延

```typescript
// 修正前
onMounted(() => {
    nextTick(() => {  // ← この nextTick の遅延中にクリックイベントが発生すると取り逃す
        referenceEl.value?.addEventListener('click', onReferenceClick);
    });
});
```

`NicoliveArea.vue` の `v-if="hasProgram"` で Popper コンポーネントがマウントされた直後に、ユーザーがメニューボタンをクリックすると `nextTick` による1ティック遅延のためリスナーが未登録のままクリックを逃していた。

### 問題2: slot VNode の `.elm` が null

```typescript
// 修正前 (Vue 2.7 Composition API では動作しない)
const referenceSlot = slots.reference?.();  // ← 毎回新しい VNode を生成
referenceEl.value = referenceSlot[0].elm;   // ← .elm が未設定
```

Vue 2.7 の Composition API では `slots.xxx()` を呼び出すたびに新しい VNode インスタンスが生成される。この VNode は実際のレンダラーが管理するものとは別物のため `.elm` が設定されない。

### 問題3: `width` 未設定での `getBoundingClientRect()` 呼び出し

`position: fixed` 要素を `width` 未設定のまま表示すると、ブラウザがビューポート端での幅を計算し、コンテンツが圧縮される。例えば `width: 88px、height: 2152px` というサイズになり、ビューポート調整ロジックが `top = viewport.height - 2152 - 10 = -1322px` を計算していた。

## 変更内容

### `app/components/shared/Popper.vue`

テンプレートに `ref="popperWrapper"` と `ref="referenceWrapper"` を追加：

```html
<span v-show="showPopper" ref="popperWrapper">
  <slot />
</span>
<span ref="referenceWrapper"><slot name="reference" /></span>
```

### `app/components/shared/Popper.vue.ts`

1. **テンプレート ref を使って DOM 要素を同期的に取得**（`nextTick` 廃止、`slots.elm` 廃止）：
   ```typescript
   onMounted(() => {
       // ラッパー span の firstElementChild が実際のコンテンツ要素
       if (referenceWrapper.value?.firstElementChild) {
           referenceEl.value = referenceWrapper.value.firstElementChild;
       }
       if (popperWrapper.value?.firstElementChild) {
           popperEl.value = popperWrapper.value.firstElementChild as HTMLElement;
       }
       referenceEl.value?.addEventListener('click', onReferenceClick);
       // ...
   });
   ```

2. **`getBoundingClientRect()` 前に `width` を設定**：
   ```typescript
   const updatePosition = () => {
       // width を先に設定してから寸法を測定する
       if (props.width !== undefined) {
           popperEl.value.style.width = props.width;
       }
       const { top, left } = calculatePosition(referenceEl.value, popperEl.value, placement);
       // ...
   };
   ```

## 影響範囲

Popper コンポーネントを使用している全7箇所：
- `app/components/nicolive-area/AreaSwitcher.vue`
- `app/components/nicolive-area/ToolBar.vue`
- `app/components/nicolive-area/ProgramInfo.vue`
- `app/components/nicolive-area/CommentFilter.vue`
- `app/components/windows/UserInfo.vue`
- `app/components/windows/RtvcSourceProperties.vue`
- `app/components/SceneSelector.vue`

## テスト

- [x] 番組取得直後にメニューボタンを1回クリックでメニューが開くこと
- [x] メニューの位置が正しいこと（ボタンの直下）
- [x] テスト配信中の開始/終了ボタンセレクタが1回クリックで開くこと
- [x] 複数のメニューを連続でクリックした際に、他のメニューが閉じること

🤖 Generated with [Claude Code](https://claude.com/claude-code)