### PR TITLE
修正: ソースのプロパティ画面で一部の設定変更が反映されないことがある問題を修正

### DIFF
--- a/app/components/obs/inputs/ObsSliderInput.vue.ts
+++ b/app/components/obs/inputs/ObsSliderInput.vue.ts
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash';
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 import Slider from '../../shared/Slider.vue';
 import { IObsSliderInputValue, ObsInput, TObsType } from './ObsInput';
 
@@ -16,7 +16,14 @@ class ObsSliderInput extends ObsInput<IObsSliderInputValue> {
   // moves the slider.  It makes the UI feel more responsive.
   localValue = this.value.value;
 
-  @Watch('value.value')
+  mounted() {
+    // workaround: avoid using @Watch decorator, use $watch instead
+    // see:
+    //   https://github.com/kaorun343/vue-property-decorator/issues/247,
+    //   https://github.com/kaorun343/vue-property-decorator/issues/228
+    this.$watch('value.value', this.onValueChange);
+  }
+
   onValueChange(newValue: number) {
     this.localValue = newValue;
   }


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue N-AIR-APP-FQV（2834 events, 651 users）を修正します。

SourceProperties ウィンドウでソースのプロパティを操作中に「TypeError: Cannot read properties of undefined (reading 'apply')」が発生するクラッシュの根本原因を取り除きます。

- First seen: 2026-03-11（`v1.1.20260311-1`）

### ユーザーから見える現象

`text_gdiplus`（テキストソース）等のソースプロパティウィンドウを開き、テキストエリアをクリック・編集すると、フォント選択などの一部プロパティが正しく更新されなくなる（操作が効かない）。アプリ自体はクラッシュしないが、Vueのエラーハンドラーが握り潰すため、ユーザーが気づきにくい形で機能不全が起きていた。

## 背景

PR #1157 で `ObsSliderInput` に追加された `@Watch('value.value')` デコレーターが、`vue-property-decorator` の既知バグ（[#247](https://github.com/kaorun343/vue-property-decorator/issues/247), [#228](https://github.com/kaorun343/vue-property-decorator/issues/228)）を引き起こしていました。

ES6クラスの静的プロパティ継承を通じて、`@Watch` デコレーターが親クラス `ObsInput.__decorators__` を汚染し、`index.ts` で後から読み込まれる兄弟コンポーネント（`ObsFontInput`, `ObsEditableListProperty`, `ObsButtonInput`, `ObsResolutionInput` 等）に存在しない `onValueChange` ウォッチャーを登録してしまいます。

これらのコンポーネントは `onValueChange` を持たないため `this.cb = undefined` となり、`value.value` の変更時に Vue が `this.cb.apply(...)` を呼んでクラッシュします。

SourceProperties で `text_gdiplus` 等のソースを開いた際、`ObsFontInput`（汚染済み）と `textarea`（`ObsTextInput`）が同時にレンダリングされ、textarea をクリック/編集するとプロパティ変更が走りクラッシュしていました。

## 変更内容

`app/components/obs/inputs/ObsSliderInput.vue.ts`

- `@Watch('value.value')` デコレーターを削除
- `mounted()` フックで `this.$watch('value.value', this.onValueChange)` を使用

`ObsBitMaskInput.vue.ts` で同一問題の回避策（コメント付き）が既に採用されており、同じパターンを適用しています。

## テスト

- [x] `pnpm run test:unit:app` — 807 tests passed
- [x] `pnpm lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)