### PR TITLE
追加: 予約番組時・番組終了後にToolBarから番組パネル初期画面に戻れるようにする

### DIFF
--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -67,11 +67,14 @@
 
       <div class="program-button">
         <button
-          v-if="
-            programStatus === 'onAir' ||
-              programStatus === 'reserved' ||
-              (programStatus === 'test' && selectedButton === 'end')
-          "
+          v-if="selectedButton === 'release'"
+          @click="releaseProgram"
+          class="button button--secondary"
+        >
+          戻る
+        </button>
+        <button
+          v-else-if="selectedButton === 'end'"
           @click="endProgram"
           :disabled="isEnding || programStatus === 'reserved'"
           class="button button--end-program button--live"
@@ -79,7 +82,7 @@
           番組終了
         </button>
         <button
-          v-else-if="programStatus === 'end'"
+          v-else-if="selectedButton === 'create'"
           @click="createProgram"
           class="button button--primary"
         >
@@ -101,32 +104,16 @@
         >
           <div class="popper">
             <ul class="popup-menu-list">
-              <li class="item">
+              <li class="item" v-for="option in dropdownOptions" :key="option.key">
                 <button
                   :class="{
                     'button-selector': true,
-                    current: selectedButton === 'start',
+                    current: selectedButton === option.key,
                   }"
-                  @click="selectButton('start')"
+                  @click="selectButton(option.key)"
                 >
-                  <span class="item-name">番組開始</span>
-                  <span class="item-text"
-                  >番組を開始して視聴者に公開します</span
-                  >
-                </button>
-              </li>
-              <li class="item">
-                <button
-                  :class="{
-                    'button-selector': true,
-                    current: selectedButton === 'end',
-                  }"
-                  @click="selectButton('end')"
-                >
-                  <span class="item-name">番組終了</span>
-                  <span class="item-text"
-                  >番組を視聴者に公開せず終了します</span
-                  >
+                  <span class="item-name">{{ option.name }}</span>
+                  <span class="item-text">{{ option.description }}</span>
                 </button>
               </li>
             </ul>
@@ -134,12 +121,14 @@
           <button
             class="button button--select-menu"
             v-tooltip.bottom="startButtonSelectorTooltip"
-            v-show="programStatus === 'test'"
+            v-show="programStatus !== 'onAir'"
             :class="{
               'is-show': showPopupMenu,
               active: showButtonSelector,
               'button--action': selectedButton === 'start',
               'button--end-program button--live': selectedButton === 'end',
+              'button--primary': selectedButton === 'create',
+              'button--secondary': selectedButton === 'release',
             }"
             slot="reference"
           >

--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -27,11 +27,45 @@ export default class ToolBar extends Vue {
   startButtonSelectorTooltip = '配信開始/終了ボタンを選択';
 
   showPopupMenu: boolean = false;
-  selectedButton: 'start' | 'end' = 'start';
+  selectedButton: 'start' | 'end' | 'create' | 'release' = 'start';
   showButtonSelector: boolean = false;
 
-  selectButton(button: 'start' | 'end') {
+  private defaultButtonForStatus(status: string): 'start' | 'end' | 'create' {
+    switch (status) {
+      case 'onAir':
+      case 'reserved':
+        return 'end';
+      case 'end':
+        return 'create';
+      default:
+        return 'start';
+    }
+  }
+
+  selectButton(button: 'start' | 'end' | 'create' | 'release') {
     this.selectedButton = button;
+  }
+
+  get dropdownOptions(): Array<{ key: 'start' | 'end' | 'create' | 'release'; name: string; description: string }> {
+    const status = this.programStatus;
+    const options: Array<{ key: 'start' | 'end' | 'create' | 'release'; name: string; description: string }> = [];
+
+    if (status === 'test') {
+      options.push(
+        { key: 'start', name: '番組開始', description: '番組を開始して視聴者に公開します' },
+        { key: 'end', name: '番組終了', description: '番組を視聴者に公開せず終了します' },
+      );
+    } else if (status === 'reserved') {
+      options.push({ key: 'end', name: '番組終了', description: '番組を終了します' });
+    } else if (status === 'end') {
+      options.push({ key: 'create', name: '番組作成', description: '新しく番組を作成します' });
+    }
+
+    if (status !== 'onAir') {
+      options.push({ key: 'release', name: '戻る', description: '番組の作成・取得画面に戻ります' });
+    }
+
+    return options;
   }
 
   get isOnAir(): boolean {
@@ -131,6 +165,7 @@ export default class ToolBar extends Vue {
 
   @Watch('programStatus')
   onStatusChange(newValue: string, oldValue: string) {
+    this.selectedButton = this.defaultButtonForStatus(newValue);
     if (newValue === 'end') {
       clearInterval(this.timeTimer);
       this.currentTime = NaN;
@@ -146,6 +181,7 @@ export default class ToolBar extends Vue {
 
   timeTimer: number = 0;
   mounted() {
+    this.selectedButton = this.defaultButtonForStatus(this.programStatus);
     if (this.programStatus !== 'end') {
       this.startTimer();
     }
@@ -218,6 +254,24 @@ export default class ToolBar extends Vue {
         throw caught;
       }
     }
+  }
+
+  async releaseProgram() {
+    const status = this.nicoliveProgramService.state.status;
+
+    if (status === 'test') {
+      const isOk = await remote.dialog
+        .showMessageBox(remote.getCurrentWindow(), {
+          type: 'warning',
+          message: 'テスト中の番組の取得を解除して最初の画面に戻りますか？',
+          buttons: ['戻る', $t('common.cancel')],
+          noLink: true,
+        })
+        .then(value => value.response === 0);
+      if (!isOk) return;
+    }
+
+    this.nicoliveProgramService.releaseProgram();
   }
 
   private async refreshProgram() {

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -225,10 +225,11 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
       });
 
     // 番組終了時にメッセージを追加する
+    // programID が空の場合は「最初の画面に戻る」操作による状態リセットなので対象外
     this.nicoliveProgramService.stateChange
       .pipe(
         distinctUntilChanged((prev, curr) => prev.status === curr.status),
-        filter(({ status }) => status === 'end'),
+        filter(({ status, programID }) => status === 'end' && programID !== ''),
       )
       .subscribe(() => {
         this.onProgramEnd();

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -614,6 +614,16 @@ test('endProgram:失敗', async () => {
   expect(setState).toHaveBeenCalledTimes(2);
 });
 
+test('releaseProgram: programInitialStateでsetStateを呼ぶ', () => {
+  setup();
+  const { NicoliveProgramService, instance, setState } = setupInstance({ mockSetState: true });
+
+  instance.releaseProgram();
+
+  expect(setState).toHaveBeenCalledTimes(1);
+  expect(setState).toHaveBeenCalledWith(NicoliveProgramService.programInitialState);
+});
+
 test('extendProgram:成功', async () => {
   setup();
   const { instance, setState } = setupInstance({ mockSetState: true });

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -426,6 +426,10 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
     }
   }
 
+  releaseProgram(): void {
+    this.setState(NicoliveProgramService.programInitialState);
+  }
+
   toggleAutoExtension(): void {
     this.stateService.toggleAutoExtension();
   }


### PR DESCRIPTION
## このpull requestが解決する内容

予約番組と即時番組が共存するシナリオで生じていた2つのUX問題を改善します。

### 問題1: 予約番組ロード中に即時番組を作れない

`status='reserved'` のとき、ToolBar の「番組終了」ボタンは無効化されており、「番組作成」ボタンも存在しないため、即時番組を作成できませんでした。

### 問題2: 番組終了後に予約番組を取得する導線が分かりにくい

即時番組を終了すると `status='end'` になり「番組作成」ボタンのみが表示されます。既存のリロードボタン（🔄）で予約番組を取得できますが、その機能を持つことが分かりにくい状態でした。

### 問題3（既存バグ）: 放送中にログアウトすると「番組が終了しました」と読み上げられる

ログアウト時に番組状態が内部的にリセットされる際、番組終了検知が誤って発火していました。

## 変更内容

### 「戻る」ボタン機能の追加

ToolBar のアクションボタン右側のドロップダウン（▼）に「戻る」選択肢を追加しました。選択後にメインボタンが「戻る」に切り替わり、クリックすると番組パネルが初期画面（「番組作成」「番組取得」の2ボタン画面）に戻ります。

| 状態 | ドロップダウンの選択肢 | 備考 |
|------|----------------------|------|
| test | 番組開始 / 番組終了 / **戻る** | 選択時は確認ダイアログあり |
| reserved | 番組終了 / **戻る** | 番組終了は従来通り無効 |
| end | 番組作成 / **戻る** | |
| onAir | （ドロップダウン非表示） | 配信停止の事故を防ぐため非表示 |

初期画面に戻ることで：
- **予約番組ロード中** → 「番組作成」で即時番組を作成できる
- **番組終了後** → 「番組取得」で予約番組をロードできる

### 番組終了メッセージの誤発火を修正

`programID` が空のとき（ログアウト・「戻る」操作によるリセット）は番組終了メッセージを読み上げないよう修正しました。

## ファイル変更

- `app/services/nicolive-program/nicolive-program.ts`: `releaseProgram()` メソッドを追加
- `app/components/nicolive-area/ToolBar.vue`: メインボタンのv-ifチェーン変更、ドロップダウンをv-for化
- `app/components/nicolive-area/ToolBar.vue.ts`: `selectedButton` 型拡張、`dropdownOptions` computed追加、`releaseProgram()` ハンドラ追加
- `app/services/nicolive-program/nicolive-comment-viewer.ts`: 番組終了メッセージのフィルタ条件追加
- `app/services/nicolive-program/nicolive-program.test.ts`: `releaseProgram` のテスト追加

## テスト

- [x] 予約番組ロード中 → ▼ → 「戻る」選択 → クリック → 初期画面に遷移 → 「番組作成」で即時番組作成できることを確認
- [x] 即時番組終了後 → ▼ → 「戻る」選択 → クリック → 初期画面に遷移 → 「番組取得」で予約番組をロードできることを確認
- [x] onAir 中はドロップダウンが表示されないことを確認
- [x] test 状態での「戻る」は確認ダイアログが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)