### PR TITLE
開発: babel-plugin-lodashを削除しlodash使用箇所をネイティブJS/deep importに移行

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,6 @@
     ]
   ],
   "plugins": [
-    "lodash",
     [
       "@babel/plugin-proposal-decorators",
       {

--- a/app/app.ts
+++ b/app/app.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { I18nService } from 'services/i18n';
 
 // eslint-disable-next-line

--- a/app/components/Selector.vue.ts
+++ b/app/components/Selector.vue.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import draggable from 'vuedraggable';
@@ -25,7 +24,7 @@ export default class Selector extends Vue {
   draggableSelector: string = this.draggable ? '.selector-item' : 'none';
 
   handleChange(change: any) {
-    const order = _.map(this.normalizedItems, item => {
+    const order = this.normalizedItems.map(item => {
       return item.value;
     });
 
@@ -61,7 +60,7 @@ export default class Selector extends Vue {
    * array of objects, so we normalize those here.
    */
   get normalizedItems(): ISelectorItem[] {
-    return _.map(this.items, item => {
+    return this.items.map(item => {
       if (typeof item === 'string') {
         return {
           name: item,

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -1,5 +1,4 @@
 import Display from 'components/shared/Display.vue';
-import _ from 'lodash';
 import { Inject } from 'services/core/injector';
 import { CustomizationService } from 'services/customization';
 import { Scene, SceneItem, ScenesService, TSceneNode } from 'services/scenes';
@@ -251,7 +250,7 @@ export default class StudioEditor extends Vue {
       this.dragHandler.move(event);
     } else if (event.buttons === 1) {
       // We might need to start dragging
-      const sourcesInPriorityOrder = _.compact(this.activeSources.concat(this.sceneItems));
+      const sourcesInPriorityOrder = this.activeSources.concat(this.sceneItems).filter(Boolean);
 
       const overSource = sourcesInPriorityOrder.find(source => {
         return this.isOverSource(event, source);
@@ -287,21 +286,21 @@ export default class StudioEditor extends Vue {
         if (options.horizontalEdge === ResizeBoxPoint.West) {
           const croppableWidth = rect.width - rect.crop.right - 2;
           const distance = croppableWidth * rect.scaleX - (rect.x - x);
-          rect.crop.left = _.clamp(distance / rect.scaleX, 0, croppableWidth);
+          rect.crop.left = Math.min(Math.max(distance / rect.scaleX, 0), croppableWidth);
         } else if (options.horizontalEdge === ResizeBoxPoint.East) {
           const croppableWidth = rect.width - rect.crop.left - 2;
           const distance = croppableWidth * rect.scaleX + (rect.x - x);
-          rect.crop.right = _.clamp(distance / rect.scaleX, 0, croppableWidth);
+          rect.crop.right = Math.min(Math.max(distance / rect.scaleX, 0), croppableWidth);
         }
 
         if (options.verticalEdge === ResizeBoxPoint.North) {
           const croppableHeight = rect.height - rect.crop.bottom - 2;
           const distance = croppableHeight * rect.scaleY - (rect.y - y);
-          rect.crop.top = _.clamp(distance / rect.scaleY, 0, croppableHeight);
+          rect.crop.top = Math.min(Math.max(distance / rect.scaleY, 0), croppableHeight);
         } else if (options.verticalEdge === ResizeBoxPoint.South) {
           const croppableHeight = rect.height - rect.crop.top - 2;
           const distance = croppableHeight * rect.scaleY + (rect.y - y);
-          rect.crop.bottom = _.clamp(distance / rect.scaleY, 0, croppableHeight);
+          rect.crop.bottom = Math.min(Math.max(distance / rect.scaleY, 0), croppableHeight);
         }
       });
     });
@@ -376,7 +375,7 @@ export default class StudioEditor extends Vue {
       if (overResize) {
         this.$refs.display.style.cursor = overResize.cursor;
       } else {
-        const overSource = _.find(this.sceneItems, source => {
+        const overSource = this.sceneItems.find(source => {
           return this.isOverSource(event, source);
         });
 
@@ -430,7 +429,7 @@ export default class StudioEditor extends Vue {
   // of the active source's resize regions.
   isOverResize(event: MouseEvent) {
     if (this.activeSources.length > 0) {
-      return _.find(this.resizeRegions, region => {
+      return this.resizeRegions.find(region => {
         return this.isOverBox(event, region.x, region.y, region.width, region.height);
       });
     }

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -1,4 +1,5 @@
-import _, { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import VueColor from 'vue-color';
 import { Component, Prop } from 'vue-property-decorator';
 import Utils from '../../../services/utils';
@@ -93,7 +94,7 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
   }
 
   private setValueImpl(rgba: IColor) {
-    if (!_.isEqual(rgba, this.obsColor)) {
+    if (!isEqual(rgba, this.obsColor)) {
       const intColor = Utils.rgbaToInt(rgba.r, rgba.g, rgba.b, Math.round(255 * rgba.a));
       this.emitInput({ ...this.value, value: intColor });
     }
@@ -115,7 +116,7 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
 
   get hexAlpha() {
     const alpha = this.obsColor.a;
-    return _.padStart(Math.floor(alpha * 255).toString(16), 2, '0');
+    return Math.floor(alpha * 255).toString(16).padStart(2, '0');
   }
 
   get hexColor() {

--- a/app/components/obs/inputs/ObsEditableListInput.vue.ts
+++ b/app/components/obs/inputs/ObsEditableListInput.vue.ts
@@ -1,5 +1,5 @@
 import * as remote from '@electron/remote';
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { Component, Prop } from 'vue-property-decorator';
 import { $t } from '../../../services/i18n';
 import { Menu } from '../../../util/menus/Menu';
@@ -51,7 +51,7 @@ class ObsEditableListProperty extends ObsInput<IObsEditableListInputValue> {
   }
 
   handleRemove() {
-    this.setList(_.without(this.list, this.activeItem));
+    this.setList(this.list.filter(item => item !== this.activeItem));
   }
 
   handleEdit() {
@@ -66,7 +66,7 @@ class ObsEditableListProperty extends ObsInput<IObsEditableListInputValue> {
     });
 
     if (filePaths && filePaths.length) {
-      const activeIndex = _.indexOf(this.list, this.activeItem);
+      const activeIndex = this.list.indexOf(this.activeItem);
 
       this.list[activeIndex] = filePaths[0];
 
@@ -105,7 +105,7 @@ class ObsEditableListProperty extends ObsInput<IObsEditableListInputValue> {
 
   get list(): string[] {
     const items = this.value.value || [];
-    return _.cloneDeep(items.map(item => item.value));
+    return cloneDeep(items.map(item => item.value));
   }
 }
 

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { $t } from 'services/i18n/index';
 import Vue from 'vue';
 import { Prop } from 'vue-property-decorator';
@@ -125,7 +124,7 @@ export interface IElectronOpenDialogFilter {
 }
 
 function parsePathFilters(filterStr: string): IElectronOpenDialogFilter[] {
-  const filters = _.compact(filterStr.split(';;'));
+  const filters = filterStr.split(';;').filter(Boolean);
 
   // Browser source uses *.*
   if (filterStr === '*.*') {
@@ -139,7 +138,7 @@ function parsePathFilters(filterStr: string): IElectronOpenDialogFilter[] {
 
   return filters.map(filter => {
     const match = filter.match(/^(.*)\((.*)\)$/);
-    const desc = _.trim(match[1]);
+    const desc = match[1].trim();
     let types = match[2].split(' ');
 
     types = types.map(type => {

--- a/app/components/obs/inputs/ObsSliderInput.vue.ts
+++ b/app/components/obs/inputs/ObsSliderInput.vue.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { Component, Prop } from 'vue-property-decorator';
 import Slider from '../../shared/Slider.vue';
 import { IObsSliderInputValue, ObsInput, TObsType } from './ObsInput';

--- a/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
@@ -1,6 +1,7 @@
 import Dropdown from 'components/shared/Dropdown.vue';
 import fontManager from 'font-manager';
-import _ from 'lodash';
+import groupBy from 'lodash/groupBy';
+import sortBy from 'lodash/sortBy';
 import { EFontStyle } from 'obs-studio-node';
 import { Component, Prop } from 'vue-property-decorator';
 import ObsFontSizeSelector from './ObsFontSizeSelector.vue';
@@ -76,7 +77,7 @@ export default class ObsSystemFontSelector extends ObsInput<IObsInput<IObsFont>>
 
     let selected_font: IFontDescriptor;
 
-    const regular = _.find(family.fonts, font => {
+    const regular = family.fonts.find(font => {
       return font.style === 'Regular';
     });
 
@@ -131,7 +132,7 @@ export default class ObsSystemFontSelector extends ObsInput<IObsInput<IObsFont>>
   }
 
   get selectedFont() {
-    return _.find(this.selectedFamily.fonts, font => {
+    return this.selectedFamily.fonts.find(font => {
       if (this.value.value.flags !== this.getFlagsFromFont(font)) {
         return false;
       }
@@ -141,12 +142,12 @@ export default class ObsSystemFontSelector extends ObsInput<IObsInput<IObsFont>>
   }
 
   get fontsByFamily() {
-    return _.groupBy(this.fonts, 'family');
+    return groupBy(this.fonts, 'family');
   }
 
   get fontFamilies() {
-    return _.sortBy(
-      _.map(this.fontsByFamily, fonts => {
+    return sortBy(
+      Object.values(this.fontsByFamily).map(fonts => {
         return this.fontsToFamily(fonts);
       }),
       'family',

--- a/app/components/pages/onboarding_steps/ObsImport.vue.ts
+++ b/app/components/pages/onboarding_steps/ObsImport.vue.ts
@@ -1,5 +1,4 @@
 import Dropdown from 'components/shared/Dropdown.vue';
-import { defer } from 'lodash';
 import { $t } from 'services/i18n';
 import { SceneCollectionsService } from 'services/scene-collections';
 import Vue from 'vue';
@@ -71,7 +70,7 @@ export default class ObsImport extends Vue {
 
   startImport() {
     this.status = 'importing';
-    defer(async () => {
+    setTimeout(async () => {
       try {
         await this.obsImporterService.load(this.selectedProfile);
         this.status = 'done';

--- a/app/components/windows/SourcesShowcase.vue.ts
+++ b/app/components/windows/SourcesShowcase.vue.ts
@@ -1,6 +1,5 @@
 import * as remote from '@electron/remote';
 import ModalLayout from 'components/ModalLayout.vue';
-import { omit } from 'lodash';
 import { Inject } from 'services/core/injector';
 import { $t } from 'services/i18n';
 import { NVoiceCharacterType, NVoiceCharacterTypes } from 'services/nvoice-character';
@@ -94,24 +93,25 @@ export default class SourcesShowcase extends Vue {
       });
     }
 
+    const { propertiesManager: optionsPropertiesManager, ...optionsWithoutManager } = options;
     if (sourceType === 'custom_cast_ndi_source') {
       const propertiesManagerSettings: Dictionary<any> = {
-        ...omit(options, 'propertiesManager'),
+        ...optionsWithoutManager,
         propertiesManager: 'custom-cast-ndi',
       };
       this.sourcesService.showAddSource('ndi_source', propertiesManagerSettings);
     } else if (NVoiceCharacterTypes.includes(sourceType as NVoiceCharacterType)) {
       const propertiesManagerSettings: Dictionary<any> = {
         NVoiceCharacterType: sourceType as NVoiceCharacterType,
-        ...omit(options, 'propertiesManager'),
+        ...optionsWithoutManager,
       };
       this.sourcesService.showAddSource('browser_source', {
         propertiesManagerSettings,
         propertiesManager: 'nvoice-character',
       });
     } else {
-      const propertiesManager = options.propertiesManager || 'default';
-      const propertiesManagerSettings: Dictionary<any> = { ...omit(options, 'propertiesManager') };
+      const propertiesManager = optionsPropertiesManager || 'default';
+      const propertiesManagerSettings: Dictionary<any> = { ...optionsWithoutManager };
 
       this.sourcesService.showAddSource(sourceType as TSelectableSourceType, {
         propertiesManagerSettings,

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -5,7 +5,6 @@ import {
   IObsNumberInputValue,
   TObsFormData,
 } from 'components/obs/inputs/ObsInput';
-import { omit } from 'lodash';
 import { EMPTY, merge, Observable, Subject, Subscription } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
 import { InitAfter, Inject, mutation, ServiceHelper, StatefulService } from 'services/core';
@@ -313,7 +312,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     const obsInput = this.sourcesService.getSourceById(sourceId).getObsInput();
 
     // Fader is ignored by this method.  Use setFader instead
-    const newPatch = omit(patch, 'fader');
+    const { fader: _fader, ...newPatch } = patch;
 
     getKeys(newPatch).forEach(name => {
       if (newPatch[name] === undefined) return;

--- a/app/services/core/__mocks__/stateful-service.ts
+++ b/app/services/core/__mocks__/stateful-service.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { Service } from '../service';
 
 export function mutation() {

--- a/app/services/core/persistent-stateful-service.ts
+++ b/app/services/core/persistent-stateful-service.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import Utils from '../utils';
 import { StatefulService } from './stateful-service';

--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -1,4 +1,3 @@
-import { defer, mapValues } from 'lodash';
 import { $t } from 'services/i18n';
 import { KeyListenerService } from 'services/key-listener';
 import { ScenesService } from 'services/scenes';
@@ -426,7 +425,7 @@ export class HotkeysService extends StatefulService<IHotkeysServiceState> {
       return hotkeys.map(h => ({ ...h.getModel(), description: h.description }));
     }
 
-    return mapValues(hotkeys, h => this.serializeHotkeys(h));
+    return Object.fromEntries(Object.entries(hotkeys).map(([k, h]) => [k, this.serializeHotkeys(h)]));
   }
 
   clearAllHotkeys() {
@@ -611,7 +610,7 @@ export class Hotkey implements IHotkey {
     if (up) {
       action.upHandler = () => {
         if (!action.isActive(entityId)) {
-          defer(() => up(entityId));
+          setTimeout(() => up(entityId), 0);
         }
       };
     }
@@ -619,7 +618,7 @@ export class Hotkey implements IHotkey {
     if (down) {
       action.downHandler = () => {
         if (!action.isActive(entityId)) {
-          defer(() => down(entityId));
+          setTimeout(() => down(entityId), 0);
         }
       };
     }

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -1,6 +1,5 @@
 import * as remote from '@electron/remote';
 import fs from 'fs';
-import defaultTo from 'lodash/defaultTo';
 import path from 'path';
 import { AudioService, DEFAULT_AUDIO_MIXERS } from 'services/audio';
 import { Inject } from 'services/core/injector';
@@ -227,9 +226,9 @@ export class ObsImporterService extends Service {
               this.audioService.getSource(source.sourceId).setMuted(sourceJSON.muted);
               this.audioService.getSource(source.sourceId).setMul(sourceJSON.volume);
               this.audioService.getSource(source.sourceId).setSettings({
-                audioMixers: defaultTo(sourceJSON.mixers, DEFAULT_AUDIO_MIXERS),
-                monitoringType: defaultTo(sourceJSON.monitoring_type, defaultMonitoring),
-                syncOffset: defaultTo(sourceJSON.sync / 1000000, 0),
+                audioMixers: sourceJSON.mixers ?? DEFAULT_AUDIO_MIXERS,
+                monitoringType: sourceJSON.monitoring_type ?? defaultMonitoring,
+                syncOffset: sourceJSON.sync != null ? sourceJSON.sync / 1000000 : 0,
                 forceMono: !!(sourceJSON.flags & obs.ESourceFlags.ForceMono),
               });
             }

--- a/app/services/scene-collections/nodes/array-node.ts
+++ b/app/services/scene-collections/nodes/array-node.ts
@@ -1,4 +1,3 @@
-import { compact } from 'lodash';
 import { Node } from './node';
 
 interface IArraySchema<TSchema> {
@@ -22,7 +21,7 @@ export abstract class ArrayNode<TSchema, TContext, TItem> extends Node<
       }),
     );
 
-    this.data = { items: compact(values) };
+    this.data = { items: values.filter(Boolean) };
   }
 
   async load(context: TContext): Promise<void> {

--- a/app/services/scene-collections/scene-collections.test.ts
+++ b/app/services/scene-collections/scene-collections.test.ts
@@ -6,7 +6,10 @@
 import * as Sentry from '@sentry/vue';
 
 // Mock dependencies
-jest.mock('@sentry/vue');
+jest.mock('@sentry/vue', () => ({
+  withScope: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 jest.mock('services/core/stateful-service');
 jest.mock('services/core/injector');
 jest.mock('@electron/remote', () => ({
@@ -41,8 +44,8 @@ describe('SceneCollectionsService', () => {
 
     mockCaptureMessage = jest.fn();
 
-    (Sentry.withScope as jest.Mock) = mockWithScope;
-    (Sentry.captureMessage as jest.Mock) = mockCaptureMessage;
+    jest.spyOn(Sentry, 'withScope').mockImplementation(mockWithScope);
+    jest.spyOn(Sentry, 'captureMessage').mockImplementation(mockCaptureMessage);
   });
 
   describe('load with partial errors', () => {

--- a/app/services/scenes/scene-folder.ts
+++ b/app/services/scenes/scene-folder.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { Inject } from 'services/core/injector';
 import { ISceneHierarchy, isFolder, isItem, SceneItem, TSceneNode } from 'services/scenes';
 import { Selection, SelectionService } from 'services/selection';

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -1,5 +1,5 @@
 import { TObsFormData } from 'components/obs/inputs/ObsInput';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { ISource, SourcesService, TSourceType } from 'services/sources';
 import { VideoService } from 'services/video';
 import { CenteringAxis, ScalableRectangle } from 'util/ScalableRectangle';

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import { filter } from 'rxjs/operators';
 import { ServiceHelper, mutation } from 'services/core';
 import { Inject } from 'services/core/injector';

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -1,4 +1,3 @@
-import { without } from 'lodash';
 import { Subject } from 'rxjs';
 import { InitAfter } from 'services/core';
 import { Inject } from 'services/core/injector';
@@ -172,7 +171,7 @@ export class ScenesService extends StatefulService<IScenesState> {
   private REMOVE_SCENE(id: string) {
     Vue.delete(this.state.scenes, id);
 
-    this.state.displayOrder = without(this.state.displayOrder, id);
+    this.state.displayOrder = this.state.displayOrder.filter(x => x !== id);
   }
 
   @mutation()

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -1,6 +1,5 @@
 import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
-import { uniq } from 'lodash';
 import { Subject } from 'rxjs';
 import { mutation, ServiceHelper, StatefulService } from 'services/core';
 import { $t } from 'services/i18n';
@@ -228,7 +227,7 @@ export class Selection {
 
   select(itemsList: TNodesList): Selection {
     let ids = this.resolveItemsList(itemsList);
-    ids = uniq(ids);
+    ids = [...new Set(ids)];
     const scene = this.getScene();
 
     // omit ids that are not presented on the scene
@@ -527,7 +526,7 @@ export class Selection {
 
     for (let ind = 0; ind < minPathLength; ind++) {
       const parents = paths.map(path => path[ind]);
-      if (uniq(parents).length === 1) {
+      if ([...new Set(parents)].length === 1) {
         closestParentId = parents[0];
       } else {
         return this.getScene().getFolder(closestParentId);
@@ -538,7 +537,7 @@ export class Selection {
   canGroupIntoFolder(): boolean {
     const selectedNodes = this.getRootNodes();
     const nodesFolders = selectedNodes.map(node => node.parentId || null);
-    const nodesHaveTheSameParent = uniq(nodesFolders).length === 1;
+    const nodesHaveTheSameParent = [...new Set(nodesFolders)].length === 1;
     const canGroupIntoFolder = selectedNodes.length > 1 && nodesHaveTheSameParent;
     return canGroupIntoFolder;
   }

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { Subject } from 'rxjs';
 import { Inject } from 'services/core/injector';
 import { SettingsService } from 'services/settings';

--- a/app/services/sources/properties-managers/properties-manager.ts
+++ b/app/services/sources/properties-managers/properties-manager.ts
@@ -1,5 +1,4 @@
 import * as input from 'components/obs/inputs/ObsInput';
-import { compact } from 'lodash';
 import * as obs from '../../../../obs-api';
 
 /**
@@ -110,7 +109,7 @@ export abstract class PropertiesManager implements IPropertyManager {
     });
 
     propsArray = propsArray.concat(obsProperties);
-    propsArray = compact(propsArray).filter(prop => !this.blacklist.includes(prop.name));
+    propsArray = propsArray.filter(Boolean).filter(prop => !this.blacklist.includes(prop.name));
 
     return propsArray;
   }

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -1,5 +1,6 @@
 import { TObsFormData } from 'components/obs/inputs/ObsInput';
-import { cloneDeep, isEqual } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 import { ScenesService } from 'services/scenes';
 import Utils from 'services/utils';
 import { assertIsDefined } from 'util/properties-type-guards';

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -1,5 +1,5 @@
 import * as remote from '@electron/remote';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { randomUUID } from 'node:crypto';
 import { getKeys } from 'util/getKeys';
 

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -1,8 +1,7 @@
 import * as Sentry from '@sentry/vue';
 // This singleton class provides a renderer-space API
 // for spawning various child windows.
-import { cloneDeep } from 'lodash';
-
+import cloneDeep from 'lodash/cloneDeep';
 import * as remote from '@electron/remote';
 import AddSource from 'components/windows/AddSource.vue';
 import AddSourceFilter from 'components/windows/AddSourceFilter.vue';

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,6 +1,5 @@
 import * as remote from '@electron/remote';
 import electron from 'electron';
-import each from 'lodash/each';
 import { InternalApiService } from 'services/api/internal-api';
 import { IMutation } from 'services/api/jsonrpc';
 import Util from 'services/utils';
@@ -17,8 +16,8 @@ const debug = process.env.NODE_ENV !== 'production';
 
 const mutations = {
   BULK_LOAD_STATE(state: any, data: any) {
-    each(data.state, (value, key) => {
-      state[key] = value;
+    Object.keys(data.state).forEach(key => {
+      state[key] = data.state[key];
     });
   },
 };

--- a/app/util/ScalableRectangle.ts
+++ b/app/util/ScalableRectangle.ts
@@ -1,4 +1,6 @@
-import { get, invert, set } from 'lodash';
+import get from 'lodash/get';
+import invert from 'lodash/invert';
+import set from 'lodash/set';
 
 // This class is used for simplifying math that deals
 // with rectangles that can be scaled, including

--- a/app/util/test-setup.ts
+++ b/app/util/test-setup.ts
@@ -1,4 +1,4 @@
-import { isFunction, merge } from 'lodash';
+import merge from 'lodash/merge';
 
 interface Table {
   [serviceName: string]: any;
@@ -18,14 +18,14 @@ export function createSetupFunction({
     injectee: injecteeFactory = {},
     state: stateFactory = {},
   }: { injectee?: Table | Factory; state?: Table | Factory } = {}) {
-    const state = isFunction(stateFactory) ? stateFactory() : stateFactory;
-    const injectee = isFunction(injecteeFactory) ? injecteeFactory() : injecteeFactory;
+    const state = typeof stateFactory === 'function' ? stateFactory() : stateFactory;
+    const injectee = typeof injecteeFactory === 'function' ? injecteeFactory() : injecteeFactory;
     const mockedStatefulService = require('services/core/stateful-service');
     const mockedInjectorUtil = require('services/core/injector');
-    if (!isFunction(mockedStatefulService.__setup)) {
+    if (typeof mockedStatefulService.__setup !== 'function') {
       throw new Error("`jest.mock('services/core/stateful-service')` が必要です");
     }
-    if (!isFunction(mockedInjectorUtil.__setup)) {
+    if (typeof mockedInjectorUtil.__setup !== 'function') {
       throw new Error("`jest.mock('services/core/injector')` が必要です");
     }
     mockedStatefulService.__setup(merge({}, defaultState, state));

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "autoprefixer": "^10.4.14",
     "ava": "^6.4.1",
     "babel-loader": "~10.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "cross-env": "~10.1.0",
     "css-loader": "^7.1.2",
     "electron": "29.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,9 +190,6 @@ importers:
       babel-loader:
         specifier: ~10.0.0
         version: 10.0.0(@babel/core@7.28.6)(webpack@5.104.1)
-      babel-plugin-lodash:
-        specifier: ^3.3.4
-        version: 3.3.4
       cross-env:
         specifier: ~10.1.0
         version: 10.1.0
@@ -2480,9 +2477,6 @@ packages:
   babel-plugin-jest-hoist@29.6.3:
     resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  babel-plugin-lodash@3.3.4:
-    resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
 
   babel-plugin-polyfill-corejs2@0.4.14:
     resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
@@ -6061,9 +6055,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  require-package-name@2.0.1:
-    resolution: {integrity: sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -10316,16 +10307,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-plugin-lodash@3.3.4:
-    dependencies:
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/types': 7.28.6
-      glob: 7.2.3
-      lodash: 4.18.1
-      require-package-name: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.6):
     dependencies:
       '@babel/compat-data': 7.28.6
@@ -14208,8 +14189,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  require-package-name@2.0.1: {}
 
   requires-port@1.0.0: {}
 

--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { IJsonRpcEvent, IJsonRpcRequest } from '../../app/services/api/jsonrpc';

--- a/test/helpers/modules/forms/form.ts
+++ b/test/helpers/modules/forms/form.ts
@@ -1,5 +1,6 @@
 import { pascalize } from 'humps';
-import { difference, isEqual, keyBy, mapValues } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import keyBy from 'lodash/keyBy';
 import { sleep } from '../../sleep';
 import { getClient, waitForDisplayed } from '../core';
 import { BaseInputController, TFiledSetterFn } from './base';
@@ -52,7 +53,7 @@ export function useForm(name?: string) {
   async function readFields(indexKey = 'name', valueKey = 'displayValue') {
     const fields = await readForm();
     const fieldsMap = keyBy(fields, indexKey);
-    return mapValues(fieldsMap, valueKey);
+    return Object.fromEntries(Object.entries(fieldsMap).map(([k, v]) => [k, (v as any)[valueKey]]));
   }
 
   /**
@@ -85,7 +86,8 @@ export function useForm(name?: string) {
     }, true);
 
     // check that we filled out all requested fields
-    const notFoundFields = difference(Object.keys(formData), filledFields);
+    const filledSet = new Set(filledFields);
+    const notFoundFields = Object.keys(formData).filter(k => !filledSet.has(k));
     if (notFoundFields.length) {
       throw new Error(`Inputs or controllers not found: ${notFoundFields.join(',')}`);
     }

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -4,7 +4,6 @@
  */
 
 import avaTest, { TestFn } from 'ava';
-import { uniq } from 'lodash';
 import { sleep } from '../../../app/util/sleep';
 import { ITestContext } from './index';
 import { tasklist } from 'tasklist';
@@ -80,7 +79,7 @@ export function saveFailedTestsToFile(failedTests: string[]) {
     // tslint:disable-next-line:no-parameter-reassignment TODO
     failedTests = JSON.parse(fs.readFileSync(FAILED_TESTS_PATH, 'utf8')).concat(failedTests);
   }
-  fs.writeFileSync(FAILED_TESTS_PATH, JSON.stringify(uniq(failedTests)));
+  fs.writeFileSync(FAILED_TESTS_PATH, JSON.stringify([...new Set(failedTests)]));
 }
 
 export function removeFailedTestFromFile(testName: string) {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,6 +8,7 @@
     "allowJs": true,
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "noImplicitThis": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "removeComments": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "resolveJsonModule": true,
     "outDir": "dist/tsc-out",
     "sourceMap": true,


### PR DESCRIPTION
## このpull requestが解決する内容

`babel-plugin-lodash` はアーカイブ済み（2023年9月）であり、`@babel/types` 7.28.6 の deprecated API（`isModuleDeclaration`）を呼び出していたため、ビルド時に毎回 deprecation warning が発生していました（[lodash/babel-plugin-lodash#259](https://github.com/lodash/babel-plugin-lodash/issues/259)）。

#1201 で導入したばかりでしたが、アーカイブ済みのプラグインのため修正見込みがなく削除します。プラグインを削除し、lodash の使用箇所をネイティブJS またはdeep importに移行します。

## 変更内容

### babel-plugin-lodash の削除

| package | before | after |
|---------|--------|-------|
| babel-plugin-lodash | 3.3.4 | 削除 |

### lodash 関数のネイティブJS置き換え

| lodash | ネイティブ代替 |
|--------|--------------|
| `compact(arr)` | `arr.filter(Boolean)` |
| `find(arr, pred)` | `arr.find(pred)` |
| `map(arr, fn)` | `arr.map(fn)` |
| `each(obj, fn)` | `Object.keys().forEach(...)` |
| `uniq(arr)` | `[...new Set(arr)]` |
| `indexOf` / `trim` / `padStart` | ネイティブ同名メソッド |
| `defer(fn)` | `setTimeout(fn, 0)` |
| `omit(obj, keys)` | destructuring + rest |
| `without(arr, val)` | `arr.filter(x => x !== val)` |
| `defaultTo(val, def)` | `val ?? def` |
| `isFunction(fn)` | `typeof fn === 'function'` |
| `clamp(v, min, max)` | `Math.min(Math.max(v, min), max)` |
| `difference(a, b)` | `a.filter(x => !b.includes(x))` |
| `mapValues(obj, fn)` | `Object.fromEntries(Object.entries(...))` |

### deep importに変更（後日ネイティブ化予定）

`cloneDeep` / `merge` / `isEqual` / `debounce` / `get` / `set` / `invert` / `uniqBy` / `sortBy` / `groupBy` / `keyBy` は `import x from 'lodash/x'` 形式に変更し、バンドルサイズを維持。

### tsconfig.json への `esModuleInterop: true` 追加

CJSモジュール（`lodash/x`）のdefault importをJestテスト環境で正しく動作させるために追加。

### テスト修正

`scene-collections.test.ts` で `@sentry/vue` のモックに直接代入していた箇所を `jest.spyOn` に変更（`esModuleInterop` 追加後にgetter-onlyになったため）。

## バンドルサイズ比較

| ファイル | 変更前 | 変更後 | 差分 |
|---------|--------|--------|------|
| `renderer.js` | 7.81 MiB | 7.81 MiB | -6,949 B |
| `vendors~renderer.js` | 6.02 MiB | 5.97 MiB | -52,022 B |

プラグインなしで同等のバンドルサイズを維持（むしろわずかに削減）。

## テスト

- [x] `pnpm run compile` でビルド成功・deprecation warning 消去を確認
- [x] `pnpm run test:unit` 全テスト通過（49 suites, 811 tests）
- [x] `pnpm lint` でlintエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)