### PR TITLE
変更: 詳細オーディオ設定の画面レイアウトを見やすく改善

### DIFF
--- a/app/components/settings/AdvancedAudio.vue
+++ b/app/components/settings/AdvancedAudio.vue
@@ -6,40 +6,54 @@
         :key="audioSource.sourceId"
         class="audio-source-card section"
       >
-        <div class="source-header">
+        <div class="source-row">
           <div class="source-name">{{ audioSource.name }}</div>
-          <div class="source-primary-controls">
-            <div
-              v-for="formInput in getPrimaryControls(audioSource)"
-              :key="`${audioSource.name}${formInput.name}`"
-              :class="['control-item', 'control-' + formInput.name]"
-            >
-              <div class="control-label">{{ formInput.description }}</div>
-              <component
-                v-if="propertyComponentForType(formInput.type)"
-                :is="propertyComponentForType(formInput.type)"
-                :value="formInput"
-                @input="value => onInputHandler(audioSource, formInput.name, value.value)"
-              />
+          <div class="source-rows">
+            <div class="source-controls">
+              <div
+                v-for="formInput in getRow1Controls(audioSource)"
+                :key="`${audioSource.name}${formInput.name}`"
+                :class="['control-item', 'control-' + formInput.name]"
+              >
+                <div class="control-label">{{ formInput.description }}</div>
+                <component
+                  v-if="propertyComponentForType(formInput.type)"
+                  :is="propertyComponentForType(formInput.type)"
+                  :value="formInput"
+                  @input="value => onInputHandler(audioSource, formInput.name, value.value)"
+                />
+              </div>
             </div>
-          </div>
-          <button class="expand-toggle" @click="toggleExpand(audioSource.sourceId)">
-            <i class="icon-drop-down-arrow" :class="{ 'is-expanded': isExpanded(audioSource.sourceId) }" />
-          </button>
-        </div>
-        <div v-if="isExpanded(audioSource.sourceId)" class="source-detail-controls">
-          <div
-            v-for="formInput in getDetailControls(audioSource)"
-            :key="`${audioSource.name}${formInput.name}`"
-            :class="['control-item', 'control-' + formInput.name]"
-          >
-            <div class="control-label">{{ formInput.description }}</div>
-            <component
-              v-if="propertyComponentForType(formInput.type)"
-              :is="propertyComponentForType(formInput.type)"
-              :value="formInput"
-              @input="value => onInputHandler(audioSource, formInput.name, value.value)"
-            />
+            <div class="source-controls">
+              <div
+                v-for="formInput in getRow2Controls(audioSource)"
+                :key="`${audioSource.name}${formInput.name}`"
+                :class="['control-item', 'control-' + formInput.name]"
+              >
+                <div class="control-label">{{ formInput.description }}</div>
+                <component
+                  v-if="propertyComponentForType(formInput.type)"
+                  :is="propertyComponentForType(formInput.type)"
+                  :value="formInput"
+                  @input="value => onInputHandler(audioSource, formInput.name, value.value)"
+                />
+              </div>
+            </div>
+            <div class="source-controls">
+              <div
+                v-for="formInput in getRow3Controls(audioSource)"
+                :key="`${audioSource.name}${formInput.name}`"
+                :class="['control-item', 'control-' + formInput.name]"
+              >
+                <div class="control-label">{{ formInput.description }}</div>
+                <component
+                  v-if="propertyComponentForType(formInput.type)"
+                  :is="propertyComponentForType(formInput.type)"
+                  :value="formInput"
+                  @input="value => onInputHandler(audioSource, formInput.name, value.value)"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -59,14 +73,15 @@
 }
 
 .audio-source-card {
-  margin-bottom: 8px;
+  padding-bottom: 16px;
+  margin-bottom: 16px;
 
   &:last-child {
     margin-bottom: 0;
   }
 }
 
-.source-header {
+.source-row {
   display: flex;
   gap: 16px;
   align-items: center;
@@ -82,44 +97,18 @@
   white-space: nowrap;
 }
 
-.source-primary-controls {
+.source-rows {
   display: flex;
   flex: 1;
-  flex-wrap: wrap;
-  gap: 8px 24px;
-  align-items: center;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.expand-toggle {
-  flex-shrink: 0;
-  padding: 4px 8px;
-  color: var(--color-object-emphasis-medium);
-  cursor: pointer;
-  background: transparent;
-  border: none;
-
-  &:hover {
-    color: var(--color-object-emphasis-high);
-  }
-
-  i {
-    display: inline-block;
-    transition: transform 0.2s;
-
-    &.is-expanded {
-      transform: rotate(180deg);
-    }
-  }
-}
-
-.source-detail-controls {
+.source-controls {
   display: flex;
   flex-wrap: wrap;
   gap: 8px 24px;
   align-items: center;
-  padding-top: 12px;
-  margin-top: 8px;
-  border-top: 1px solid var(--color-border-emphasis-low);
 }
 
 .control-item {

--- a/app/components/settings/AdvancedAudio.vue
+++ b/app/components/settings/AdvancedAudio.vue
@@ -1,33 +1,48 @@
 <template>
   <modal-layout :show-controls="false" no-scroll>
-    <div slot="content" class="table-wrapper section">
-      <table>
-        <thead>
-          <tr>
-            <th class="device">{{ $t('common.name') }}</th>
-            <th class="volume">{{ $t('audio.volumeInPercent') }}</th>
-            <th class="downmix">{{ $t('audio.downmixToMono') }}</th>
-            <th class="syncOffset">{{ $t('audio.syncOffsetInMs') }}</th>
-            <th class="audioMonitor">{{ $t('audio.audioMonitoring') }}</th>
-            <th class="track">{{ $t('audio.tracks') }}</th>
-          </tr>
-        </thead>
-        <tr v-for="audioSource in audioSources" :key="audioSource.sourceId">
-          <td>{{ audioSource.name }}</td>
-          <td
-            v-for="formInput in audioSource.getSettingsForm()"
+    <div slot="content" class="audio-sources-list">
+      <div
+        v-for="audioSource in audioSources"
+        :key="audioSource.sourceId"
+        class="audio-source-card section"
+      >
+        <div class="source-header">
+          <div class="source-name">{{ audioSource.name }}</div>
+          <div class="source-primary-controls">
+            <div
+              v-for="formInput in getPrimaryControls(audioSource)"
+              :key="`${audioSource.name}${formInput.name}`"
+              :class="['control-item', 'control-' + formInput.name]"
+            >
+              <div class="control-label">{{ formInput.description }}</div>
+              <component
+                v-if="propertyComponentForType(formInput.type)"
+                :is="propertyComponentForType(formInput.type)"
+                :value="formInput"
+                @input="value => onInputHandler(audioSource, formInput.name, value.value)"
+              />
+            </div>
+          </div>
+          <button class="expand-toggle" @click="toggleExpand(audioSource.sourceId)">
+            <i class="icon-drop-down-arrow" :class="{ 'is-expanded': isExpanded(audioSource.sourceId) }" />
+          </button>
+        </div>
+        <div v-if="isExpanded(audioSource.sourceId)" class="source-detail-controls">
+          <div
+            v-for="formInput in getDetailControls(audioSource)"
             :key="`${audioSource.name}${formInput.name}`"
-            :class="'column-' + formInput.name"
+            :class="['control-item', 'control-' + formInput.name]"
           >
+            <div class="control-label">{{ formInput.description }}</div>
             <component
               v-if="propertyComponentForType(formInput.type)"
               :is="propertyComponentForType(formInput.type)"
               :value="formInput"
               @input="value => onInputHandler(audioSource, formInput.name, value.value)"
             />
-          </td>
-        </tr>
-      </table>
+          </div>
+        </div>
+      </div>
     </div>
   </modal-layout>
 </template>
@@ -37,80 +52,113 @@
 <style lang="less" scoped>
 @import url('../../styles/index');
 
-.table-wrapper {
-  .radius();
-
+.audio-sources-list {
   flex-grow: 1;
-  padding: 0;
-  margin: 0;
-  overflow: auto;
+  padding: 8px;
+  overflow-y: auto;
 }
 
-table {
-  min-width: 1170px;
-  margin: 0;
+.audio-source-card {
+  margin-bottom: 8px;
 
-  // reset
-  tr {
-    background-color: transparent;
-    border-color: transparent;
-    border-radius: 0;
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
 
-    td {
-      padding: 16px;
-      border: none;
+.source-header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
 
-      &:last-child {
-        padding-right: 16px;
-      }
+.source-name {
+  flex-shrink: 0;
+  width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: bold;
+  color: var(--color-object-emphasis-high);
+  white-space: nowrap;
+}
+
+.source-primary-controls {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 8px 24px;
+  align-items: center;
+}
+
+.expand-toggle {
+  flex-shrink: 0;
+  padding: 4px 8px;
+  color: var(--color-object-emphasis-medium);
+  cursor: pointer;
+  background: transparent;
+  border: none;
+
+  &:hover {
+    color: var(--color-object-emphasis-high);
+  }
+
+  i {
+    display: inline-block;
+    transition: transform 0.2s;
+
+    &.is-expanded {
+      transform: rotate(180deg);
     }
   }
 }
 
-.volume {
+.source-detail-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 24px;
+  align-items: center;
+  padding-top: 12px;
+  margin-top: 8px;
+  border-top: 1px solid var(--color-border-emphasis-low);
 }
 
-.device {
-  width: 150px;
+.control-item {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+
+  :deep(.input-container) {
+    display: block;
+  }
+
+  :deep(.input-label) {
+    display: none;
+  }
+
+  :deep(.input-wrapper) {
+    width: auto;
+    margin-bottom: 0;
+  }
 }
 
-.downmix {
-  width: 120px;
+.control-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-object-emphasis-medium);
+  white-space: nowrap;
 }
 
-.syncOffset {
+.control-deflection :deep(input),
+.control-syncOffset :deep(input) {
+  width: 80px;
 }
 
-.audioMonitor {
+.control-forceMono {
+  flex-direction: row-reverse;
 }
 
-.track {
-}
-
-.device,
-.volume,
-.downmix,
-.syncOffset,
-.audioMonitor,
-.track {
-  color: var(--color-text-dark);
-  text-align: center;
-}
-
-th,
-td {
-  text-align: left;
-}
-
-.column-deflection {
-  width: 104px;
-}
-
-.column-syncOffset {
-  width: 120px;
-}
-
-.column-monitoringType {
-  width: 350px;
+.control-monitoringType :deep(.dropdown) {
+  width: 300px;
 }
 </style>

--- a/app/components/settings/AdvancedAudio.vue.ts
+++ b/app/components/settings/AdvancedAudio.vue.ts
@@ -6,8 +6,6 @@ import { Inject } from 'services/core/injector';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 
-const PRIMARY_CONTROLS = ['deflection', 'monitoringType'];
-
 @Component({
   components: { ModalLayout },
 })
@@ -16,26 +14,22 @@ export default class AdvancedAudio extends Vue {
 
   propertyComponentForType = propertyComponentForType;
 
-  expandedSources: Record<string, boolean> = {};
-
   get audioSources() {
     return this.audioService.getSourcesForCurrentScene();
   }
 
-  getPrimaryControls(audioSource: IAudioSourceApi) {
-    return audioSource.getSettingsForm().filter(f => PRIMARY_CONTROLS.includes(f.name));
+  getRow1Controls(audioSource: IAudioSourceApi) {
+    const form = audioSource.getSettingsForm();
+    return ['monitoringType', 'deflection'].flatMap(name => form.filter(f => f.name === name));
   }
 
-  getDetailControls(audioSource: IAudioSourceApi) {
-    return audioSource.getSettingsForm().filter(f => !PRIMARY_CONTROLS.includes(f.name));
+  getRow2Controls(audioSource: IAudioSourceApi) {
+    const form = audioSource.getSettingsForm();
+    return ['syncOffset', 'forceMono'].flatMap(name => form.filter(f => f.name === name));
   }
 
-  isExpanded(sourceId: string) {
-    return !!this.expandedSources[sourceId];
-  }
-
-  toggleExpand(sourceId: string) {
-    this.$set(this.expandedSources, sourceId, !this.expandedSources[sourceId]);
+  getRow3Controls(audioSource: IAudioSourceApi) {
+    return audioSource.getSettingsForm().filter(f => f.name === 'audioMixers');
   }
 
   onInputHandler(audioSource: IAudioSourceApi, name: string, value: TObsValue) {

--- a/app/components/settings/AdvancedAudio.vue.ts
+++ b/app/components/settings/AdvancedAudio.vue.ts
@@ -3,21 +3,39 @@ import { TObsValue } from 'components/obs/inputs/ObsInput';
 import ModalLayout from 'components/shared/ModalLayout.vue';
 import { IAudioServiceApi, IAudioSourceApi } from 'services/audio';
 import { Inject } from 'services/core/injector';
-import { WindowsService } from 'services/windows';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
+
+const PRIMARY_CONTROLS = ['deflection', 'monitoringType'];
 
 @Component({
   components: { ModalLayout },
 })
 export default class AdvancedAudio extends Vue {
   @Inject() audioService: IAudioServiceApi;
-  @Inject() windowsService: WindowsService;
 
   propertyComponentForType = propertyComponentForType;
 
+  expandedSources: Record<string, boolean> = {};
+
   get audioSources() {
     return this.audioService.getSourcesForCurrentScene();
+  }
+
+  getPrimaryControls(audioSource: IAudioSourceApi) {
+    return audioSource.getSettingsForm().filter(f => PRIMARY_CONTROLS.includes(f.name));
+  }
+
+  getDetailControls(audioSource: IAudioSourceApi) {
+    return audioSource.getSettingsForm().filter(f => !PRIMARY_CONTROLS.includes(f.name));
+  }
+
+  isExpanded(sourceId: string) {
+    return !!this.expandedSources[sourceId];
+  }
+
+  toggleExpand(sourceId: string) {
+    this.$set(this.expandedSources, sourceId, !this.expandedSources[sourceId]);
   }
 
   onInputHandler(audioSource: IAudioSourceApi, name: string, value: TObsValue) {

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -5,7 +5,7 @@ import {
   IObsNumberInputValue,
   TObsFormData,
 } from 'components/obs/inputs/ObsInput';
-import { EMPTY, merge, Observable, Subject, Subscription } from 'rxjs';
+import { EMPTY, merge, Observable, Subject } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
 import { InitAfter, Inject, mutation, ServiceHelper, StatefulService } from 'services/core';
 import { $t } from 'services/i18n';
@@ -442,26 +442,6 @@ export class AudioSource implements IAudioSourceApi {
         type: 'OBS_PROPERTY_INT',
       },
 
-      <IObsInput<boolean>>{
-        value: this.forceMono,
-        name: 'forceMono',
-        description: $t('audio.downmixToMono'),
-        showDescription: false,
-        type: 'OBS_PROPERTY_BOOL',
-        visible: true,
-        enabled: true,
-      },
-
-      <IObsInput<number>>{
-        value: this.syncOffset,
-        name: 'syncOffset',
-        description: $t('audio.syncOffsetInMs'),
-        showDescription: false,
-        type: 'OBS_PROPERTY_UINT',
-        visible: true,
-        enabled: true,
-      },
-
       <IObsListInput<obs.EMonitoringType>>{
         value: this.monitoringType,
         name: 'monitoringType',
@@ -480,6 +460,16 @@ export class AudioSource implements IAudioSourceApi {
         ],
       },
 
+      <IObsInput<number>>{
+        value: this.syncOffset,
+        name: 'syncOffset',
+        description: $t('audio.syncOffsetInMs'),
+        showDescription: false,
+        type: 'OBS_PROPERTY_UINT',
+        visible: true,
+        enabled: true,
+      },
+
       <IObsBitmaskInput>{
         value: this.audioMixers,
         name: 'audioMixers',
@@ -489,6 +479,16 @@ export class AudioSource implements IAudioSourceApi {
         visible: true,
         enabled: true,
         size: 6,
+      },
+
+      <IObsInput<boolean>>{
+        value: this.forceMono,
+        name: 'forceMono',
+        description: $t('audio.downmixToMono'),
+        showDescription: false,
+        type: 'OBS_PROPERTY_BOOL',
+        visible: true,
+        enabled: true,
       },
     ];
   }


### PR DESCRIPTION
## 変更内容

詳細オーディオ設定ウィンドウのレイアウトを大幅に改善しました。

### 背景
従来のテーブル形式は列数が多く横スクロールが必須で、トラック割り当てなど
細かい設定を変更するたびにスクロール操作が必要で使いづらい状態でした。

### 改善点
- **横スクロールを廃止**  ウィンドウ幅に収まるレイアウトに刷新
- **優先度で分けた表示**  「音量」「音声出力」は全ソースの一覧行に常時表示し、すぐに変更できる
- **折りたたみで情報を整理**  「音声遅延」「トラック」「モノラル」は展開ボタンで必要なときだけ表示。普段は見えないので画面がすっきりする
- **ソース名の幅を統一**  複数ソース並んでも各項目の開始位置がそろい、一覧性が向上

<img width="998" height="446" alt="Monosnap work 2026-04-21 14-01-32" src="https://github.com/user-attachments/assets/4211d03e-30bb-4599-85e3-22b9de65246c" />

