### PR TITLE
開発: SoundDetector の設定UIでOFF→ON切り替えが即時反映されない問題を修正

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -198,7 +198,7 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
   }
 
   syncSoundDetectorSubscription(): void {
-    if (this.state.enabled && this.state.soundDetectorEnabled) {
+    if (this.state.enabled && this.soundDetectorService.isEnabled()) {
       this.subscribeSoundDetector();
     } else {
       this.unsubscribeSoundDetector();


### PR DESCRIPTION
## このpull requestが解決する内容

SoundDetector（コメント読み上げ停止機能）の設定UIで、disabled 状態からトグルを ON に切り替えても、コメント読み上げが実際に停止しない問題を修正します。

レベルメーターは正しく音声を検出していましたが、読み上げキューへの pause/resume 制御が機能していませんでした。

## 背景

`syncSoundDetectorSubscription()` 内で synthesizer の `state.soundDetectorEnabled`（キャッシュ値）を参照していたため、古い値（`false`）のまま `subscribeSoundDetector()` が呼ばれなかった。

具体的なフロー:
1. 設定画面を `enabled=false` の状態で開く
2. `mounted()` → `enableSoundDetector(true)` → `isEnabled()` = `false(enabled) && 1 > 0` = `false` → `state.soundDetectorEnabled = false` で固定
3. ユーザーがトグル ON → `setEnabled(true)` → `state.enabled = true`
4. `syncSoundDetectorSubscription()` → `state.soundDetectorEnabled` が `false` のまま → 条件不成立 → 未サブスクライブのまま

## 変更内容

`syncSoundDetectorSubscription()` でキャッシュ値 `this.state.soundDetectorEnabled` の代わりに `this.soundDetectorService.isEnabled()` のライブ値を参照するよう変更。

## テスト

- [x] `pnpm run test:unit:app` — 全テスト通過（47スイート・769テスト）
- [x] SoundDetector disabled の状態で設定画面を開き、トグルを ON にしてテスト再生 → マイクに声を入れてコメント読み上げが停止すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)