### PR TITLE
開発: refreshProgramタイマーのUnhandledRejectionを修正 (N-AIR-APP-FF4)

### DIFF
--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -551,7 +551,7 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
           if (caught instanceof NicoliveFailure) {
             console.warn('refreshProgram failed:', caught);
           } else {
-            throw caught;
+            throw new Error('refreshProgram failed unexpectedly', { cause: caught });
           }
         });
       }, waitTime);

--- a/app/services/nicolive-program/nicolive-program.ts
+++ b/app/services/nicolive-program/nicolive-program.ts
@@ -547,7 +547,13 @@ export class NicoliveProgramService extends StatefulService<INicoliveProgramStat
       // 次に放送状態が変化する予定の時刻（より少し後）に放送情報を更新するタイマーを仕込む
       clearTimeout(this.refreshProgramTimer);
       this.refreshProgramTimer = window.setTimeout(() => {
-        this.refreshProgram();
+        this.refreshProgram().catch(caught => {
+          if (caught instanceof NicoliveFailure) {
+            console.warn('refreshProgram failed:', caught);
+          } else {
+            throw caught;
+          }
+        });
       }, waitTime);
     } else if (prev && !next) {
       clearTimeout(this.refreshProgramTimer);


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue N-AIR-APP-FF4 (`UnhandledRejection: Object captured as promise rejection with keys: additionalMessage, errorCode, method, reason, type`) を修正します。

- 486件 / 173ユーザーに影響、High優先度、2025/12/19〜継続発生中

## 原因

放送状態更新タイマーが `refreshProgram()` を fire-and-forget で呼び出しており、ネットワークエラー時に `NicoliveFailure` インスタンスが catch されず `UnhandledRejection` になっていた。

```typescript
// 修正前: Promise の返り値を無視
this.refreshProgramTimer = window.setTimeout(() => {
  this.refreshProgram();  // ← async だが catch なし
}, waitTime);
```

`NicoliveFailure` は `Error` を継承していないため、Sentry ではスタックトレースなし・タイトル `<unknown>` で記録されていた。

### エラー発生の流れ

1. `refreshProgramTimer` が発火
2. `refreshProgram()` が `client.fetchProgram(programID)` を呼ぶ（`GET live2.nicovideo.jp/watch/{id}/programinfo`）
3. ネットワーク障害で `TypeError: Failed to fetch`
4. `NicoliveFailure.fromClientError` が throw される
5. タイマーコールバックが catch しないため `UnhandledRejection` になる

## 変更内容

タイマーコールバックに `.catch()` を追加。`NicoliveFailure` 以外の予期しないエラーは `cause` 付きで re-throw。

```typescript
// 修正後: NicoliveFailure を catch してログ
this.refreshProgramTimer = window.setTimeout(() => {
  this.refreshProgram().catch(caught => {
    if (caught instanceof NicoliveFailure) {
      console.warn("refreshProgram failed:", caught);
    } else {
      throw new Error("refreshProgram failed unexpectedly", { cause: caught });
    }
  });
}, waitTime);
```

同ファイル内の `extendProgramForAutoExtension()` が同様のタイマーパターンで try/catch を使っていることを参考にした。タイマーによる状態ポーリングの失敗は一時的なネットワーク障害によるものが多いため、ユーザーへのダイアログ表示は行わず `console.warn` のみとした。

## ユーザー影響

**なし。** エラーハンドリングのみの変更。

- ユーザーに見える動作変化はない（以前も失敗時のダイアログは表示されていなかった）
- 次回タイマー発火または手動操作時に自動リトライされる
- `NicoliveFailure` 以外の予期しないエラーは `cause` 付きで re-throw して検出を維持

## テスト

- [x] `pnpm run test:unit:app`: 825件 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)