### PR TITLE
開発: TranscriptionSourceService でアクティブシーンが null の場合のクラッシュを修正

### DIFF
--- a/app/services/transcription/transcription-source.test.ts
+++ b/app/services/transcription/transcription-source.test.ts
@@ -1,0 +1,172 @@
+import { jest_fn } from 'util/jest_fn';
+import { createSetupFunction } from 'util/test-setup';
+import type { TranscriptionSourceService as TranscriptionSourceServiceType } from './transcription-source';
+
+const setup = createSetupFunction({
+  state: {},
+  injectee: {
+    SourcesService: {
+      createSource: jest_fn().mockName('createSource'),
+      suggestName: jest_fn().mockName('suggestName').mockReturnValue('テキスト (文字起こし)'),
+      getSource: jest_fn().mockName('getSource'),
+    },
+    VideoService: {
+      baseWidth: 1920,
+      baseHeight: 1080,
+    },
+    TranscriptionService: {
+      state: { textFileMaxLine: 2 },
+      getTextFilePath: jest_fn().mockName('getTextFilePath').mockReturnValue('/fake/transcription.txt'),
+    },
+    ScenesService: {
+      activeScene: null as unknown,
+    },
+  },
+});
+
+beforeEach(() => {
+  jest.doMock('services/core/stateful-service');
+  jest.doMock('services/core/injector');
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+});
+
+function prepare(activeScene: unknown = null) {
+  setup({
+    injectee: {
+      ScenesService: {
+        activeScene,
+      },
+    },
+  });
+
+  const { TranscriptionSourceService } = require('./transcription-source') as {
+    TranscriptionSourceService: typeof TranscriptionSourceServiceType;
+  };
+  return TranscriptionSourceService.instance;
+}
+
+describe('TranscriptionSourceService', () => {
+  describe('getTranscriptionItemsInActiveScene', () => {
+    it('activeScene が null のとき空配列を返す（クラッシュしない）', () => {
+      const instance = prepare(null);
+      expect(() => instance.getTranscriptionItemsInActiveScene()).not.toThrow();
+      expect(instance.getTranscriptionItemsInActiveScene()).toEqual([]);
+    });
+
+    it('activeScene が存在するがアイテムがないとき空配列を返す', () => {
+      const mockScene = {
+        getItems: jest_fn().mockName('getItems').mockReturnValue([]),
+      };
+      const instance = prepare(mockScene);
+      expect(instance.getTranscriptionItemsInActiveScene()).toEqual([]);
+    });
+
+    it('activeScene に text_transcription アイテムがあるときそれを返す', () => {
+      const mockGetSource = jest_fn().mockName('getSource').mockReturnValue({
+        getComparisonDetails: () => ({ propertiesManager: 'text_transcription' }),
+      });
+      setup({
+        injectee: {
+          SourcesService: {
+            createSource: jest_fn().mockName('createSource'),
+            suggestName: jest_fn().mockName('suggestName').mockReturnValue('テキスト (文字起こし)'),
+            getSource: mockGetSource,
+          },
+          VideoService: { baseWidth: 1920, baseHeight: 1080 },
+          TranscriptionService: {
+            state: { textFileMaxLine: 2 },
+            getTextFilePath: jest_fn().mockName('getTextFilePath').mockReturnValue('/fake/transcription.txt'),
+          },
+          ScenesService: {
+            activeScene: {
+              getItems: jest_fn().mockName('getItems').mockReturnValue([
+                { sourceId: 'source-1' },
+                { sourceId: 'source-2' },
+              ]),
+            },
+          },
+        },
+      });
+      const { TranscriptionSourceService } = require('./transcription-source') as {
+        TranscriptionSourceService: typeof TranscriptionSourceServiceType;
+      };
+      const instance = TranscriptionSourceService.instance;
+      const items = instance.getTranscriptionItemsInActiveScene();
+      expect(items).toEqual([{ sourceId: 'source-1' }, { sourceId: 'source-2' }]);
+    });
+
+    it('activeScene に text_transcription 以外のアイテムのみのとき空配列を返す', () => {
+      const mockGetSource = jest_fn().mockName('getSource').mockReturnValue({
+        getComparisonDetails: () => ({ propertiesManager: 'default' }),
+      });
+      setup({
+        injectee: {
+          SourcesService: {
+            createSource: jest_fn().mockName('createSource'),
+            suggestName: jest_fn().mockName('suggestName').mockReturnValue('テキスト (文字起こし)'),
+            getSource: mockGetSource,
+          },
+          VideoService: { baseWidth: 1920, baseHeight: 1080 },
+          TranscriptionService: {
+            state: { textFileMaxLine: 2 },
+            getTextFilePath: jest_fn().mockName('getTextFilePath').mockReturnValue('/fake/transcription.txt'),
+          },
+          ScenesService: {
+            activeScene: {
+              getItems: jest_fn().mockName('getItems').mockReturnValue([
+                { sourceId: 'source-other' },
+              ]),
+            },
+          },
+        },
+      });
+      const { TranscriptionSourceService } = require('./transcription-source') as {
+        TranscriptionSourceService: typeof TranscriptionSourceServiceType;
+      };
+      const instance = TranscriptionSourceService.instance;
+      expect(instance.getTranscriptionItemsInActiveScene()).toEqual([]);
+    });
+  });
+
+  describe('containsTranscriptionInActiveScene', () => {
+    it('activeScene が null のとき false を返す', () => {
+      const instance = prepare(null);
+      expect(instance.containsTranscriptionInActiveScene()).toBe(false);
+    });
+
+    it('activeScene に text_transcription があるとき true を返す', () => {
+      const mockGetSource = jest_fn().mockName('getSource').mockReturnValue({
+        getComparisonDetails: () => ({ propertiesManager: 'text_transcription' }),
+      });
+      setup({
+        injectee: {
+          SourcesService: {
+            createSource: jest_fn().mockName('createSource'),
+            suggestName: jest_fn().mockName('suggestName').mockReturnValue('テキスト (文字起こし)'),
+            getSource: mockGetSource,
+          },
+          VideoService: { baseWidth: 1920, baseHeight: 1080 },
+          TranscriptionService: {
+            state: { textFileMaxLine: 2 },
+            getTextFilePath: jest_fn().mockName('getTextFilePath').mockReturnValue('/fake/transcription.txt'),
+          },
+          ScenesService: {
+            activeScene: {
+              getItems: jest_fn().mockName('getItems').mockReturnValue([{ sourceId: 'source-1' }]),
+            },
+          },
+        },
+      });
+      const { TranscriptionSourceService } = require('./transcription-source') as {
+        TranscriptionSourceService: typeof TranscriptionSourceServiceType;
+      };
+      const instance = TranscriptionSourceService.instance;
+      expect(instance.containsTranscriptionInActiveScene()).toBe(true);
+    });
+  });
+});

--- a/app/services/transcription/transcription-source.ts
+++ b/app/services/transcription/transcription-source.ts
@@ -140,7 +140,9 @@ export class TranscriptionSourceService extends Service {
    * @returns 文字起こしソースのSceneItem配列
    */
   getTranscriptionItemsInActiveScene(): SceneItem[] {
-    return this.scenesService.activeScene.getItems().filter(item => {
+    const scene = this.scenesService.activeScene;
+    if (!scene) return [];
+    return scene.getItems().filter(item => {
       const sourceDetails = this.sourcesService.getSource(item.sourceId).getComparisonDetails();
       return sourceDetails.propertiesManager === 'text_transcription';
     });


### PR DESCRIPTION
## このpull requestが解決する内容

`TranscriptionSourceUsageService` の初期化時に `getTranscriptionItemsInActiveScene()` が呼ばれ、`scenesService.activeScene` が `null` を返す状況で TypeError クラッシュが発生していた問題を修正します。

## 背景

Sentry issue **N-AIR-APP-FT6** として報告。

サービス初期化タイミング（子ウィンドウプロセスへのサービス遅延初期化、またはシーン未設定状態）で `activeScene` が `null` になるケースがあり、そのまま `.getItems()` を呼び出してクラッシュしていた。

呼び出し経路：
```
TranscriptionSourceUsageService.init()
  → updateTranscriptionUsage()
    → containsTranscriptionInActiveScene()
      → getTranscriptionItemsInActiveScene()
        → this.scenesService.activeScene.getItems()  ← null クラッシュ
```

`ScenesService.activeScene` の戻り値型は `Scene`（`null` の可能性あり）であるが、呼び出し側でガードしていなかった。

## 変更内容

| ファイル | 変更 |
|---|---|
| `app/services/transcription/transcription-source.ts` | `getTranscriptionItemsInActiveScene()` に `activeScene` の null ガードを追加。null の場合は空配列を返す |

## テスト

コードレビューのみ。クラッシュはサイレントかつ再現条件（初期化タイミング依存）が特定困難なため、手動確認は省略。

🤖 Generated with [Claude Code](https://claude.com/claude-code)