### PR TITLE
開発: optimizerの不要なSentryイベント送信を削除

### DIFF
--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/vue';
 import { IObsInput, IObsListInput, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { $t } from 'services/i18n';
 import { getKeys } from 'util/getKeys';
@@ -502,13 +501,7 @@ class OptKeyProperty {
   value(v: any): string {
     if (v === undefined) {
       const path = i18nPath('settings', this.category, this.subCategory, this.setting);
-      Sentry.withScope(scope => {
-        scope.setLevel('info');
-        scope.setTag('optimization.key', this.key);
-        scope.setTag('settings.path', path);
-        scope.setFingerprint(['OptKeyProperty', 'value(undefined)']);
-        Sentry.captureMessage(`OptKeyProperty: value(undefined): ${path}`);
-      });
+      console.warn(`OptKeyProperty: value(undefined): ${path}`);
       return;
     }
     if (this.lookupValueName) {


### PR DESCRIPTION
## このpull requestが解決する内容

`OptKeyProperty.value()` で値が `undefined` のとき `Sentry.captureMessage` を呼んでいたが、これは正常な状態であり不要なイベントだった。`console.warn` に変更してSentryクォータの無駄消費を解消する。

## 背景

Sentry issue **N-AIR-APP-BSW** (`OptKeyProperty: value(undefined): settings.Output.Streaming.UseAdvanced`) が 122,778 イベント・1,139 ユーザーと大量に発生しており、現在も継続している。

`UseAdvanced` は `Simple` 出力モードでエンコーダー依存のパラメータ（`dependents` 内）で、AMD エンコーダー使用時など特定の設定では存在しない。これは異常ではなく正常な状態。

`optimizeInfo()` は `current` と `optimized` を合算して走査するため、片方にしか存在しないキーを処理する際に `undefined` が発生する。

## 変更内容

- `app/services/settings/optimizer.ts`: `Sentry.withScope` + `captureMessage` ブロックを `console.warn` 1行に置き換え
- 不要になった `import * as Sentry from '@sentry/vue'` を削除

## 影響範囲

- `optimizeInfo()` の表示動作は変わらない（`undefined` 時に `return` するのは同じ）
- 開発時はコンソールでパラメータ設定ミスを検出可能
- 本番で Sentry にイベントが送信されなくなる（クォータ節約）

## テスト

- [x] `pnpm run test:unit:app` 全 807 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)