### PR TITLE
開発: ログイン必須カテゴリの判定を定数 CATEGORIES_REQUIRING_LOGIN にまとめる

### DIFF
--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -40,6 +40,9 @@ const CATEGORIES_WITH_TOC: string[] = [
   'Comment',
 ];
 
+// ニコニコログインが必要なカテゴリ
+const CATEGORIES_REQUIRING_LOGIN: SettingsCategory[] = ['Comment', 'SpeechEngine'];
+
 @Component({
   components: {
     ModalLayout,
@@ -149,7 +152,7 @@ export default class Settings extends Vue {
   get showLoginRequiredNotice(): boolean {
     return (
       !this.isLoggedIn &&
-      (this.categoryName === 'Comment' || this.categoryName === 'SpeechEngine')
+      CATEGORIES_REQUIRING_LOGIN.includes(this.categoryName)
     );
   }
 
@@ -216,7 +219,7 @@ export default class Settings extends Vue {
   }
 
   public hasSections(category: SettingsCategory): boolean {
-    if (!this.isLoggedIn && (category === 'Comment' || category === 'SpeechEngine')) {
+    if (!this.isLoggedIn && CATEGORIES_REQUIRING_LOGIN.includes(category)) {
       return false;
     }
     return CATEGORIES_WITH_TOC.includes(category);


### PR DESCRIPTION
## このpull requestが解決する内容

#1197 で追加した「ログインが必要なカテゴリ（Comment/SpeechEngine）」の判定が `Settings.vue.ts` 内に2箇所散在していたため、定数にまとめてリファクタリングします。

## 変更内容

`app/components/windows/Settings.vue.ts` のみ変更。

```typescript
// ニコニコログインが必要なカテゴリ
const CATEGORIES_REQUIRING_LOGIN: SettingsCategory[] = ['Comment', 'SpeechEngine'];
```

この定数を以下の2箇所で使用:
- `showLoginRequiredNotice` computed property
- `hasSections()` メソッド

新しいログイン必須カテゴリを追加する際は、この定数を修正するだけで対応できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)