### PR TITLE
開発: Jestのrootsをホワイトリストでappとmain-processに限定する

### DIFF
--- a/jest.bin-config.js
+++ b/jest.bin-config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  roots: ['<rootDir>/bin'],
   testMatch: ['**/bin/**/*.test.js'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
       options: ['no-sandbox'],
     },
   },
+  roots: ['<rootDir>/app', '<rootDir>/main-process'],
   testMatch: ['**/app/**/*.test.ts', '**/main-process/*.test.ts'],
   transformIgnorePatterns: [
     'node_modules/(?!(ml-kmeans|ml-distance-euclidean|ml-matrix|ml-nearest-vector|ml-random|ml-xsadd))',


### PR DESCRIPTION
## このpull requestが解決する内容

Claude Code が worktree 機能を使うとプロジェクトルート内の `.claude/worktrees/` にworktreeを作成します。この状態で `pnpm run test:unit:app` を実行すると、worktree 内のテストファイルまで拾われてしまい、テストが数倍の時間かかる問題を修正します。

## 原因

`jest.config.js` に `roots` が未設定のため、デフォルトの `['<rootDir>']`（プロジェクトルート全体）が対象となっていました。`testMatch: ['**/app/**/*.test.ts']` のような `**` パターンはディレクトリの深さに関わらずマッチするため、`.claude/worktrees/<name>/app/` のような worktree 内のパスも対象に含まれていました。

## 変更内容

`jest.config.js` と `jest.bin-config.js` に `roots` を追加し、テスト対象ディレクトリをホワイトリストで明示します。

```js
// jest.config.js
roots: ['<rootDir>/app', '<rootDir>/main-process'],

// jest.bin-config.js
roots: ['<rootDir>/bin'],
```

**除外リスト（`testPathIgnorePatterns`）ではなくホワイトリストを使用した理由**: Claude 以外の coding agent が作業ディレクトリを作った場合、除外リストでは対応できないため。

## テスト
- [x] worktree が存在する状態で `pnpm run test:unit:app` を実行し、テストスイート数が本来の数（50前後）であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)