### PR TITLE
追加: screen_capture (統合画面キャプチャ) ソースを有効化する

### DIFF
--- a/app/components/sources/SourcesShowcase.vue
+++ b/app/components/sources/SourcesShowcase.vue
@@ -165,6 +165,14 @@
         <MonitorCaptureIcon slot="media" />
       </add-source-info>
 
+      <add-source-info
+        v-if="inspectedSource === 'screen_capture'"
+        sourceType="screen_capture"
+        key="25"
+      >
+        <MonitorCaptureIcon slot="media" />
+      </add-source-info>
+
       <div class="source-info" v-if="inspectedSource === null">
         <div class="source-info__text">
           <h3>{{ $t('sources.sourcesWelcomeMessage') }}</h3>

--- a/app/components/studio/SourceSelector.vue.ts
+++ b/app/components/studio/SourceSelector.vue.ts
@@ -19,6 +19,7 @@ const sourceIconMap = {
   wasapi_output_capture: 'icon-speaker',
   monitor_capture: 'icon-display',
   game_capture: 'icon-game-capture',
+  screen_capture: 'icon-display',
   browser_source: 'icon-browser',
   scene: 'icon-studio-mode',
   color_source: 'icon-color',

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -298,6 +298,16 @@
       "name": "Placeholder Image"
     }
   },
+  "screen_capture": {
+    "name": "Screen Capture",
+    "description": "Capture your game, other applications, or your entire monitor.",
+    "capture_cursor": {
+      "name": "Capture Cursor"
+    },
+    "capture_source_list": {
+      "name": "Capture Target"
+    }
+  },
   "dshow_input": {
     "name": "WebCam / Video Input",
     "description": "Select from your build in USB webcam or an external.",

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -298,6 +298,16 @@
       "name": "プレースホルダー画像"
     }
   },
+  "screen_capture": {
+    "name": "スクリーンキャプチャ",
+    "description": "ゲーム、アプリケーション、またはモニター全体をキャプチャします。",
+    "capture_cursor": {
+      "name": "カーソルをキャプチャ"
+    },
+    "capture_source_list": {
+      "name": "キャプチャ対象"
+    }
+  },
   "dshow_input": {
     "name": "Webカメラ/映像入力機器",
     "description": "シーンに内蔵/外付けのWebカメラやキャプチャーボードを通したゲーム画面などを追加します。",

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -335,6 +335,7 @@ export class SourcesNode extends Node<ISchema, {}> {
               const sourceTypesWithAudio = [
                 'nair-rtvc-source',
                 'game_capture',
+                'screen_capture',
                 'wasapi_input_capture',
                 'wasapi_output_capture',
               ];

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -180,7 +180,7 @@ export class Scene {
     }
 
     this.scenesService.itemAdded.next(sceneItem.getModel());
-    if (source.type === 'monitor_capture' || source.type === 'game_capture') {
+    if (source.type === 'monitor_capture' || source.type === 'game_capture' || source.type === 'screen_capture') {
       this.fixupSceneItemWhenReady(sourceId, () => {
         const sceneItem = this.getItem(sceneItemId);
         sceneItem?.fitToScreen();

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -100,6 +100,7 @@ export type TSourceType =
   | 'monitor_capture'
   | 'window_capture'
   | 'game_capture'
+  | 'screen_capture'
   | 'dshow_input'
   | 'wasapi_input_capture'
   | 'wasapi_output_capture'

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -367,6 +367,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       'monitor_capture',
       'window_capture',
       'game_capture',
+      'screen_capture',
       'dshow_input',
       'wasapi_input_capture',
       'wasapi_output_capture',


### PR DESCRIPTION
## このpull requestが解決する内容

関連: #1224

統合画面キャプチャソース `screen_capture` をN AirのUIに追加します（ソース追加ダイアログへの表示まで）。

## 背景

`screen_capture` は Streamlabs が `stream-labs/obs-studio` フォークに独自追加した Windows 専用ソース（2021年9月）。`monitor_capture` + `window_capture` + `game_capture` を1つのUIで選択できる統合キャプチャソースです。

N Air が使用する osn 0.25.56 (LibOBS 30.2.4sl41) に既に含まれており、`win-capture.dll` バイナリ内への文字列存在と Streamlabs obs-studio フォーク (tag 30.2.4sl41) のソースコードで確認済み。TypeScript コード側で未登録だったためUIに表示されていませんでした。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `app/services/sources/sources-api.ts` | `TSourceType` に `'screen_capture'` 追加 |
| `app/services/sources/sources.ts` | `whitelistedTypes` に `'screen_capture'` 追加 |
| `app/components/sources/SourcesShowcase.vue` | ソース追加ダイアログに `<add-source-info>` ブロック追加 |
| `app/components/studio/SourceSelector.vue.ts` | アイコンマップに `screen_capture: 'icon-display'` 追加 |
| `app/i18n/ja-JP/source-props.json` | 日本語翻訳追加 |
| `app/i18n/en-US/source-props.json` | 英語翻訳追加 |
| `app/services/scenes/scene.ts` | fitToScreen 対象に `screen_capture` 追加 |
| `app/services/scene-collections/nodes/sources.ts` | `sourceTypesWithAudio` に `screen_capture` 追加 |

### 方針

- Streamlabs Desktop の専用 React UI (`ScreenCaptureProperties.tsx`) は移植せず、N Air 標準の OBS ネイティブプロパティダイアログを使用
- 既存の `monitor_capture` / `window_capture` / `game_capture` とは共存（置き換えなし）
- `default-manager.ts:112` が既に `screen_capture` を `game_capture` と同様に扱っており、auto_capture_rules（ゲームキャプチャリスト・プレースホルダー）が自動的に適用される

## 現状の課題（未解決）

実機確認の結果、ネイティブプロパティダイアログに「カーソルをキャプチャ」しか表示されず、**キャプチャ対象の選択ができない**。

### 原因（調査済み）

`capture_source_list` は `OBS_PROPERTY_CAPTURE` (`EPropertyType.Capture = 14`) という Streamlabs 独自のプロパティタイプで登録されている。osn 0.25.56 の `module.d.ts` には `EPropertyType.Capture` と `ICaptureProperty` が定義されているが、N Air の `getPropertiesFormData()` (`app/components/obs/inputs/ObsInput.ts`) の switch 文にこのケースがなく、プロパティがサイレントにスキップされる。

### 残作業

`capture_source_list` を操作できるようにするには以下が必要:

1. `ObsInput.ts` の switch に `EPropertyType.Capture` ケースを追加
2. `TObsType` に `'OBS_PROPERTY_CAPTURE'` を追加
3. `ObsCaptureInput.vue` コンポーネントを新規作成（キャプチャ候補は `ICaptureProperty` が公開しないため Electron の `desktopCapturer.getSources()` で自前取得）
4. `Components.ts` と `index.ts` に登録

または `screen_capture` 専用のカスタムプロパティ画面として実装する方法もある（Streamlabs の `ScreenCaptureProperties.tsx` 相当）。

このため本 PR は **draft のまま** 維持し、対応方針が決まってから続ける。

## 備考

- `obs.InputFactory.types()` が `screen_capture` を返さない場合は `whitelistedTypes` とのフィルタリングにより自動的に非表示になる（クラッシュしない）
- 新ビルドで保存した `screen_capture` を含むシーンは旧ビルドでは読み込めない（前方互換性の制約）

## テスト

- [x] ソース追加ダイアログに「スクリーンキャプチャ」が表示されることを確認
- [x] ネイティブプロパティダイアログが表示されることを確認（「カーソルをキャプチャ」のみ表示）
- [ ] キャプチャ対象選択の実装後に動作確認（未着手）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
