### PR TITLE
開発: OneComme/VOICEVOX 未起動時のエラーを Sentry から除去

### DIFF
--- a/app/services/nicolive-program/OneCommeRelation.test.ts
+++ b/app/services/nicolive-program/OneCommeRelation.test.ts
@@ -1,0 +1,60 @@
+import fetchMock from '@fetch-mock/jest';
+
+jest.mock('services/nicolive-program/state', () => ({ NicoliveProgramStateService: {} }));
+jest.mock('services/nicolive-program/nicolive-program', () => ({ NicoliveProgramService: {} }));
+jest.mock('services/dev-hosts', () => ({ transformUrl: (url: string) => url }));
+
+beforeEach(() => {
+  jest.doMock('services/core/stateful-service');
+  jest.doMock('services/core/injector');
+  fetchMock.mockGlobal();
+});
+
+afterEach(() => {
+  fetchMock.mockRestore({ includeSticky: true });
+  jest.resetModules();
+  jest.restoreAllMocks();
+});
+
+describe('OneCommeRelation', () => {
+  describe('sendService', () => {
+    it('fetch失敗 (Failed to fetch) は console.warn のみで false を返す', async () => {
+      fetchMock.any({ throws: new TypeError('Failed to fetch') });
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { OneCommeRelation } = require('./OneCommeRelation');
+      const relation = new OneCommeRelation();
+      const result = await (relation as any).sendService({
+        id: 'test-id',
+        url: 'http://localhost:11180/watch/lv000',
+        enabled: true,
+        name: '#N_Air',
+      });
+
+      expect(result).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('[OneCommeRelation]');
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('その他のエラーは console.error を呼び false を返す', async () => {
+      fetchMock.any({ throws: new Error('unexpected error') });
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { OneCommeRelation } = require('./OneCommeRelation');
+      const relation = new OneCommeRelation();
+      const result = await (relation as any).sendService({
+        id: 'test-id',
+        url: 'http://localhost:11180/watch/lv000',
+        enabled: true,
+        name: '#N_Air',
+      });
+
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/services/nicolive-program/OneCommeRelation.ts
+++ b/app/services/nicolive-program/OneCommeRelation.ts
@@ -3,10 +3,6 @@ import { NicoliveProgramService } from 'services/nicolive-program/nicolive-progr
 import { NicoliveProgramStateService } from 'services/nicolive-program/state';
 import { transformUrl } from 'services/dev-hosts';
 
-function isLocalServiceUnavailableError(e: unknown): e is TypeError {
-  return e instanceof TypeError && /Failed to fetch/.test(e.message);
-}
-
 /**
  * OneCommeサービスとのやり取りに使用するデータ構造
  */
@@ -90,8 +86,8 @@ export class OneCommeRelation {
       const result = await fetchJSON<OneCommeServiceData>(url, makeRequest('PUT', data));
       return !!result;
     } catch (e) {
-      if (isLocalServiceUnavailableError(e)) {
-        console.warn('[OneCommeRelation] OneComme server unavailable:', e.message);
+      if (e instanceof TypeError && e.message.includes('Failed to fetch')) {
+        console.warn('[OneCommeRelation] OneComme server unavailable');
         return false;
       }
       console.error('OneCommeRelation sendService error', e);

--- a/app/services/nicolive-program/OneCommeRelation.ts
+++ b/app/services/nicolive-program/OneCommeRelation.ts
@@ -3,6 +3,10 @@ import { NicoliveProgramService } from 'services/nicolive-program/nicolive-progr
 import { NicoliveProgramStateService } from 'services/nicolive-program/state';
 import { transformUrl } from 'services/dev-hosts';
 
+function isLocalServiceUnavailableError(e: unknown): e is TypeError {
+  return e instanceof TypeError && /Failed to fetch/.test(e.message);
+}
+
 /**
  * OneCommeサービスとのやり取りに使用するデータ構造
  */
@@ -86,6 +90,10 @@ export class OneCommeRelation {
       const result = await fetchJSON<OneCommeServiceData>(url, makeRequest('PUT', data));
       return !!result;
     } catch (e) {
+      if (isLocalServiceUnavailableError(e)) {
+        console.warn('[OneCommeRelation] OneComme server unavailable:', e.message);
+        return false;
+      }
       console.error('OneCommeRelation sendService error', e);
       return false;
     }

--- a/app/services/nicolive-program/speech/VoicevoxSynthesizer.test.ts
+++ b/app/services/nicolive-program/speech/VoicevoxSynthesizer.test.ts
@@ -1,0 +1,64 @@
+import * as Sentry from '@sentry/vue';
+import { Speech } from '../nicolive-comment-synthesizer';
+import { VoicevoxSynthesizer } from './VoicevoxSynthesizer';
+
+jest.mock('@sentry/vue', () => ({
+  withScope: jest.fn((fn: (scope: any) => void) =>
+    fn({
+      setLevel: jest.fn(),
+      setTag: jest.fn(),
+      setExtra: jest.fn(),
+      setFingerprint: jest.fn(),
+    }),
+  ),
+  captureException: jest.fn(),
+}));
+
+const makeSpeech = (): Speech => ({
+  text: 'テスト',
+  synthesizer: 'voicevox',
+  rate: 1.0,
+  voicevox: { id: '1', name: 'ずんだもん' },
+});
+
+describe('VoicevoxSynthesizer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('speakText', () => {
+    it('VOICEVOX 未起動 (Failed to fetch) の場合、Sentry に送らず console.warn のみ', async () => {
+      const synth = new VoicevoxSynthesizer();
+      jest.spyOn(synth, 'output').mockRejectedValue(new TypeError('Failed to fetch'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const speech = makeSpeech();
+      const outer = synth.speakText(speech, jest.fn(), jest.fn());
+      const inner = await outer();
+      const result = await inner!();
+      if (result) await result.running;
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('[VoicevoxSynthesizer]');
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('その他のエラーは Sentry.captureException を呼ぶ', async () => {
+      const synth = new VoicevoxSynthesizer();
+      jest.spyOn(synth, 'output').mockRejectedValue(new Error('unexpected error'));
+      jest.spyOn(console, 'info').mockImplementation(() => {});
+
+      const speech = makeSpeech();
+      const outer = synth.speakText(speech, jest.fn(), jest.fn());
+      const inner = await outer();
+      const result = await inner!();
+      if (result) await result.running;
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/services/nicolive-program/speech/VoicevoxSynthesizer.ts
+++ b/app/services/nicolive-program/speech/VoicevoxSynthesizer.ts
@@ -2,6 +2,10 @@ import * as Sentry from '@sentry/vue';
 import { Speech } from '../nicolive-comment-synthesizer';
 import { ISpeechSynthesizer } from './ISpeechSynthesizer';
 
+function isLocalServiceUnavailableError(e: unknown): e is TypeError {
+  return e instanceof TypeError && /Failed to fetch/.test(e.message);
+}
+
 export const VoicevoxURL = `http://localhost:50021`;
 
 export class VoicevoxSynthesizer implements ISpeechSynthesizer {
@@ -74,6 +78,12 @@ export class VoicevoxSynthesizer implements ISpeechSynthesizer {
       onstart();
       this.output(speech)
         .catch(error => {
+          if (isLocalServiceUnavailableError(error)) {
+            console.warn(
+              `[VoicevoxSynthesizer] VOICEVOX server unavailable - text:${speech.text}`,
+            );
+            return;
+          }
           Sentry.withScope(scope => {
             scope.setLevel('error');
             scope.setTag('in', 'VoicevoxSynthesizer:speakText');

--- a/app/services/nicolive-program/speech/VoicevoxSynthesizer.ts
+++ b/app/services/nicolive-program/speech/VoicevoxSynthesizer.ts
@@ -2,10 +2,6 @@ import * as Sentry from '@sentry/vue';
 import { Speech } from '../nicolive-comment-synthesizer';
 import { ISpeechSynthesizer } from './ISpeechSynthesizer';
 
-function isLocalServiceUnavailableError(e: unknown): e is TypeError {
-  return e instanceof TypeError && /Failed to fetch/.test(e.message);
-}
-
 export const VoicevoxURL = `http://localhost:50021`;
 
 export class VoicevoxSynthesizer implements ISpeechSynthesizer {
@@ -78,10 +74,8 @@ export class VoicevoxSynthesizer implements ISpeechSynthesizer {
       onstart();
       this.output(speech)
         .catch(error => {
-          if (isLocalServiceUnavailableError(error)) {
-            console.warn(
-              `[VoicevoxSynthesizer] VOICEVOX server unavailable - text:${speech.text}`,
-            );
+          if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
+            console.warn(`[VoicevoxSynthesizer] VOICEVOX server unavailable - text:${speech.text}`);
             return;
           }
           Sentry.withScope(scope => {


### PR DESCRIPTION
## このpull requestが解決する内容

リリース `1.1.20260513-1` の Sentry イベントを調査した結果、ローカルアプリ（OneComme / VOICEVOX）が未起動のときに発生するネットワークエラーが大量に Sentry へ流入していた問題を修正します。

| Sentry ID | タイトル | events | users |
|---|---|---:|---:|
| N-AIR-APP-EE3 | OneCommeRelation sendService error | 16,982 | 312 |
| N-AIR-APP-DZX | TypeError: Failed to fetch (localhost:50021) | 11,061 | 291 |

## 原因

どちらも `localhost` で動作するローカルアプリ（OneComme / VOICEVOX）が起動していない場合に `fetch` が `TypeError: Failed to fetch` を投げるケースで、これが error レベルで Sentry に送信されていました。ユーザーが連携設定を ON にしたまま外部アプリを起動していない状態は常態化しており、バグではなく環境問題です。

PR #1254 と同じパターン（既知の正常系を識別 → Sentry 送信をスキップ → `console.warn` のみ）で対処しました。

## 変更内容

### `app/services/nicolive-program/OneCommeRelation.ts`

`sendService` の catch ブロックで `isLocalServiceUnavailableError` 型述語を使って `TypeError: Failed to fetch` を判別。該当する場合は `console.warn` のみで Sentry には送信しない。

### `app/services/nicolive-program/speech/VoicevoxSynthesizer.ts`

`speakText` の `.catch()` ハンドラで同様の判別を追加。`Failed to fetch` の場合は `Sentry.captureException` をスキップし `console.warn` のみ。

### `app/services/nicolive-program/OneCommeRelation.test.ts`（新規）

- fetch 失敗時は `console.warn` のみ、`console.error` は未呼び出しで `false` が返ること
- 別系統のエラー時は従来通り `console.error` が呼ばれること

### `app/services/nicolive-program/speech/VoicevoxSynthesizer.test.ts`（新規）

- fetch 失敗時は `Sentry.captureException` が呼ばれないこと
- 別系統のエラー時は `Sentry.captureException` が呼ばれること

## テスト

- [x] `pnpm run test:unit:app` 全54スイート (849テスト) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
