### PR TITLE
開発: TCPサーバーのEADDRINUSEエラーをunhandled exceptionにしない

### DIFF
--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -163,7 +163,11 @@ export class TcpServerService
 
     server.nativeServer.on('connection', socket => this.onConnectionHandler(socket, server));
 
-    server.nativeServer.on('error', error => {
+    server.nativeServer.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE') {
+        console.warn(`TcpServerService: ${server.type} server failed to listen: ${error.message}`);
+        return;
+      }
       throw error;
     });
   }


### PR DESCRIPTION
## このpull requestが解決する内容

N Air 起動時に前回プロセスが残存している場合などに発生する `EADDRINUSE` エラーが unhandled exception として Sentry に大量送信されている問題を修正します。

## ユーザーへの影響

**ユーザーが直接気づく影響はありません。** `EADDRINUSE` が発生しても `requestSingleInstanceLock()` により2つ目のインスタンスは終了するか、前回プロセス終了後に再起動することで回復します。エラーダイアログも表示されません。

ただし、この状態が Sentry に unhandled exception として大量送信されており、ノイズとなっているため修正します。

## 背景

以下の Sentry issue が継続的に発生しています:

- **N-AIR-APP-D0D**: `listen EADDRINUSE: address already in use 127.0.0.1:28194` (TCP) — 4,300 events / 56 users
- **N-AIR-APP-EQX**: `listen EADDRINUSE: address already in use \.\pipe\n-air-app` (Named Pipe) — 109 events / 19 users

`tcp-server.ts` の `listenConnections` メソッドでサーバーエラーを無条件に `throw` しているため、ポートが使用中の場合に unhandled exception となって Sentry に送信されていました。

`main.js` には `app.requestSingleInstanceLock()` による2重起動防止がありますが、前回のプロセスが異常終了してポートを握ったままの状態で起動した場合にも発生します。

## 変更内容

### `app/services/api/tcp-server/tcp-server.ts`

`listenConnections` メソッドのエラーハンドラで `EADDRINUSE` を個別に処理するよう修正:

- `EADDRINUSE` の場合: `console.warn` でログ出力のみ（Sentry送信なし）
- その他のエラー: 従来通り `throw`

## テスト

- [x] ユニットテスト全通過 (823 tests passed)

関連: N-AIR-APP-D0D, N-AIR-APP-EQX

🤖 Generated with [Claude Code](https://claude.com/claude-code)