### PR TITLE
修正: 番組終了などの確認ダイアログのXボタンを押すと操作が実行されてしまう問題を修正

### DIFF
--- a/app/components/nicolive-area/ToolBar.vue.ts
+++ b/app/components/nicolive-area/ToolBar.vue.ts
@@ -237,6 +237,7 @@ export default class ToolBar extends Vue {
           message: '番組を終了しますか？',
           buttons: ['終了する', $t('common.cancel')],
           noLink: true,
+          cancelId: 1,
         })
         .then(value => value.response === 0);
 
@@ -266,6 +267,7 @@ export default class ToolBar extends Vue {
           message: 'テスト中の番組の取得を解除して最初の画面に戻りますか？',
           buttons: ['戻る', $t('common.cancel')],
           noLink: true,
+          cancelId: 1,
         })
         .then(value => value.response === 0);
       if (!isOk) return;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -163,7 +163,8 @@ export class StreamingService
       type: 'warning',
       message: $t('streaming.notBroadcastingMessage'),
       noLink: true,
-      buttons: [$t('streaming.notBroadcastingCreateProgram'), 'Close'],
+      buttons: [$t('streaming.notBroadcastingCreateProgram'), $t('common.close')],
+      cancelId: 1,
     });
     if (response === 0) {
       await this.nicoliveProgramService.createProgram(true);


### PR DESCRIPTION
## このpull requestが解決する内容

確認ダイアログで右上のX（バツ）ボタンやEscキーを押すと、キャンセルではなく破壊的な操作（番組終了・テスト解除・番組作成）が実行されてしまう問題を修正します。

## 原因

`showMessageBox` の呼び出しで `cancelId` が未指定だったことが原因です。

Electron の仕様として:
- `cancelId` 未指定時、ボタンラベルから `"cancel"` / `"no"` を自動検出して cancelId を決定する
- 日本語ラベル `"キャンセル"` や英語ラベル `"Close"` はこの自動検出にマッチしない
- マッチするボタンがない場合、`cancelId` はデフォルトの `0`（最初のボタン＝破壊的ボタン）に設定される
- XボタンやEscキーで閉じると `response = cancelId = 0` が返り、破壊的操作が実行されてしまう

## 変更内容

| ファイル | メソッド | ダイアログ | 修正内容 |
|---------|---------|-----------|---------|
| `ToolBar.vue.ts` | `endProgram()` | 「番組を終了しますか？」 | `cancelId: 1` を追加 |
| `ToolBar.vue.ts` | `releaseProgram()` | 「テスト中の番組の取得を解除して最初の画面に戻りますか？」 | `cancelId: 1` を追加 |
| `streaming.ts` | `showNotBroadcastingMessageBox()` | 「番組が作成されていません」 | `cancelId: 1` を追加、`'Close'` → `$t('common.close')` に修正（i18n未対応も解消） |

## テスト

- [x] 番組終了ダイアログのXボタンを押す → 番組が終了しないことを確認
- [x] 番組終了ダイアログのEscキーを押す → 番組が終了しないことを確認
- [x] 番組終了ダイアログの「終了する」ボタンを押す → 番組が終了することを確認
- [x] 番組終了ダイアログの「キャンセル」ボタンを押す → 番組が終了しないことを確認
- [x] テスト解除ダイアログのXボタンを押す → 解除されないことを確認
- [x] 番組未作成状態で配信開始を試みた際のダイアログのXボタンを押す → 番組作成が実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)