### PR TITLE
開発: bin/ minimatch を 3.1.2 → 3.1.5 に更新（Alert 126, 135, 137 解消）

### DIFF
--- a/bin/pnpm-lock.yaml
+++ b/bin/pnpm-lock.yaml
@@ -981,8 +981,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -2429,7 +2429,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -2561,7 +2561,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 


### PR DESCRIPTION
## このpull requestが解決する内容

PR #1178 での `bin/pnpm-lock.yaml` minimatch 更新漏れを修正します。

`bin/pnpm-lock.yaml` の minimatch@3.1.2 が更新されなかったため、以下のDependabotセキュリティアラートが残存していました：

- **Alert 126** (CVE-2026-26996, High): minimatch@3.x ReDoS
- **Alert 135** (CVE-2026-27904, High): minimatch@3.x ReDoS
- **Alert 137** (CVE-2026-27903, High): minimatch@3.x ReDoS

## 変更内容

### bin/（bin/pnpm-lock.yaml）

| package | before | after | 解消するアラート |
|---------|--------|-------|----------------|
| minimatch | 3.1.2 | 3.1.5 | Alert 126 (CVE-2026-26996), 135 (CVE-2026-27904), 137 (CVE-2026-27903) |

**更新コマンド**:
```bash
cd bin && PNPM_HOME="" pnpm update minimatch --ignore-workspace
```

## テスト

- [x] `bin/pnpm-lock.yaml` に minimatch@3.1.5 が記録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)