### PR TITLE
開発: 未使用の依存パッケージ(babel, webpack関連)を削除

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,11 +18,8 @@
     ],
     "@babel/plugin-transform-class-properties",
     "@babel/plugin-transform-export-namespace-from",
-    "@babel/plugin-proposal-function-sent",
     "@babel/plugin-transform-json-strings",
     "@babel/plugin-transform-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions",
-    "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-syntax-import-meta"
+    "@babel/plugin-proposal-throw-expressions"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -96,10 +96,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.6",
     "@babel/plugin-proposal-decorators": "^7.28.6",
-    "@babel/plugin-proposal-function-sent": "^7.22.5",
     "@babel/plugin-proposal-throw-expressions": "^7.22.5",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-transform-class-properties": "^7.28.6",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",
     "@babel/plugin-transform-json-strings": "^7.28.6",
@@ -167,8 +164,7 @@
     "webdriverio": "7.30.2",
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.1.0",
-    "webpack-merge": "^6.0.1"
+    "webpack-dev-server": "^5.1.0"
   },
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,18 +127,9 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.6
         version: 7.28.6(@babel/core@7.28.6)
-      '@babel/plugin-proposal-function-sent':
-        specifier: ^7.22.5
-        version: 7.27.1(@babel/core@7.28.6)
       '@babel/plugin-proposal-throw-expressions':
         specifier: ^7.22.5
         version: 7.27.1(@babel/core@7.28.6)
-      '@babel/plugin-syntax-dynamic-import':
-        specifier: ^7.8.3
-        version: 7.8.3(@babel/core@7.28.6)
-      '@babel/plugin-syntax-import-meta':
-        specifier: ^7.10.4
-        version: 7.10.4(@babel/core@7.28.6)
       '@babel/plugin-transform-class-properties':
         specifier: ^7.28.6
         version: 7.28.6(@babel/core@7.28.6)
@@ -343,9 +334,6 @@ importers:
       webpack-dev-server:
         specifier: ^5.1.0
         version: 5.2.2(webpack-cli@6.0.1)(webpack@5.104.1)
-      webpack-merge:
-        specifier: ^6.0.1
-        version: 6.0.1
 
 packages:
 
@@ -539,12 +527,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-proposal-function-sent@7.27.1':
-    resolution: {integrity: sha512-xA8Bqt8p12TxOFy3os20LxmOoHjyhzRC3zBql57d2W/YarNHgxHB4IlLHf3nXb7N6vSZ6kAdOoK2z5h0evGMhw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
@@ -581,11 +563,6 @@ packages:
   '@babel/plugin-syntax-decorators@7.28.6':
     resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
     engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-dynamic-import@7.8.3':
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -5763,10 +5740,6 @@ packages:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
 
-  popper.js@1.16.1:
-    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
-    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
-
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -7681,14 +7654,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-function-sent@7.27.1(@babel/core@7.28.6)':
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-wrap-function': 7.28.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
@@ -7722,11 +7687,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.6)':
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.28.6)':
     dependencies:
@@ -13879,8 +13839,6 @@ snapshots:
       irregular-plurals: 3.5.0
 
   pngjs@3.4.0: {}
-
-  popper.js@1.16.1: {}
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## 概要

使用されていない依存パッケージを削除します。

## 変更内容

### 削除したパッケージ（devDependencies）

- @babel/plugin-proposal-function-sent — .babelrc に記載があったが未使用
- @babel/plugin-syntax-dynamic-import — webpack に組み込み済みのため不要
- @babel/plugin-syntax-import-meta — webpack に組み込み済みのため不要
- webpack-merge — webpack 設定がシングルファイル構成のため不要

## 確認方法

- pnpm install が正常に完了すること
- pnpm compile が正常に完了すること
- pnpm lint がエラーなしで完了すること