### PR TITLE
修正: インフォ一覧が、RSSフィードが空だったときにエラー表示になる問題を修正

### DIFF
--- a/app/services/informations/informations.test.ts
+++ b/app/services/informations/informations.test.ts
@@ -40,6 +40,19 @@ const setup = createSetupFunction({
   },
 });
 
+test('pluckItems: itemあり', () => {
+  const { InformationsService } = require('./informations');
+  const feedResult = {
+    rss: { channel: [{ item: [{ title: ['t'], link: ['u'], pubDate: ['Mon, 01 Jan 2024 00:00:00 GMT'] }] }] },
+  };
+  expect(InformationsService.pluckItems(feedResult)).toHaveLength(1);
+});
+
+test('pluckItems: itemなし（空フィード）', () => {
+  const { InformationsService } = require('./informations');
+  expect(InformationsService.pluckItems({ rss: { channel: [{}] } })).toEqual([]);
+});
+
 test('get instance', () => {
   setup();
   const { InformationsService } = require('./informations');
@@ -150,6 +163,26 @@ test('updateInformations:失敗', async () => {
   expect((instance as any).SET_HAS_ERROR).toHaveBeenNthCalledWith(1, false);
   expect((instance as any).SET_HAS_ERROR).toHaveBeenNthCalledWith(2, true);
   expect((instance as any).SET_INFORMATIONS).not.toHaveBeenCalled();
+});
+
+test('updateInformations:item欠落（空フィード）', async () => {
+  setup();
+  const m = require('./informations');
+
+  m.InformationsService.prototype.afterInit = jest.fn();
+  const instance = m.InformationsService.instance;
+  expect(instance.afterInit).toHaveBeenCalledTimes(1);
+
+  // item を持たないフィード
+  (instance as any).fetchFeed = jest.fn().mockResolvedValue({ rss: { channel: [{}] } });
+  (instance as any).SET_HAS_ERROR = jest.fn();
+  (instance as any).SET_INFORMATIONS = jest.fn();
+
+  await expect(instance.updateInformations()).resolves.toBeUndefined();
+  expect((instance as any).SET_HAS_ERROR).toHaveBeenCalledTimes(1);
+  expect((instance as any).SET_HAS_ERROR).toHaveBeenNthCalledWith(1, false);
+  expect((instance as any).SET_INFORMATIONS).toHaveBeenCalledTimes(1);
+  expect((instance as any).SET_INFORMATIONS).toHaveBeenNthCalledWith(1, []);
 });
 
 test('hasUnseenItem:あるとき', () => {

--- a/app/services/informations/informations.ts
+++ b/app/services/informations/informations.ts
@@ -23,7 +23,9 @@ function parseXml(xml: String): Promise<object> {
 }
 
 function pluckItems(feedResult: any) {
-  return feedResult.rss.channel[0].item.map((i: any) => ({
+  const items = feedResult?.rss?.channel?.[0]?.item;
+  if (!items) return [];
+  return items.map((i: any) => ({
     title: i.title[0],
     url: i.link[0],
     date: Date.parse(i.pubDate[0]),


### PR DESCRIPTION
## このpull requestが解決する内容

`InformationsService.pluckItems` で RSS フィードに `<item>` が含まれない場合、`feedResult.rss.channel[0].item` が `undefined` となり `.map()` で TypeError が発生する問題を修正します。

Sentry issue: [N-AIR-APP-G2K](https://n-air-app2.sentry.io/issues/7475304122/)（255 events / 164 users、2026/5/12 発生）

## 背景

`https://blog.nicovideo.jp/niconews/category/se_n-air/feed/index.xml` が一時的に `<item>` を含まない空フィードを返したため多発しました。`updateInformations` の try/catch で拾われるものの `hasError=true` になりインフォ一覧UIにエラー表示されてしまっていました。空フィードは「エラー」ではなく「お知らせなし」として正常扱いすべきです。

## 変更内容

### `app/services/informations/informations.ts`

`pluckItems` 関数でオプショナルチェーンによるガードを追加。`item` が `undefined` のとき空配列を返すよう修正。

### `app/services/informations/informations.test.ts`

空フィード対応のテストを追加：
- `pluckItems: itemなし（空フィード）` — 空配列を返すこと
- `pluckItems: itemあり` — 通常ケースが引き続き正常動作すること
- `updateInformations:item欠落（空フィード）` — `SET_HAS_ERROR` が立たず `SET_INFORMATIONS([])` が呼ばれること

## テスト

- [x] `pnpm run test:unit:app -- informations` 全12件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
