### PR TITLE
開発: ログアウトAPIをDELETE /v1/sessions/meに変更

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -11,9 +11,6 @@ export class HostsService extends Service {
     // dev-hosts config takes priority over DEV_SERVER localhost proxy
     if (isDevHosts()) return url;
     if (this.useDevServer) {
-      if (url.startsWith(this.niconicoAccount)) {
-        return url.replace(this.niconicoAccount, 'http://localhost:8080/account');
-      }
       if (url.startsWith(this.niconicoId)) {
         return url.replace(this.niconicoId, 'http://localhost:8080/id');
       }
@@ -25,9 +22,6 @@ export class HostsService extends Service {
       }
     }
     return url;
-  }
-  get niconicoAccount() {
-    return transformUrl('https://account.nicovideo.jp');
   }
   get niconicoId() {
     return transformUrl('https://api.id.nicovideo.jp');

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -1,6 +1,8 @@
+import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
 import { Inject } from 'services/core/injector';
 import { Service } from 'services/core/service';
+import { getCookieDomain, transformUrl } from 'services/dev-hosts';
 import { HostsService } from 'services/hosts';
 import { isOk, NicoliveClient } from 'services/nicolive-program/NicoliveClient';
 import { SettingsService } from 'services/settings';
@@ -8,7 +10,9 @@ import { EStreamingState, StreamingService } from 'services/streaming';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
 import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
+import { fetchViaMainProcess } from 'util/fetchViaMainProcess';
 import { authorizedHeaders, handleErrors } from 'util/requests';
+import { RequestError } from 'util/RequestError';
 import { sleep } from 'util/sleep';
 import { IPlatformService, IStreamingSetting } from '.';
 import { FrontendIdHeader } from './niconicoDefs';
@@ -52,17 +56,27 @@ export class NiconicoService extends Service implements IPlatformService {
 
   client: NicoliveClient = new NicoliveClient();
 
+  private sessionsMeParams(
+    method: string = 'GET',
+    extraHeaders?: Record<string, string>,
+  ): { url: string; init: RequestInit } {
+    const url = this.hostsService.replaceHost(`${this.hostsService.niconicoId}/v1/sessions/me`);
+    return {
+      url,
+      init: {
+        method,
+        credentials: 'same-origin',
+        headers: { ...FrontendIdHeader, ...extraHeaders },
+      },
+    };
+  }
+
   async getUserId(): Promise<string> {
     if (isFakeMode()) {
       return FakeUserAuth.platform.id; // dummy user ID
     }
-    const url = `${this.hostsService.niconicoId}/v1/sessions/me`;
-    const request = new Request(this.hostsService.replaceHost(url), {
-      credentials: 'same-origin',
-      headers: FrontendIdHeader,
-    });
-
-    const response = await fetch(request);
+    const { url, init } = this.sessionsMeParams();
+    const response = await fetch(url, init);
     if (response.status === 400 || response.status === 401) {
       return '';
     }
@@ -104,10 +118,26 @@ export class NiconicoService extends Service implements IPlatformService {
     if (isFakeMode()) {
       return;
     }
-    const url = `${this.hostsService.niconicoAccount}/logout`;
-    const request = new Request(this.hostsService.replaceHost(url), { credentials: 'same-origin' });
-    const response = await fetch(request);
-    await handleErrors(response);
+    const { session } = remote.getCurrentWebContents();
+    const cookies = await session.cookies.get({
+      url: `https://${getCookieDomain()}`,
+      name: 'user_session',
+    });
+    if (cookies.length < 1) {
+      return; // セッションクッキーがない場合はすでにログアウト済
+    }
+    const { url, init } = this.sessionsMeParams('DELETE', {
+      Origin: transformUrl('https://n-air-app.nicovideo.jp'),
+      Cookie: `user_session=${cookies[0].value}`,
+    });
+    const response = await fetchViaMainProcess(url, init);
+    Sentry.addBreadcrumb({
+      category: 'niconico',
+      message: `logout: ${response.status}`,
+    });
+    if (!response.ok) {
+      throw new RequestError(response.status, url, 'DELETE');
+    }
   }
 
   get authUrl() {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -196,7 +196,11 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     this.appService.startLoading();
 
     // TODO niconico専用なので抽象化する
-    getPlatformService('niconico').logout();
+    try {
+      await getPlatformService('niconico').logout();
+    } catch (e) {
+      console.warn('NiconicoService.logout failed:', e);
+    }
 
     await this.sceneCollectionsService.save();
 

--- a/app/util/RequestError.ts
+++ b/app/util/RequestError.ts
@@ -1,7 +1,7 @@
 // Sentry.captureException で内容が見えるようにするために Response ではなく Error にする
 export class RequestError extends Error {
-  constructor(public status: number, public url: string) {
-    super(`${status}`);
+  constructor(public status: number, public url: string, public method?: string) {
+    super(method ? `${method} ${status}` : `${status}`);
 
     this.name = new.target.name;
     Object.setPrototypeOf(this, new.target.prototype);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -156,12 +156,6 @@ module.exports = function (env, argv) {
         },
         proxy: [
           {
-            context: ['/account'],
-            target: 'https://account.nicovideo.jp',
-            changeOrigin: true,
-            pathRewrite: { '^/account': '' },
-          },
-          {
             context: ['/id'],
             target: 'https://api.id.nicovideo.jp',
             changeOrigin: true,


### PR DESCRIPTION
## このpull requestが解決する内容

`NiconicoService.logout()` が Webページ (`https://account.nicovideo.jp/logout`) を呼び出していた実装を、REST API (`DELETE /v1/sessions/me`) に変更します。

呼び替えにより `account.nicovideo.jp` を参照する箇所がなくなったため、関連する設定・コードも合わせて撤去しています。

## 変更内容

### `app/services/platforms/niconico.ts`

- `sessionsMeParams()` privateメソッドを追加し、`getUserId()`（GET）と`logout()`（DELETE）のURL・ヘッダー構築を共通化
- `logout()` を `DELETE /v1/sessions/me` に変更
  - main process経由のfetchを使用（`Origin` ヘッダーはrenderer processのforbidden headerのため）
  - `user_session` クッキーを明示的に付与（Node.js fetchはElectronセッションのクッキーを自動送信しないため）
  - Sentryブレッドクラムでレスポンスステータスを記録

### `app/services/hosts.ts`

- `niconicoAccount` getter と `replaceHost()` 内の対応する分岐を削除
  - `logout()` が唯一の使用箇所であり、呼び替えにより不要になった

### `webpack.config.js`

- devServer の `/account` → `https://account.nicovideo.jp` プロキシ設定を削除
  - `niconicoAccount` 削除に伴い不要になった

### `app/util/RequestError.ts`

- `method?: string` オプションパラメータを追加し、エラーメッセージに HTTPメソッドを含める（例: `DELETE 401`）

### `app/services/user.ts`

- `logout()` 呼び出しに `await` と `try/catch` を追加
  - 従来はfire-and-forgetでUnhandled Promiseエラーになっていた
  - エラー時は `console.warn` で記録しつつローカルのログアウト処理（クッキー削除等）は続行

## テスト

- [x] ログアウト操作でサーバー側セッションが正常に削除されることを確認
- [x] ユニットテスト (`pnpm run test:unit:app`) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)