### PR TITLE
修正: AMDエンコーダー使用時のニコニコ最適化が毎回失敗していた問題を修正

### DIFF
--- a/app/services/settings/__snapshots__/optimizer.test.ts.snap
+++ b/app/services/settings/__snapshots__/optimizer.test.ts.snap
@@ -117,6 +117,20 @@ exports[`filterKeyDescriptions 1`] = `
                   "jim_nvenc",
                 ],
               },
+              {
+                "params": [
+                  {
+                    "category": "Output",
+                    "key": "simpleUseAdvanced",
+                    "lookupValueName": true,
+                    "setting": "UseAdvanced",
+                    "subCategory": "Streaming",
+                  },
+                ],
+                "values": [
+                  "amd",
+                ],
+              },
             ],
             "key": "encoder",
             "lookupValueName": true,

--- a/app/services/settings/niconico-optimization.test.ts
+++ b/app/services/settings/niconico-optimization.test.ts
@@ -1,11 +1,11 @@
 import { TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { getBestSettingsForNiconico } from './niconico-optimization';
 import {
-    EncoderFamily,
-    ISettingsAccessor,
-    OptimizationKey,
-    OptimizeSettings,
-    SettingsKeyAccessor,
+  EncoderFamily,
+  ISettingsAccessor,
+  OptimizationKey,
+  OptimizeSettings,
+  SettingsKeyAccessor,
 } from './optimizer';
 import { ISettingsSubCategory } from './settings-api';
 
@@ -188,4 +188,5 @@ describe('getBestSettingsForNiconico', () => {
       audioBitrate: '192',
       videoBitrate: 6000 - 192,
     });
-  }); });
+  });
+});

--- a/app/services/settings/niconico-optimization.test.ts
+++ b/app/services/settings/niconico-optimization.test.ts
@@ -1,11 +1,11 @@
 import { TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 import { getBestSettingsForNiconico } from './niconico-optimization';
 import {
-  EncoderFamily,
-  ISettingsAccessor,
-  OptimizationKey,
-  OptimizeSettings,
-  SettingsKeyAccessor,
+    EncoderFamily,
+    ISettingsAccessor,
+    OptimizationKey,
+    OptimizeSettings,
+    SettingsKeyAccessor,
 } from './optimizer';
 import { ISettingsSubCategory } from './settings-api';
 
@@ -33,6 +33,30 @@ const outputSettings: ISettingsSubCategory[] = [
         description: 'StreamEncoder',
         value: 'qsv',
         options: [{ value: 'qsv', description: 'qsv' }],
+      },
+    ],
+  },
+];
+
+const outputSettingsAmd: ISettingsSubCategory[] = [
+  {
+    nameSubCategory: 'Untitled',
+    parameters: [
+      {
+        name: 'Mode',
+        description: 'outputMode',
+        value: 'Simple',
+      },
+    ],
+  },
+  {
+    nameSubCategory: 'Streaming',
+    parameters: [
+      {
+        name: 'StreamEncoder',
+        description: 'StreamEncoder',
+        value: 'amd',
+        options: [{ value: 'amd', description: 'amd' }],
       },
     ],
   },
@@ -74,7 +98,17 @@ test('mock outputSettings', () => {
 });
 
 describe('getBestSettingsForNiconico', () => {
+  class MockSettingAccessorAmd extends MockSettingAccessor {
+    getSettingsFormData(categoryName: string): ISettingsSubCategory[] {
+      if (categoryName === 'Output') {
+        return outputSettingsAmd;
+      }
+      return [];
+    }
+  }
+
   const accessor = new SettingsKeyAccessor(new MockSettingAccessor());
+  const accessorAmd = new SettingsKeyAccessor(new MockSettingAccessorAmd());
   const commonSettings: Partial<OptimizeSettings> = {
     simpleUseAdvanced: true,
     audioSampleRate: 48000,
@@ -91,6 +125,11 @@ describe('getBestSettingsForNiconico', () => {
     ...commonSettings,
     encoder: EncoderFamily.qsv,
     targetUsage: 'speed',
+  };
+  const amdSettings: Partial<OptimizeSettings> = {
+    ...commonSettings,
+    simpleUseAdvanced: false,
+    encoder: EncoderFamily.amd,
   };
 
   test.each([
@@ -138,4 +177,15 @@ describe('getBestSettingsForNiconico', () => {
       expect(settings).toEqual(shouldBe);
     },
   );
-});
+  test('AMD encoder is selected when available', () => {
+    const settings = getBestSettingsForNiconico(
+      { bitrate: 6000, height: 1080, fps: 30 },
+      accessorAmd,
+    );
+    expect(settings).toEqual({
+      ...amdSettings,
+      quality: '1920x1080',
+      audioBitrate: '192',
+      videoBitrate: 6000 - 192,
+    });
+  }); });

--- a/app/services/settings/optimizer.test.ts
+++ b/app/services/settings/optimizer.test.ts
@@ -1,12 +1,12 @@
 import {
-    AllKeyDescriptions,
-    EncoderFamily,
-    filterKeyDescriptions,
-    iterateKeyDescriptions,
-    OptimizationKey,
-    Optimizer,
-    OptimizeSettings,
-    SettingsKeyAccessor,
+  AllKeyDescriptions,
+  EncoderFamily,
+  filterKeyDescriptions,
+  iterateKeyDescriptions,
+  OptimizationKey,
+  Optimizer,
+  OptimizeSettings,
+  SettingsKeyAccessor,
 } from './optimizer';
 type ISettingsSubCategory = import('./settings-api').ISettingsSubCategory;
 jest.mock('./settings-api');

--- a/app/services/settings/optimizer.test.ts
+++ b/app/services/settings/optimizer.test.ts
@@ -1,12 +1,12 @@
 import {
-  AllKeyDescriptions,
-  EncoderFamily,
-  filterKeyDescriptions,
-  iterateKeyDescriptions,
-  OptimizationKey,
-  Optimizer,
-  OptimizeSettings,
-  SettingsKeyAccessor,
+    AllKeyDescriptions,
+    EncoderFamily,
+    filterKeyDescriptions,
+    iterateKeyDescriptions,
+    OptimizationKey,
+    Optimizer,
+    OptimizeSettings,
+    SettingsKeyAccessor,
 } from './optimizer';
 type ISettingsSubCategory = import('./settings-api').ISettingsSubCategory;
 jest.mock('./settings-api');
@@ -135,6 +135,33 @@ test('iterateKeyDescriptions', () => {
     [OptimizationKey.encoder, 'StreamEncoder'],
     [OptimizationKey.simpleUseAdvanced, 'UseAdvanced'],
     [OptimizationKey.encoderPreset, 'Preset'],
+    [OptimizationKey.audioBitrate, 'ABitrate'],
+    [OptimizationKey.quality, 'Output'],
+    [OptimizationKey.fpsType, 'FPSType'],
+    [OptimizationKey.fpsCommon, 'FPSCommon'],
+  ]);
+});
+
+test('iterateKeyDescriptions: AMD encoder', () => {
+  const best: OptimizeSettings = {
+    outputMode: 'Simple',
+    videoBitrate: 5808,
+    audioBitrate: '192',
+    quality: '1280x720',
+    fpsType: 'Common FPS Values',
+    fpsCommon: '30',
+    encoder: EncoderFamily.amd,
+    simpleUseAdvanced: false,
+  };
+  const pairs = [...iterateKeyDescriptions(best, AllKeyDescriptions)].map(desc => [
+    desc.key,
+    desc.setting,
+  ]);
+  expect(pairs).toEqual([
+    [OptimizationKey.outputMode, 'Mode'],
+    [OptimizationKey.videoBitrate, 'VBitrate'],
+    [OptimizationKey.encoder, 'StreamEncoder'],
+    [OptimizationKey.simpleUseAdvanced, 'UseAdvanced'],
     [OptimizationKey.audioBitrate, 'ABitrate'],
     [OptimizationKey.quality, 'Output'],
     [OptimizationKey.fpsType, 'FPSType'],

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -374,6 +374,18 @@ export const AllKeyDescriptions: KeyDescription[] = [
                   },
                 ],
               },
+              {
+                values: ['amd'],
+                params: [
+                  {
+                    key: OptimizationKey.simpleUseAdvanced,
+                    category: 'Output',
+                    subCategory: 'Streaming',
+                    setting: 'UseAdvanced',
+                    lookupValueName: true,
+                  },
+                ],
+              },
             ],
           },
           {


### PR DESCRIPTION
## 問題

AMDエンコーダーを使用している環境でニコニコ最適化を実行すると、
毎回 Sentry に以下のエラーが送信されていた。

- `optimizeForNiconico: optimization setting is not set perfectly` (warning × 4回)
- `optimizeForNiconico: 最適化リトライ満了したが設定できなかった` (error)

## 原因

`optimizer.ts` の `AllKeyDescriptions` の Simple モードの `StreamEncoder` の
`dependents` に `'amd'` のエントリが存在しなかった。

そのため `getBestSettingsForNiconico()` が返す `simpleUseAdvanced: false` が
`iterateKeyDescriptions` で処理されず、`UseAdvanced` 設定への書き込みがスキップされ、
最適化後の差分チェックで永遠に不一致と判定されていた。

## 修正

`AllKeyDescriptions` の Simple モード `StreamEncoder` の `dependents` に
`'amd'` → `simpleUseAdvanced`(`UseAdvanced`) のエントリを追加した。

## テスト

- `iterateKeyDescriptions` に AMD エンコーダーのケースを追加
- `getBestSettingsForNiconico` に AMD エンコーダーが選択されるケースを追加
