### PR TITLE
変更: 設定画面のコメント設定・音声エンジンタブを未ログイン時も表示するよう変更

### DIFF
--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -28,12 +28,16 @@
           <i class="notification-icon icon-notification" />
           <p class="notification-message">{{ $t('settings.noticeWhileStreaming') }}</p>
         </aside>
+        <aside class="notification-root" v-if="showLoginRequiredNotice">
+          <i class="notification-icon icon-notification" />
+          <p class="notification-message">{{ $t('settings.noticeLoginRequired') }}</p>
+        </aside>
 
         <extra-settings v-if="categoryName === 'General'" />
         <language-settings v-if="categoryName === 'General'" />
         <hotkeys v-if="categoryName === 'Hotkeys'" />
-        <comment-settings v-if="categoryName === 'Comment'" />
-        <speech-engine-settings v-if="categoryName === 'SpeechEngine'" />
+        <comment-settings v-if="categoryName === 'Comment' && isLoggedIn" />
+        <speech-engine-settings v-if="categoryName === 'SpeechEngine' && isLoggedIn" />
         <sub-stream-settings v-if="categoryName === 'SubStream'" />
         <transcription-settings v-if="categoryName === 'Transcription'" />
         <GenericFormGroups

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -216,6 +216,9 @@ export default class Settings extends Vue {
   }
 
   public hasSections(category: SettingsCategory): boolean {
+    if (!this.isLoggedIn && (category === 'Comment' || category === 'SpeechEngine')) {
+      return false;
+    }
     return CATEGORIES_WITH_TOC.includes(category);
   }
 }

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -116,8 +116,6 @@ export default class Settings extends Vue {
     this.userSubscription = this.userService.userLoginState.subscribe(loggedIn => {
       this.isLoggedIn = !!loggedIn;
       this.categoryNames = this.settingsService.getCategories();
-      // reopen settings because new categories may not have previous category
-      this.settingsService.showSettings();
     });
     this.isLoggedIn = this.userService.isLoggedIn();
 
@@ -146,6 +144,13 @@ export default class Settings extends Vue {
 
   get isStreaming() {
     return this.streamingService.isStreaming;
+  }
+
+  get showLoginRequiredNotice(): boolean {
+    return (
+      !this.isLoggedIn &&
+      (this.categoryName === 'Comment' || this.categoryName === 'SpeechEngine')
+    );
   }
 
   getInitialCategoryName(): SettingsCategory {

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -667,6 +667,7 @@
   "cacheIdCopy": "Copy",
   "cacheManagement": "Management of the cache",
   "noticeWhileStreaming": "Some settings cannot be changed while streaming.",
+  "noticeLoginRequired": "This feature is for niconico live comments only. Please log in to your niconico account to use it.",
   "noticeForStreaming": "The URL/stream key will be set automatically according to the niconico account you are logged in to on N Air when you start streaming.",
   "noticeForStreamingNotLoggedIn": "When streaming on niconico live, you can omit entering the URL/stream key by logging in to your niconico account in N Air.",
   "showCacheDirectory": "Show Cache Directory",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -667,6 +667,7 @@
   "cacheIdCopy": "コピーする",
   "cacheManagement": "キャッシュ管理",
   "noticeWhileStreaming": "現在配信中のため、一部の設定は変更できません。",
+  "noticeLoginRequired": "本機能はニコニコ生放送のコメント専用です。利用するにはニコニコアカウントにログインしてください。",
   "noticeForStreaming": "N Airでログイン中のニコニコアカウントに合わせて、配信開始時に自動で設定されます",
   "noticeForStreamingNotLoggedIn": "ニコニコ生放送で配信する場合、N Airでニコニコアカウントにログインすると、URL／ストリームキーの入力を省略できます。",
   "showCacheDirectory": "キャッシュディレクトリーを表示",

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -183,10 +183,8 @@ export class SettingsService
 
     categories.push('Transcription');
 
-    if (this.userService.isLoggedIn()) {
-      categories.push('Comment');
-      categories.push('SpeechEngine');
-    }
+    categories.push('Comment');
+    categories.push('SpeechEngine');
 
     categories.push('SubStream');
 


### PR DESCRIPTION
## このpull requestが解決する内容

「コメント設定」「音声エンジン」タブをニコニコ未ログイン時でも設定画面のサイドバーに表示するよう変更します。

<img width="1201" height="1200" alt="image" src="https://github.com/user-attachments/assets/1ed7e2f8-5b41-40c0-87c0-022f9588e03e" />

## 背景

現在、これらのタブはニコニコ未ログイン時にサイドバーから非表示になっています。そのため：

- タブの存在に気づかないユーザーがいる
- 「コメントが表示されない」「読み上げが使えない」等の問題でログインが原因だと気づかず答えに辿り着けないユーザーがいる

## 変更内容

### UXの変更

- 「コメント設定」「音声エンジン」タブを未ログイン時でも常にサイドバーに表示
- 未ログイン時にこれらのタブを選択すると、コンテンツ上部に案内メッセージを表示:
  > 本機能はニコニコ生放送のコメント専用です。利用するにはニコニコアカウントにログインしてください。
- 未ログイン時のタブ内コンテンツは非表示（空）にする

### コード変更

| ファイル | 変更内容 |
|---------|---------|
| `app/services/settings/settings.ts` | `getCategories()` のログインガードを削除、Comment/SpeechEngine を常に追加 |
| `app/components/windows/Settings.vue` | 未ログイン通知の `<aside>` 追加、コンテンツの `v-if` に `&& isLoggedIn` 追加 |
| `app/components/windows/Settings.vue.ts` | `showLoginRequiredNotice` computed 追加、ログイン変化時の `showSettings()` 廃止 |
| `app/i18n/ja-JP/settings.json` | `noticeLoginRequired` メッセージ追加 |
| `app/i18n/en-US/settings.json` | `noticeLoginRequired` メッセージ追加 |

## テスト

- [x] 未ログイン状態で設定画面を開き、「コメント設定」「音声エンジン」タブがサイドバーに表示されることを確認
- [x] 各タブを選択したとき、案内メッセージが表示され、設定内容が空であることを確認
- [x] ニコニコにログイン後、案内メッセージが消えて設定内容が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)