### PR TITLE
開発: CI の changes job を ubuntu-latest に移行して待ち時間を短縮

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   changes:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## このpull requestが解決する内容

GitHub Actions CI の `changes` job を `windows-2022` から `ubuntu-latest` に移行します。

## 背景

`changes` job は `dorny/paths-filter` action を実行してパス変更フィルタリングを行うだけで、Windows 固有の処理が一切ありません。
Ubuntuランナーはコストが低く、一般的にキュー待ちも短い傾向があるため、この job を ubuntu-latest に移行します。

この job は他のすべての job のクリティカルパスにあるため、ランナーが即座に確保できる状況ではほぼ差がありませんが、混雑時には若干の改善が期待できます。

なお、同様に Windows 固有の処理を持たない `test-summary` job はすでに `ubuntu-latest` で動作しており、今回はその方針を `changes` job にも適用します。

## 変更内容

| ファイル | 変更 |
|----------|------|
| `.github/workflows/test.yml` | `changes` job の `runs-on` を `windows-2022` → `ubuntu-latest` に変更 |

## 影響なしの理由

- `dorny/paths-filter` はクロスプラットフォーム対応
- `actions/checkout` もクロスプラットフォーム対応
- この job はキャッシュを作成しない（`runner.os` キーの問題なし）
- 下流の job は `changes` の outputs（`app`, `bin` のboolean値）のみを参照しており、OS依存なし

## テスト

- [x] CIが正常に動作し、`changes` job が ubuntu-latest 上で成功することを確認
- [x] 下流の job（`setup-app` 等）が正しく条件分岐されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)