### PR TITLE
開発: セキュリティアラート110/184/185のlodash脆弱性をbin/lockfile更新で解消

### DIFF
--- a/bin/pnpm-lock.yaml
+++ b/bin/pnpm-lock.yaml
@@ -1011,8 +1011,8 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -2718,7 +2718,7 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -2967,7 +2967,7 @@ snapshots:
       '@xmldom/xmldom': 0.7.13
       argparse: 2.0.1
       cubic2quad: 1.2.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       microbuffer: 1.0.0
       svgpath: 2.6.0
 


### PR DESCRIPTION
## 概要

\`bin/pnpm-lock.yaml\` の lodash を 4.17.21 → 4.18.1 に更新し、以下のセキュリティアラートを解消します。

## 解消されるアラート

| Alert | CVE | 重大度 | 概要 |
|-------|-----|--------|------|
| [Alert 184](https://github.com/n-air-app/n-air-app/security/dependabot/184) | CVE-2026-2950 | Medium | Prototype Pollution via array path bypass in \`_.unset\` and \`_.omit\` |
| [Alert 185](https://github.com/n-air-app/n-air-app/security/dependabot/185) | CVE-2026-4800 | High | Code Injection via \`_.template\` imports key names |
| [Alert 110](https://github.com/n-air-app/n-air-app/security/dependabot/110) | CVE-2025-13465 | Medium | （既存アラート、bin/pnpm-lock.yaml経由） |

## 依存経路

\`webfont\` → \`svg2ttf@6.0.3\` → \`lodash@^4.17.10\`

svg2ttf@6.0.3 は \`lodash@^4.17.10\` を要求しており、4.18.x も範囲内のため lockfile 更新のみで解消できます。

## 変更内容

- \`bin/pnpm-lock.yaml\`: lodash 4.17.21 → 4.18.1

関連: #1073