### PR TITLE
開発: エラー再スロー時にError.causeを設定してスタックトレースチェーンを維持する

### DIFF
--- a/app/services/i18n/i18n.ts
+++ b/app/services/i18n/i18n.ts
@@ -216,6 +216,7 @@ export class I18nService extends PersistentStatefulService<II18nState> implement
       }
       throw new Error(
         `in file: ${require('path').resolve(lastReadFilePath)}\n${(e as Error).message}${lineInfo}`,
+        { cause: e },
       );
     }
     rawJSON = '';

--- a/app/services/nicolive-program/NdgrFetchError.ts
+++ b/app/services/nicolive-program/NdgrFetchError.ts
@@ -5,7 +5,7 @@ export class NdgrFetchError extends Error {
     public label: string,
     public phase: 'head' | 'backwards' | 'previous' | 'segment',
   ) {
-    super(`Failed to fetch[${label}:${phase}]: ${status}`);
+    super(`Failed to fetch[${label}:${phase}]: ${status}`, status instanceof Error ? { cause: status } : undefined);
 
     this.name = new.target.name;
     Object.setPrototypeOf(this, new.target.prototype);

--- a/app/services/transcription/downloadAndUnzip.ts
+++ b/app/services/transcription/downloadAndUnzip.ts
@@ -20,6 +20,7 @@ export class DownloadError extends Error {
       `Failed to download: ${
         detail.reason === 'fetch' ? detail.error.message : detail.response.statusText
       }`,
+      detail.reason === 'fetch' ? { cause: detail.error } : undefined,
     );
 
     this.name = new.target.name;
@@ -29,7 +30,7 @@ export class DownloadError extends Error {
 
 export class ExtractError extends Error {
   constructor(public baseError: Error) {
-    super(`Failed to extract: ${baseError.message}`);
+    super(`Failed to extract: ${baseError.message}`, { cause: baseError });
 
     this.name = new.target.name;
     Object.setPrototypeOf(this, new.target.prototype);
@@ -37,8 +38,8 @@ export class ExtractError extends Error {
 }
 
 export class CancelledError extends Error {
-  constructor() {
-    super('Download cancelled by user');
+  constructor(cause?: unknown) {
+    super('Download cancelled by user', cause !== undefined ? { cause } : undefined);
 
     this.name = new.target.name;
     Object.setPrototypeOf(this, new.target.prototype);
@@ -102,7 +103,7 @@ export async function downloadAndUnzip(
         console.log('Download completed:', zipPath);
       } catch (error) {
         if (signal?.aborted) {
-          throw new CancelledError();
+          throw new CancelledError(error);
         }
         throw error;
       } finally {


### PR DESCRIPTION
## このpull requestが解決する内容

エラーを再スローする際に `Error.cause` を設定することで、Sentryでスタックトレースチェーンが「Caused by:」セクションとして自動表示され、エラーの根本原因の追跡が容易になります。

## 背景

`new Error(message, { cause: originalError })` はES2022で標準化されたエラーチェーン機能です。Sentryはこの `cause` チェーンを自動的に辿り、連結されたスタックトレースを表示します。

コードベースを調査したところ、カスタムエラークラスが独自プロパティ（`status`, `detail`, `baseError`）で元エラーを保持しているものの、標準の `cause` を設定していない箇所が複数ありました。

## 動作環境での対応確認

| 環境 | バージョン | Error.cause対応 |
|------|-----------|----------------|
| Electron 29.3.x (本プロジェクト) | Chromium 122 / Node.js 20.9.0 | ✅ |
| Error.cause 最小対応バージョン | Chrome 93+ / Node.js 16.9.0+ | （V8 9.3 で追加） |

Electron 29 は Chromium 122 を搭載しており、Chrome 93 から使える `Error.cause` は完全対応しています（[MDN: Error.cause](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)）。

## 変更内容

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `app/services/nicolive-program/NdgrFetchError.ts` | `super()` に `status instanceof Error ? { cause: status } : undefined` を追加 |
| `app/services/transcription/downloadAndUnzip.ts` — `DownloadError` | `super()` に `detail.reason === 'fetch' ? { cause: detail.error } : undefined` を追加 |
| `app/services/transcription/downloadAndUnzip.ts` — `ExtractError` | `super()` に `{ cause: baseError }` を追加 |
| `app/services/transcription/downloadAndUnzip.ts` — `CancelledError` | コンストラクタに `cause?: unknown` を追加し、呼び出し側も `new CancelledError(error)` に更新 |
| `app/services/i18n/i18n.ts` | `throw new Error(...)` に `{ cause: e }` を追加 |

### 互換性

- 既存のプロパティ（`status`, `detail`, `baseError`）はそのまま保持し、破壊的変更なし
- `tsconfig.json` の `lib` に `ES2022` が含まれており、型サポートあり

## テスト

- [x] `pnpm run compile` でTypeScriptコンパイルエラーなし
- [x] `npx jest app/services/i18n/i18n.test.ts` — 2テスト通過
- [x] `npx jest app/services/nicolive-program/NdgrClient.test.ts` — 5テスト通過
- [x] `npx jest app/services/transcription/` — 54テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)