### PR TITLE
開発: リリース設定のSentry org名を n-air-app2 に修正

### DIFF
--- a/bin/release/configs/public-stable.js
+++ b/bin/release/configs/public-stable.js
@@ -14,12 +14,12 @@ module.exports = {
     branch: 'n-air_stable',
   },
   sentry: {
-    organization: 'n-air-app',
+    organization: 'n-air-app2',
     project: 'n-air-app',
   },
   upload: {
     githubToken: process.env.NAIR_GITHUB_TOKEN,
     s3BucketName: process.env.RELEASE_S3_BUCKET_NAME,
     s3KeyPrefix: 'download/windows',
-  }
+  },
 };


### PR DESCRIPTION
## このpull requestが解決する内容

公開版リリース設定 (`bin/release/configs/public-stable.js`) のSentry org名が古い `n-air-app` のままだったため、リリース実行時にSentryリリース登録が失敗していた問題を修正します。

## 原因

Sentryの組織名が `n-air-app` から `n-air-app2` に変更されていたが、リリース設定ファイルが更新されていなかった。

## 変更内容

| ファイル | 変更箇所 | 変更内容 |
|---------|---------|---------|
| `bin/release/configs/public-stable.js` | `sentry.organization` | `'n-air-app'` → `'n-air-app2'` |

あわせてtrailing commaも修正。

## 経緯

リリース中に問題が発覚し、応急処置としてリリースブランチ(n-air_unstable)上のcommit `973091f30` で直接修正済み。本PRはその変更をn-air_developmentにcherry-pickしたもの。

## テスト

- リリース設定ファイルの内容確認のみ（CIで自動テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)