### PR TITLE
修正: コメント読み上げ停止機能の設定案内ダイアログを初回のみ表示するよう変更

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -404,6 +404,27 @@ export default class CommentViewer extends Vue {
     });
 
     this.nicoliveCommentViewerService.enableSoundDetector(true);
+    if (this.speakingEnabled && !this.soundDetectorService.isDialogShown) {
+      // 放送者の声を避けたコメント読み上げ機能を案内する（初回のみ）
+      this.soundDetectorService.markDialogShown();
+      remote.dialog
+        .showMessageBox(remote.getCurrentWindow(), {
+          type: 'question',
+          buttons: ['yes', 'no'],
+          title: 'コメント読み上げ停止機能',
+          message: '放送者がしゃべっているときにコメント読み上げを停止する設定をしますか?',
+          defaultId: 0,
+          cancelId: 1,
+        })
+        .then(({ response }) => {
+          if (response === 0) {
+            this.nicoliveCommentViewerService.setSoundDetectorEnabled(true);
+            this.settingsService.showSoundDetectorSettings();
+          } else {
+            this.nicoliveCommentViewerService.setSoundDetectorEnabled(false);
+          }
+        });
+    }
   }
 
   beforeDestroy() {

--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -404,31 +404,6 @@ export default class CommentViewer extends Vue {
     });
 
     this.nicoliveCommentViewerService.enableSoundDetector(true);
-    if (
-      this.speakingEnabled &&
-      this.nicoliveCommentViewerService.isSoundDetectorSourceEnabled &&
-      !this.nicoliveCommentViewerService.isSoundDetectorCalibrated &&
-      !this.nicoliveCommentViewerService.isSoundDetectorDeclined
-    ) {
-      // 放送者の声を避けたコメント読み上げ機能を提案する
-      remote.dialog
-        .showMessageBox(remote.getCurrentWindow(), {
-          type: 'question',
-          buttons: ['yes', 'no'],
-          title: 'コメント読み上げ抑制機能',
-          message: '放送者がしゃべっているときにコメント読み上げを停止する設定をしますか?',
-          defaultId: 0,
-          cancelId: 1,
-        })
-        .then(({ response }) => {
-          if (response === 0) {
-            this.nicoliveCommentViewerService.setSoundDetectorEnabled(true);
-            this.settingsService.showSoundDetectorSettings();
-          } else {
-            this.nicoliveCommentViewerService.markSoundDetectorDeclined();
-          }
-        });
-    }
   }
 
   beforeDestroy() {

--- a/app/components/settings/SoundDetectorSettings.vue.ts
+++ b/app/components/settings/SoundDetectorSettings.vue.ts
@@ -83,7 +83,6 @@ export default class SoundDetectorSettings extends Vue {
     if (this.isTestPlaybackActive) return; // 連続クリック防止
 
     this.isTestPlaybackActive = true;
-    this.soundDetectorService.markCalibrated();
     this.play(); // 最初のテストメッセージを再生
   }
 

--- a/app/components/settings/SoundDetectorSettings.vue.ts
+++ b/app/components/settings/SoundDetectorSettings.vue.ts
@@ -281,10 +281,6 @@ export default class SoundDetectorSettings extends Vue {
     );
   }
 
-  get isCalibrated(): boolean {
-    return this.soundDetectorService.isCalibrated;
-  }
-
   get soundDetectorAudioSources(): AudioSource[] {
     // audioSourcesVersionにアクセスすることで、これが変更されたときにgetterが再評価される
     this.audioSourcesVersion;

--- a/app/services/nicolive-program/nicolive-comment-synthesizer.ts
+++ b/app/services/nicolive-program/nicolive-comment-synthesizer.ts
@@ -218,16 +218,6 @@ export class NicoliveCommentSynthesizerService extends StatefulService<ICommentS
     }
     this.setState({ soundDetectorEnabled: this.soundDetectorService.isEnabled() });
   }
-  get isSoundDetectorSourceEnabled(): boolean {
-    return this.soundDetectorService.state.sourceId !== null;
-  }
-  get isSoundDetectorCalibrated(): boolean {
-    return this.soundDetectorService.isCalibrated;
-  }
-  get isSoundDetectorDeclined(): boolean {
-    return this.soundDetectorService.isDeclined;
-  }
-
   private dictionary = new ParaphraseDictionary();
 
   makeSpeechText(chat: WrappedMessage, engine: SynthesizerId): string {

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -153,18 +153,6 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
   enableSoundDetector(enabled: boolean) {
     this.nicoliveCommentSynthesizerService.enableSoundDetector(enabled);
   }
-  get isSoundDetectorSourceEnabled(): boolean {
-    return this.nicoliveCommentSynthesizerService.isSoundDetectorSourceEnabled;
-  }
-  get isSoundDetectorCalibrated(): boolean {
-    return this.nicoliveCommentSynthesizerService.isSoundDetectorCalibrated;
-  }
-  get isSoundDetectorDeclined(): boolean {
-    return this.nicoliveCommentSynthesizerService.isSoundDetectorDeclined;
-  }
-  markSoundDetectorDeclined(): void {
-    this.nicoliveCommentSynthesizerService.soundDetectorService.markDeclined();
-  }
   setSoundDetectorEnabled(enabled: boolean): void {
     this.nicoliveCommentSynthesizerService.soundDetectorService.setEnabled(enabled);
   }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -853,20 +853,6 @@ export class SettingsService
           },
         ],
       },
-      {
-        nameSubCategory: 'SoundDetector',
-        codeSubCategory: 'SoundDetector',
-        parameters: [
-          <IObsInput<boolean>>{
-            value: this.soundDetectorService.isCalibrated,
-            name: 'Calibrated',
-            description: '読み上げ停止の音量設定済み',
-            type: 'OBS_PROPERTY_BOOL',
-            visible: true,
-            enabled: true,
-          },
-        ],
-      },
     ];
   }
 
@@ -887,17 +873,6 @@ export class SettingsService
           for (const item of setting.parameters) {
             if (item.name === 'ResetNameplateHint' && !item.value) {
               this.nicoliveProgramStateService.updateNameplateHint(undefined);
-            }
-          }
-          break;
-        case 'SoundDetector':
-          for (const item of setting.parameters) {
-            if (item.name === 'Calibrated') {
-              if (item.value) {
-                this.soundDetectorService.markCalibrated();
-              } else {
-                this.soundDetectorService.resetCalibrated();
-              }
             }
           }
           break;

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -853,6 +853,20 @@ export class SettingsService
           },
         ],
       },
+      {
+        nameSubCategory: 'SoundDetector',
+        codeSubCategory: 'SoundDetector',
+        parameters: [
+          <IObsInput<boolean>>{
+            value: !this.soundDetectorService.isDialogShown,
+            name: 'ResetDialogShown',
+            description: '読み上げ停止設定の案内ダイアログをリセットする',
+            type: 'OBS_PROPERTY_BOOL',
+            visible: true,
+            enabled: this.soundDetectorService.isDialogShown,
+          },
+        ],
+      },
     ];
   }
 
@@ -873,6 +887,13 @@ export class SettingsService
           for (const item of setting.parameters) {
             if (item.name === 'ResetNameplateHint' && !item.value) {
               this.nicoliveProgramStateService.updateNameplateHint(undefined);
+            }
+          }
+          break;
+        case 'SoundDetector':
+          for (const item of setting.parameters) {
+            if (item.name === 'ResetDialogShown' && item.value) {
+              this.soundDetectorService.resetDialogShown();
             }
           }
           break;

--- a/app/services/sound-detector/sound-detector.test.ts
+++ b/app/services/sound-detector/sound-detector.test.ts
@@ -488,15 +488,6 @@ describe('SoundDetectorService', () => {
     });
   });
 
-  describe('markDeclined', () => {
-    test('declined=true かつ enabled=false になること', () => {
-      const { instance } = prepare();
-      instance.markDeclined();
-      expect(instance.state.declined).toBe(true);
-      expect(instance.state.enabled).toBe(false);
-    });
-  });
-
   describe('isBlockingObservable', () => {
     test('pause の場合は loud でブロックする', () => {
       const { instance, micStream } = prepare({ speechActionOnSoundDetected: 'pause' });

--- a/app/services/sound-detector/sound-detector.ts
+++ b/app/services/sound-detector/sound-detector.ts
@@ -22,8 +22,6 @@ export interface ISoundDetectorState {
   resumeSilenceMs: number;
   speechActionOnSoundDetected: SpeechActionOnSoundDetected;
   noSignalTimeoutMs: number;
-  calibrated: boolean; // 音声しきい値が設定されているか
-  declined: boolean; // ユーザーがダイアログで「いいえ」を選択したか
 }
 
 export class SoundDetectorService extends PersistentStatefulService<ISoundDetectorState> {
@@ -35,8 +33,6 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     soundThresholdDb: -19,
     resumeSilenceMs: 500,
     speechActionOnSoundDetected: 'graceful',
-    calibrated: false,
-    declined: false,
     noSignalTimeoutMs: 1000,
   };
 
@@ -330,31 +326,11 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     return this.getCandidateWatchSources(watchSourceId).filter(s => !s.muted);
   }
 
-  get isCalibrated(): boolean {
-    return this.state.calibrated;
-  }
-
-  markCalibrated(): void {
-    this.setState({ calibrated: true });
-  }
-
-  resetCalibrated(): void {
-    this.setState({ calibrated: false });
-  }
-
-  get isDeclined(): boolean {
-    return this.state.declined;
-  }
-
-  markDeclined(): void {
-    this.setState({ declined: true, enabled: false });
-  }
-
   updateSourceId(id: string | null): void {
     this.setState({ sourceId: id });
   }
   updateSoundThresholdDb(db: number): void {
-    this.setState({ soundThresholdDb: db, calibrated: true });
+    this.setState({ soundThresholdDb: db });
   }
   updateResumeSilenceMs(ms: number): void {
     if (!Number.isFinite(ms) || ms <= 0) {
@@ -373,16 +349,11 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
       soundThresholdDb: this.state.soundThresholdDb,
       resumeSilenceMs: this.state.resumeSilenceMs,
       speechActionOnSoundDetected: this.state.speechActionOnSoundDetected,
-      calibrated: this.state.calibrated,
     };
   }
 
   private setState(nextState: Partial<ISoundDetectorState>): void {
     const newState = { ...this.state, ...nextState };
-    if (this.state.sourceId !== newState.sourceId) {
-      newState.calibrated = false;
-      newState.declined = false;
-    }
     this.stateSubject.next(newState);
     this.SET_STATE(newState);
   }

--- a/app/services/sound-detector/sound-detector.ts
+++ b/app/services/sound-detector/sound-detector.ts
@@ -22,6 +22,7 @@ export interface ISoundDetectorState {
   resumeSilenceMs: number;
   speechActionOnSoundDetected: SpeechActionOnSoundDetected;
   noSignalTimeoutMs: number;
+  dialogShown: boolean; // 設定を促すダイアログを表示済みか
 }
 
 export class SoundDetectorService extends PersistentStatefulService<ISoundDetectorState> {
@@ -34,6 +35,7 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     resumeSilenceMs: 500,
     speechActionOnSoundDetected: 'graceful',
     noSignalTimeoutMs: 1000,
+    dialogShown: false,
   };
 
   private stateSubject: Subject<ISoundDetectorState> = new BehaviorSubject<ISoundDetectorState>(
@@ -324,6 +326,18 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
   getEffectiveWatchSources(watchSourceId: ISoundDetectorState['sourceId']): AudioSource[] {
     // mutedなソースは監視対象から除外
     return this.getCandidateWatchSources(watchSourceId).filter(s => !s.muted);
+  }
+
+  get isDialogShown(): boolean {
+    return this.state.dialogShown;
+  }
+
+  markDialogShown(): void {
+    this.setState({ dialogShown: true });
+  }
+
+  resetDialogShown(): void {
+    this.setState({ dialogShown: false });
   }
 
   updateSourceId(id: string | null): void {

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -146,7 +146,6 @@ const createInjectee = ({
       soundThresholdDb: -19,
       resumeSilenceMs: 500,
       speechActionOnSoundDetected: 'graceful',
-      calibrated: false,
     }),
   },
   NVoiceCharacterUsageService: {

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -66,7 +66,6 @@ export type SoundDetectorLog = {
   soundThresholdDb: number;
   resumeSilenceMs: number;
   speechActionOnSoundDetected: SpeechActionOnSoundDetected;
-  calibrated: boolean;
 };
 
 export type TranscriptionLog = {


### PR DESCRIPTION
## このpull requestが解決する内容

コメント読み上げの「読み上げ停止設定」について、配信開始のたびに表示される案内ダイアログを**初回のみ**表示するよう変更します。

## 背景

このダイアログは、放送者の声を検知してコメント読み上げを停止する機能（SoundDetector）の設定を促すものでした。

もともと自動閾値キャリブレーション（K-Meansクラスタリング）と組み合わせて使う想定でしたが、その機能は削除済みです。その結果、以下の問題が発生していました：

- **初期状態（未設定）のユーザーは配信開始のたびに毎回ダイアログが表示される**
  - ダイアログで「はい」を選ぶと設定画面が開くが、設定は特に問題なさそうに見えてそのまま閉じることが想定される。この場合 `calibrated=true` にならず、次回の配信でもまたダイアログが出る
  - 「いいえ」を選べば`declined=true`になり表示が止まるが、デバイスを変更すると`calibrated`と`declined`が両方リセットされ再び毎回表示される
- 止め方がわからないまま毎回ダイアログが出続ける状態になっていた

（`calibrated=true` になるのは、設定画面で閾値スライダーを操作するか、テスト再生を実行した場合のみ）

## 変更内容

### ダイアログ表示ロジックの刷新
- `calibrated` / `declined` の2フラグを廃止し、`dialogShown`（一度でも表示したか）の1フラグに置き換え
- `dialogShown` はデバイス変更でリセットしない → **一度見たら二度と出ない**
- 「いいえ」を選択した場合は読み上げ停止機能をoffにする
- ダイアログタイトルの誤記を修正：「読み上げ**抑制**機能」→「読み上げ**停止**機能」

### Developer設定
- `dialogShown` フラグのリセット機能をDeveloper設定画面に追加（デバッグ用途）

### 削除したもの
- `calibrated` / `declined` フラグと関連メソッド群（`markCalibrated`, `resetCalibrated`, `markDeclined`, 中継ゲッター類）
- 使用統計ログの `calibrated` フィールド

## テスト
- [x] `unit tests(app)` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)