### PR TITLE
修正: 設定画面の左の不要な目次を削減

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <toc-section v-if="isNiconicoLoggedIn()" :title="$t('settings.optimizationForNiconicoLiveService')" :visible="isNiconicoLoggedIn()">
+    <div v-if="isNiconicoLoggedIn()">
       <div class="section">
         <div class="input-label">
           <label>{{ $t('settings.optimizationForNiconicoLiveService') }}</label>
@@ -19,9 +19,9 @@
           class="optional-item"
         />
       </div>
-    </toc-section>
+    </div>
 
-    <toc-section :title="$t('settings.compactMode')">
+    <div>
       <div class="section">
         <div class="input-label">
           <label>{{ $t('settings.compactMode') }}</label>
@@ -30,9 +30,9 @@
         <ObsBoolInput :value="showAutoCompactDialogModel" @input="setShowAutoCompactDialog" />
         <ObsBoolInput :value="compactAlwaysOnTopModel" @input="setCompactAlwaysOnTop" />
       </div>
-    </toc-section>
+    </div>
 
-    <toc-section :title="$t('settings.cacheManagement')">
+    <div>
       <div class="section">
         <div class="input-label">
           <label>{{ $t('settings.cacheManagement') }}</label>
@@ -72,9 +72,9 @@
           </a>
         </div>
       </div>
-    </toc-section>
+    </div>
 
-    <toc-section :title="$t('settings.pollingPerformanceStatistics')">
+    <div>
       <div class="section">
         <ObsBoolInput
           :value="pollingPerformanceStatisticsModel"
@@ -82,7 +82,7 @@
         />
         <p>{{ $t('settings.pollingPerformanceStatisticsDescription') }}</p>
       </div>
-    </toc-section>
+    </div>
   </div>
 </template>
 

--- a/app/components/LanguageSettings.vue
+++ b/app/components/LanguageSettings.vue
@@ -1,11 +1,11 @@
 <template>
-  <toc-section :title="$t('common.language')">
+  <div>
     <div class="section">
       <div class="section-content">
         <GenericForm :value="settings" @input="save"></GenericForm>
       </div>
     </div>
-  </toc-section>
+  </div>
 </template>
 
 <script lang="ts" src="./LanguageSettings.vue.ts"></script>

--- a/app/components/TranscriptionSettings.vue
+++ b/app/components/TranscriptionSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="setting-section">
-    <toc-section :title="$t('settings.transcription.enable')">
+    <div>
       <div class="section">
         <div class="input-container">
           <div class="input-wrapper">
@@ -26,8 +26,8 @@
           {{ $t('settings.transcription.help.afterLink') }}
         </p>
       </div>
-    </toc-section>
-    <toc-section :title="$t('settings.transcription.audioSettings')">
+    </div>
+    <div>
       <div class="section">
         <div class="input-label section-heading">
           <label>{{ $t('settings.transcription.audioSettings') }}</label>
@@ -87,8 +87,8 @@
           </div>
         </div>
       </div>
-    </toc-section>
-    <toc-section :title="$t('settings.transcription.displaySettings')">
+    </div>
+    <div>
       <div class="section">
         <div class="input-label section-heading">
           <label>{{ $t('settings.transcription.displaySettings') }}</label>
@@ -183,7 +183,7 @@
           </div>
         </div>
       </div>
-    </toc-section>
+    </div>
   </div>
 </template>
 

--- a/app/components/obs/inputs/GenericFormGroups.vue.ts
+++ b/app/components/obs/inputs/GenericFormGroups.vue.ts
@@ -45,6 +45,6 @@ export default class GenericFormGroups extends Vue {
 
   get isSimpleCategory(): boolean {
     // Categories with few settings that don't need TOC
-    return ['Stream', 'Audio', 'Video'].includes(this.category);
+    return ['Stream', 'Audio', 'Video', 'General', 'Output'].includes(this.category);
   }
 }

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -35,11 +35,8 @@ interface TocSectionData {
 
 // 目次を持っているカテゴリ
 const CATEGORIES_WITH_TOC: string[] = [
-  'General',
-  'Output',
   'Hotkeys',
   'Advanced',
-  'Transcription',
   'Comment',
 ];
 


### PR DESCRIPTION
## このpull requestが解決する内容

設定画面のサイドバーで「一般」カテゴリを開いた状態だと、TOC（小見出し一覧）の行数が多く下端のカテゴリ（コメント等）がスクロール外に隠れてしまい、1クリックでアクセスできない問題を解決します。

## 変更後の画面イメージ

<img width="1195" height="772" alt="image" src="https://github.com/user-attachments/assets/a50e2b6c-1da7-4802-a4cf-2f7e6ad517bd" />

## 変更内容

以下3カテゴリのTOCを削除しました：

| カテゴリ | 理由 |
|---------|------|
| 一般 (General) | 小見出しの粒度が細かすぎてTOC行数が多く、サイドバーを圧迫していた |
| 出力 (Output) | スクロールせずに全小見出しが画面内に収まるためTOC不要 |
| 自動文字起こし (Transcription) | 同上 |

### 変更ファイル

- `app/components/windows/Settings.vue.ts`: `CATEGORIES_WITH_TOC` から `General`, `Output`, `Transcription` を削除
- `app/components/ExtraSettings.vue`: `<toc-section>` を `<div>` に置換
- `app/components/LanguageSettings.vue`: `<toc-section>` を `<div>` に置換
- `app/components/obs/inputs/GenericFormGroups.vue.ts`: `isSimpleCategory` に `'General'`, `'Output'` を追加
- `app/components/TranscriptionSettings.vue`: `<toc-section>` を `<div>` に置換

## テスト

- [x] 設定画面を開き、「一般」「出力」「自動文字起こし」のNavItemに矢印が表示されないことを確認
- [x] これらのカテゴリをクリックしてもTOCが展開されないことを確認
- [x] 「ショートカットキー」「詳細」「コメント」のTOCが従来通り動作することを確認
- [x] 「一般」カテゴリ選択時にサイドバーの全カテゴリがスクロールなしで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)