### PR TITLE
追加: シーン切り替え時にソースがスムーズに移動する「モーション」を追加

### DIFF
--- a/app/components/settings/TransitionSettings.vue.ts
+++ b/app/components/settings/TransitionSettings.vue.ts
@@ -18,20 +18,22 @@ export default class SceneTransitions extends Vue {
 
   @Prop() transitionId: string;
 
-  // child window の Vuex sync が非同期のため、選択直後の表示ずれを防ぐ local state
-  pendingTypeValue: ETransitionType | null = null;
+  // child window の Vuex sync が非同期で typeModel computed が再評価されないため、
+  // local state で表示と双方向 bind し、setter で即座に更新する (properties と同じパターン)
+  // @ts-expect-error: ts2729: use before initialization
+  localType: ETransitionType = this.transition.type;
 
   get typeModel(): IObsListInput<ETransitionType> {
     return {
       description: $t('transitions.transitionType'),
       name: 'type',
-      value: this.pendingTypeValue ?? this.transition.type,
+      value: this.localType,
       options: this.transitionsService.getTypes(),
     };
   }
 
   set typeModel(model: IObsListInput<ETransitionType>) {
-    this.pendingTypeValue = model.value;
+    this.localType = model.value;
     this.transitionsService.changeTransitionType(this.transitionId, model.value);
     this.properties = this.transitionsService.getPropertiesFormData(this.transitionId);
   }

--- a/app/components/settings/TransitionSettings.vue.ts
+++ b/app/components/settings/TransitionSettings.vue.ts
@@ -18,16 +18,20 @@ export default class SceneTransitions extends Vue {
 
   @Prop() transitionId: string;
 
+  // child window の Vuex sync が非同期のため、選択直後の表示ずれを防ぐ local state
+  pendingTypeValue: ETransitionType | null = null;
+
   get typeModel(): IObsListInput<ETransitionType> {
     return {
       description: $t('transitions.transitionType'),
       name: 'type',
-      value: this.transition.type,
+      value: this.pendingTypeValue ?? this.transition.type,
       options: this.transitionsService.getTypes(),
     };
   }
 
   set typeModel(model: IObsListInput<ETransitionType>) {
+    this.pendingTypeValue = model.value;
     this.transitionsService.changeTransitionType(this.transitionId, model.value);
     this.properties = this.transitionsService.getPropertiesFormData(this.transitionId);
   }

--- a/app/components/settings/TransitionSettings.vue.ts
+++ b/app/components/settings/TransitionSettings.vue.ts
@@ -20,7 +20,6 @@ export default class SceneTransitions extends Vue {
 
   // child window の Vuex sync が非同期で typeModel computed が再評価されないため、
   // local state で表示と双方向 bind し、setter で即座に更新する (properties と同じパターン)
-  // @ts-expect-error: ts2729: use before initialization
   localType: ETransitionType = this.transition.type;
 
   get typeModel(): IObsListInput<ETransitionType> {

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -547,5 +547,9 @@
   "ffmpeg_source_replay": {
     "name": "Replay playback",
     "description": "Add a replay playback source to your scene."
+  },
+  "motion_transition": {
+    "bezier_x": { "name": "Acceleration (x-axis)" },
+    "bezier_y": { "name": "Acceleration (y-axis)" }
   }
 }

--- a/app/i18n/en-US/transitions.json
+++ b/app/i18n/en-US/transitions.json
@@ -7,6 +7,7 @@
   "fade_to_color_transition": "Fade to Color",
   "wipe_transition": "Luma Wipe",
   "obs_stinger_transition": "Stinger",
+  "motion_transition": "Motion",
   "transitionName": "名前",
   "transitionType": "Transition",
   "duration": "Duration",

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -547,5 +547,9 @@
   "ffmpeg_source_replay": {
     "name": "リプレイ録画の再生",
     "description": "シーンにリプレイ録画の再生を追加します。"
+  },
+  "motion_transition": {
+    "bezier_x": { "name": "加速度 (X軸)" },
+    "bezier_y": { "name": "加速度 (Y軸)" }
   }
 }

--- a/app/i18n/ja-JP/transitions.json
+++ b/app/i18n/ja-JP/transitions.json
@@ -7,6 +7,7 @@
   "fade_to_color_transition": "カラーフェード",
   "wipe_transition": "ルミナンスワイプ",
   "obs_stinger_transition": "スティンガー",
+  "motion_transition": "モーション",
   "transitionName": "名前",
   "transitionType": "種類",
   "duration": "時間（ミリ秒）",

--- a/app/services/scene-collections/nodes/transitions.test.ts
+++ b/app/services/scene-collections/nodes/transitions.test.ts
@@ -1,0 +1,205 @@
+jest.mock('electron', () => ({}));
+jest.mock('@electron/remote', () => ({}));
+jest.mock('services/core/injector', () => ({
+  Inject: () => () => {},
+}));
+jest.mock('services/transitions', () => ({
+  ETransitionType: {
+    Cut: 'cut_transition',
+    Fade: 'fade_transition',
+    Swipe: 'swipe_transition',
+    Slide: 'slide_transition',
+    FadeToColor: 'fade_to_color_transition',
+    LumaWipe: 'wipe_transition',
+    Stinger: 'obs_stinger_transition',
+    Motion: 'motion_transition',
+  },
+  TransitionsService: class {},
+}));
+jest.mock('components/obs/inputs/ObsInput', () => ({}));
+jest.mock('@sentry/vue', () => ({
+  withScope: jest.fn(),
+}));
+
+import { TransitionsNode } from './transitions';
+
+function createMockService(transitionOverrides: any[] = []) {
+  return {
+    state: {
+      transitions: transitionOverrides,
+      connections: [] as any[],
+      defaultTransitionId: transitionOverrides[0]?.id ?? null,
+    },
+    getSettings: jest.fn().mockReturnValue({}),
+    getPropertiesManagerSettings: jest.fn().mockReturnValue({}),
+    deleteAllTransitions: jest.fn(),
+    createTransition: jest.fn(),
+    deleteAllConnections: jest.fn(),
+    addConnection: jest.fn(),
+    setDefaultTransition: jest.fn(),
+  };
+}
+
+function createNode(mockService: ReturnType<typeof createMockService>) {
+  const node = new TransitionsNode();
+  (node as any).transitionsService = mockService;
+  return node;
+}
+
+describe('TransitionsNode save()', () => {
+  test('レガシー型(Cut)はそのまま type フィールドに保存し typeV2 は付けない', async () => {
+    const service = createMockService([
+      { id: 'id1', name: 'Global Transition', type: 'cut_transition', duration: 300 },
+    ]);
+    const node = createNode(service);
+
+    await node.save();
+
+    const saved = (node as any).data.transitions[0];
+    expect(saved.type).toBe('cut_transition');
+    expect(saved.typeV2).toBeUndefined();
+  });
+
+  test('レガシー型(Fade)はそのまま type フィールドに保存し typeV2 は付けない', async () => {
+    const service = createMockService([
+      { id: 'id1', name: 'Fade', type: 'fade_transition', duration: 500 },
+    ]);
+    const node = createNode(service);
+
+    await node.save();
+
+    const saved = (node as any).data.transitions[0];
+    expect(saved.type).toBe('fade_transition');
+    expect(saved.typeV2).toBeUndefined();
+  });
+
+  test('非レガシー型(Motion)は type=cut、typeV2=motion_transition で保存する', async () => {
+    const service = createMockService([
+      { id: 'id1', name: 'Motion', type: 'motion_transition', duration: 300 },
+    ]);
+    const node = createNode(service);
+
+    await node.save();
+
+    const saved = (node as any).data.transitions[0];
+    expect(saved.type).toBe('cut_transition');
+    expect(saved.typeV2).toBe('motion_transition');
+  });
+
+  test('複数 transition が混在するとき各々が正しく分類される', async () => {
+    const service = createMockService([
+      { id: 'id1', name: 'Cut', type: 'cut_transition', duration: 300 },
+      { id: 'id2', name: 'Motion', type: 'motion_transition', duration: 500 },
+      { id: 'id3', name: 'Fade', type: 'fade_transition', duration: 400 },
+    ]);
+    const node = createNode(service);
+
+    await node.save();
+
+    const saved = (node as any).data.transitions;
+    expect(saved[0].type).toBe('cut_transition');
+    expect(saved[0].typeV2).toBeUndefined();
+    expect(saved[1].type).toBe('cut_transition');
+    expect(saved[1].typeV2).toBe('motion_transition');
+    expect(saved[2].type).toBe('fade_transition');
+    expect(saved[2].typeV2).toBeUndefined();
+  });
+});
+
+describe('TransitionsNode load()', () => {
+  test('typeV2 なしのデータは type フィールドの値で createTransition する', async () => {
+    const service = createMockService();
+    const node = createNode(service);
+    (node as any).data = {
+      transitions: [{ id: 'id1', name: 'Fade', type: 'fade_transition', duration: 500, settings: {} }],
+      connections: [],
+      defaultTransitionId: 'id1',
+    };
+
+    await node.load();
+
+    expect(service.createTransition).toHaveBeenCalledWith(
+      'fade_transition',
+      'Fade',
+      expect.objectContaining({ id: 'id1', duration: 500 }),
+    );
+  });
+
+  test('typeV2 があるデータは typeV2 の値で createTransition する', async () => {
+    const service = createMockService();
+    const node = createNode(service);
+    (node as any).data = {
+      transitions: [
+        {
+          id: 'id1',
+          name: 'Motion',
+          type: 'cut_transition',
+          typeV2: 'motion_transition',
+          duration: 300,
+          settings: {},
+        },
+      ],
+      connections: [],
+      defaultTransitionId: 'id1',
+    };
+
+    await node.load();
+
+    expect(service.createTransition).toHaveBeenCalledWith(
+      'motion_transition',
+      'Motion',
+      expect.objectContaining({ id: 'id1', duration: 300 }),
+    );
+  });
+
+  test('typeV2 が将来の未知型のとき createTransition にそのまま渡す(service 側でフォールバック)', async () => {
+    // createTransition 内の静的 enum フォールバックが Cut に落とす。
+    // このテストは node が typeV2 をそのまま渡すことを保証する。
+    const service = createMockService();
+    const node = createNode(service);
+    (node as any).data = {
+      transitions: [
+        {
+          id: 'id1',
+          name: 'Future',
+          type: 'cut_transition',
+          typeV2: 'future_unknown_transition',
+          duration: 300,
+          settings: {},
+        },
+      ],
+      connections: [],
+      defaultTransitionId: 'id1',
+    };
+
+    await node.load();
+
+    expect(service.createTransition).toHaveBeenCalledWith(
+      'future_unknown_transition',
+      'Future',
+      expect.any(Object),
+    );
+  });
+
+  test('save → load の round-trip で Motion 型が復元される', async () => {
+    const service = createMockService([
+      { id: 'id1', name: 'Motion', type: 'motion_transition', duration: 300 },
+    ]);
+    const node = createNode(service);
+
+    await node.save();
+
+    // save 後のデータを別ノードで load
+    const node2 = createNode(createMockService());
+    (node2 as any).data = (node as any).data;
+    const service2 = (node2 as any).transitionsService;
+
+    await node2.load();
+
+    expect(service2.createTransition).toHaveBeenCalledWith(
+      'motion_transition',
+      'Motion',
+      expect.objectContaining({ id: 'id1', duration: 300 }),
+    );
+  });
+});

--- a/app/services/scene-collections/nodes/transitions.ts
+++ b/app/services/scene-collections/nodes/transitions.ts
@@ -3,10 +3,25 @@ import { Inject } from 'services/core/injector';
 import { ETransitionType, TransitionsService } from 'services/transitions';
 import { Node } from './node';
 
+// motion_transition 追加前から存在していた型。旧フィールド(type)に書いても旧バージョンが安全に読める。
+// 新しい型を追加する際はここに追加しないこと — 旧版互換 fallback の意味が失われる。
+const LEGACY_COMPATIBLE_TYPES = new Set<string>([
+  'cut_transition',
+  'fade_transition',
+  'swipe_transition',
+  'slide_transition',
+  'fade_to_color_transition',
+  'wipe_transition',
+  'obs_stinger_transition',
+]);
+
 interface ITransition {
   id: string;
   name: string;
+  // 旧バージョン互換フィールド: 常にレガシー互換型(cut 等)を入れる。新型は typeV2 を使う。
   type: ETransitionType;
+  // 新型(motion 等)を保存するフィールド。旧バージョンは無視するため破壊的変更なし。
+  typeV2?: string;
   duration: number;
   settings: Dictionary<TObsValue>;
   propertiesManagerSettings?: Dictionary<any>;
@@ -36,10 +51,13 @@ export class TransitionsNode extends Node<ISchema, {}> {
   async save() {
     this.data = {
       transitions: this.transitionsService.state.transitions.map(transition => {
+        const actualType = transition.type;
+        const isLegacy = LEGACY_COMPATIBLE_TYPES.has(actualType);
         return {
           id: transition.id,
           name: transition.name,
-          type: transition.type,
+          type: isLegacy ? actualType : ETransitionType.Cut,
+          ...(isLegacy ? {} : { typeV2: actualType }),
           duration: transition.duration,
           settings: this.transitionsService.getSettings(transition.id),
           propertiesManagerSettings: this.transitionsService.getPropertiesManagerSettings(
@@ -62,7 +80,8 @@ export class TransitionsNode extends Node<ISchema, {}> {
     // Double check we are starting from a blank state
     this.transitionsService.deleteAllTransitions();
     this.data.transitions.forEach(transition => {
-      this.transitionsService.createTransition(transition.type, transition.name, {
+      const type = (transition.typeV2 ?? transition.type) as ETransitionType;
+      this.transitionsService.createTransition(type, transition.name, {
         id: transition.id,
         duration: transition.duration,
         settings: transition.settings,

--- a/app/services/scene-collections/nodes/transitions.ts
+++ b/app/services/scene-collections/nodes/transitions.ts
@@ -21,7 +21,7 @@ interface ITransition {
   // 旧バージョン互換フィールド: 常にレガシー互換型(cut 等)を入れる。新型は typeV2 を使う。
   type: ETransitionType;
   // 新型(motion 等)を保存するフィールド。旧バージョンは無視するため破壊的変更なし。
-  typeV2?: string;
+  typeV2?: ETransitionType;
   duration: number;
   settings: Dictionary<TObsValue>;
   propertiesManagerSettings?: Dictionary<any>;
@@ -80,7 +80,7 @@ export class TransitionsNode extends Node<ISchema, {}> {
     // Double check we are starting from a blank state
     this.transitionsService.deleteAllTransitions();
     this.data.transitions.forEach(transition => {
-      const type = (transition.typeV2 ?? transition.type) as ETransitionType;
+      const type = transition.typeV2 ?? transition.type;
       this.transitionsService.createTransition(type, transition.name, {
         id: transition.id,
         duration: transition.duration,

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import { IObsListOption, TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { Subject } from 'rxjs';
 import { Inject } from 'services/core/injector';
@@ -285,6 +286,20 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   }
 
   createTransition(type: ETransitionType, name: string, options: ITransitionCreateOptions = {}) {
+    // 旧バージョンで開いた際に未知の transition type が保存されているケースのフォールバック。
+    // 静的 enum でチェックする (動的な obs.TransitionFactory.types() だと init timing で空を返し、
+    // 既知 type まで Cut に誤変換される問題があるため)。
+    const knownTypes: string[] = Object.values(ETransitionType);
+    if (!knownTypes.includes(type)) {
+      console.warn(`Unknown transition type "${type}", falling back to Cut`);
+      Sentry.withScope(scope => {
+        scope.setLevel('warning');
+        scope.setExtra('unknownType', type);
+        scope.setExtra('name', name);
+        Sentry.captureMessage('Unknown transition type, falling back to Cut');
+      });
+      type = ETransitionType.Cut;
+    }
     const id = options.id || uuidv4();
     const transition = obs.TransitionFactory.create(type, id, options.settings || {});
     const manager = new DefaultManager(transition, options.propertiesManagerSettings || {});

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -285,9 +285,6 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   }
 
   createTransition(type: ETransitionType, name: string, options: ITransitionCreateOptions = {}) {
-    if (!this.getTypes().find(t => t.value === type)) {
-      type = ETransitionType.Cut;
-    }
     const id = options.id || uuidv4();
     const transition = obs.TransitionFactory.create(type, id, options.settings || {});
     const manager = new DefaultManager(transition, options.propertiesManagerSettings || {});

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -19,6 +19,7 @@ export enum ETransitionType {
   FadeToColor = 'fade_to_color_transition',
   LumaWipe = 'wipe_transition',
   Stinger = 'obs_stinger_transition',
+  Motion = 'motion_transition',
 }
 
 interface ITransitionsState {
@@ -98,7 +99,7 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   }
 
   getTypes(): IObsListOption<ETransitionType>[] {
-    return [
+    const allTypes: IObsListOption<ETransitionType>[] = [
       { description: $t('transitions.cut_transition'), value: ETransitionType.Cut },
       { description: $t('transitions.fade_transition'), value: ETransitionType.Fade },
       { description: $t('transitions.swipe_transition'), value: ETransitionType.Swipe },
@@ -109,7 +110,10 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
       },
       { description: $t('transitions.wipe_transition'), value: ETransitionType.LumaWipe },
       { description: $t('transitions.obs_stinger_transition'), value: ETransitionType.Stinger },
+      { description: $t('transitions.motion_transition'), value: ETransitionType.Motion },
     ];
+    const obsAvailableTypes = obs.TransitionFactory.types();
+    return allTypes.filter(t => obsAvailableTypes.includes(t.value));
   }
 
   enableStudioMode() {
@@ -281,6 +285,9 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   }
 
   createTransition(type: ETransitionType, name: string, options: ITransitionCreateOptions = {}) {
+    if (!this.getTypes().find(t => t.value === type)) {
+      type = ETransitionType.Cut;
+    }
     const id = options.id || uuidv4();
     const transition = obs.TransitionFactory.create(type, id, options.settings || {});
     const manager = new DefaultManager(transition, options.propertiesManagerSettings || {});


### PR DESCRIPTION
## このpull requestが解決する内容

`motion-transition.dll` とデータファイルは obs-studio-node に同梱済みだが、`ETransitionType` に未登録のため UI に表示されていなかった。登録を追加して有効化する。

Closes #1222

## モーショントランジションとは

シーン切り替え時に、**両シーンに共通して存在するソースの位置・サイズ変化をアニメーション**するトランジション効果。

例: シーン A とシーン B に同じソースがあり、それぞれ異なる位置・サイズで配置されている場合、切り替え時にソースがスムーズに移動・リサイズされる。

設定パラメータ:
- 加速度 X軸 / Y軸 (bezier_x / bezier_y): -5.0 〜 5.0 の範囲で動きの加速を調整

OBS Studio では "Move Transition" プラグインとして人気が高い機能。

## 画面イメージ

<img width="1201" height="976" alt="image" src="https://github.com/user-attachments/assets/e6471503-ef03-491b-a23e-3036a83dedbf" />

## 変更内容

### `app/services/transitions.ts`
- `ETransitionType` に `Motion = 'motion_transition'` を追加
- `getTypes()` に `obs.TransitionFactory.types()` との交差フィルタを導入（`source-filters.ts` と同パターン、DLL が存在しない環境でも安全に動作）
- 未知 transition type に対する起動時フォールバックを追加（backward compatibility）
  - 新しい type を含むシーンコレクションを、その type を知らない旧バージョンで開くと `obs.TransitionFactory.create()` が無効 transition を返し、シーン切替時にクラッシュや映像停止が起き得る
  - `Object.values(ETransitionType)`（静的 enum）でチェックし、未知 type は `cut_transition` にフォールバック
  - `console.warn` + Sentry（warning レベル）で実環境での発生を検知できるようにした
  - ※ 初版では動的な `getTypes()` ベースのフォールバックを実装したが、OBS 型リストが init timing で空の場合に既知 type まで Cut に誤変換される副作用があったため撤去し、静的 enum ベースに差し替えた

### `app/components/settings/TransitionSettings.vue.ts`
- 「種類」combo box で選択しても表示が更新されない不具合を修正
  - 設定ウィンドウは子ウィンドウで、サービス呼び出しは `@electron/remote` 経由でメインプロセスで実行される。Vuex mutation は子ウィンドウへ IPC 非同期ブロードキャストされるため、setter 直後の再レンダー時点で `this.transition.type` がまだ古い値のままになっていた
  - `localType: ETransitionType = this.transition.type` を local state として持ち、setter で即座に更新する。既存の `properties` field と同じパターン

### `app/services/scene-collections/nodes/transitions.ts`
- シーンコレクションの保存形式を下位互換に変更
  - レガシー互換型（Cut/Fade/Swipe/Slide/FadeToColor/LumaWipe/Stinger）は従来通り `type` フィールドに保存
  - 新型（Motion 等）は `type` に `cut_transition` を書き、実際の型を新フィールド `typeV2` に保存
  - 旧バージョンは `typeV2` を無視して `type=cut_transition` として読むため、**このPRより前のバージョンでもクラッシュせず Cut として動作する**
  - 新バージョンは `typeV2 ?? type` で正しい型を復元する
  - 旧形式（`typeV2` なしで `type=motion_transition`）で保存されたコレクションも正しく読み込め、次回保存時に新形式へ自動正規化される

### i18n
- `transitions.json` (ja-JP / en-US): `motion_transition` のトランジション名を追加
- `source-props.json` (ja-JP / en-US): プロパティの翻訳を追加
  - `bezier_x` → "加速度 (X軸)" / "Acceleration (x-axis)"
  - `bezier_y` → "加速度 (Y軸)" / "Acceleration (y-axis)"
  - ※ INI キー名 (`Acceleration.X/Y`) と実際の OBS プロパティ名 (`bezier_x/y`) は異なる

## 旧バージョンとの互換性について

このPRで保存した（`typeV2` 付き）シーンコレクションをこのPRより前のバージョンで開いた場合:

- `typeV2` フィールドは無視され、`type=cut_transition` として読み込まれる → **クラッシュせず Cut として動作する**
- ただし Motion 設定は失われ、「カット」で再生される
- シーンコレクションは自動保存（起動中 60 秒ごと・終了時・コレクション切替時）されるため、旧バージョンで開いた時点で `typeV2` は自動的に上書き消去される。**旧バージョンで一度開くと Motion 設定は失われる**

## OBS からの設定インポートについて

`app/services/obs-importer.ts` の `importTransitions()` も `transitionsService.createTransition()` を経由するため、上記フォールバックと同じ保護が効く。

- OBS 側で `motion_transition` が設定されていれば N Air にそのまま取り込まれる
- N Air が知らない OBS 独自の transition type が来た場合も Cut にフォールバックし、Sentry に warning が記録される

## 調査結果

- **GenericForm で動作**: Streamlabs Desktop でも motion_transition は GenericForm をそのまま使用しており、専用 UI は不要だった（issue #1224 の screen_capture とは異なる）
- **プロパティ翻訳**: `source-props.json` の既存の仕組み (`source-props.${sourceType}['${propName}'].name`) でアプリ側から翻訳できる。ini ファイルの配置は不要
- **motion-filter は利用不可**: `motion-transition.dll` はトランジション型のみを登録しており、フィルター型は含まれていない (`obs.FilterFactory.types()` で未確認)

## テスト

- [x] シーン切り替え設定のドロップダウンに「モーション」が表示される
- [x] モーショントランジションのプロパティが日本語で表示される（加速度 X軸/Y軸）
- [x] シーンを複製してアイテムの位置をずらし、モーショントランジション設定後にシーンを交互に切り替えるとアイテムがスムーズに移動することを確認
- [x] 「種類」を切り替えると combo box 表示が即座に新しい値に反映される
- [x] モーション ⇄ カット ⇄ その他 を行き来しても combo box 表示とプロパティ欄が整合する
- [x] シーンコレクション保存/読み込みでモーショントランジションが永続化されることを確認
- [x] シーンコレクション JSON に `type=cut_transition, typeV2=motion_transition` が保存されることを確認
- [x] 既存のトランジション（カット、フェード等）が引き続き正常に動作することを確認
- [x] ユニットテスト: save/load round-trip・typeV2 分離・旧フォーマット読み込みの動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
