### PR TITLE
開発: 番組取得前画面に戻る際にssngフィルター取得APIが空のprogramIDで呼ばれる問題を修正

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-filter.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs';
-import { distinctUntilChanged, map } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { Inject } from 'services/core/injector';
 import { StatefulService, mutation } from 'services/core/stateful-service';
 import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
@@ -58,6 +58,7 @@ export class NicoliveCommentFilterService extends StatefulService<INicoliveComme
       .pipe(
         map(({ programID }) => programID),
         distinctUntilChanged(),
+        filter(programID => programID !== ''),
       )
       .subscribe(() => {
         this.fetchFilters().catch(caught => {


### PR DESCRIPTION
## このpull requestが解決する内容

ニコ生の番組画面から「戻る」ボタンで番組取得前画面に戻ると、ssng（コメントフィルター）取得API `fetchFilters()` が空の `programID=""` で呼ばれ、APIが not found を返していた問題を修正します。

関連: #1217（「戻る」機能を導入したPR）での修正漏れです。

## 原因

`NicoliveCommentFilterService.init()` で `nicoliveProgramService.stateChange` の `programID` 変更を購読しているが、`programID` が空文字列に変わる場合（「戻る」操作による `releaseProgram()` のリセット）をフィルターしておらず `fetchFilters()` が呼ばれていた。

```typescript
// 修正前: 空のprogramIDも通過する
this.nicoliveProgramService.stateChange
  .pipe(
    map(({ programID }) => programID),
    distinctUntilChanged(),
  )
  .subscribe(() => { this.fetchFilters()... });
```

`NicoliveCommentViewerService` では同様のケースを `filter(({ programID }) => programID !== '')` で対処済みであり、同じパターンを適用しました。

## 変更内容

- `app/services/nicolive-program/nicolive-comment-filter.ts`: RxJSパイプに `filter(programID => programID !== '')` を追加

## テスト

- [x] 番組を取得する
- [x] 「戻る」ボタンで番組取得前画面に戻る
- [x] コンソールにssng取得APIのnot foundエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)