### PR TITLE
開発: NicoliveClientのデッドコード（fetchStatistics, fetchNicoadStatistics）を撤去

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -162,20 +162,6 @@ const suites: Suite[] = [
     args: [programID, { text: 'comment text', isPermanent: true }],
   },
   {
-    name: 'fetchStatistics',
-    method: 'get',
-    base: NicoliveClient.live2BaseURL,
-    path: `/watch/${programID}/statistics`,
-    args: [programID],
-  },
-  {
-    name: 'fetchNicoadStatistics',
-    method: 'get',
-    base: NicoliveClient.nicoadBaseURL,
-    path: `/v1/live/statusarea/${programID}`,
-    args: [programID],
-  },
-  {
     name: 'fetchModerators',
     method: 'get',
     base: NicoliveClient.live2BaseURL,

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -14,7 +14,6 @@ import {
   Filters,
   IngestInfoData,
   Moderator,
-  NicoadStatistics,
   OnairChannelData,
   OnairChannelProgramData,
   OnairUserProgramData,
@@ -22,7 +21,6 @@ import {
   ProgramPassword,
   ProgramSchedules,
   Segment,
-  Statistics,
   Supporters,
   UserFollow,
   UserFollowStatus,
@@ -141,7 +139,6 @@ export class NicoliveClient {
   static live2BaseURL = transformUrl('https://live2.nicovideo.jp');
   static liveBaseURL = transformUrl('https://live.nicovideo.jp');
   static live2ApiBaseURL = transformUrl('https://api.live2.nicovideo.jp');
-  static nicoadBaseURL = transformUrl('https://api.nicoad.nicovideo.jp');
   static userFollowBaseURL = transformUrl('https://user-follow-api.nicovideo.jp');
   static userIconBaseURL = transformUrl('https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/');
 
@@ -386,26 +383,6 @@ export class NicoliveClient {
       'POST',
       `${NicoliveClient.live2BaseURL}/unama/tool/v2/programs/${programID}/comments`,
       NicoliveClient.jsonBody({ text, vpos, modifier }, FrontendIdHeader),
-    );
-  }
-
-  /** 統計情報（視聴者とコメント数）を取得 */
-  async fetchStatistics(programID: string): Promise<WrappedResult<Statistics['data']>> {
-    return this.requestAPI<Statistics['data']>(
-      'GET',
-      `${NicoliveClient.live2BaseURL}/watch/${programID}/statistics`,
-    );
-  }
-
-  // 関心が別だが他の場所におく程の理由もないのでここにおく
-  /**
-   * ニコニ広告ptとギフトptを取得
-   * 放送開始前は404になる
-   **/
-  async fetchNicoadStatistics(programID: string): Promise<WrappedResult<NicoadStatistics['data']>> {
-    return this.requestAPI<NicoadStatistics['data']>(
-      'GET',
-      `${NicoliveClient.nicoadBaseURL}/v1/live/statusarea/${programID}`,
     );
   }
 

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -127,31 +127,6 @@ export interface OperatorComment {
   };
 }
 
-export interface Statistics {
-  meta: {
-    status: 200;
-    errorCode: 'OK';
-  };
-  data: {
-    watchCount: number;
-    commentCount: number;
-  };
-}
-
-export interface NicoadStatistics {
-  meta: {
-    status: 200;
-  };
-  data: {
-    totalAdPoint: number;
-    totalGiftPoint: number;
-    conductors: {
-      text: string;
-      url: string;
-    }[];
-  };
-}
-
 export type FilterRecord = {
   id: number;
   type: 'word' | 'user' | 'command';


### PR DESCRIPTION
## このpull requestが解決する内容

`NicoliveClient` に本番コードから一切参照されていないメソッドが2つ存在したため、それらと派生するデッドコードをまとめて撤去する。

## 背景

PR #1045「改善: ニコ生パネルのコメント数・来場者数表示をwebと同じ値に」で、統計情報取得をREST APIポーリングからNdgrのリアルタイムメッセージに移行した際、`nicolive-program.ts` 側の呼び出しコード（`updateStatistics()` / `refreshStatisticsPolling()`）は削除されたが、`NicoliveClient.ts` 側のメソッド本体（`fetchStatistics` / `fetchNicoadStatistics`）と対応する型定義が削除されないまま残っていた。

## 変更内容

### 削除したメソッド（本番コードから参照なし・テストのみ）

- `NicoliveClient.fetchStatistics` — 統計情報（視聴者とコメント数）取得
- `NicoliveClient.fetchNicoadStatistics` — ニコニ広告pt・ギフトpt取得

### 派生的に削除したコード

| ファイル | 削除内容 |
|---|---|
| `NicoliveClient.ts` | `nicoadBaseURL` 静的フィールド（`fetchNicoadStatistics` でのみ使用） |
| `NicoliveClient.ts` | `Statistics` / `NicoadStatistics` の import |
| `ResponseTypes.ts` | `Statistics` interface、`NicoadStatistics` interface |
| `NicoliveClient.test.ts` | `fetchStatistics` / `fetchNicoadStatistics` の suites エントリ |

## テスト

- [x] `pnpm run test:unit:app` — 50 suites, 821 tests 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)