### PR TITLE
開発: パッチノート生成でn-air_development以外の直接マージが除外される問題を修正

### DIFF
--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -96,10 +96,12 @@ function writePatchNoteFile(patchNoteFileName, version, contents) {
 /**
  * Get merge commit log since previous version
  * @param {string} previousVersion - Previous version tag
+ * @param {{ firstParent?: boolean }} [options]
  * @returns {string} Git log output
  */
-function gitLog(previousVersion) {
-  return executeCmd(`git log --oneline --merges v${previousVersion}..`, { silent: true }).stdout;
+function gitLog(previousVersion, { firstParent = false } = {}) {
+  const flags = ['--oneline', '--merges', firstParent && '--first-parent'].filter(Boolean).join(' ');
+  return executeCmd(`git log ${flags} v${previousVersion}..`, { silent: true }).stdout;
 }
 
 /**
@@ -183,8 +185,10 @@ async function collectPullRequestMerges({ octokit, owner, repo }, previousVersio
  * @returns {Promise<string>} Formatted merge commits with their included commits
  */
 async function collectNonPRMerges(previousVersion) {
-  // Get all merge commits since previous version
-  const merges = gitLog(previousVersion);
+  // Using --first-parent avoids traversing into merged branches, which prevents
+  // merge commits internal to PRs (e.g. custom-message conflict resolutions)
+  // from appearing in the output.
+  const merges = gitLog(previousVersion, { firstParent: true });
 
   /** @type {Array<{subject: string, hash: string, includedCommits: string[]}>} */
   const nonPRMerges = [];

--- a/bin/release/scripts/patchNote.js
+++ b/bin/release/scripts/patchNote.js
@@ -207,11 +207,12 @@ async function collectNonPRMerges(previousVersion) {
 
     const [, hash, subject] = match;
 
-    // Skip merges into feature branches (these are PR internal syncs)
-    // Example: "Merge branch 'n-air_development' into feature/xyz"
-    // These are already captured by the PR merge that eventually happened
-    // NOTE: This only filters top-level merge commits, not commits within the merged branch
-    if (subject.match(/\sinto\s/)) {
+    // Skip merges from n-air_development (these are already captured by collectPullRequestMerges)
+    // Examples:
+    //   "Merge branch 'n-air_development'"
+    //   "Merge branch 'n-air_development' into n-air_stable"
+    //   "Merge branch 'n-air_development' into dwango-internal-release"
+    if (subject.match(/Merge branch 'n-air_development'/)) {
       continue;
     }
 

--- a/bin/release/scripts/patchNote.test.js
+++ b/bin/release/scripts/patchNote.test.js
@@ -455,16 +455,15 @@ describe('collectNonPRMerges', () => {
     expect(result).toBe('');
   });
 
-  test('PRブランチ内のマージ(into付き)は除外される', async () => {
+  test("n-air_development からのマージは除外される", async () => {
     executeCmd.mockReturnValueOnce({
-      stdout: 'abc1234 Merge branch "n-air_development" into feature/test',
+      stdout: "abc1234 Merge branch 'n-air_development' into feature/test",
     });
-    // into付きなので親チェックもsh.execも呼ばれない
 
     const result = await collectNonPRMerges('1.0.20190826-2');
 
     expect(result).toBe('');
-    // into付きのマージは処理がスキップされるため、親チェック(executeCmd)もsh.execも呼ばれない
+    // n-air_developmentマージは処理がスキップされるため、親チェック(executeCmd)もsh.execも呼ばれない
     expect(executeCmd).toHaveBeenCalledTimes(1); // git logのみ
     expect(execSpy).not.toHaveBeenCalled();
   });
@@ -488,55 +487,54 @@ describe('collectNonPRMerges', () => {
     expect(result).toContain('修正: 緊急パッチ (def456)');
   });
 
-  test('混在シナリオ: into付きは除外、intoなしは含む', async () => {
+  test("混在シナリオ: n-air_development からのマージは除外、それ以外は含む", async () => {
     executeCmd
       .mockReturnValueOnce({
-        // 3つのマージコミット: 1つ目と3つ目はinto付き(除外)、2つ目はintoなし(含む)
+        // 3つのマージコミット: 1つ目はn-air_development(除外)、2つ目と3つ目は含む
         stdout:
-          'aaa1111 Merge branch "n-air_development" into feature/A\n' +
+          "aaa1111 Merge branch 'n-air_development' into internal-release\n" +
           'bbb2222 Merge branch "hotfix/critical"\n' +
-          'ccc3333 Merge branch "main" into refactor/B',
+          "ccc3333 Merge branch 'feature/new-ui' into internal-release",
       })
-      // aaa1111はinto付きなので、親チェックの前にスキップされる
-      .mockReturnValueOnce({ stdout: 'bbb2222 parent1 parent2' });
-    // bbb2222のみ親チェックが実行される
-    // ccc3333もinto付きなので、親チェックの前にスキップされる
+      // aaa1111はn-air_developmentなのでスキップ
+      .mockReturnValueOnce({ stdout: 'bbb2222 parent1 parent2' })
+      .mockReturnValueOnce({ stdout: 'ccc3333 parent1 parent2' });
 
-    execSpy.mockReturnValue({
-      code: 0,
-      stdout: '修正: 重大なバグ修正 (xyz789)',
-    });
+    sh.exec
+      .mockReturnValueOnce({ code: 0, stdout: '修正: 重大なバグ修正 (xyz789)' })
+      .mockReturnValueOnce({ code: 0, stdout: '追加: 新UI実装 (uvw123)' });
 
     const result = await collectNonPRMerges('1.0.20190826-2');
 
-    // bbb2222のみ含まれる
+    // bbb2222とccc3333が含まれる
     expect(result).toContain('Merge branch "hotfix/critical" (bbb2222)');
     expect(result).toContain('修正: 重大なバグ修正 (xyz789)');
-    // aaa1111とccc3333は含まれない
-    expect(result).not.toContain('feature/A');
-    expect(result).not.toContain('refactor/B');
-    // sh.execは1回だけ呼ばれる(bbb2222のため)
-    expect(execSpy).toHaveBeenCalledTimes(1);
+    expect(result).toContain("Merge branch 'feature/new-ui' into internal-release (ccc3333)");
+    expect(result).toContain('追加: 新UI実装 (uvw123)');
+    // aaa1111は含まれない
+    expect(result).not.toContain('n-air_development');
   });
 
-  test('エッジケース: マージ内のコミットメッセージに"into"があっても影響しない', async () => {
+  test("内部テストリリースブランチ: feature ブランチの直接マージ (into 付き) は含まれる", async () => {
+    // internal-release のような内部テストリリースブランチでは
+    // "Merge branch 'feature/xxx' into internal-release" の形式で
+    // feature ブランチが直接マージされる。これは残すべきエントリ。
     executeCmd
       .mockReturnValueOnce({
-        stdout: 'abc1234 Merge branch "feature/refactor"',
+        stdout: "abc1234 Merge branch 'feature/new-ui' into internal-release",
       })
       .mockReturnValueOnce({
         stdout: 'abc1234 parent1 parent2',
       });
     execSpy.mockReturnValue({
       code: 0,
-      stdout: '変更: Refactor code into modules (def456)', // コミットメッセージに"into"
+      stdout: '追加: 新UI実装 (def456)',
     });
 
     const result = await collectNonPRMerges('1.0.20190826-2');
 
-    // マージ件名に"into"がなければ含まれる
-    expect(result).toContain('Merge branch "feature/refactor" (abc1234)');
-    expect(result).toContain('変更: Refactor code into modules (def456)');
+    expect(result).toContain("Merge branch 'feature/new-ui' into internal-release (abc1234)");
+    expect(result).toContain('追加: 新UI実装 (def456)');
   });
 
   test('direct mergeブランチ内のsync merge (into付き)は掲載される', async () => {
@@ -586,33 +584,10 @@ describe('collectNonPRMerges', () => {
 
     const result = await collectNonPRMerges('1.0.20190826-2');
 
-    // intoフィルタにより除外される
+    // n-air_developmentフィルタにより除外される
     expect(result).toBe('');
-    // into付きなので親チェック(executeCmd)もsh.execも呼ばれない
+    // n-air_developmentマージは処理がスキップされるため、親チェック(executeCmd)もsh.execも呼ばれない
     expect(executeCmd).toHaveBeenCalledTimes(1); // git logのみ
     expect(execSpy).not.toHaveBeenCalled();
-  });
-
-  test('カスタムメッセージのマージコミットは既存フィルタをすり抜けて出力される（--first-parentが必要な理由）', async () => {
-    // "into"を含まないカスタムメッセージのマージコミットは、
-    // PRマージフィルタにも"into"フィルタにもかからない。
-    // --first-parentなしで n-air_stable から実行すると、
-    // n-air_development 内部のこのようなコミットが拾われてしまっていた。
-    executeCmd
-      .mockReturnValueOnce({
-        stdout: 'abc1234 開発: n-air_developmentとのマージコンフリクトを解決',
-      })
-      .mockReturnValueOnce({
-        stdout: 'abc1234 parent1 parent2', // 2 parents
-      });
-    execSpy.mockReturnValueOnce({
-      code: 0,
-      stdout: '追加: 機能A (def456)',
-    });
-
-    const result = await collectNonPRMerges('1.0.20190826-2');
-
-    // カスタムメッセージのマージは"into"フィルタをすり抜けるため出力される
-    expect(result).toContain('開発: n-air_developmentとのマージコンフリクトを解決 (abc1234)');
   });
 });

--- a/bin/release/scripts/patchNote.test.js
+++ b/bin/release/scripts/patchNote.test.js
@@ -566,4 +566,53 @@ describe('collectNonPRMerges', () => {
     expect(result).toContain('Merge branch "n-air_development" into hotfix/urgent (ghi789)');
     expect(result).toContain('追加: 新機能追加 (jkl012)');
   });
+
+  test('git logに--first-parentオプションが指定される', async () => {
+    executeCmd.mockReturnValueOnce({ stdout: '' });
+
+    await collectNonPRMerges('1.0.20190826-2');
+
+    // 最初のexecuteCmdの呼び出し引数に--first-parentが含まれることを確認
+    const firstCallArgs = executeCmd.mock.calls[0][0];
+    expect(firstCallArgs).toContain('--first-parent');
+  });
+
+  test('n-air_stableシナリオ: n-air_developmentをマージするコミットのみの場合は空を返す', async () => {
+    // n-air_stableブランチから実行した場合、--first-parentにより
+    // "Merge branch 'n-air_development' into n-air_stable"のみが見える
+    executeCmd.mockReturnValueOnce({
+      stdout: "6a8c236 Merge branch 'n-air_development' into n-air_stable",
+    });
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    // intoフィルタにより除外される
+    expect(result).toBe('');
+    // into付きなので親チェック(executeCmd)もsh.execも呼ばれない
+    expect(executeCmd).toHaveBeenCalledTimes(1); // git logのみ
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  test('カスタムメッセージのマージコミットは既存フィルタをすり抜けて出力される（--first-parentが必要な理由）', async () => {
+    // "into"を含まないカスタムメッセージのマージコミットは、
+    // PRマージフィルタにも"into"フィルタにもかからない。
+    // --first-parentなしで n-air_stable から実行すると、
+    // n-air_development 内部のこのようなコミットが拾われてしまっていた。
+    executeCmd
+      .mockReturnValueOnce({
+        stdout: 'abc1234 開発: n-air_developmentとのマージコンフリクトを解決',
+      })
+      .mockReturnValueOnce({
+        stdout: 'abc1234 parent1 parent2', // 2 parents
+      });
+    execSpy.mockReturnValueOnce({
+      code: 0,
+      stdout: '追加: 機能A (def456)',
+    });
+
+    const result = await collectNonPRMerges('1.0.20190826-2');
+
+    // カスタムメッセージのマージは"into"フィルタをすり抜けるため出力される
+    expect(result).toContain('開発: n-air_developmentとのマージコンフリクトを解決 (abc1234)');
+  });
 });


### PR DESCRIPTION
## このpull requestが解決する内容

パッチノート生成（`pnpm patch-note`）時に、2つの問題を修正します。

1. `n-air_stable` から実行した際に不要なマージコミットが "Merge Commits:" セクションに大量出力される問題
2. 内部テストリリースブランチで、feature/hotfix の直接マージが誤って除外される問題

## 背景と原因

`collectNonPRMerges` が `--first-parent` なしで `git log` を実行していたうえ、フィルタのロジックが不適切でした。

### 問題1: `--first-parent` の欠如

`n-air_stable` からの実行時、`--first-parent` がなかったため `n-air_development` 内部のマージ履歴まで走査。その中のカスタムメッセージ付きマージコミット（例: `開発: n-air_developmentとのマージコンフリクトを解決`）が後述の `into` フィルタをすり抜け、配下コミット約50件ごと出力されていた。

### 問題2: `into` フィルタの過剰除外

`into` を含む全マージを除外していたため、内部テストリリースブランチで feature/hotfix を直接マージした際の記録（形式: `Merge branch 'feature/xxx' into <branch>`）も誤って除外されていた。

## 変更内容

### `bin/release/scripts/patchNote.js`

- `gitLog()` を `{ firstParent?: boolean }` オプション対応に拡張
- `collectNonPRMerges` で `--first-parent` を使用（問題1の修正）
- フィルタを `into` → `Merge branch 'n-air_development'` に変更（問題2の修正）
  - `n-air_development` からのマージのみ除外（PRマージとして別途収集済みのため）
  - `feature/xxx into <branch>` は除外しない

### `bin/release/scripts/patchNote.test.js`

各ブランチシナリオに対応したテストを追加・更新:
- `n-air_development` からのマージのみ除外されることを確認
- `feature/xxx into <branch>` が**残る**ことを確認（内部テストリリースブランチのシナリオ）
- `n-air_stable` シナリオで空を返すことを確認

## 各ブランチでの期待動作

| ブランチ | non-PR merges セクション |
|---|---|
| `n-air_development` | 空（全てPRマージ） |
| `n-air_stable` | 空（通常）、hotfix直接マージがあれば表示 |
| 内部テストリリースブランチ | feature/hotfix の直接マージを表示 |

## テスト

- [x] `pnpm run test:unit:bin` 通過（53テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)