### PR TITLE
修正: 最大化状態でマルチモニター間を移動後に間違ったモニターで復元される問題を修正

### DIFF
--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -19,6 +19,7 @@ const config = {
     'splash/splash-window.js',
     'index.html',
     'main.js',
+    'main-process/window-startup-state.js',
     'obs-api',
   ],
   extraFiles: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
       options: ['no-sandbox'],
     },
   },
-  testMatch: ['**/app/**/*.test.ts'],
+  testMatch: ['**/app/**/*.test.ts', '**/main-process/*.test.ts'],
   transformIgnorePatterns: [
     'node_modules/(?!(ml-kmeans|ml-distance-euclidean|ml-matrix|ml-nearest-vector|ml-random|ml-xsadd))',
   ],

--- a/main-process/window-startup-state.d.ts
+++ b/main-process/window-startup-state.d.ts
@@ -1,0 +1,48 @@
+export interface Display {
+  bounds: { x: number; y: number; width: number; height: number };
+  workArea: { x: number; y: number; width: number; height: number };
+}
+
+export interface Screen {
+  getAllDisplays(): Display[];
+  getDisplayNearestPoint(point: { x: number; y: number }): Display;
+  getPrimaryDisplay(): Display;
+}
+
+export interface SavedState {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  isMaximized?: boolean;
+  displayBounds?: { x: number; y: number; width: number; height: number };
+}
+
+export interface WindowState {
+  x: number | undefined;
+  y: number | undefined;
+  width: number;
+  height: number;
+}
+
+export interface WindowBounds {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  shouldMaximize: boolean;
+}
+
+export function findTargetDisplay(
+  savedDisplayBounds: SavedState['displayBounds'],
+  savedX: number | undefined,
+  savedY: number | undefined,
+  screen: Screen,
+): Display;
+
+export function resolveWindowBounds(
+  rawSavedState: SavedState,
+  windowState: WindowState,
+  screen: Screen,
+  defaults?: { defaultWidth: number; defaultHeight: number },
+): WindowBounds;

--- a/main-process/window-startup-state.js
+++ b/main-process/window-startup-state.js
@@ -41,7 +41,7 @@ function findTargetDisplay(savedDisplayBounds, savedX, savedY, screen) {
  * 消してしまう。そのため windowStateKeeper() 呼び出し前に window-state.json を直接読んだ
  * rawSavedState を最大化・ディスプレイ判定に使う。
  *
- * @param {object} rawSavedState - window-state.json の生データ（{}の場合は初回起動扱い）
+ * @param {{ x?: number, y?: number, width?: number, height?: number, isMaximized?: boolean, displayBounds?: { x: number, y: number, width: number, height: number } }} rawSavedState - window-state.json の生データ（{}の場合は初回起動扱い）
  * @param {{ x: number|undefined, y: number|undefined, width: number, height: number }} windowState
  *   - windowStateKeeper が返す値（validateState() 後の値なので isMaximized/displayBounds が消える可能性あり）
  * @param {{ getAllDisplays(): Electron.Display[], getDisplayNearestPoint(point: {x:number,y:number}): Electron.Display, getPrimaryDisplay(): Electron.Display }} screen

--- a/main-process/window-startup-state.js
+++ b/main-process/window-startup-state.js
@@ -1,0 +1,99 @@
+/**
+ * 保存された displayBounds から対応する現在接続中のディスプレイを見つける。
+ *
+ * electron-window-state は最大化中に x/y を更新しないため、保存された x/y は
+ * 最大化前の古いモニター位置を指している可能性がある。
+ * displayBounds は最大化時にも正しく更新されるため、復元先モニターの特定に使う。
+ *
+ * @param {({x: number, y: number, width: number, height: number})|undefined} savedDisplayBounds
+ * @param {number|undefined} savedX - フォールバック用の保存された x 座標
+ * @param {number|undefined} savedY - フォールバック用の保存された y 座標
+ * @param {{ getAllDisplays(): Electron.Display[], getDisplayNearestPoint(point: {x:number,y:number}): Electron.Display, getPrimaryDisplay(): Electron.Display }} screen
+ * @returns {Electron.Display}
+ */
+function findTargetDisplay(savedDisplayBounds, savedX, savedY, screen) {
+  if (savedDisplayBounds) {
+    // 保存された位置と一致するディスプレイを探す
+    const allDisplays = screen.getAllDisplays();
+    const match = allDisplays.find(
+      d => d.bounds.x === savedDisplayBounds.x && d.bounds.y === savedDisplayBounds.y,
+    );
+    if (match) return match;
+    // 完全一致がなければ中心点から最近接ディスプレイを返す（モニター切断時のフォールバック）
+    const center = {
+      x: savedDisplayBounds.x + savedDisplayBounds.width / 2,
+      y: savedDisplayBounds.y + savedDisplayBounds.height / 2,
+    };
+    return screen.getDisplayNearestPoint(center);
+  }
+  if (Number.isInteger(savedX) && Number.isInteger(savedY)) {
+    return screen.getDisplayNearestPoint({ x: savedX, y: savedY });
+  }
+  return screen.getPrimaryDisplay();
+}
+
+/**
+ * 保存状態からウィンドウの初期位置・サイズ・最大化フラグを決定する。
+ *
+ * rawSavedState を使う理由:
+ * electron-window-state の validateState() → resetStateToDefault() は保存された x/y が
+ * どのディスプレイにも含まれない場合に state を上書きし、isMaximized と元の displayBounds を
+ * 消してしまう。そのため windowStateKeeper() 呼び出し前に window-state.json を直接読んだ
+ * rawSavedState を最大化・ディスプレイ判定に使う。
+ *
+ * @param {object} rawSavedState - window-state.json の生データ（{}の場合は初回起動扱い）
+ * @param {{ x: number|undefined, y: number|undefined, width: number, height: number }} windowState
+ *   - windowStateKeeper が返す値（validateState() 後の値なので isMaximized/displayBounds が消える可能性あり）
+ * @param {{ getAllDisplays(): Electron.Display[], getDisplayNearestPoint(point: {x:number,y:number}): Electron.Display, getPrimaryDisplay(): Electron.Display }} screen
+ * @param {{ defaultWidth: number, defaultHeight: number }} [defaults]
+ * @returns {{ x?: number, y?: number, width: number, height: number, shouldMaximize: boolean }}
+ */
+function resolveWindowBounds(rawSavedState, windowState, screen, defaults) {
+  const defaultWidth = defaults?.defaultWidth ?? 1600;
+  const defaultHeight = defaults?.defaultHeight ?? 1000;
+
+  if (rawSavedState.isMaximized) {
+    // 最大化状態で復元する場合: rawSavedState の displayBounds から正しいモニターを特定して配置する。
+    // x/y は最大化前の古い値（別モニターの可能性あり）なので使わない。
+    const targetDisplay = findTargetDisplay(
+      rawSavedState.displayBounds,
+      rawSavedState.x,
+      rawSavedState.y,
+      screen,
+    );
+    const workArea = targetDisplay.workArea;
+    const width = Math.min(windowState.width || rawSavedState.width || defaultWidth, workArea.width);
+    const height = Math.min(
+      windowState.height || rawSavedState.height || defaultHeight,
+      workArea.height,
+    );
+    // maximize() 前の配置はターゲットディスプレイの workArea 中央に置く
+    return {
+      x: workArea.x + Math.round((workArea.width - width) / 2),
+      y: workArea.y + Math.round((workArea.height - height) / 2),
+      width,
+      height,
+      shouldMaximize: true,
+    };
+  }
+
+  // 通常状態で復元する場合: 保存された x/y が有効なディスプレイ上にあるか確認する
+  const allDisplays = screen.getAllDisplays();
+  const isVisible = allDisplays.some(
+    display =>
+      display.workArea.x < windowState.x + windowState.width &&
+      windowState.x < display.workArea.x + display.workArea.width &&
+      display.workArea.y < windowState.y &&
+      windowState.y < display.workArea.y + display.workArea.height,
+  );
+
+  return {
+    ...(isVisible ? { x: windowState.x, y: windowState.y } : {}),
+    // isVisible が false の場合は x/y を省略し、Electron がプライマリディスプレイ中央に配置する
+    width: windowState.width,
+    height: windowState.height,
+    shouldMaximize: false,
+  };
+}
+
+module.exports = { findTargetDisplay, resolveWindowBounds };

--- a/main-process/window-startup-state.js
+++ b/main-process/window-startup-state.js
@@ -78,14 +78,17 @@ function resolveWindowBounds(rawSavedState, windowState, screen, defaults) {
   }
 
   // 通常状態で復元する場合: 保存された x/y が有効なディスプレイ上にあるか確認する
+  const hasPosition = Number.isInteger(windowState.x) && Number.isInteger(windowState.y);
   const allDisplays = screen.getAllDisplays();
-  const isVisible = allDisplays.some(
-    display =>
-      display.workArea.x < windowState.x + windowState.width &&
-      windowState.x < display.workArea.x + display.workArea.width &&
-      display.workArea.y < windowState.y &&
-      windowState.y < display.workArea.y + display.workArea.height,
-  );
+  const isVisible =
+    hasPosition &&
+    allDisplays.some(
+      display =>
+        display.workArea.x < windowState.x + windowState.width &&
+        windowState.x < display.workArea.x + display.workArea.width &&
+        display.workArea.y < windowState.y &&
+        windowState.y < display.workArea.y + display.workArea.height,
+    );
 
   return {
     ...(isVisible ? { x: windowState.x, y: windowState.y } : {}),

--- a/main-process/window-startup-state.test.ts
+++ b/main-process/window-startup-state.test.ts
@@ -1,0 +1,203 @@
+import { findTargetDisplay, resolveWindowBounds } from './window-startup-state';
+
+// electron.Screen の最小限のモック型
+type MockScreen = {
+  getAllDisplays: jest.Mock;
+  getDisplayNearestPoint: jest.Mock;
+  getPrimaryDisplay: jest.Mock;
+};
+
+function makeDisplay(x: number, y: number, width: number, height: number) {
+  return {
+    bounds: { x, y, width, height },
+    workArea: { x, y, width, height: height - 40 }, // タスクバー分を引いた近似値
+  };
+}
+
+function makeScreen(displays: ReturnType<typeof makeDisplay>[]): MockScreen {
+  const primary = displays[0];
+  return {
+    getAllDisplays: jest.fn(() => displays),
+    getDisplayNearestPoint: jest.fn(({ x, y }: { x: number; y: number }) => {
+      // 最近接ディスプレイを返す（中心距離で判定）
+      return displays.reduce((nearest, d) => {
+        const cx = d.bounds.x + d.bounds.width / 2;
+        const cy = d.bounds.y + d.bounds.height / 2;
+        const ncx = nearest.bounds.x + nearest.bounds.width / 2;
+        const ncy = nearest.bounds.y + nearest.bounds.height / 2;
+        return Math.hypot(x - cx, y - cy) < Math.hypot(x - ncx, y - ncy) ? d : nearest;
+      });
+    }),
+    getPrimaryDisplay: jest.fn(() => primary),
+  };
+}
+
+const displayA = makeDisplay(0, 0, 1920, 1080);
+const displayB = makeDisplay(1920, 0, 1920, 1080);
+
+describe('findTargetDisplay', () => {
+  test('displayBounds が一致するディスプレイを返す', () => {
+    const screen = makeScreen([displayA, displayB]);
+    const result = findTargetDisplay(
+      { x: 1920, y: 0, width: 1920, height: 1080 },
+      undefined,
+      undefined,
+      screen,
+    );
+    expect(result).toBe(displayB);
+  });
+
+  test('displayBounds が一致しない場合は中心点から最近接を返す（モニター切断時）', () => {
+    const screen = makeScreen([displayA]); // displayB が切断された状態
+    const result = findTargetDisplay(
+      { x: 1920, y: 0, width: 1920, height: 1080 },
+      undefined,
+      undefined,
+      screen,
+    );
+    expect(result).toBe(displayA);
+    expect(screen.getDisplayNearestPoint).toHaveBeenCalledWith({ x: 2880, y: 540 });
+  });
+
+  test('displayBounds が undefined の場合は savedX/Y から最近接を返す', () => {
+    const screen = makeScreen([displayA, displayB]);
+    const result = findTargetDisplay(undefined, 1950, 100, screen);
+    expect(result).toBe(displayB);
+    expect(screen.getDisplayNearestPoint).toHaveBeenCalledWith({ x: 1950, y: 100 });
+  });
+
+  test('displayBounds も savedX/Y も undefined の場合はプライマリを返す', () => {
+    const screen = makeScreen([displayA, displayB]);
+    const result = findTargetDisplay(undefined, undefined, undefined, screen);
+    expect(result).toBe(displayA);
+    expect(screen.getPrimaryDisplay).toHaveBeenCalled();
+  });
+});
+
+describe('resolveWindowBounds', () => {
+  test('通常モード・同モニター: 保存された x/y がそのまま返る', () => {
+    const screen = makeScreen([displayA, displayB]);
+    const result = resolveWindowBounds(
+      { x: 100, y: 50, width: 1600, height: 1000, isMaximized: false },
+      { x: 100, y: 50, width: 1600, height: 1000 },
+      screen,
+    );
+    expect(result).toEqual({ x: 100, y: 50, width: 1600, height: 1000, shouldMaximize: false });
+  });
+
+  test('最大化・同モニター: displayBounds で同モニターを特定し workArea 中央 + shouldMaximize=true', () => {
+    const screen = makeScreen([displayA, displayB]);
+    // モニターAで最大化していた: displayBounds はモニターA
+    const result = resolveWindowBounds(
+      {
+        x: 100,
+        y: 50,
+        width: 1600,
+        height: 1000,
+        isMaximized: true,
+        displayBounds: { x: 0, y: 0, width: 1920, height: 1080 },
+      },
+      { x: 100, y: 50, width: 1600, height: 1000 },
+      screen,
+    );
+    const workArea = displayA.workArea;
+    const expectedWidth = Math.min(1600, workArea.width);
+    const expectedHeight = Math.min(1000, workArea.height);
+    expect(result).toEqual({
+      x: workArea.x + Math.round((workArea.width - expectedWidth) / 2),
+      y: workArea.y + Math.round((workArea.height - expectedHeight) / 2),
+      width: expectedWidth,
+      height: expectedHeight,
+      shouldMaximize: true,
+    });
+  });
+
+  test('最大化・別モニターに移動: displayBounds でモニターBを特定し Bの workArea 中央 + shouldMaximize=true', () => {
+    const screen = makeScreen([displayA, displayB]);
+    // モニターAで通常モード、その後モニターBに移動して最大化:
+    // x/y はモニターAの古い値のまま、displayBounds はモニターB
+    const result = resolveWindowBounds(
+      {
+        x: 100,
+        y: 50,
+        width: 1600,
+        height: 1000,
+        isMaximized: true,
+        displayBounds: { x: 1920, y: 0, width: 1920, height: 1080 },
+      },
+      { x: 100, y: 50, width: 1600, height: 1000 },
+      screen,
+    );
+    const workArea = displayB.workArea;
+    const expectedWidth = Math.min(1600, workArea.width);
+    const expectedHeight = Math.min(1000, workArea.height);
+    expect(result.shouldMaximize).toBe(true);
+    expect(result.x).toBe(workArea.x + Math.round((workArea.width - expectedWidth) / 2));
+    expect(result.y).toBe(workArea.y + Math.round((workArea.height - expectedHeight) / 2));
+  });
+
+  test('最大化 + モニター切断: displayBounds が一致しないが残存モニターに最大化で復元される', () => {
+    // モニターBで最大化して終了 → モニターBを切断して再起動
+    // この時 electron-window-state の validateState() が resetStateToDefault() を呼ぶ可能性があるが、
+    // rawSavedState は保持されているため isMaximized=true と displayBounds は使える
+    const screen = makeScreen([displayA]); // displayB が切断された状態
+
+    // rawSavedState は切断前の状態を持つ（window-state.json から直接読んだ値）
+    const result = resolveWindowBounds(
+      {
+        x: 1920 + 100,
+        y: 50,
+        width: 1600,
+        height: 1000,
+        isMaximized: true,
+        displayBounds: { x: 1920, y: 0, width: 1920, height: 1080 },
+      },
+      // windowState は resetStateToDefault() の影響でデフォルト値になっている可能性がある
+      { x: 0, y: 0, width: 1600, height: 1000 },
+      screen,
+    );
+    expect(result.shouldMaximize).toBe(true);
+    // 残存モニター（displayA）の workArea 内に配置されること
+    const workArea = displayA.workArea;
+    expect(result.x).toBeGreaterThanOrEqual(workArea.x);
+    expect(result.y).toBeGreaterThanOrEqual(workArea.y);
+  });
+
+  test('通常モード + モニター切断: x/y が画面外 → x/y=undefined でデフォルト配置', () => {
+    // モニターBで通常モード → モニターB切断 → 再起動
+    const screen = makeScreen([displayA]); // displayB が切断された状態
+    const result = resolveWindowBounds(
+      { x: 1920 + 100, y: 50, width: 1600, height: 1000, isMaximized: false },
+      { x: 1920 + 100, y: 50, width: 1600, height: 1000 },
+      screen,
+    );
+    expect(result.x).toBeUndefined();
+    expect(result.y).toBeUndefined();
+    expect(result.shouldMaximize).toBe(false);
+  });
+
+  test('初回起動（空の rawSavedState）: デフォルトサイズ・shouldMaximize=false', () => {
+    const screen = makeScreen([displayA]);
+    const result = resolveWindowBounds(
+      {}, // rawSavedState が空 = window-state.json が存在しない
+      { x: 0, y: 0, width: 1600, height: 1000 },
+      screen,
+    );
+    expect(result.shouldMaximize).toBe(false);
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(1000);
+  });
+
+  test('displayBounds が undefined の最大化: savedX/Y からフォールバックで最近接ディスプレイ', () => {
+    const screen = makeScreen([displayA, displayB]);
+    const result = resolveWindowBounds(
+      { x: 1950, y: 100, width: 1600, height: 1000, isMaximized: true, displayBounds: undefined },
+      { x: 1950, y: 100, width: 1600, height: 1000 },
+      screen,
+    );
+    expect(result.shouldMaximize).toBe(true);
+    // displayBounds が undefined なので savedX/Y (1950, 100) からモニターBを特定
+    const workArea = displayB.workArea;
+    expect(result.x).toBeGreaterThanOrEqual(workArea.x);
+  });
+});

--- a/main-process/window-startup-state.test.ts
+++ b/main-process/window-startup-state.test.ts
@@ -176,14 +176,16 @@ describe('resolveWindowBounds', () => {
     expect(result.shouldMaximize).toBe(false);
   });
 
-  test('初回起動（空の rawSavedState）: デフォルトサイズ・shouldMaximize=false', () => {
+  test('初回起動（空の rawSavedState）: デフォルトサイズ・x/y=undefined・shouldMaximize=false', () => {
     const screen = makeScreen([displayA]);
     const result = resolveWindowBounds(
       {}, // rawSavedState が空 = window-state.json が存在しない
-      { x: 0, y: 0, width: 1600, height: 1000 },
+      { x: undefined, y: undefined, width: 1600, height: 1000 },
       screen,
     );
     expect(result.shouldMaximize).toBe(false);
+    expect(result.x).toBeUndefined();
+    expect(result.y).toBeUndefined();
     expect(result.width).toBe(1600);
     expect(result.height).toBe(1000);
   });

--- a/main.js
+++ b/main.js
@@ -627,35 +627,43 @@ function initialize(crashHandler) {
       });
     }
 
+    const { resolveWindowBounds } = require('./main-process/window-startup-state');
+
+    // electron-window-state の validateState() → resetStateToDefault() は
+    // 保存された x/y がどのディスプレイにも含まれない場合に state を上書きし、
+    // isMaximized と元の displayBounds を消してしまう。
+    // そのため windowStateKeeper() を呼ぶ前に元の値を直接読み出しておく。
+    let rawSavedState = {};
+    try {
+      rawSavedState = require('jsonfile').readFileSync(
+        require('path').join(app.getPath('userData'), 'window-state.json'),
+      );
+    } catch (err) {
+      // 初回起動時などファイルが無い場合は無視
+    }
+
     const mainWindowState = windowStateKeeper({
+      defaultWidth: 1600,
+      defaultHeight: 1000,
+      maximize: false, // 正しいモニターに配置してから自前で maximize するため無効化
+    });
+
+    const windowBounds = resolveWindowBounds(rawSavedState, mainWindowState, electron.screen, {
       defaultWidth: 1600,
       defaultHeight: 1000,
     });
 
-    const mainWindowIsVisible = electron.screen
-      .getAllDisplays()
-      .some(
-        display =>
-          display.workArea.x < mainWindowState.x + mainWindowState.width &&
-          mainWindowState.x < display.workArea.x + display.workArea.width &&
-          display.workArea.y < mainWindowState.y &&
-          mainWindowState.y < display.workArea.y + display.workArea.height,
-      );
-
     mainWindow = new BrowserWindow({
       minWidth: 448,
       minHeight: 600,
-      width: mainWindowState.width,
-      height: mainWindowState.height,
+      width: windowBounds.width,
+      height: windowBounds.height,
       show: false,
       frame: false,
       backgroundColor: '#17242D',
       title: process.env.NAIR_PRODUCT_NAME,
-      ...(mainWindowIsVisible
-        ? {
-          x: mainWindowState.x,
-          y: mainWindowState.y,
-        }
+      ...(windowBounds.x !== undefined && windowBounds.y !== undefined
+        ? { x: windowBounds.x, y: windowBounds.y }
         : {}),
       webPreferences: {
         nodeIntegration: true,
@@ -665,7 +673,10 @@ function initialize(crashHandler) {
     });
 
     remote.enable(mainWindow.webContents);
-    mainWindowState.manage(mainWindow);
+    mainWindowState.manage(mainWindow); // maximize: false なのでリスナー登録のみ
+    if (windowBounds.shouldMaximize) {
+      mainWindow.maximize();
+    }
     mainWindow.removeMenu();
     mainWindow.loadURL(`${global.indexUrl}?windowId=main`);
 
@@ -679,7 +690,7 @@ function initialize(crashHandler) {
     mainWindow.webContents.once('did-finish-load', () => {
       // Give Vue a moment to render before showing
       setTimeout(() => {
-        if (mainWindowIsVisible) mainWindow.show();
+        mainWindow.show();
         closeSplashWindow();
       }, 100);
     });


### PR DESCRIPTION
## このpull requestが解決する内容

Closes #187

最大化状態でマルチモニター間を移動後にアプリを終了・再起動すると、前回と異なるモニターで最大化されて起動する問題を修正する。

> **Note**: issue #187 では「ウィンドウ移動後すぐ（100ms以内）に閉じると位置が保存されない」というタイミング問題も指摘されていた。このPRでは直接対処していないが、アプリの2段階クローズシーケンス（非同期シャットダウン完了後に close イベントが発火）により実際には再現しにくい状態になっている。

## 背景

`electron-window-state` は最大化中に `isNormal(win)` が false になるため `x/y/width/height` を更新しない。`displayBounds` は正しく更新されるが、`x/y` は最大化前の別モニターの値のまま保持される。

また、`validateState()` → `resetStateToDefault()` が保存された `x/y` をどのディスプレイにも含まれない場合（モニター切断時など）に `state` を上書きし、`isMaximized` と元の `displayBounds` を消してしまう問題もあった。

## 変更内容

### 修正した問題

1. **最大化でモニター間移動→再起動で間違ったモニターに復元される**（issue #187 の本体）
2. **最大化で終了→モニター切断→再起動で最大化が復元されない**（テスト中に発見）
3. **`mainWindowIsVisible` が false の時に `mainWindow.show()` が呼ばれない**（副次的バグ）

### 実装

- `windowStateKeeper()` 呼び出し前に `window-state.json` を直読みして `rawSavedState` を保持（ライブラリの `validateState()` による状態破壊の前に `isMaximized`/`displayBounds` を確保）
- `displayBounds` から正しい復元先モニターを特定する `findTargetDisplay` を実装
- 最大化時は `displayBounds` で特定したモニターの workArea 中央に配置してから `maximize()` を呼ぶ
- ロジックを `main-process/window-startup-state.js` に切り出し、ユニットテスト（11ケース）を追加

### ファイル変更

- `main.js`: ウィンドウ復元ロジックを `resolveWindowBounds` 呼び出しに置き換え
- `main-process/window-startup-state.js`: `findTargetDisplay`, `resolveWindowBounds` の実装
- `main-process/window-startup-state.d.ts`: TypeScript 型宣言
- `main-process/window-startup-state.test.ts`: ユニットテスト（11ケース）
- `jest.config.js`: `testMatch` に `main-process/` を追加
- `electron-builder/stable.config.js`: `files` に `main-process/window-startup-state.js` を追加

## テスト

### 自動テスト
- [x] `pnpm run test:unit:app` — `main-process/window-startup-state.test.ts` 11ケース全パス

### 手動テスト（2モニター環境）
- [x] モニターAで通常モード → 閉じる → 再起動 → モニターAで復元
- [x] モニターBに移動して最大化 → 閉じる → 再起動 → モニターBで最大化復元
- [x] モニターBで最大化 → 閉じる → モニターB切断 → 再起動 → モニターAで最大化復元
- [x] モニターBで通常モード → 閉じる → モニターB切断 → 再起動 → モニターAで通常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)