### PR TITLE
開発: GitHub Actions ワークフローのセキュリティハードニング（permissions 最小化・script injection 耐性向上）

### DIFF
--- a/.github/workflows/add_project.yml
+++ b/.github/workflows/add_project.yml
@@ -7,6 +7,8 @@ on:
     types: [opened]
     branches: ['n-air_development']
 
+permissions: {}
+
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
@@ -38,6 +40,7 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
           ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
           PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          PROJECT_ID: ${{ steps.get_project.outputs.project_id }}
         run: |
           ORG_NAME="n-air-app"
           PROJECT_NUMBER=3
@@ -48,7 +51,7 @@ jobs:
             CONTENT_ID="$PR_NODE_ID"
           fi
 
-          echo "Adding content ID: $CONTENT_ID to project ID: ${{ steps.get_project.outputs.project_id }}"
+          echo "Adding content ID: $CONTENT_ID to project ID: $PROJECT_ID"
 
           MUTATION='mutation($projectId: ID!, $contentId: ID!) {
             addProjectV2ItemById(input: {
@@ -65,6 +68,6 @@ jobs:
             -H "Authorization: Bearer $GH_PAT" \
             -H "Content-Type: application/json" \
             -d "$(jq -n \
-              --arg pid "${{ steps.get_project.outputs.project_id }}" \
+              --arg pid "$PROJECT_ID" \
               --arg cid "$CONTENT_ID" \
               '{ query: "'"${MUTATION//[$'\n']}"'", variables: { projectId: $pid, contentId: $cid } }')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.app == 'true' || needs.changes.outputs.bin == 'true' }}
     runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -103,6 +106,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.bin == 'true' }}
     runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -131,6 +137,9 @@ jobs:
     needs: [changes, setup-app]
     if: ${{ needs.changes.outputs.app == 'true' }}
     runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout code
@@ -159,6 +168,9 @@ jobs:
     needs: [changes, setup-app, setup-bin]
     if: ${{ needs.changes.outputs.bin == 'true' }}
     runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout code
@@ -193,6 +205,9 @@ jobs:
     name: e2e tests
     needs: [changes, setup-app]
     runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         directory:
@@ -237,6 +252,9 @@ jobs:
     needs: [changes, setup-app]
     if: ${{ needs.changes.outputs.app == 'true' }}
     runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: read
     env:
       MIN_INSTALLER_SIZE_MB: 300  # Minimum installer size in MB (adjust if needed)
 
@@ -308,6 +326,7 @@ jobs:
     # 注意: needs に setupも入れないと、setupで失敗すると後段のresultが `skipped` になってしまい、すりぬけてしまう
     needs: [setup-app, setup-bin, unit_test-app, unit_test-bin, e2e_test, build_check]
     if: always()
+    permissions: {}
     steps:
       - name: test-summary
         run: |


### PR DESCRIPTION
## このpull requestが解決する内容

GitHub Actions ワークフローのセキュリティハードニングを行います。supply chain attack 対策の観点からワークフロー全体を監査し、改善点を適用します。

## 背景

近年の supply chain attack 対策として `pull_request_target` イベントへの注意が呼びかけられています。本プロジェクトの利用状況を監査した結果：

**監査で確認できた安全な点（変更なし）:**
- `pull_request_target` は `add_project.yml` のみで使用。PR コードを checkout していないため典型的な pwn-request RCE には非該当
- 全 third-party action が SHA full-hash で pin 済み
- `dependabot.yml` で `github-actions` ecosystem も weekly 更新対象
- Organization 設定「Run workflows from fork pull requests」がオフ → fork PR ではワークフロー自体が実行されないため secrets 露出リスクなし

**改善余地として本 PR で対応する点:**
- ワークフローレベルおよび job レベルの `permissions:` 宣言が不足しており、最小権限の原則が明示されていない
- `add_project.yml` の `run:` 内で steps output を `${{ ... }}` 直接展開している箇所がある（`env:` 経由が望ましい）

## 変更内容

### `.github/workflows/add_project.yml`

| 変更 | 内容 |
|------|------|
| トップレベルに `permissions: {}` を追加 | `GH_PAT` で Project v2 操作するため、`GITHUB_TOKEN` には何も権限不要と明示 |
| `steps.get_project.outputs.project_id` を `env:` 経由に変更 | `run:` 内での `${{ ... }}` 直接展開を排除し script injection 耐性を向上 |

### `.github/workflows/test.yml`

各 job に `permissions:` を追加:

| job | permissions |
|-----|-------------|
| `changes` | 既存の `contents: read, pull-requests: read` を維持 |
| `setup-app`, `setup-bin`, `unit_test-app`, `unit_test-bin`, `e2e_test`, `build_check` | `contents: read, packages: read`（checkout と GitHub Packages からの `@n-air-app/*` 取得のため） |
| `test-summary` | `{}` （checkout 不要、集計のみ） |

## 範囲外事項（手動確認推奨）

- [x] `secrets.GH_PAT` のスコープが `read:org` と `project` のみであることを確認済み（最小権限）
- [x] Organization 設定「Run workflows from fork pull requests」がオフであることを確認済み（fork PR ではワークフロー自体が実行されないため、secrets 露出なし）

## テスト

- [x] `test.yml` の変更は CI 自体の実行で検証済み（全 job pass）
- [x] `add_project.yml` の動作を PR #1253 (dry-run) にて確認済み（全 job pass・Project v2 への自動追加成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
