### PR TITLE
開発: SoundDetectorSettings のバグ修正（スライダー入力バリデーション・ソース不在表示）

### DIFF
--- a/app/components/SoundDetectorSettings.vue
+++ b/app/components/SoundDetectorSettings.vue
@@ -24,6 +24,9 @@
             <label>基本設定</label>
           </div>
           <ObsListInput v-model="soundDetectorSourceModel" />
+          <p v-if="!sourceAvailable" class="source-unavailable-warning">
+            選択したソースがこのシーンに存在しません。入力音声ソースを選び直してください。
+          </p>
           <ObsSliderInput v-model="soundThresholdDbModel" />
         </div>
       </toc-section>
@@ -136,5 +139,11 @@
 .sound-detector-volmeter-label {
   font-size: var(--font-size-xs);
   color: var(--color-object-emphasis-medium);
+}
+
+.source-unavailable-warning {
+  margin: 4px 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-warning);
 }
 </style>

--- a/app/components/SoundDetectorSettings.vue.ts
+++ b/app/components/SoundDetectorSettings.vue.ts
@@ -109,6 +109,19 @@ export default class SoundDetectorSettings extends Vue {
     this.sourceMutedSubscription.unsubscribe();
   }
 
+  sourceAvailable = true;
+  sourceAvailableSubscription: Subscription;
+  subscribeSourceAvailable() {
+    this.sourceAvailableSubscription = this.soundDetectorService.sourceAvailable.subscribe({
+      next: available => {
+        this.sourceAvailable = available;
+      },
+    });
+  }
+  unsubscribeSourceAvailable() {
+    this.sourceAvailableSubscription.unsubscribe();
+  }
+
   subscribeAudioSourcesChanged() {
     const sub = new Subscription();
     sub.add(
@@ -136,12 +149,14 @@ export default class SoundDetectorSettings extends Vue {
     this.startMonitorSpeaking();
     this.startSoundDetection();
     this.subscribeMuted();
+    this.subscribeSourceAvailable();
     this.subscribeAudioSourcesChanged();
   }
 
   beforeDestroy() {
     this.stopContinuousPlayback();
     this.unsubscribeMuted();
+    this.unsubscribeSourceAvailable();
     this.unsubscribeAudioSourcesChanged();
     this.endSoundDetection();
     this.endMonitorSpeaking();
@@ -179,21 +194,27 @@ export default class SoundDetectorSettings extends Vue {
     // audioSourcesChanged/muteChanged 時にgetterを再評価させる
     this.audioSourcesVersion;
     const sources = this.soundDetectorService.getAvailableSources();
+    const sourceId = this.soundDetectorService.state.sourceId;
+    const options: { description: string; value: string }[] = [
+      {
+        description: 'マイクまたはボイスチェンジャー(自動)',
+        value: 'mic',
+      },
+      ...sources.map(source => ({
+        description: source.name,
+        value: source.sourceId,
+      })),
+    ];
+    // 選択中のソースがオプションに存在しない場合、不在表示を追加
+    if (sourceId !== null && sourceId !== 'mic' && !options.some(o => o.value === sourceId)) {
+      options.push({ description: '(このシーンにありません)', value: sourceId });
+    }
     return {
       description: '入力音声ソース',
       name: 'audioWatchSource',
-      value: this.soundDetectorService.state.sourceId,
+      value: sourceId,
       enabled: this.soundDetectorEnabled,
-      options: [
-        {
-          description: 'マイクまたはボイスチェンジャー(自動)',
-          value: 'mic',
-        },
-        ...sources.map(source => ({
-          description: source.name,
-          value: source.sourceId,
-        })),
-      ],
+      options,
     };
   }
   set soundDetectorSourceModel(model: IObsListInput<string>) {

--- a/app/components/shared/Slider.vue
+++ b/app/components/shared/Slider.vue
@@ -20,9 +20,12 @@
     <input
       v-if="valueBox && !usePercentages"
       class="slider-input"
-      type="text"
+      type="number"
       :value="value"
       :disabled="disabled"
+      :min="min"
+      :max="max"
+      :step="interval"
       @change="updateValue(parseFloat($event.target.value))"
       @keydown="handleKeydown"
     />

--- a/app/components/shared/Slider.vue.ts
+++ b/app/components/shared/Slider.vue.ts
@@ -33,17 +33,30 @@ export default class SliderInput extends Vue {
   }
 
   updateValue(value: number) {
-    this.$emit('input', this.roundNumber(value));
+    this.$emit('input', this.roundNumber(this.clampValue(value)));
   }
 
   handleKeydown(event: KeyboardEvent) {
-    if (event.code === 'ArrowUp') this.updateValue(this.value + this.interval);
-    if (event.code === 'ArrowDown') this.updateValue(this.value - this.interval);
+    if (event.code === 'ArrowUp') {
+      event.preventDefault();
+      this.updateValue(this.value + this.interval);
+    }
+    if (event.code === 'ArrowDown') {
+      event.preventDefault();
+      this.updateValue(this.value - this.interval);
+    }
   }
 
   // Javascript precision is weird
   roundNumber(num: number) {
     return parseFloat(num.toFixed(6));
+  }
+
+  clampValue(value: number): number {
+    if (Number.isNaN(value)) {
+      return this.value;
+    }
+    return Math.min(Math.max(value, this.min), this.max);
   }
 
   formatter(value: number) {

--- a/app/services/sound-detector/sound-detector.test.ts
+++ b/app/services/sound-detector/sound-detector.test.ts
@@ -30,13 +30,15 @@ function makeAudioSource({
   sourceId,
   name,
   stream,
+  isMuted,
 }: {
   type: TSourceType;
   sourceId: string;
   name: string;
   stream: Subject<IVolmeter>;
+  isMuted?: () => boolean;
 }): AudioSource {
-  return {
+  const audioSource = {
     sourceId,
     name,
     source: {
@@ -49,6 +51,12 @@ function makeAudioSource({
     } as Source,
     getVolmeterStream: () => stream.asObservable(),
   } as AudioSource;
+  Object.defineProperty(audioSource, 'muted', {
+    get: () => (isMuted ? isMuted() : false),
+    enumerable: true,
+    configurable: true,
+  });
+  return audioSource;
 }
 
 function prepare(
@@ -62,12 +70,14 @@ function prepare(
   // AudioService
   const audioSourcesChanged = new Subject<void>();
   const muteChanged = new Subject<{ sourceId: string; muted: boolean }>();
+  const mutedSources = new Set<string>();
   const micStream = new Subject<IVolmeter>();
   const micSource = makeAudioSource({
     sourceId: 'mic',
     name: 'マイク',
     type: 'wasapi_input_capture',
     stream: micStream,
+    isMuted: () => mutedSources.has('mic'),
   });
   const rtvcStream = new Subject<IVolmeter>();
   const rtvcSource = makeAudioSource({
@@ -75,8 +85,8 @@ function prepare(
     sourceId: 'rtvc',
     type: 'nair-rtvc-source',
     stream: rtvcStream,
+    isMuted: () => mutedSources.has('rtvc'),
   });
-  const mutedSources = new Set<string>();
   const mute = (sourceId: string, muted: boolean) => {
     if (mutedSources.has(sourceId) === muted) {
       return;
@@ -225,6 +235,120 @@ describe('SoundDetectorService', () => {
     expect(sourceMuted).toBe(false);
     mute('rtvc', false);
     expect(sourceMuted).toBe(false);
+  });
+
+  test('監視対象のソースが存在しない場合 sourceMuted は false になる', () => {
+    const { instance } = prepare();
+
+    let sourceMuted: boolean;
+    instance.sourceMuted.subscribe(muted => {
+      sourceMuted = muted;
+    });
+
+    // 空のソースリストで subscribeAudioSource を呼ぶ（シーン切り替えで対象ソースがない場合を再現）
+    instance.subscribeAudioSource([]);
+    expect(sourceMuted).toBe(false);
+  });
+
+  describe('sourceAvailable', () => {
+    test('sourceId が mic の場合は常に true', () => {
+      // sourceId='mic' はデフォルト値
+      const { instance } = prepare();
+
+      let sourceAvailable: boolean;
+      instance.sourceAvailable.subscribe(available => {
+        sourceAvailable = available;
+      });
+
+      expect(sourceAvailable).toBe(true);
+    });
+
+    test('特定ソースが存在する場合は true', () => {
+      const audioSourcesChanged = new Subject<void>();
+      const muteChanged = new Subject<{ sourceId: string; muted: boolean }>();
+      const micStream = new Subject<IVolmeter>();
+      const micSource = makeAudioSource({
+        sourceId: 'mic',
+        name: 'マイク',
+        type: 'wasapi_input_capture',
+        stream: micStream,
+      });
+
+      const availableSources: AudioSource[] = [micSource];
+
+      setup({
+        state: { SoundDetectorService: { sourceId: 'mic' } },
+        injectee: {
+          AudioService: {
+            audioSourcesChanged,
+            muteChanged,
+            getVisibleSourcesForCurrentScene: () => availableSources,
+            getSource: (sourceId: string) => ({ muted: false }),
+          },
+        },
+      });
+
+      const { SoundDetectorService } = require('./sound-detector');
+      const instance = SoundDetectorService.instance as SoundDetectorService;
+      instance.enable();
+
+      let sourceAvailable: boolean;
+      instance.sourceAvailable.subscribe(available => {
+        sourceAvailable = available;
+      });
+
+      // 特定ソースを選択
+      instance.updateSourceId('mic');
+      expect(sourceAvailable).toBe(true);
+    });
+
+    test('選択中のソースがシーン切り替えで消えた場合は false になる', () => {
+      const audioSourcesChanged = new Subject<void>();
+      const muteChanged = new Subject<{ sourceId: string; muted: boolean }>();
+      const micStream = new Subject<IVolmeter>();
+      const micSource = makeAudioSource({
+        sourceId: 'specific-mic',
+        name: 'マイク(特定)',
+        type: 'wasapi_input_capture',
+        stream: micStream,
+      });
+
+      let availableSources: AudioSource[] = [micSource];
+
+      setup({
+        state: { SoundDetectorService: { sourceId: 'specific-mic' } },
+        injectee: {
+          AudioService: {
+            audioSourcesChanged,
+            muteChanged,
+            getVisibleSourcesForCurrentScene: () => availableSources,
+            getSource: (sourceId: string) => ({ muted: false }),
+          },
+        },
+      });
+
+      const { SoundDetectorService } = require('./sound-detector');
+      const instance = SoundDetectorService.instance as SoundDetectorService;
+      instance.enable();
+
+      let sourceAvailable: boolean;
+      instance.sourceAvailable.subscribe(available => {
+        sourceAvailable = available;
+      });
+
+      // 初期状態: ソースが存在する
+      expect(sourceAvailable).toBe(true);
+
+      // シーン切り替えでソースが消える
+      availableSources = [];
+      audioSourcesChanged.next();
+      expect(sourceAvailable).toBe(false);
+
+      // 元のシーンに戻ってソースが復活
+      availableSources = [micSource];
+      audioSourcesChanged.next();
+      expect(sourceAvailable).toBe(true);
+    });
   });
 
   describe('init() の不正値補正', () => {

--- a/app/services/sound-detector/sound-detector.ts
+++ b/app/services/sound-detector/sound-detector.ts
@@ -278,44 +278,56 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     });
     this.audioSubscriptions = newSourcesMap;
     this.updateSourceMuted();
+    this.updateSourceAvailable();
   }
   unsubscribeAudioSource() {
     this.audioSubscriptions.forEach(sub => sub.unsubscribe());
     this.audioSubscriptions.clear();
     this.updateSourceMuted();
+    this.updateSourceAvailable();
   }
   private sourceMutedSubject: Subject<boolean> = new BehaviorSubject<boolean>(false);
   sourceMuted: Observable<boolean> = this.sourceMutedSubject.asObservable();
   updateSourceMuted() {
-    let muted = true;
-    for (const sourceId of this.audioSubscriptions.keys()) {
-      if (!this.audioService.getSource(sourceId).muted) {
-        muted = false;
-        break;
-      }
-    }
+    const candidates = this.getCandidateWatchSources(this.state.sourceId);
+    // ソースが存在し、すべてミュートされている場合のみ true
+    // ソースが存在しない（シーン切り替えで対象ソースがない場合など）は false
+    const muted = candidates.length > 0 && candidates.every(s => s.muted);
     this.sourceMutedSubject.next(muted);
+  }
+
+  private sourceAvailableSubject: Subject<boolean> = new BehaviorSubject<boolean>(true);
+  sourceAvailable: Observable<boolean> = this.sourceAvailableSubject.asObservable();
+  updateSourceAvailable() {
+    const sourceId = this.state.sourceId;
+    // 'mic'モードや未選択(null)の場合は常に利用可能
+    if (sourceId === null || sourceId === 'mic') {
+      this.sourceAvailableSubject.next(true);
+      return;
+    }
+    const candidates = this.getCandidateWatchSources(sourceId);
+    this.sourceAvailableSubject.next(candidates.length > 0);
   }
 
   getAvailableSources(): AudioSource[] {
     const sources = this.audioService.getVisibleSourcesForCurrentScene();
     return sources;
   }
-  getEffectiveWatchSources(watchSourceId: ISoundDetectorState['sourceId']): AudioSource[] {
+  private getCandidateWatchSources(watchSourceId: ISoundDetectorState['sourceId']): AudioSource[] {
     const sources = this.getAvailableSources();
     if (watchSourceId === null) {
       return [];
     }
-    let filtered: AudioSource[];
     if (watchSourceId === 'mic') {
-      filtered = sources.filter(s =>
+      return sources.filter(s =>
         ['wasapi_input_capture', 'nair-rtvc-source'].includes(s.source.type),
       );
-    } else {
-      filtered = sources.filter(s => s.sourceId === watchSourceId);
     }
+    return sources.filter(s => s.sourceId === watchSourceId);
+  }
+  getEffectiveWatchSources(watchSourceId: ISoundDetectorState['sourceId']): AudioSource[] {
     // mutedなソースは監視対象から除外
-    return filtered.filter(s => !s.muted);
+    return this.getCandidateWatchSources(watchSourceId).filter(s => !s.muted);
   }
 
   get isCalibrated(): boolean {
@@ -345,6 +357,9 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     this.setState({ soundThresholdDb: db, calibrated: true });
   }
   updateResumeSilenceMs(ms: number): void {
+    if (!Number.isFinite(ms) || ms <= 0) {
+      return;
+    }
     this.setState({ resumeSilenceMs: ms });
   }
   updateSpeechActionOnSoundDetected(action: SpeechActionOnSoundDetected): void {


### PR DESCRIPTION
## このpull requestが解決する内容

読み上げ停止設定（SoundDetectorSettings）に報告された3件の問題を修正します。

## 背景

1. 「読み上げ再開までの時間」のスライダーで、テキスト入力に非数値文字を入れると NaN になり読み上げが即時再開する
2. シーン切り替え後、ミュートでないのに「(ミュート状態)」と表示される
3. シーン切り替え後、選択中のソースが新シーンに存在しない場合にUIが「マイクまたはボイスチェンジャー(自動)」を表示するが、実際には音声検出が動作しない（内部状態と表示の乖離）

## 変更内容

### Bug 1: スライダーテキスト入力のバリデーション

**`app/components/shared/Slider.vue`**
- テキスト入力を `type="text"` → `type="number"` に変更
- `:min` / `:max` / `:step` 属性を追加

<img width="812" height="126" alt="image" src="https://github.com/user-attachments/assets/622c96cd-e308-491a-9799-96972bcc5920" />

**`app/components/shared/Slider.vue.ts`**
- `clampValue()` メソッドを追加（NaN → 現在値維持、範囲外 → クランプ）
- `updateValue()` と `handleKeydown()` に適用
- ArrowUp/Down に `event.preventDefault()` を追加してブラウザのネイティブ増減と競合しないよう修正

**`app/services/sound-detector/sound-detector.ts`**
- `updateResumeSilenceMs()` に `NaN`/`Infinity`/`<=0` の防御的バリデーションを追加

### Bug 2: ミュート状態の誤検出

**`app/services/sound-detector/sound-detector.ts`**
- `getCandidateWatchSources()` プライベートメソッドを追加（ミュートフィルタ適用前の候補ソース取得）
- `getEffectiveWatchSources()` を `getCandidateWatchSources()` + ミュートフィルタに簡略化
- `updateSourceMuted()` を修正: `audioSubscriptions`（空になり得る）ではなく候補ソースで判定することで「ソース不在」と「全ソースミュート」を正確に区別

### Bug 3: ソース不在時の動作不正（新規対応）

自動切り替えは放送事故リスクがあるため、UIで状態を明示して手動切り替えを促す方針。

<img width="823" height="220" alt="image" src="https://github.com/user-attachments/assets/2d51e0a1-850a-46ab-bb35-6c795aa1977d" />

**`app/services/sound-detector/sound-detector.ts`**
- `sourceAvailable` Observable を追加（選択ソースが現在シーンに存在するか）
- `updateSourceAvailable()` を追加し `subscribeAudioSource()` から呼ぶ

**`app/components/SoundDetectorSettings.vue.ts`**
- `sourceAvailable` プロパティ追加 + subscribe/unsubscribe
- `soundDetectorSourceModel` getter を修正: 不在ソースを「(このシーンにありません)」付きでオプションに追加し、実際の選択状態を正しく表示

**`app/components/SoundDetectorSettings.vue`**
- ドロップダウン直下に警告テキストを追加（`v-if="!sourceAvailable"`）

## テスト

- [x] `pnpm run test:unit:app` 全テスト通過（768テスト）
- [x] 手動テスト: スライダーのテキスト入力に非数値・範囲外値を入力 → クランプされること
- [x] 手動テスト: シーン切り替え後、ミュート表示が正しいこと
- [x] 手動テスト: 特定ソースを選択 → シーン切り替えでそのソースが消える → 警告表示 + ドロップダウンに「(このシーンにありません)」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)