### PR TITLE
開発: ドラッグ中にSceneSelectorがアンマウントされるとクラッシュする問題を修正 (N-AIR-APP-F3Z)

### DIFF
--- a/app/components/shared/Selector.vue
+++ b/app/components/shared/Selector.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="selector-list" @contextmenu="handleContextMenu()" data-test="Selector">
-    <draggable :list="normalizedItems" :draggable="draggableSelector" @change="handleChange">
+    <draggable ref="draggable" :list="normalizedItems" :draggable="draggableSelector" @change="handleChange">
       <li
         v-for="(item, index) in normalizedItems"
         :key="item.value"

--- a/app/components/shared/Selector.vue.ts
+++ b/app/components/shared/Selector.vue.ts
@@ -38,17 +38,21 @@ export default class Selector extends Vue {
     //
     // Vue 3 移行時: beforeDestroy → beforeUnmount にリネーム、実行順序は同じなのでロジック流用可能。
     // sortablejs 上流でこのバグが修正されたらこの workaround は除去可能。
+    // sortablejs の型定義がないため、使用する内部プロパティの最小限の型を定義する
+    interface SortableInstance {
+      el: HTMLElement | null;
+      handleEvent(evt: Event): void;
+      _nulling?(): void;
+    }
     try {
-      const draggableVm = this.$refs.draggable as any;
+      const draggableVm = this.$refs.draggable as Vue & { _sortable?: SortableInstance };
       const sortable = draggableVm?._sortable;
       if (sortable) {
         const origHandleEvent = sortable.handleEvent.bind(sortable);
-        sortable.handleEvent = function (evt: Event) {
+        sortable.handleEvent = function (this: SortableInstance, evt: Event) {
           if (!this.el) {
             // destroy() 済み: ドラッグ結果は既に反映済みなので、グローバル変数のリセットのみ行う
-            if (typeof this._nulling === 'function') {
-              this._nulling();
-            }
+            this._nulling?.();
             Sentry.withScope(scope => {
               scope.setLevel('warning');
               scope.setTag('issue', 'N-AIR-APP-F3Z');

--- a/app/components/shared/Selector.vue.ts
+++ b/app/components/shared/Selector.vue.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import draggable from 'vuedraggable';
+import * as Sentry from '@sentry/vue';
 
 interface ISelectorItem {
   name: string;
@@ -22,6 +23,46 @@ export default class Selector extends Vue {
 
   // @ts-expect-error: ts2729: use before initialization
   draggableSelector: string = this.draggable ? '.selector-item' : 'none';
+
+  beforeDestroy() {
+    // sortablejs 1.10.2 (および最新 1.15.7 でも未修正) のバグ回避:
+    // destroy() が this._onDrop() を引数なしで呼ぶため、dragEl からの dragend リスナー解除
+    // コード (if (evt) ブロック内) に到達しない。その後 this.el = null が設定されるが、
+    // ブラウザの dragend イベントが非同期で発火し handleEvent → _onDrop(evt) が呼ばれ、
+    // this.el が null のため TypeError: Cannot read properties of null (reading 'removeEventListener')
+    // が発生する。(Sentry: N-AIR-APP-F3Z, GitHub: #1230)
+    //
+    // Vue 2 では親の beforeDestroy が子より先に実行されるため、ここで sortable の
+    // handleEvent をラップすることで、vuedraggable の beforeDestroy → sortable.destroy()
+    // の後に来る dragend イベントを安全に処理できる。
+    //
+    // Vue 3 移行時: beforeDestroy → beforeUnmount にリネーム、実行順序は同じなのでロジック流用可能。
+    // sortablejs 上流でこのバグが修正されたらこの workaround は除去可能。
+    try {
+      const draggableVm = this.$refs.draggable as any;
+      const sortable = draggableVm?._sortable;
+      if (sortable) {
+        const origHandleEvent = sortable.handleEvent.bind(sortable);
+        sortable.handleEvent = function (evt: Event) {
+          if (!this.el) {
+            // destroy() 済み: ドラッグ結果は既に反映済みなので、グローバル変数のリセットのみ行う
+            if (typeof this._nulling === 'function') {
+              this._nulling();
+            }
+            Sentry.withScope(scope => {
+              scope.setLevel('warning');
+              scope.setTag('issue', 'N-AIR-APP-F3Z');
+              Sentry.captureMessage(`sortablejs: ${evt.type} event after destroy() suppressed`);
+            });
+            return;
+          }
+          origHandleEvent(evt);
+        };
+      }
+    } catch {
+      // best-effort: コンポーネント破棄をブロックしない
+    }
+  }
 
   handleChange(change: any) {
     const order = this.normalizedItems.map(item => {

--- a/app/components/shared/Selector.vue.ts
+++ b/app/components/shared/Selector.vue.ts
@@ -45,8 +45,10 @@ export default class Selector extends Vue {
       _nulling?(): void;
     }
     try {
-      const draggableVm = this.$refs.draggable as Vue & { _sortable?: SortableInstance };
-      const sortable = draggableVm?._sortable;
+      const draggableRef = this.$refs.draggable;
+      if (!(draggableRef instanceof Vue)) return;
+      const draggableVm = draggableRef as Vue & { _sortable?: SortableInstance };
+      const sortable = draggableVm._sortable;
       if (sortable) {
         const origHandleEvent = sortable.handleEvent.bind(sortable);
         sortable.handleEvent = function (this: SortableInstance, evt: Event) {


### PR DESCRIPTION
## このpull requestが解決する内容

ドラッグ操作中に `SceneSelector` がアンマウントされると `TypeError: Cannot read properties of null (reading 'removeEventListener')` が発生していた問題を修正します。

Sentry: [N-AIR-APP-F3Z](https://n-air-app2.sentry.io/issues/6977033168/)
Closes #1230

---

## 実際に起きていたルート（Sentry のブレッドクラムから判明）

1. アプリ起動後、新バージョンのパッチノートを未読の場合に `setTimeout(..., 0)` で `PatchNotes` ページへ自動遷移する
2. この遷移は `<component :is="page" />` による `v-if` 相当の切り替えなので、Studio ページ全体（`SceneSelector` → `Selector` → `vuedraggable`）がアンマウントされる
3. ユーザーがちょうどシーン一覧をドラッグ操作中だった場合、`vuedraggable` の `beforeDestroy` → `sortablejs` の `destroy()` が呼ばれ `this.el = null` がセットされる
4. その後（ウィンドウが背後に回っていた場合は `window.focus` で）ブラウザが `dragend` イベントを非同期に発火する
5. `Sortable.handleEvent` → `_onDrop(evt)` が呼ばれるが、`this.el` は既に `null` → `off(null, ...)` → `TypeError`

---

## 根本原因（sortablejs のバグ）

`sortablejs` 1.10.2 の `destroy()` は内部で `this._onDrop()` を **引数なし** で呼ぶため、`if (evt)` ブロック内にある `off(dragEl, 'dragend', this)` が実行されず、`dragEl` 上の `dragend` リスナーが残ってしまう。その直後に `this.el = null` が設定されるため、後から `dragend` が発火すると `this.el` が `null` の状態で `handleEvent` → `_onDrop` が呼ばれクラッシュする。

最新版 sortablejs **1.15.7 でも同じバグが残っている**ため、バージョンアップでは解決しない。

---

## 修正方針の選択経緯

以下の選択肢を検討した。

| 案 | 内容 | 採否 |
|----|------|------|
| pnpm patch で sortablejs にnullガードを追加 | ライブラリを直接修正できるが、アップデート時にパッチ再確認が必要 | 今回は見送り |
| `v-if` → `v-show` に変更 | `StudioControls` の特定箇所しか直らない | ❌ |
| アプリ側で `handleEvent` をラップ | ライブラリ不変・Vue2 のライフサイクル順序を利用して確実に対処できる | ✅ 採用 |

**採用した修正:** `Selector.vue.ts` の `beforeDestroy` フックで、`vuedraggable` の `beforeDestroy`（子コンポーネント）より先に `sortable.handleEvent` をラップする。`destroy()` 後に `dragend` が来たとき `this.el === null` ならグローバル変数のリセット（`_nulling()`）だけ行い、クラッシュを防ぐ。この場合、ドラッグ結果は1回目の `_onDrop()` で既に反映済みのため、ユーザー操作への影響はない。

---

## ユーザーへの影響

- **なし**: ドラッグ中にパッチノートが表示されるという稀なタイミングでのみ発生し、並び替え結果自体は既に反映されている
- 修正後は同条件で `dragend` が来ても Sentry に **warning** レベルで通知されるだけになる（error → warning に降格）

---

## 手元での確認方法

再現に工夫が必要だったためメモしておく。

**再現の難しさ:** `v-if` 切り替えで DOM が削除されると、ブラウザが `dragend` を**同期的に**（`destroy()` の前に）発火させるため、単純に「ドラッグ中にタブ切り替え」しても再現できない。Sentry での実発生は「ウィンドウがバックグラウンドになった状態で `destroy()` が完了し、`window.focus` 時に `dragend` が遅延発火」というタイミングであった。

**ローカルで再現した手順:**

1. 下部パネルを開いた状態で起動
2. シーンコレクション左列でシーンをドラッグ開始（ゴースト表示を確認）
3. 持ったまま約2秒待つ → デバッグコード（削除済み）でパネルが自動クローズ → `SceneSelector` がアンマウント
4. マウスボタンを離す → `dragend` が発火

修正なし: `TypeError: Cannot read properties of null (reading 'removeEventListener')` が発生  
修正あり: `sortablejs: dragend event after destroy() suppressed`（warning）が Sentry に送信され、クラッシュなし

---

## Vue 3 移行時の注意

- `beforeDestroy` → `beforeUnmount` にリネームが必要（ロジックは流用可能）
- `vuedraggable` 4.x（Vue 3 用）も sortablejs 1.14.0+ を依存に持つが、1.15.7 でも同じバグがあるためこの修正は引き続き必要
- sortablejs 上流でバグが修正されたら workaround を除去可能（コードにコメントあり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)