### PR TITLE
開発: calibrated/declined フラグを dialogShown へマイグレーションする処理を追加

### DIFF
--- a/app/services/sound-detector/sound-detector.test.ts
+++ b/app/services/sound-detector/sound-detector.test.ts
@@ -65,6 +65,9 @@ function prepare(
     soundThresholdDb?: number;
     resumeSilenceMs?: number;
     noSignalTimeoutMs?: number;
+    calibrated?: boolean;
+    declined?: boolean;
+    dialogShown?: boolean;
   } = {},
 ) {
   // AudioService
@@ -101,7 +104,10 @@ function prepare(
     options.speechActionOnSoundDetected !== undefined ||
     options.soundThresholdDb !== undefined ||
     options.resumeSilenceMs !== undefined ||
-    options.noSignalTimeoutMs !== undefined
+    options.noSignalTimeoutMs !== undefined ||
+    options.calibrated !== undefined ||
+    options.declined !== undefined ||
+    options.dialogShown !== undefined
   ) {
     stateOverride.SoundDetectorService = {};
     if (options.speechActionOnSoundDetected !== undefined) {
@@ -116,6 +122,15 @@ function prepare(
     }
     if (options.noSignalTimeoutMs !== undefined) {
       stateOverride.SoundDetectorService.noSignalTimeoutMs = options.noSignalTimeoutMs;
+    }
+    if (options.calibrated !== undefined) {
+      stateOverride.SoundDetectorService.calibrated = options.calibrated;
+    }
+    if (options.declined !== undefined) {
+      stateOverride.SoundDetectorService.declined = options.declined;
+    }
+    if (options.dialogShown !== undefined) {
+      stateOverride.SoundDetectorService.dialogShown = options.dialogShown;
     }
   }
 
@@ -589,6 +604,36 @@ describe('SoundDetectorService', () => {
       });
       cancelTest.micStream.next({ peak: [cancelTest.instance.state.soundThresholdDb + 1] } as IVolmeter);
       expect(cancelBlocking).toBe(true);
+    });
+  });
+
+  describe('calibrated/declined → dialogShown マイグレーション', () => {
+    test('calibrated=true のユーザーは dialogShown=true になり calibrated はクリアされる', () => {
+      const { instance } = prepare({ calibrated: true });
+      expect(instance.state.dialogShown).toBe(true);
+      expect(instance.state.calibrated).toBe(false);
+    });
+
+    test('declined=true のユーザーは dialogShown=true になり declined はクリアされる', () => {
+      const { instance } = prepare({ declined: true });
+      expect(instance.state.dialogShown).toBe(true);
+      expect(instance.state.declined).toBe(false);
+    });
+
+    test('calibrated=true かつ既に dialogShown=true の場合も calibrated はクリアされる', () => {
+      const { instance } = prepare({ calibrated: true, dialogShown: true });
+      expect(instance.state.dialogShown).toBe(true);
+      expect(instance.state.calibrated).toBe(false);
+    });
+
+    test('calibrated=false, declined=false の場合は dialogShown に影響しない', () => {
+      const { instance } = prepare({ calibrated: false, declined: false });
+      expect(instance.state.dialogShown).toBe(false);
+    });
+
+    test('calibrated/declined 未設定（新規ユーザー）は dialogShown=false のまま', () => {
+      const { instance } = prepare();
+      expect(instance.state.dialogShown).toBe(false);
     });
   });
 });

--- a/app/services/sound-detector/sound-detector.ts
+++ b/app/services/sound-detector/sound-detector.ts
@@ -23,6 +23,8 @@ export interface ISoundDetectorState {
   speechActionOnSoundDetected: SpeechActionOnSoundDetected;
   noSignalTimeoutMs: number;
   dialogShown: boolean; // 設定を促すダイアログを表示済みか
+  calibrated: boolean; // レガシー: dialogShown へのマイグレーション元
+  declined: boolean; // レガシー: dialogShown へのマイグレーション元
 }
 
 export class SoundDetectorService extends PersistentStatefulService<ISoundDetectorState> {
@@ -36,6 +38,8 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     speechActionOnSoundDetected: 'graceful',
     noSignalTimeoutMs: 1000,
     dialogShown: false,
+    calibrated: false,
+    declined: false,
   };
 
   private stateSubject: Subject<ISoundDetectorState> = new BehaviorSubject<ISoundDetectorState>(
@@ -71,6 +75,11 @@ export class SoundDetectorService extends PersistentStatefulService<ISoundDetect
     // noSignalTimeoutMs の不正値補正（NaN/Infinity/0以下 → デフォルト値に戻す）
     if (!Number.isFinite(this.state.noSignalTimeoutMs) || this.state.noSignalTimeoutMs <= 0) {
       this.setState({ noSignalTimeoutMs: SoundDetectorService.defaultState.noSignalTimeoutMs });
+    }
+
+    // Migration: calibrated/declined が true のユーザーには初回ダイアログを表示しない
+    if (this.state.calibrated || this.state.declined) {
+      this.setState({ dialogShown: true, calibrated: false, declined: false });
     }
 
     this.stateSubject = new BehaviorSubject<ISoundDetectorState>(this.state);


### PR DESCRIPTION
## このpull requestが解決する内容

PR #1232 で `calibrated` / `declined` フラグを `dialogShown` フラグに置き換えましたが、既存ユーザーの localStorage に残った `calibrated: true` / `declined: true` がマイグレーションされず、初回ダイアログが再表示されてしまう問題を修正します。

## 背景

#1232 は未リリースのため、ユーザー向けの変更告知はそちらで十分です。本PRはその内部実装の調整です。

## 変更内容

### `app/services/sound-detector/sound-detector.ts`
- `ISoundDetectorState` に `calibrated` / `declined` をレガシーフラグとして追加（型安全なマイグレーションのため）
- `defaultState` にも `false` で追加
- `init()` にマイグレーションロジックを追加：
  - `calibrated === true` または `declined === true` の場合、`dialogShown: true` をセット
  - 同時に `calibrated` / `declined` を `false` にクリア（次回起動で再マイグレーションされないよう）

### `app/services/sound-detector/sound-detector.test.ts`
- `prepare()` の options に `calibrated` / `declined` / `dialogShown` を追加
- マイグレーション動作を検証するテストケースを5件追加

## テスト

- [x] ユニットテスト追加・全件通過（`calibrated=true → dialogShown=true` など5ケース）

🤖 Generated with [Claude Code](https://claude.com/claude-code)