### PR TITLE
開発: アプリ終了時にstream_endのactionLogが送信されない問題を修正

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -19,6 +19,7 @@ import { ScenesService } from 'services/scenes';
 import { VideoSettingsService } from 'services/settings-v2';
 import { ShortcutsService } from 'services/shortcuts';
 import { SourcesService } from 'services/sources';
+import { StreamingService } from 'services/streaming';
 import { TranscriptionService } from 'services/transcription/transcription';
 import { TransitionsService } from 'services/transitions';
 import { UsageStatisticsService } from 'services/usage-statistics';
@@ -77,6 +78,7 @@ export class AppService extends StatefulService<IAppState> {
   @Inject() private crashReporterService: CrashReporterService;
   @Inject() private customizationService: CustomizationService;
   @Inject() private transcriptionService: TranscriptionService;
+  @Inject() private streamingService: StreamingService;
   private loadingPromises: Dictionary<Promise<any>> = {};
 
   readonly pid = require('process').pid;
@@ -171,6 +173,14 @@ export class AppService extends StatefulService<IAppState> {
         this.videoSettingsService.shutdown();
         if (!this.skipSavingOnShutdown) {
           await this.fileManagerService.flushAll();
+        }
+        try {
+          await Promise.race([
+            this.streamingService.logStreamEnd(),
+            new Promise<void>(resolve => { setTimeout(resolve, 5000); }),
+          ]);
+        } catch (e) {
+          console.error('[SHUTDOWN] Error sending stream_end log:', e);
         }
         obs.NodeObs.RemoveSourceCallback();
         obs.NodeObs.OBS_service_removeCallback();

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -91,6 +91,7 @@ const createInjectee = ({
   UsageStatisticsService: {
     recordEvent,
     generateStreamingTrackID,
+    uuidService: { uuid: 'test-uuid' },
   },
   CustomizationService: {
     state: {
@@ -820,4 +821,76 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
 
   expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
+});
+
+test('logStreamEndがstreamingTrackIdが設定されている場合にstream_endを送信する', () => {
+  const recordEvent = jest.fn();
+  setup({
+    injectee: createInjectee({
+      recordEvent,
+      generateStreamingTrackID: () => 'test-track-id',
+    }),
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Live,
+        streamingTrackId: 'test-track-id',
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const instance = StreamingService.instance;
+
+  instance.logStreamEnd();
+
+  expect(recordEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      event: 'stream_end',
+      stream_track_id: 'test-track-id',
+    }),
+  );
+});
+
+test('logStreamEndがstreamingTrackIdが空の場合に何もしない', () => {
+  const recordEvent = jest.fn();
+  setup({
+    injectee: createInjectee({ recordEvent }),
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Starting,
+        streamingTrackId: '',
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const instance = StreamingService.instance;
+
+  instance.logStreamEnd();
+
+  expect(recordEvent).not.toHaveBeenCalled();
+});
+
+test('logStreamEndが冪等である（2回呼んでもrecordEventは1回のみ）', () => {
+  const recordEvent = jest.fn();
+  setup({
+    injectee: createInjectee({
+      recordEvent,
+      generateStreamingTrackID: () => 'test-track-id',
+    }),
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Live,
+        streamingTrackId: 'test-track-id',
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const instance = StreamingService.instance;
+
+  instance.logStreamEnd();
+  instance.logStreamEnd();
+
+  expect(recordEvent).toHaveBeenCalledTimes(1);
 });

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -716,7 +716,7 @@ export class StreamingService
     );
   }
 
-  private actionLog(eventType: 'stream_start' | 'stream_end', streamingTrackId: string) {
+  private actionLog(eventType: 'stream_start' | 'stream_end', streamingTrackId: string): Promise<Response | undefined> {
     const settings = this.settingsService.getStreamEncoderSettings();
 
     const voicevoxFilter = (src: SynthesizerSelector, value: string) =>

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -700,8 +700,9 @@ export class StreamingService
     this.transcriptionService.startStreaming();
   }
 
-  private logStreamEnd() {
+  logStreamEnd() {
     const streamingTrackId = this.state.streamingTrackId;
+    if (!streamingTrackId) return;
     this.SET_STREAMING_TRACK_ID('');
     this.actionLog('stream_end', streamingTrackId);
     this.customcastUsageService.stopStreaming();

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -700,10 +700,19 @@ export class StreamingService
     this.transcriptionService.startStreaming();
   }
 
-  async logStreamEnd(): Promise<void> {
+  private logStreamEndPromise: Promise<void> | null = null;
+
+  logStreamEnd(): Promise<void> {
+    // すでに実行中のPromiseがあればそれを返す（OBSシグナルとshutdownの両方から呼ばれた場合も同じPromiseを待てる）
+    if (this.logStreamEndPromise !== null) return this.logStreamEndPromise;
     const streamingTrackId = this.state.streamingTrackId;
-    if (!streamingTrackId) return;
+    if (!streamingTrackId) return Promise.resolve();
     this.SET_STREAMING_TRACK_ID('');
+    this.logStreamEndPromise = this.sendLogStreamEnd(streamingTrackId);
+    return this.logStreamEndPromise;
+  }
+
+  private async sendLogStreamEnd(streamingTrackId: string): Promise<void> {
     await this.actionLog('stream_end', streamingTrackId);
     this.customcastUsageService.stopStreaming();
     this.rtvcStateService.stopStreaming();

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -708,7 +708,9 @@ export class StreamingService
     const streamingTrackId = this.state.streamingTrackId;
     if (!streamingTrackId) return Promise.resolve();
     this.SET_STREAMING_TRACK_ID('');
-    this.logStreamEndPromise = this.sendLogStreamEnd(streamingTrackId);
+    this.logStreamEndPromise = this.sendLogStreamEnd(streamingTrackId).finally(() => {
+      this.logStreamEndPromise = null;
+    });
     return this.logStreamEndPromise;
   }
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -700,16 +700,16 @@ export class StreamingService
     this.transcriptionService.startStreaming();
   }
 
-  logStreamEnd() {
+  async logStreamEnd(): Promise<void> {
     const streamingTrackId = this.state.streamingTrackId;
     if (!streamingTrackId) return;
     this.SET_STREAMING_TRACK_ID('');
-    this.actionLog('stream_end', streamingTrackId);
+    await this.actionLog('stream_end', streamingTrackId);
     this.customcastUsageService.stopStreaming();
     this.rtvcStateService.stopStreaming();
     this.transcriptionService.stopStreaming();
 
-    HttpRelation.sendLog(
+    await HttpRelation.sendLog(
       this.nicoliveProgramService.state.programID,
       this.usageStatisticsService.uuidService.uuid,
       this.nicoliveProgramStateService.state.httpRelation,
@@ -805,7 +805,7 @@ export class StreamingService
     }
     event.soundDetector = this.soundDetectorService.getActionLog();
 
-    this.usageStatisticsService.recordEvent(event);
+    return this.usageStatisticsService.recordEvent(event);
   }
 
   private outputErrorOpen = false;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -691,10 +691,10 @@ export class StreamingService
     return duration.shiftTo('hours', 'minutes', 'seconds').toFormat('hh:mm:ss');
   }
 
-  private logStreamStart() {
+  private async logStreamStart() {
     const streamingTrackId = this.usageStatisticsService.generateStreamingTrackID();
     this.SET_STREAMING_TRACK_ID(streamingTrackId);
-    this.actionLog('stream_start', streamingTrackId);
+    await this.actionLog('stream_start', streamingTrackId);
     this.customcastUsageService.startStreaming();
     this.rtvcStateService.startStreaming();
     this.transcriptionService.startStreaming();
@@ -833,7 +833,7 @@ export class StreamingService
           this.startReplayBuffer();
         }
 
-        this.logStreamStart();
+        void this.logStreamStart(); // fire-and-forget: シグナルコールバックはawaitできないため
       } else if (info.signal === EOBSOutputSignal.Starting) {
         this.SET_STREAMING_STATUS(EStreamingState.Starting, time);
         this.streamingStatusChange.next(EStreamingState.Starting);
@@ -843,7 +843,7 @@ export class StreamingService
       } else if (info.signal === EOBSOutputSignal.Stopping) {
         this.SET_STREAMING_STATUS(EStreamingState.Ending, time);
         this.streamingStatusChange.next(EStreamingState.Ending);
-        this.logStreamEnd();
+        void this.logStreamEnd(); // fire-and-forget: シグナルコールバックはawaitできないため
       } else if (info.signal === EOBSOutputSignal.Reconnect) {
         this.SET_STREAMING_STATUS(EStreamingState.Reconnecting);
         this.streamingStatusChange.next(EStreamingState.Reconnecting);


### PR DESCRIPTION
## このpull requestが解決する内容

配信中にアプリを直接終了した場合、`stream_end` の actionLog が送信されない問題を修正します。

Closes #1190

## 背景

`logStreamEnd()` は OBS の `Stopping` シグナルが発火したときのみ呼ばれていましたが、アプリ終了時は OBS IPC の切断がシグナル到達より先に発生するため、`stream_end` actionLog が送信されませんでした。

## 変更内容

### ファイル変更

- `app/services/streaming/streaming.ts`: `logStreamEnd()` を `private` から public に変更し、冪等ガードと Promise caching を追加
- `app/services/app/app.ts`: `StreamingService` を inject し、シャットダウン時に OBS IPC 切断直前で `logStreamEnd()` を呼び出す（5秒タイムアウト付き）
- `app/services/streaming/streaming.test.ts`: `logStreamEnd()` のユニットテストを追加

### 設計のポイント

**冪等性の保証（`streamingTrackId` によるガード）**:
`logStreamEnd()` 冒頭で `streamingTrackId` を同期的にクリアするため、二重呼び出し時は2回目が no-op になります。

| 状態 | trackId | シャットダウン時の動作 |
|------|---------|---------------------|
| Live / Reconnecting | 非空 | `stream_end` を送信 |
| Starting | 空（stream_start 未送信） | 何もしない |
| Ending | 空（既に送信済み） | 何もしない（二重送信なし） |
| Offline | 空 | 何もしない |

**Promise caching による競合対応**:
OBS `Stopping` シグナルとシャットダウンがほぼ同時に `logStreamEnd()` を呼ぶ可能性があります。実行中の Promise を `logStreamEndPromise` フィールドにキャッシュすることで、2回目の呼び出しは同じ Promise を返します。これにより、shutdown 側は `Promise.race` で実行中の HTTP リクエストの完了を正しく待てます。Promise 完了後は `.finally()` で `null` にリセットされるため、次の配信セッションでも正しく動作します。

```
// 競合シナリオ（どちらが先でも安全）
OBS Stopping → void this.logStreamEnd()    → Promise をキャッシュして送信開始
shutdown     → await this.logStreamEnd()   → キャッシュ済み Promise を返して待機
```

**タイムアウト保護**: 5秒のタイムアウトを設定し、HTTP リクエストが失敗・遅延してもシャットダウンがブロックされません。

## テスト

- [x] `pnpm run test:unit:app` 全テストパス（新規3テスト含む）
- [x] 配信中にアプリを終了 → `stream_end` が送信されることを確認
- [x] 通常の配信停止後にアプリを終了 → `stream_end` が二重送信されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)