### PR TITLE
改善: 起動後の最初のコメント読み上げで待たされないようにする

### DIFF
--- a/app/components/CommentSettings.vue.ts
+++ b/app/components/CommentSettings.vue.ts
@@ -78,6 +78,9 @@ export default class CommentSettings extends Vue {
   mounted() {
     this.startVoicevoxChecker();
     this.initOneComme();
+    if (this.synthesizerEnabled) {
+      this.nicoliveCommentSynthesizerService.prefetchNVoice();
+    }
   }
 
   close() {

--- a/app/services/nicolive-program/n-voice-client.ts
+++ b/app/services/nicolive-program/n-voice-client.ts
@@ -121,6 +121,14 @@ export class NVoiceClientService
     this.client = new NVoiceClient({ baseDir: getNVoicePath(), onError: showError });
   }
 
+  async prefetch(): Promise<void> {
+    try {
+      await this.client.startNVoice();
+    } catch (e) {
+      console.warn('NVoice prefetch failed:', e);
+    }
+  }
+
   private index = 0;
   private speaking: Promise<void> | undefined;
 

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -14,6 +14,7 @@ import { ISpeechSynthesizer } from './speech/ISpeechSynthesizer';
 import { NVoiceSynthesizer } from './speech/NVoiceSynthesizer';
 import { VoicevoxSynthesizer } from './speech/VoicevoxSynthesizer';
 import { WebSpeechSynthesizer } from './speech/WebSpeechSynthesizer';
+import { NicoliveProgramService } from './nicolive-program';
 import { NicoliveProgramStateService, SynthesizerId, SynthesizerSelector } from './state';
 import { WrappedChat, WrappedMessage } from './WrappedChat';
 
@@ -55,6 +56,7 @@ export interface ICommentSynthesizerState {
 @InitAfter('NicoliveProgramStateService')
 export class NicoliveCommentSynthesizerService extends StatefulService<ICommentSynthesizerState> {
   @Inject('NicoliveProgramStateService') stateService: NicoliveProgramStateService;
+  @Inject() private nicoliveProgramService: NicoliveProgramService;
   @Inject() nVoiceClientService: NVoiceClientService;
   @Inject() nVoiceCharacterService: NVoiceCharacterService;
   @Inject() private userService: UserService;
@@ -400,10 +402,26 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     this.queue.runNext();
   }
 
+  private isNVoiceConfigured(): boolean {
+    const { selector } = this.state;
+    return selector.normal === 'nVoice' || selector.operator === 'nVoice' || selector.system === 'nVoice';
+  }
+
+  prefetchNVoice(): void {
+    if (!this.state.enabled || !this.isNVoiceConfigured()) {
+      return;
+    }
+    this.nVoiceClientService.prefetch().catch(() => {
+      // already logged inside prefetch()
+    });
+  }
+
   private setEnabled(enabled: boolean) {
     this.setState({ enabled });
     if (!enabled) {
       this.queue.cancel();
+    } else if (this.nicoliveProgramService.state.viewUri) {
+      this.prefetchNVoice();
     }
   }
   get enabled(): boolean {

--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -128,7 +128,7 @@ test('接続先情報が来たら接続する', async () => {
   const instance = NicoliveCommentViewerService.instance as NicoliveCommentViewerService;
 
   expect(clientSubject.observers).toHaveLength(0);
-  expect(stateChange.observers).toHaveLength(2);
+  expect(stateChange.observers).toHaveLength(3);
   stateChange.next({ viewUri: 'https://example.com' });
   expect(clientSubject.observers).toHaveLength(1);
 });
@@ -149,7 +149,7 @@ test('接続先情報が欠けていたら接続しない', () => {
   const instance = NicoliveCommentViewerService.instance as NicoliveCommentViewerService;
 
   expect(clientSubject.observers).toHaveLength(0);
-  expect(stateChange.observers).toHaveLength(2);
+  expect(stateChange.observers).toHaveLength(3);
   stateChange.next({ viewUri: '' });
   expect(clientSubject.observers).toHaveLength(0);
 });

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -213,6 +213,17 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
       )
       .subscribe(state => this.onNextConfig(state));
 
+    // 番組接続時にNVoiceエンジンをプリフェッチする
+    this.nicoliveProgramService.stateChange
+      .pipe(
+        map(({ viewUri }) => viewUri),
+        distinctUntilChanged(),
+        filter(viewUri => !!viewUri),
+      )
+      .subscribe(() => {
+        this.nicoliveCommentSynthesizerService.prefetchNVoice();
+      });
+
     // 番組終了時にメッセージを追加する
     this.nicoliveProgramService.stateChange
       .pipe(

--- a/app/services/nicolive-program/speech/NVoiceClient.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.ts
@@ -255,6 +255,7 @@ class NVoiceEngineError extends Error {
 const supportedProtocolVersion = '1.0.0';
 export class NVoiceClient {
   private commandLineClient: CommandLineClient | undefined;
+  private startingPromise: Promise<void> | undefined;
 
   constructor(
     readonly options: {
@@ -266,9 +267,15 @@ export class NVoiceClient {
   }
 
   async startNVoice(): Promise<void> {
-    if (this.commandLineClient === undefined) {
-      await this._startNVoice();
+    if (this.commandLineClient !== undefined) {
+      return;
     }
+    if (this.startingPromise === undefined) {
+      this.startingPromise = this._startNVoice().finally(() => {
+        this.startingPromise = undefined;
+      });
+    }
+    await this.startingPromise;
   }
 
   async _startNVoice(): Promise<void> {


### PR DESCRIPTION
## このpull requestが解決する内容

NVoice（コメント読み上げエンジン）は初回合成時に初めて起動するため、最初のコメント読み上げで数秒の遅延が発生していた。番組接続時・読み上げON時・コメント設定画面表示時にエンジンを事前起動（プリフェッチ）することで、この遅延を解消する。

## 背景

`n-voice-engine.exe` は PyTorchモデルの読み込みと Open JTalk 辞書の読み込みを起動時に行うため、初回起動に数秒かかる。テストでは20秒のタイムアウトが設定されているほど重い処理であり、最初のコメントが来たタイミングで起動すると読み上げが大きく遅れる。

## 変更内容

### プリフェッチのトリガー

| トリガー | 条件 | 変更ファイル |
|---------|------|------------|
| A: 番組接続時 | `viewUri` が空→非空 + 読み上げ有効 + NVoice設定あり | `nicolive-comment-viewer.ts` |
| B: 読み上げON時 | `enabled=true` + 番組接続中 + NVoice設定あり | `nicolive-comment-synthesizer.ts` |
| C: コメント設定画面表示時 | 読み上げ有効 + NVoice設定あり | `CommentSettings.vue.ts` |

### 主な実装

- **`NVoiceClientService.prefetch()`** (`n-voice-client.ts`): エンジン事前起動メソッドを追加。エラーは握りつぶし、失敗時は従来の遅延起動がフォールバックとして機能する
- **`NicoliveCommentSynthesizerService.prefetchNVoice()`** (`nicolive-comment-synthesizer.ts`): NVoiceが設定されていて読み上げ有効なときのみプリフェッチを呼ぶ
- **`NVoiceClient.startNVoice()`** レースコンディション修正 (`NVoiceClient.ts`): プリフェッチと初回合成が同時に呼ばれた場合に二重起動しないよう、起動中の Promise を共有する

## テスト

- [x] `pnpm run test:unit:app` 全テスト通過
- [x] 読み上げONの状態で番組を取得 → 最初のコメントが遅延なく読み上げられることを確認
- [x] 番組接続後に読み上げをONにする → 同上
- [x] コメント設定画面を開く → エンジンが事前起動されることを確認（タスクマネージャーで `n-voice-engine.exe` を監視）
- [ ] 読み上げ設定でNVoiceを全タイプ未使用にする → エンジンが起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)