### PR TITLE
開発: 全キャッシュ削除ボタンでシーンコレクションが残るバグを修正 (#1173)

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -61,6 +61,9 @@ export class AppService extends StatefulService<IAppState> {
   /** OBS init前にbasic.iniが存在していたか。falseの場合はOBSがデフォルト値で初期化している */
   obsConfigExisted = true;
 
+  /** シャットダウン時にシーンコレクション等の保存をスキップするフラグ（全キャッシュ削除時に使用） */
+  private skipSavingOnShutdown = false;
+
   @Inject() transitionsService: TransitionsService;
   @Inject() sourcesService: SourcesService;
   @Inject() scenesService: ScenesService;
@@ -160,10 +163,15 @@ export class AppService extends StatefulService<IAppState> {
         NicoliveClient.closeOpenWindows();
         this.ipcServerService.stopListening();
         this.stopMonitoringStudioMode();
-        await this.sceneCollectionsService.deinitialize();
+        await this.sceneCollectionsService.deinitialize({
+          // 全キャッシュ削除時はシーンコレクションを保存しない（再起動後に削除されるため）
+          saveOnExit: !this.skipSavingOnShutdown,
+        });
         this.transitionsService.shutdown();
         this.videoSettingsService.shutdown();
-        await this.fileManagerService.flushAll();
+        if (!this.skipSavingOnShutdown) {
+          await this.fileManagerService.flushAll();
+        }
         obs.NodeObs.RemoveSourceCallback();
         obs.NodeObs.OBS_service_removeCallback();
         obs.IPC.disconnect();
@@ -290,6 +298,7 @@ export class AppService extends StatefulService<IAppState> {
         // シーンコレクションを含むすべてを削除
         args.push('--clearCacheDir');
         args.push('--includeSceneCollections');
+        this.skipSavingOnShutdown = true;
         break;
     }
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -194,12 +194,16 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   /**
    * Generally called on application shutdown.
    */
-  async deinitialize() {
+  async deinitialize({ saveOnExit = true }: { saveOnExit?: boolean } = {}) {
     this.disableAutoSave();
-    await this.save();
+    if (saveOnExit) {
+      await this.save();
+    }
     this.tcpServerService.stopRequestsHandling();
-    await this.deloadCurrentApplicationState();
-    await this.stateService.flushManifestFile();
+    await this.deloadCurrentApplicationState({ saveOnExit });
+    if (saveOnExit) {
+      await this.stateService.flushManifestFile();
+    }
   }
 
   /**
@@ -609,13 +613,15 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * ready to load a new config file.  This should only ever be
    * performed while the application is already in a "LOADING" state.
    */
-  private async deloadCurrentApplicationState() {
+  private async deloadCurrentApplicationState({ saveOnExit = true }: { saveOnExit?: boolean } = {}) {
     if (!this.initialized) return;
 
     this.collectionWillSwitch.next();
 
     this.disableAutoSave();
-    await this.save();
+    if (saveOnExit) {
+      await this.save();
+    }
 
     // we should remove inactive scenes first to avoid the switching between scenes
     try {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
- 
+
 ////////////////////////////////////////////////////////////////////////////////
 // Set Up Environment Variables
 ////////////////////////////////////////////////////////////////////////////////
@@ -47,14 +47,18 @@ const remote = require('@electron/remote/main');
 
 function removePathWithRetry(rmPath) {
   const MAX_RETRIES = 3;
-  for (let t = MAX_RETRIES; t > 0; t--) {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       fs.rmSync(rmPath, { recursive: true, force: true });
+      return; // 成功したら即座に終了
     } catch (e) {
-      console.error(`failed to delete '${rmPath}: `, e);
-      if (!t) {
+      console.error(`failed to delete '${rmPath}' (attempt ${attempt}/${MAX_RETRIES}): `, e);
+      if (attempt === MAX_RETRIES) {
         // Sentry未初期化のため送信できない
         dialog.showErrorBox('ファイルの削除に失敗しました', `Failed to delete '${rmPath}'.\n${e}`);
+      } else {
+        // ファイルロック解放を待つ
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
       }
     }
   }
@@ -290,7 +294,7 @@ function initialize(crashHandler) {
     logFromRemote(msg.level, msg.sender, msg.message);
   });
 
-   
+
   function logFromRemote(level, sender, msg) {
     msg.split('\n').forEach(line => {
       writeLogLine(`[${new Date().toISOString()}] [${level}] [${sender}] - ${line}`);
@@ -367,7 +371,7 @@ function initialize(crashHandler) {
 
   const lineBuffer = [];
 
-   
+
   function writeLogLine(line) {
     // Also print to stdout
     consoleLog(line);
@@ -377,7 +381,7 @@ function initialize(crashHandler) {
   }
 
   // Synchronously flush all pending log lines
-   
+
   function flushLogBufferSync() {
     if (lineBuffer.length === 0) return;
     try {
@@ -391,7 +395,7 @@ function initialize(crashHandler) {
 
   let writeInProgress = false;
 
-   
+
   function flushNextLine() {
     if (lineBuffer.length === 0) return;
     if (writeInProgress) return;
@@ -420,7 +424,7 @@ function initialize(crashHandler) {
   });
 
   // Source: https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
-   
+
   function humanFileSize(bytes, si) {
     const thresh = si ? 1000 : 1024;
     if (Math.abs(bytes) < thresh) {
@@ -499,7 +503,7 @@ function initialize(crashHandler) {
     };
   }
 
-  // eslint-disable-next-line no-inner-declarations
+
   function openDevTools() {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.openDevTools({ mode: 'undocked' });
@@ -565,7 +569,7 @@ function initialize(crashHandler) {
   // Safely send IPC messages to a BrowserWindow or WebContents.
   // During dev hot reload, the render frame may be disposed while the window is still alive.
   // BrowserWindow.isDestroyed() does not catch this — only the frame is replaced, not the window.
-  // eslint-disable-next-line no-inner-declarations
+
   function safeSend(target, channel, ...args) {
     try {
       if (target.isDestroyed()) return false;
@@ -580,7 +584,7 @@ function initialize(crashHandler) {
     }
   }
 
-  // eslint-disable-next-line no-inner-declarations
+
   async function startApp() {
     if (process.argv.includes('--clearCookies')) {
       SentryElectron.captureEvent({
@@ -1015,7 +1019,7 @@ function initialize(crashHandler) {
     mainWindow.focus();
   });
 
-   
+
   function preventClose(e) {
     if (!shutdownStarted) {
       e.preventDefault();
@@ -1037,7 +1041,7 @@ function initialize(crashHandler) {
    * rendererプロセスからは遷移前に止められないのでここに実装がある
    * @see https://github.com/electron/electron/pull/11679#issuecomment-359180722
    **/
-   
+
   function preventLogout(e, url) {
     const urlObj = new URL(url);
     const isLogout =
@@ -1059,7 +1063,7 @@ function initialize(crashHandler) {
    * rendererプロセスからは処理を止められないのでここに実装がある
    * @see https://github.com/electron/electron/pull/11679#issuecomment-359180722
    **/
-   
+
   function preventNewWindow(e, url) {
     e.preventDefault();
     shell.openExternal(url);


### PR DESCRIPTION
## このpull requestが解決する内容

PR #1173 で追加した「シーンコレクションを含むすべてのキャッシュを削除して再起動」ボタンを押しても、再起動後にシーンコレクションのデータが残るバグを修正します。

## 原因

### `removePathWithRetry` のバグ（main.js）

3つのバグが複合的に問題を引き起こしていました：

1. **成功時に `break` がない**: 削除成功後もループが3回回り続ける（実害は少ないが無駄）
2. **エラーダイアログが表示されない**: `for (let t = MAX_RETRIES; t > 0; t--)` のループ内で `if (!t)` を判定しているが、ループ条件 `t > 0` の間は `!t` が常に `false` → 削除失敗がサイレントに無視される
3. **リトライ間の待機がない**: Windows ではファイルロック解放に時間がかかるが、即座にリトライするため意味がなかった

再起動後の新プロセスが `userData` ディレクトリを削除しようとする際、旧プロセスの Chromium サブプロセス（GPU プロセス等）がまだファイルをロックしている可能性があり、`fs.rmSync` が失敗する。エラーはサイレントに握りつぶされるため、シーンコレクションが残ったままになっていた。

### 不要なファイル書き込み

シャットダウン時に `sceneCollectionsService.deinitialize()` → `save()` でシーンコレクションをディスクに書き込んでいたが、どうせ全削除するなら不要であり、ファイルロックの原因にもなる。

## 変更内容

### main.js — `removePathWithRetry` の修正

- 成功時に `return` で即座に終了
- エラーダイアログ条件を `if (!t)` → `if (attempt === MAX_RETRIES)` に修正
- リトライ間に `Atomics.wait` で1秒の同期待機を追加（ファイルロック解放を待つ）

### app/services/app/app.ts

- `skipSavingOnShutdown` フラグを追加
- `relaunch({ clearCacheDir: 'all' })` 時にフラグを立てる
- シャットダウン時にフラグが立っている場合、`deinitialize()` の保存と `fileManagerService.flushAll()` をスキップ

### app/services/scene-collections/scene-collections.ts

- `deinitialize({ saveOnExit?: boolean })` オプションを追加
- `saveOnExit: false` の場合、`save()` と `flushManifestFile()` をスキップ
- `deloadCurrentApplicationState()` にも同オプションを伝播

## テスト

- [x] 「シーンコレクションを含むすべてのキャッシュを削除して再起動」を押すと、再起動後に以前のシーンコレクションのデータが削除されることを確認
- [x] 「キャッシュを削除して再起動」（シーンコレクション保持版）でシーンコレクションが保持されることを確認
- [x] GPU cache エラー「Unable to move the cache」が出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)