### PR TITLE
追加: Spout2キャプチャソースのサポートを追加

### DIFF
--- a/app/components/SourceSelector.vue.ts
+++ b/app/components/SourceSelector.vue.ts
@@ -26,6 +26,7 @@ const sourceIconMap = {
   liv_capture: 'icon-vr-google',
   ndi_source: 'icon-NDI',
   custom_cast_ndi_source: 'icon-character-source',
+  spout_capture: 'icon-display',
   near: 'icon-character-source',
   'decklink-input': 'icon-blackmagic',
   vlc_source: 'icon-play',

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -84,14 +84,6 @@
       </add-source-info>
 
       <add-source-info
-        v-if="inspectedSource === 'spout_capture'"
-        sourceType="spout_capture"
-        key="24"
-      >
-        <NdiSourceIcon slot="media" />
-      </add-source-info>
-
-      <add-source-info
         v-if="inspectedSource === 'decklink-input'"
         sourceType="decklink-input"
         key="14"
@@ -163,6 +155,14 @@
         key="23"
       >
         <FfmpegSourceIcon slot="media" />
+      </add-source-info>
+
+      <add-source-info
+        v-if="inspectedSource === 'spout_capture'"
+        sourceType="spout_capture"
+        key="24"
+      >
+        <MonitorCaptureIcon slot="media" />
       </add-source-info>
 
       <div class="source-info" v-if="inspectedSource === null">

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -84,6 +84,14 @@
       </add-source-info>
 
       <add-source-info
+        v-if="inspectedSource === 'spout_capture'"
+        sourceType="spout_capture"
+        key="24"
+      >
+        <NdiSourceIcon slot="media" />
+      </add-source-info>
+
+      <add-source-info
         v-if="inspectedSource === 'decklink-input'"
         sourceType="decklink-input"
         key="14"

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -396,7 +396,7 @@
     },
     "tickspeedlimit": {
       "name": "Poll time for new senders",
-      "1": "crazy",
+      "1": "Extremely fast",
       "100": "fast",
       "500": "normal",
       "1000": "slow"

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -380,6 +380,28 @@
     "name": "Blackmagic Device",
     "description": "Add video / audio from Blackmagic device."
   },
+  "spout_capture": {
+    "name": "Spout2 Capture",
+    "description": "Capture video from Spout2-compatible applications.",
+    "spoutsenders": {
+      "name": "Spout Senders",
+      "usefirstavailablesender": "Use first available sender"
+    },
+    "compositemode": {
+      "name": "Composite mode",
+      "1": "Opaque",
+      "2": "Converted Premultiplied Alpha (legacy)",
+      "3": "Default",
+      "4": "Premultiplied Alpha"
+    },
+    "tickspeedlimit": {
+      "name": "Poll time for new senders",
+      "1": "crazy",
+      "100": "fast",
+      "500": "normal",
+      "1000": "slow"
+    }
+  },
   "ndi_source": {
     "name": "NDI® Source",
     "description": "Allow you to capture NDI® output streams.",

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -384,7 +384,7 @@
     "name": "Spout2キャプチャ",
     "description": "Spout2対応アプリの映像をN Airに取り込みます。",
     "spoutsenders": {
-      "name": "Spoutセンダー",
+      "name": "Spout Senders",
       "usefirstavailablesender": "利用可能な最初のセンダーを使用"
     },
     "compositemode": {

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -380,6 +380,28 @@
     "name": "Blackmagicデバイス",
     "description": "シーンにBlackmagicデバイスからの映像・音声を追加します"
   },
+  "spout_capture": {
+    "name": "Spout2キャプチャ",
+    "description": "Spout2対応アプリの映像をN Airに取り込みます。",
+    "spoutsenders": {
+      "name": "Spoutセンダー",
+      "usefirstavailablesender": "利用可能な最初のセンダーを使用"
+    },
+    "compositemode": {
+      "name": "合成モード",
+      "1": "不透明",
+      "2": "変換済み事前乗算アルファ（レガシー）",
+      "3": "デフォルト",
+      "4": "事前乗算アルファ"
+    },
+    "tickspeedlimit": {
+      "name": "新センダーのポーリング間隔",
+      "1": "超高速",
+      "100": "高速",
+      "500": "標準",
+      "1000": "低速"
+    }
+  },
   "ndi_source": {
     "name": "NDI®ソース",
     "description": "NDI®の出力ストリームをキャプチャします。",

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -1,6 +1,6 @@
 import { IObsListOption, TObsFormData } from 'components/obs/inputs/ObsInput';
 import { Observable } from 'rxjs';
-import { NVoiceCharacterType, NVoiceAvatarStyle } from 'services/nvoice-character';
+import { NVoiceAvatarStyle, NVoiceCharacterType } from 'services/nvoice-character';
 import { IPartialTransform } from 'services/scenes';
 import * as obs from '../../../obs-api';
 import { IAudioSource } from '../audio';
@@ -113,7 +113,8 @@ export type TSourceType =
   | 'wasapi_process_output_capture'
   | 'custom_cast_ndi_source'
   | 'custom_cast_ndi_guide'
-  | 'nair-rtvc-source';
+  | 'nair-rtvc-source'
+  | 'spout_capture';
 
 // 仮想ソースを含むSourceType 選択時には別だが登録時にいずれかの通常SourceTypeに変換される
 export type TSelectableSourceType =

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -377,6 +377,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       'vlc_source',
       'wasapi_process_output_capture',
       'nair-rtvc-source', // voice changer
+      'spout_capture',
     ];
 
     const availableWhitelistedType = whitelistedTypes.filter(type =>


### PR DESCRIPTION
## 概要

Spout2キャプチャ（spout_capture）ソースタイプのサポートを追加します。

## 変更内容

- TSourceType に spout_capture を追加
- ホワイトリストに spout_capture を追加（sources.ts）
- ソースセレクターのアイコンマップに spout_capture を追加（icon-display）
- SourcesShowcase に spout_capture の表示エントリを追加
- 日本語・英語の翻訳（source-props.json）を追加
  - センダー選択、合成モード、ポーリング間隔の各プロパティ

## 動作確認

- Spout2対応アプリの映像をN Airのソースとして追加できること