### PR TITLE
改善: 起動時にパッチノートがすぐに表示されるように

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -107,10 +107,14 @@ export class AppService extends StatefulService<IAppState> {
       // the apps to already be in place when their sources are created.
       // await this.platformAppsService.initialize();
 
+      // パッチノートはOBS/シーンに依存しないため、シーン初期化前に表示判定する
+      const willOnboard = this.onboardingService.willOnboardOnStartup();
+      this.patchNotesService.showPatchNotesIfRequired(willOnboard);
+
       await this.sceneCollectionsService.initialize();
 
       this.startMonitoringStudioMode();
-      const onboarded = this.onboardingService.startOnboardingIfRequired();
+      this.onboardingService.startOnboardingIfRequired();
 
       electron.ipcRenderer.on('shutdown', () => {
         electron.ipcRenderer.send('acknowledgeShutdown');
@@ -122,8 +126,6 @@ export class AppService extends StatefulService<IAppState> {
 
       this.ipcServerService.listen();
       this.tcpServerService.listen();
-
-      this.patchNotesService.showPatchNotesIfRequired(onboarded);
 
       this.informationsService;
 

--- a/app/services/onboarding.ts
+++ b/app/services/onboarding.ts
@@ -148,17 +148,32 @@ export class OnboardingService extends StatefulService<IOnboardingServiceState> 
     }
   }
 
-  startOnboardingIfRequired(): boolean {
-    if (localStorage.getItem(this.localStorageKey)) {
-      const started = this.forceLoginForSecurityUpgradeIfRequired();
-      if (!started) {
-        this.completed.next();
-      }
+  /**
+   * 起動時にオンボーディングが必要かどうかを副作用なしで判定する。
+   * パッチノートの早期表示判定に使用。
+   */
+  willOnboardOnStartup(): boolean {
+    if (!localStorage.getItem(this.localStorageKey)) {
+      return true;
+    }
+    // forceLoginForSecurityUpgradeIfRequired と同じ条件（副作用なし）
+    if (this.userService.isLoggedIn() && !this.userService.apiToken) {
+      return true;
+    }
+    return false;
+  }
 
-      return started;
+  startOnboardingIfRequired(): boolean {
+    if (!this.willOnboardOnStartup()) {
+      this.completed.next();
+      return false;
     }
 
-    this.start();
+    if (localStorage.getItem(this.localStorageKey)) {
+      this.forceLoginForSecurityUpgradeIfRequired();
+    } else {
+      this.start();
+    }
     return true;
   }
 


### PR DESCRIPTION
## このpull requestが解決する内容

起動時にパッチノート（更新内容のお知らせ）が表示されるまでの待ち時間を短縮します。

## 背景

従来の起動シーケンスでは、パッチノートの表示判定が `sceneCollectionsService.initialize()` の完了後に行われていました。シーンコレクションの初期化はOBSのシーン・ソースをロードする重い処理であり、これが完了するまでパッチノートが表示されませんでした。

パッチノートはOBSやシーンコレクションに依存しない静的データであるため、この順序制約は不要です。

## 変更内容

### `app/services/onboarding.ts`

`willOnboardOnStartup()` メソッドを追加し、`startOnboardingIfRequired()` の判定ロジックを共通化しました。判定だけを副作用なし（ナビゲーション・状態変更なし）で行います。

### `app/services/app/app.ts`

`load()` 内の順序を変更：

| | 変更前 | 変更後 |
|---|---|---|
| パッチノート表示判定 | `sceneCollectionsService.initialize()` の**後** | `sceneCollectionsService.initialize()` の**前** |

## 動作の仕組み

- `Main.vue` の `shouldLockContent` は `page === 'Studio'` のときのみローディングスピナーを表示するため、PatchNotes ページはローディング中でも表示される
- `showPatchNotesIfRequired` 内の `setTimeout(..., 0)` がナビゲーションを defer するため、`sceneCollectionsService.initialize()` を await している間にイベントループが回り、パッチノートが表示される

## テスト

動作確認済み（開発環境にて確認）。

## レビュー観点

- `willOnboardOnStartup()` の判定条件が `startOnboardingIfRequired()` と一致しているか
- 新規インストール時（オンボーディングあり）にパッチノートが表示されないこと

## 補足

OBS 初期化 (`OBS_API_initAPI`) は同期ブロックのため今回のスコープ外です。シーンコレクション読み込みの時間分（体感で数秒）が短縮されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)