### PR TITLE
開発: SoundDetector の「いいえ」/OFF→ON切り替え時の動作修正

### DIFF
--- a/app/components/SoundDetectorSettings.vue.ts
+++ b/app/components/SoundDetectorSettings.vue.ts
@@ -188,6 +188,7 @@ export default class SoundDetectorSettings extends Vue {
       this.stopContinuousPlayback();
     }
     this.soundDetectorService.setEnabled(b);
+    this.nicoliveCommentSynthesizerService.syncSoundDetectorSubscription();
   }
 
   get soundDetectorSourceModel(): IObsListInput<string> {

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -422,6 +422,7 @@ export default class CommentViewer extends Vue {
         })
         .then(({ response }) => {
           if (response === 0) {
+            this.nicoliveCommentViewerService.setSoundDetectorEnabled(true);
             this.settingsService.showSoundDetectorSettings();
           } else {
             this.nicoliveCommentViewerService.markSoundDetectorDeclined();

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -147,11 +147,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
           ...persistentState.speechSynthesizerSettings,
         };
         this.SET_STATE(newState);
-        if (newState.enabled && newState.soundDetectorEnabled) {
-          this.subscribeSoundDetector();
-        } else {
-          this.unsubscribeSoundDetector();
-        }
+        this.syncSoundDetectorSubscription();
       },
     });
     this.nVoice = new NVoiceSynthesizer(this.nVoiceClientService);
@@ -199,6 +195,14 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
       this.soundDetectorSubscription = null;
     }
     this.queue.enable();
+  }
+
+  syncSoundDetectorSubscription(): void {
+    if (this.state.enabled && this.state.soundDetectorEnabled) {
+      this.subscribeSoundDetector();
+    } else {
+      this.unsubscribeSoundDetector();
+    }
   }
 
   // 音声検出の有効/無効化(ネスト対応)

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -165,6 +165,9 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   markSoundDetectorDeclined(): void {
     this.nicoliveCommentSynthesizerService.soundDetectorService.markDeclined();
   }
+  setSoundDetectorEnabled(enabled: boolean): void {
+    this.nicoliveCommentSynthesizerService.soundDetectorService.setEnabled(enabled);
+  }
 
   get filterFn() {
     return (chat: WrappedMessageWithComponent) =>

--- a/app/services/sound-detector/sound-detector.test.ts
+++ b/app/services/sound-detector/sound-detector.test.ts
@@ -488,6 +488,15 @@ describe('SoundDetectorService', () => {
     });
   });
 
+  describe('markDeclined', () => {
+    test('declined=true かつ enabled=false になること', () => {
+      const { instance } = prepare();
+      instance.markDeclined();
+      expect(instance.state.declined).toBe(true);
+      expect(instance.state.enabled).toBe(false);
+    });
+  });
+
   describe('isBlockingObservable', () => {
     test('pause の場合は loud でブロックする', () => {
       const { instance, micStream } = prepare({ speechActionOnSoundDetected: 'pause' });

--- a/app/services/sound-detector/sound-detector.ts
+++ b/app/services/sound-detector/sound-detector.ts
@@ -347,7 +347,7 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
   }
 
   markDeclined(): void {
-    this.setState({ declined: true });
+    this.setState({ declined: true, enabled: false });
   }
 
   updateSourceId(id: string | null): void {


### PR DESCRIPTION
## このpull requestが解決する内容

SoundDetector（コメント読み上げ停止機能）の2つの問題を修正します。

### 1. 「いいえ」選択時に読み上げ停止設定がONのまま残る問題

初回番組作成後のダイアログで「いいえ」を選択しても、`markDeclined()` が `declined=true` を設定するだけで `enabled` を変更していなかったため、SoundDetector が有効なままでした。

「はい」を選択した場合も `enabled=true` を明示的に設定せず、設定画面を開いたときトグルが OFF 状態になっていました。

### 2. 設定UIでOFF→ONに切り替えても即時反映されない問題

`soundDetectorEnabled` setter が `soundDetectorService.setEnabled(b)` のみ呼んでいたため、`NicoliveCommentSynthesizerService` の `subscribeSoundDetector()` がトリガーされず、音声検出結果がキューの pause/resume に反映されませんでした。ON→OFF は `endSoundDetected()` 経由で即時動作するため非対称な動作になっていました。

## 変更内容

- `markDeclined()`: `declined: true` と同時に `enabled: false` を設定
- `CommentViewer.vue.ts`: 「はい」選択時に `setSoundDetectorEnabled(true)` で有効化してから設定画面を開く
- `nicolive-comment-viewer.ts`: `setSoundDetectorEnabled()` プロキシメソッドを追加
- `NicoliveCommentSynthesizerService`: `syncSoundDetectorSubscription()` を追加し、設定変更時に即時反映するよう修正
- `SoundDetectorSettings.vue.ts`: enabled setter で `syncSoundDetectorSubscription()` を呼ぶ

## テスト

- [x] `pnpm run test:unit:app` — 全テスト通過（47スイート・769テスト）
- [x] `markDeclined()` で `declined=true` かつ `enabled=false` になることを確認（新規ユニットテスト追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)