### PR TITLE
修正: ニコニ・コモンズのコンテンツツリーURLを /tree/ から /works/ に更新

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -72,7 +72,7 @@ export class HostsService extends Service {
   }
 
   getContentTreeURL(programID: string): string {
-    return `https://commons.nicovideo.jp/tree/${programID}`;
+    return `https://commons.nicovideo.jp/works/${programID}`;
   }
 
   getCreatorsProgramURL(programID: string): string {


### PR DESCRIPTION
## このpull requestが解決する内容
ニコニ・コモンズのコンテンツツリーのURLパスが `/tree/` から `/works/` に変更され、経過措置のリダイレクトも終了したため、新しいURLに更新します。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `app/services/hosts.ts` | `getContentTreeURL()` のURLを `/tree/` → `/works/` に変更 |

### URL変更
- 変更前: `https://commons.nicovideo.jp/tree/{programID}`
- 変更後: `https://commons.nicovideo.jp/works/{programID}`

## テスト
- [x] 配信画面のコンテンツツリーリンクが正しいURLに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)