### PR TITLE
開発: ユニットテスト失敗時にElectronの孤児プロセスが残る問題を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,13 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'additional/additional.json', 'additional/main.mjs') }}
 
       - name: Run unit tests(app)
+        timeout-minutes: 20
         run: pnpm run test:unit:app
+
+      - name: Cleanup orphan Electron processes
+        if: always()
+        run: taskkill /F /T /IM electron.exe 2>nul || exit /b 0
+        shell: cmd
 
   unit_test-bin:
     name: unit tests(bin)

--- a/app/test-setup/electron-watchdog.ts
+++ b/app/test-setup/electron-watchdog.ts
@@ -1,0 +1,21 @@
+// Watchdog that exits this Electron process when the parent Jest runner dies.
+// Runs only in the Electron main process (isMain=true) spawned by jest-electron-runner.
+// This is a second line of defense in case the jest wrapper process itself crashes
+// before tree-kill can clean up.
+
+if (process.env.isMain === 'true') {
+  const parentPid = process.ppid;
+  const interval = setInterval(() => {
+    try {
+      process.kill(parentPid, 0); // alive check — sends no actual signal
+    } catch {
+      clearInterval(interval);
+      try {
+        require('electron').app.exit(1);
+      } catch {
+        process.exit(1);
+      }
+    }
+  }, 1000);
+  interval.unref(); // don't prevent Jest from exiting normally
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
       options: ['no-sandbox'],
     },
   },
+  setupFiles: ['<rootDir>/app/test-setup/electron-watchdog.ts'],
   roots: ['<rootDir>/app', '<rootDir>/main-process'],
   testMatch: ['**/app/**/*.test.ts', '**/main-process/*.test.ts'],
   transformIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start:unstable": "cross-env NAIR_UNSTABLE=1 electron .",
     "test": "node bin/i18n-early-check.js && tsc -p test && ava -v -s",
     "test:unit": "pnpm run test:unit:app && pnpm run test:unit:bin",
-    "test:unit:app": "jest --silent --config ./jest.config.js",
+    "test:unit:app": "node scripts/run-jest-app.js",
     "test:unit:bin": "pnpm install --dir bin --ignore-workspace && jest --silent --config ./jest.bin-config.js",
     "update-gamecapture": "node bin/update-gamecapture.js",
     "version": "git add app/services/patch-notes/notes.ts",

--- a/scripts/run-jest-app.js
+++ b/scripts/run-jest-app.js
@@ -1,0 +1,31 @@
+// Jest runner wrapper that guarantees all spawned Electron child processes are
+// killed on exit, even on Windows where POSIX process group kill is a no-op.
+// @kayahr/jest-electron-runner uses process.kill(-pid) which silently fails on
+// Windows, leaving renderer/GPU/utility processes as orphans.
+
+const { spawn } = require('node:child_process');
+const treeKill = require('tree-kill');
+
+const jestBin = require.resolve('jest/bin/jest');
+const child = spawn(
+  process.execPath,
+  [jestBin, '--silent', '--config', './jest.config.js', ...process.argv.slice(2)],
+  { stdio: 'inherit', env: process.env },
+);
+
+let cleaning = false;
+function cleanup(exitCode) {
+  if (cleaning) return;
+  cleaning = true;
+  if (child.pid != null) {
+    treeKill(child.pid, 'SIGKILL', () => process.exit(exitCode ?? 1));
+  } else {
+    process.exit(exitCode ?? 1);
+  }
+}
+
+process.on('SIGINT', () => cleanup(130));
+process.on('SIGTERM', () => cleanup(143));
+process.on('SIGHUP', () => cleanup(129));
+process.on('uncaughtException', (e) => { console.error(e); cleanup(1); });
+child.on('exit', (code, signal) => cleanup(code ?? (signal ? 1 : 0)));


### PR DESCRIPTION
## このpull requestが解決する内容

`pnpm run test:unit:app` 実行中にテスト失敗・クラッシュ・Ctrl+C などが起きると、Windows上で `electron.exe` が孤児として残り続けPCの負荷が上昇する問題を修正します。

## 背景

`@kayahr/jest-electron-runner` はテストファイルごとに `child_process.spawn(..., { detached: true })` で Electron を起動しますが、終了時のクリーンアップは POSIX 方式の `process.kill(-pid, "SIGKILL")` に依存しています。Windows にはプロセスグループの概念がないためこの kill は失敗し（catch で握り潰される）、フォールバックの `child.kill("SIGKILL")` は Electron の直接の親プロセスしか殺せません。その結果、Electron が内部生成する renderer/GPU/utility プロセスが孤児として残ります。

このライブラリは 2025年1月にアーカイブ済み（メンテナが Vitest 移行）のため、upstream 修正は期待できません。

## 変更内容

### ファイル変更

| ファイル | 変更内容 |
|---------|---------|
| `scripts/run-jest-app.js` | 新規: Jest ラッパースクリプト（tree-kill 使用） |
| `app/test-setup/electron-watchdog.ts` | 新規: Electron 子プロセス内 watchdog |
| `jest.config.js` | `setupFiles` に electron-watchdog を追加 |
| `package.json` | `test:unit:app` スクリプト変更 + `tree-kill` devDep 追加 |
| `.github/workflows/test.yml` | `timeout-minutes` と孤児クリーンアップステップを追加 |

### 対策の二層構造

**層1 — Jest ラッパースクリプト** (`scripts/run-jest-app.js`)

Jest を子プロセスとして spawn し、終了・シグナル受信時に `tree-kill` でプロセスツリー全体を再帰的に kill します。
`tree-kill` は Windows 内部で `taskkill /pid <pid> /T /F` を使うため、対象 Jest 以下のプロセスのみを掃除します（N Air 本体や他の Electron プロセスには影響しません）。

**層2 — Electron 子プロセス内 watchdog** (`app/test-setup/electron-watchdog.ts`)

`setupFiles` として各テストファイル冒頭で読まれます。`isMain=true` 環境（= jest-electron-runner が起動した Electron main プロセス）でのみ動作し、setInterval で親プロセスの生存を監視します。親が死んだら `app.exit(1)` で自殺します。層1が機能しなかった場合の最終防衛です。

**CI 防護** (`.github/workflows/test.yml`)

- `unit_test-app` ジョブに `timeout-minutes: 20` を追加（孤児による hang 時の安全弁）
- `if: always()` のクリーンアップステップで `taskkill /F /T /IM electron.exe` を実行（CI runner は使い捨てのため全 electron.exe を掃除してよい）

## テスト

- [x] `pnpm run test:unit:app` を正常実行してテストが通ることを確認（50 passed、NVoiceClient は環境依存の既存失敗のため除く）
- [x] テスト後に `Get-Process electron` が 0 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
