### PR TITLE
開発: セキュリティアラート214/215のlodash脆弱性をlockfile更新で解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "font-manager": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/font-manager-1.2.10-win64.tar.gz",
     "fuse.js": "~7.1.0",
     "iconv-lite": "^0.7.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "long": "^5.2.3",
     "luxon": "^3.5.0",
     "node-fontinfo": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/node-fontinfo-1.1.12-win64.tar.gz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
       long:
         specifier: ^5.2.3
         version: 5.3.2
@@ -321,7 +321,7 @@ importers:
         version: 9.4.3(eslint@9.39.2(jiti@2.6.1))
       vue-loader:
         specifier: 15.11.1
-        version: 15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.17.23)(nunjucks@3.2.4(chokidar@3.6.0))(vue-template-compiler@2.7.14)(webpack@5.104.1)
+        version: 15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(nunjucks@3.2.4(chokidar@3.6.0))(vue-template-compiler@2.7.14)(webpack@5.104.1)
       vue-svg-loader:
         specifier: 0.16.0
         version: 0.16.0(vue-template-compiler@2.7.14)
@@ -5054,8 +5054,8 @@ packages:
   lodash.zip@4.2.0:
     resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -8758,7 +8758,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fs-extra: 9.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
@@ -9727,9 +9727,9 @@ snapshots:
       postcss: 8.5.6
       source-map: 0.6.1
 
-  '@vue/component-compiler-utils@3.3.0(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.17.23)(nunjucks@3.2.4(chokidar@3.6.0))':
+  '@vue/component-compiler-utils@3.3.0(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(nunjucks@3.2.4(chokidar@3.6.0))':
     dependencies:
-      consolidate: 0.15.1(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.17.23)(nunjucks@3.2.4(chokidar@3.6.0))
+      consolidate: 0.15.1(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(nunjucks@3.2.4(chokidar@3.6.0))
       hash-sum: 1.0.2
       lru-cache: 4.1.5
       merge-source-map: 1.1.0
@@ -10321,7 +10321,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.28.6
       glob: 7.2.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       require-package-name: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10802,7 +10802,7 @@ snapshots:
       esutils: 2.0.3
       fast-diff: 1.3.0
       js-string-escape: 1.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       md5-hex: 3.0.1
       semver: 7.7.3
       well-known-symbols: 2.0.0
@@ -10818,13 +10818,13 @@ snapshots:
 
   consola@3.4.2: {}
 
-  consolidate@0.15.1(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.17.23)(nunjucks@3.2.4(chokidar@3.6.0)):
+  consolidate@0.15.1(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(nunjucks@3.2.4(chokidar@3.6.0)):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
       ejs: 3.1.10
       handlebars: 4.7.9
-      lodash: 4.17.23
+      lodash: 4.18.1
       nunjucks: 3.2.4(chokidar@3.6.0)
 
   content-disposition@0.5.4:
@@ -11304,7 +11304,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -13225,7 +13225,7 @@ snapshots:
 
   lodash.zip@4.2.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -15344,7 +15344,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.7.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
@@ -15355,9 +15355,9 @@ snapshots:
     dependencies:
       vue: 2.7.14
 
-  vue-loader@15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.17.23)(nunjucks@3.2.4(chokidar@3.6.0))(vue-template-compiler@2.7.14)(webpack@5.104.1):
+  vue-loader@15.11.1(css-loader@7.1.2(webpack@5.104.1))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(nunjucks@3.2.4(chokidar@3.6.0))(vue-template-compiler@2.7.14)(webpack@5.104.1):
     dependencies:
-      '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.17.23)(nunjucks@3.2.4(chokidar@3.6.0))
+      '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(nunjucks@3.2.4(chokidar@3.6.0))
       css-loader: 7.1.2(webpack@5.104.1)
       hash-sum: 1.0.2
       loader-utils: 1.4.2


### PR DESCRIPTION
## 概要

root の lodash を 4.17.23 → 4.18.1 に更新し、以下のセキュリティアラートを解消します。

## 解消されるアラート

| Alert | CVE | 重大度 | 概要 |
|-------|-----|--------|------|
| [Alert 215](https://github.com/n-air-app/n-air-app/security/dependabot/215) | CVE-2026-4800 | High | Code Injection via \`_.template\` imports key names |
| [Alert 214](https://github.com/n-air-app/n-air-app/security/dependabot/214) | CVE-2026-2950 | Medium | Prototype Pollution via array path bypass in \`_.unset\` and \`_.omit\` |

## 原因

`package.json` の dependencies に `"lodash": "^4.17.23"` が直接指定されていたため、lockfile が 4.17.23 に固定されていた。4.18.x は `^4.17.23` の範囲内だが pnpm はロックファイルの既存バージョンを保持するため、package.json を `^4.18.1` に更新して再解決。

## 変更内容

- `package.json`: lodash `^4.17.23` → `^4.18.1`
- `pnpm-lock.yaml`: lodash 4.17.23 → 4.18.1（および関連するピア依存表記の更新）

## 備考

同 CVE の bin/ 側は #1202 で解消済み（Alert 110/184/185）。

関連: #1073