### PR TITLE
修正: 配信開始時の番組なし/通信エラーのエラーメッセージを区別する

### DIFF
--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import { Inject } from 'services/core/injector';
 import { Service } from 'services/core/service';
 import { HostsService } from 'services/hosts';
@@ -174,6 +175,15 @@ export class NiconicoService extends Service implements IPlatformService {
     } catch (e) {
       // リトライは1回だけ
       console.error('NiconicoService.setupStreamSettings(2)', e);
+      Sentry.addBreadcrumb({
+        category: 'streaming',
+        message: 'setupStreamSettings failed',
+        data: {
+          programId,
+          error: e instanceof Error ? e.message : String(e),
+          isNetworkError: e instanceof TypeError,
+        },
+      });
       return NiconicoService.emptyStreamingSetting();
     }
   }

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -150,10 +150,13 @@ export class StreamingService
     this.toggleStreaming();
   }
 
-  private async showNotBroadcastingMessageBoxForNicolive() {
+  private async showNotBroadcastingMessageBoxForNicolive(
+    reason: 'no_user_program' | 'no_program_id',
+  ) {
     Sentry.addBreadcrumb({
       category: 'streaming',
       message: 'showNotBroadcastingMessageBox',
+      data: { reason },
     });
     const { response } = await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
       title: $t('streaming.notBroadcasting'),
@@ -227,7 +230,7 @@ export class StreamingService
 
           // 配信可能チャンネルがなく、配信できるユーザー生放送もない場合
           if (!broadcastableUserProgram.programId && !broadcastableUserProgram.nextProgramId) {
-            return this.showNotBroadcastingMessageBoxForNicolive();
+            return this.showNotBroadcastingMessageBoxForNicolive('no_user_program');
           }
         }
 
@@ -242,13 +245,24 @@ export class StreamingService
 
         // 配信番組選択ウィンドウでユーザー番組を選んだが、配信可能なユーザー番組がない場合
         if (!programId) {
-          return this.showNotBroadcastingMessageBoxForNicolive();
+          return this.showNotBroadcastingMessageBoxForNicolive('no_program_id');
         }
 
         const setting = await this.userService.updateStreamSettings(programId);
         const streamKey = setting.key;
         if (streamKey === '') {
-          return this.showNotBroadcastingMessageBoxForNicolive();
+          Sentry.addBreadcrumb({
+            category: 'streaming',
+            message: 'streamKey is empty',
+            data: { programId },
+          });
+          await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
+            title: $t('streaming.streamingError'),
+            type: 'warning',
+            message: $t('streaming.broadcastStatusFetchingError.default'),
+            buttons: ['Close'],
+          });
+          return;
         }
 
         // [番組情報を取得]してニコ生パネルを更新する


### PR DESCRIPTION
## このpull requestが解決する内容

番組を作成済みなのに「番組が作成されていません」と表示されて配信できないという問い合わせがあった。Sentryログを調査したところ、実際には `NiconicoService.setupStreamSettings(2) Error: Error invoking remote method 'fetch': TypeError: fetch failed` が発生しており、ingest_info API への通信自体が失敗していた。

しかし、番組未作成・通信エラーのどちらでも同じメッセージが表示されるため、ユーザーも開発者も原因を切り分けられなかった。

## 変更内容

### 1. streamKey 空（通信エラー）のケースを別メッセージに分離

`setupStreamSettings` が失敗して streamKey が空になった場合（番組は存在するが配信情報の取得に失敗したケース）、「番組が作成されていません」ではなく既存の「配信エラー」タイトル＋「配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。」を表示するよう変更。

- ユーザーが「番組を作成する」ボタンを誤って押してしまうことを防ぐ
- 通信環境の確認を促す正確なメッセージを表示できる

### 2. `showNotBroadcastingMessageBoxForNicolive` に `reason` 引数を追加

Sentry breadcrumb に `reason` を記録し、事後調査を容易にする。

| reason | 発生箇所 | 意味 |
|--------|---------|------|
| `no_user_program` | fetchOnairUserProgram が空を返した | 番組が本当にない |
| `no_program_id` | Selectorウィンドウ経由でも programId が空 | 番組が本当にない |

### 3. `setupStreamSettings` 失敗時にエラー詳細を Sentry breadcrumb に記録

リトライ後も失敗した場合（streamKey 空になる直前）に、エラーの内容を Sentry に記録するよう変更。

| breadcrumb のフィールド | 内容 |
|------------------------|------|
| `error` | エラーメッセージ（例: `TypeError: fetch failed`）|
| `isNetworkError` | `true` = 通信経路の障害（TypeError）、`false` = HTTPエラー応答 |
| `programId` | 対象番組ID |

## テスト

- [x] 通常の番組なし状態で配信開始を試みると従来通り「番組が作成されていません」が表示される
- [ ] 手動でネットワークを切断した状態で配信開始を試みると「配信エラー」「配信に必要な情報を取得できませんでした」が表示される（再現が難しい場合はコードレビューで代替）

🤖 Generated with [Claude Code](https://claude.com/claude-code)