### PR TITLE
開発: アプリ終了時のnode-libuiohookクリーンアップ改善とSentryデバッグシンボルアップロード

### DIFF
--- a/bin/release/mini-release.js
+++ b/bin/release/mini-release.js
@@ -109,6 +109,9 @@ async function postReleaseToSlack({ version, environment, channel, link, notes }
  * @param {string} param0.upload.githubToken
  * @param {string} param0.upload.s3BucketName
  * @param {string} param0.upload.s3KeyPrefix
+ * @param {object} param0.sentry
+ * @param {string} param0.sentry.organization
+ * @param {string} param0.sentry.project
  * @param {object} param0.patchNote
  * @param {string} param0.patchNote.version
  * @param {string} param0.patchNote.notes
@@ -122,6 +125,7 @@ async function runScript({
   releaseChannel,
   target,
   upload,
+  sentry,
   patchNote,
 
   skipLocalModificationCheck, // for DEBUG
@@ -235,6 +239,20 @@ async function runScript({
 
     info('Making the package...');
     executeCmd(`pnpm run package:${releaseEnvironment}-${releaseChannel}`);
+  }
+
+  if (!skipBuild) {
+    info('Uploading debug symbols to Sentry...');
+    // Upload PDB files for native modules so that native crash stack traces can be symbolicated.
+    // node_modules/ contains PDB files built with RelWithDebInfo from the native-deps release.
+    const sentryCliArgs = [
+      `--org ${sentry.organization}`,
+      `--project ${sentry.project}`,
+      `node_modules/node-libuiohook/node_libuiohook.pdb`,
+      `node_modules/obs-studio-node/`,
+      `node_modules/crash-handler/`,
+    ].join(' ');
+    executeCmd(`npx @sentry/cli debug-files upload ${sentryCliArgs}`);
   }
 
   info('Pushing to the repository...');

--- a/main.js
+++ b/main.js
@@ -749,7 +749,9 @@ function initialize(crashHandler) {
       // Ensure splash window is closed
       closeSplashWindow();
 
-      require('node-libuiohook').stopHook();
+      const libuiohook = require('node-libuiohook');
+      libuiohook.unregisterAllCallbacks();
+      libuiohook.stopHook();
       console.log('[EXIT] Stopped libuiohook');
 
       session.defaultSession.flushStorageData();


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue N-AIR-APP-D0A（`node::AsyncWrap::EmitDestroy` ネイティブクラッシュ）への対応。  
アプリ終了時に `node-libuiohook` ネイティブモジュールの NAPI async work が不正なメモリアドレスにアクセスしてクラッシュする問題を軽減する。

## 背景

Sentry issue N-AIR-APP-D0A は 39,881イベント / 162ユーザー、2023年9月から現在まで継続中（High優先度）。

クラッシュはアプリ終了時の DLL アンロード（`LdrShutdownProcess`）の際に `node_libuiohook.node` の NAPI async work 破棄が Node.js 環境の部分的な破棄後に走ることで発生する。

Streamlabs Desktop（upstream）との比較で、N Air のシャットダウン順序に以下の差異が判明：

| 項目 | Streamlabs Desktop | N Air (修正前) |
|------|-------------------|----------------|
| `stopHook()` 前の処理 | `unregisterAllCallbacks()` を呼ぶ | 呼んでいない |
| cleanup タイミング | ウィンドウを閉じる**前** | `closed`（破棄後） |

`unregisterAllCallbacks()` でコールバックを解除してから `stopHook()` を呼ぶことで、残留する NAPI async work が減り、クラッシュが軽減される。

## 変更内容

### 変更1: `main.js` — `unregisterAllCallbacks()` を追加

`stopHook()` の前に `unregisterAllCallbacks()` を呼んでコールバックを解除する。  
Streamlabs Desktop が採用している作法に倣った修正。

### 変更2: `bin/release/mini-release.js` — Sentry デバッグシンボルアップロードを追加

リリースビルド後に `sentry-cli debug-files upload` で PDB ファイルを Sentry にアップロードするステップを追加。

- 対象: `node-libuiohook`、`obs-studio-node`、`crash-handler` の PDB
- PDB は各ネイティブモジュールの tarball に既に含まれている（RelWithDebInfo ビルド）
- `@sentry/cli` は `@sentry/webpack-plugin` の transitive dependency として既にインストール済み
- `SENTRY_AUTH_TOKEN` は既存の `checkEnv` で検証済み
- release config の `sentry.organization` / `sentry.project` プロパティを活用（定義済みだが未使用だった）

## PDB アップロード後に判明したクラッシュの詳細

`node_libuiohook.pdb` を手動アップロード後、N-AIR-APP-FV7（同ファミリー）のイベントで symbolicate されたスタックトレースを確認：

```
node::AsyncWrap::EmitDestroy          ← クラッシュ地点
node::AsyncResource::~AsyncResource
`anonymous namespace'::uvimpl::Work::~Work
napi_delete_async_work
Napi::AsyncWorker::~AsyncWorker       ← ここから node_libuiohook.node 内
HotKey::~HotKey                       ← ホットキーオブジェクトの破棄
std::_Tree_val::_Erase_tree
gThreadData                           ← グローバル変数のデストラクタ
_execute_onexit_table（onexit.cpp）
dllmain_crt_process_detach
dllmain_dispatch                      ← DLL アンロード
```

**根本原因:** `node_libuiohook.node` 内の `gThreadData` グローバル変数のデストラクタが DLL アンロード時（`LdrShutdownProcess`）に走り、`HotKey` オブジェクトを破棄しようとする。このとき Node.js 環境はすでに部分的に破棄されており、`napi_delete_async_work` が無効なメモリにアクセスしてクラッシュする。

**本 PR の効果と限界:**  
`unregisterAllCallbacks()` で事前にコールバックを解除することで `HotKey` オブジェクトを減らせる可能性があり、クラッシュ頻度の軽減が期待される。ただし `gThreadData` の静的デストラクタ自体は残るため、**完全解決ではない**。根本解決には `node-libuiohook`（upstream: `stream-labs/node-libuiohook`）側での修正が必要。

## テスト

変更1はサイレントな効果のため直接確認できない。リリース後の Sentry 統計で評価する。

- [ ] リリース後、Sentry N-AIR-APP-D0A の新規イベント数が減少傾向になることを確認（長期）
- [x] `node_libuiohook.node` 内フレームが symbolicate されていることを確認（手動アップロードにて確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)