### PR TITLE
開発: fetchViaMainProcess失敗時にcause詳細とURLをrendererに伝搬する

### DIFF
--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -16,18 +16,18 @@ import { FrontendIdHeader } from './niconicoDefs';
 // /v1/sessions/me のレスポンス型
 type NiconicoSessionsMeResponse =
   | {
-      user: {
-        id: number;
-      };
-    }
-  | {
-      error: {
-        status: number;
-        code: string;
-        message?: string;
-        debug?: string;
-      };
+    user: {
+      id: number;
     };
+  }
+  | {
+    error: {
+      status: number;
+      code: string;
+      message?: string;
+      debug?: string;
+    };
+  };
 
 function isSessionsMeResponse(obj: any): obj is NiconicoSessionsMeResponse {
   if ('user' in obj) {
@@ -169,7 +169,7 @@ export class NiconicoService extends Service implements IPlatformService {
       const result = await this._setupStreamSettings(programId);
       return result;
     } catch (e) {
-      console.error('NiconicoService.setupStreamSettings(1)', e);
+      console.error('NiconicoService.setupStreamSettings(1)', e.toString());
       // APIのレスポンスに番組状態が反映されるのが遅れる場合があるので、少し待ってリトライ
       await sleep(3000);
     }
@@ -179,7 +179,7 @@ export class NiconicoService extends Service implements IPlatformService {
       return result;
     } catch (e) {
       // リトライは1回だけ
-      console.error('NiconicoService.setupStreamSettings(2)', e);
+      console.error('NiconicoService.setupStreamSettings(2)', e.toString());
       Sentry.addBreadcrumb({
         category: 'streaming',
         message: 'setupStreamSettings failed',
@@ -237,10 +237,10 @@ export class NiconicoService extends Service implements IPlatformService {
     key: string,
     quality?:
       | {
-          bitrate: number;
-          height: number;
-          fps: number;
-        }
+        bitrate: number;
+        height: number;
+        fps: number;
+      }
       | undefined,
   ): IStreamingSetting {
     return { url, key, quality };

--- a/main.js
+++ b/main.js
@@ -127,7 +127,7 @@ function devHostsTransformUrl(url) {
           return urlObj.toString();
         }
       }
-    } catch {}
+    } catch { }
   }
   return url;
 }
@@ -1325,14 +1325,23 @@ function initialize(crashHandler) {
      * @returns {Promise<import('./app/util/fetchViaMainProcess.ts').MainProcessFetchResponse>}
      * */
     async (_e, url, options) => {
-      const response = await fetch(url, options);
-      const text = await response.text();
-      return {
-        ok: response.ok,
-        headers: response.headers.entries(),
-        status: response.status,
-        text,
-      };
+      try {
+        const response = await fetch(url, options);
+        const text = await response.text();
+        return {
+          ok: response.ok,
+          headers: response.headers.entries(),
+          status: response.status,
+          text,
+        };
+      } catch (e) {
+        // cause チェーンとURLを文字列化してrendererに伝搬する
+        // (Electron の IPC シリアライズでは cause が失われるため)
+        const cause = e.cause
+          ? `${e.cause.name}: ${e.cause.message} (code: ${e.cause.code})`
+          : undefined;
+        throw new Error(`${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`);
+      }
     },
   );
 }


### PR DESCRIPTION
## このpull requestが解決する内容

`fetchIngestInfo` (PUT /unama/api/v4/ingest_info) が失敗した際、Sentry や console に記録されるエラーが原因不明だった問題を改善する。

## 背景

`fetchIngestInfo` は `Origin` ヘッダーが必要なため、renderer process から main process 経由（IPC: `ipcRenderer.invoke('fetch')`）で fetch を実行している。main process の Node.js undici が `TypeError: fetch failed` を throw する際、`cause` プロパティに具体的なネットワークエラー（`ECONNREFUSED`、`ETIMEDOUT`、TLSエラー等）が含まれているが、**Electron の IPC シリアライズでは `Error.cause` が失われ `[Error]` に丸まってしまう**。

さらに、IPC 経由で返ってきた Error オブジェクトは `console.error(e)` に渡すと `{}` と表示され内容が見えない問題もあった。

## 変更内容

### 1. `main.js`: fetch ハンドラに try-catch を追加

fetch 失敗時に `cause` チェーンとリクエスト URL を文字列化して再 throw することで、IPC を越えてエラー詳細を伝搬する。

**変更前のエラーメッセージ（Sentryに記録される内容）:**
```
Error invoking remote method 'fetch': TypeError: fetch failed
  cause: [Error]
```

**変更後:**
```
Error invoking remote method 'fetch': Error: fetch failed [url: https://live2.nicovideo.jp/unama/api/v4/ingest_info?nicoliveProgramId=lv..., cause: Error: connect ECONNREFUSED 127.0.0.1:443 (code: ECONNREFUSED)]
```

### 2. `niconico.ts`: `console.error` で `e.toString()` を使用

IPC 経由の Error オブジェクトは `console.error(e)` で `{}` と表示されるため、`e.toString()` に変更して内容を可視化する。

## テスト

- `fetchIngestInfo` が失敗する環境でエラーメッセージに URL と cause が含まれることを確認（ローカルで疑似エラーを発生させて検証済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)