### PR TITLE
修正: 起動時にコメント読み上げ設定がデフォルト値にリセットされる問題を修正

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -130,16 +130,10 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
       queueRunnerState: null, // 起動時にはnull
     });
 
-    this.queueStateSubscription = this.queue.state$.subscribe(queueRunnerState => {
-      this.setState({ queueRunnerState });
-    });
-
-    this.queue.state$.pipe(debounceTime(0)).subscribe(() => {
-      if (!this.queue.isRunning) {
-        this.queueBecameIdleSubject.next();
-      }
-    });
-
+    // stateService.updated はBehaviorSubjectなので即座にemitし、
+    // this.state が正しい永続化された値に更新される。
+    // この後に queue.state$ を subscribe することで、setState() 内で
+    // this.state を参照する際に正しい値が使われるようになる。
     this.stateService.updated.subscribe({
       next: persistentState => {
         const newState = {
@@ -149,6 +143,16 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
         this.SET_STATE(newState);
         this.syncSoundDetectorSubscription();
       },
+    });
+
+    this.queueStateSubscription = this.queue.state$.subscribe(queueRunnerState => {
+      this.setState({ queueRunnerState });
+    });
+
+    this.queue.state$.pipe(debounceTime(0)).subscribe(() => {
+      if (!this.queue.isRunning) {
+        this.queueBecameIdleSubject.next();
+      }
     });
     this.nVoice = new NVoiceSynthesizer(this.nVoiceClientService);
 


### PR DESCRIPTION
## このpull requestが解決する内容

v1.1.20260311-1 で追加されたコメント読み上げ停止機能（SoundDetector）の実装で、起動時にコメント読み上げ設定（速度・音量・声の高さ・最大秒数・音声エンジン選択など）がデフォルト値にリセットされる問題を修正します。

## 背景

`97a0b78eb` (追加: コメント読み上げ停止機能) で `NicoliveCommentSynthesizerService.init()` に `queueStateSubscription` が導入された際、subscription の順序に問題がありました。

## 根本原因

`init()` メソッド内の subscription 設定順序のバグ:

1. `this.setState(mergedState)` — 永続化された設定を `stateService` に書き込む。ただし **`NicoliveCommentSynthesizerService` 自身の `this.state` は更新されない**（`setState()` は `stateService.updateSpeechSynthesizerSettings()` を呼ぶのみで、自身の `SET_STATE()` は呼ばない設計）
2. `this.queue.state$.subscribe(...)` — `QueueRunner.state$` は `BehaviorSubject` なので **即座に emit** → callback 内で `this.setState({ queueRunnerState })` が呼ばれる
3. このとき `this.state` は static `initialState`（デフォルト値）のまま → `nextState = { ...this.state, ...{ queueRunnerState } }` がデフォルト値で `stateService` を上書き
4. `PersistentStatefulService` の `store.watch` が発火 → **デフォルト値が localStorage に保存される**
5. その後 `stateService.updated.subscribe(...)` が設定されるが、既にデフォルト値で上書きされた後なので手遅れ

## 変更内容

`app/services/nicolive-program/nicolive-comment-synthesizer.ts` の `init()` 内で、`stateService.updated.subscribe()` を `queue.state$.subscribe()` より**前**に移動。

これにより:
- `stateService.updated` に subscribe した時点で `BehaviorSubject` が即座に emit → `SET_STATE()` により `this.state` が正しい永続化された値に更新される
- その後の `queue.state$.subscribe()` が emit した際に、`this.state` が正しい値を持っているため永続化された設定が保持される

## テスト

- [x] `pnpm run test:unit:app` — 全47テストスイート (769テスト) がパス
- [x] 手動確認: アプリ起動 → コメント読み上げ設定を変更 → アプリ再起動 → 設定が保持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)