### PR TITLE
修正: 外部ツール連携機能で接続切断時にエラーが発生する問題を修正

### DIFF
--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -245,7 +245,7 @@ export class TcpServerService
 
     socket.on('error', (e: NodeJS.ErrnoException) => {
       if (e.code === 'EPIPE' || e.code === 'ERR_STREAM_WRITE_AFTER_END') {
-        // Client has silently disconnected
+        // Expected errors from closed/ended connections
         console.debug('TCP Server: Socket was disconnected', e);
         this.onDisconnectHandler(client);
       } else {
@@ -431,10 +431,8 @@ export class TcpServerService
 
     this.log('send response', response);
 
-    // Node.js emits ERR_STREAM_WRITE_AFTER_END asynchronously when writing to an ended socket,
-    // so the try/catch below can't catch it. Skip write if the socket is already closed.
-    const socket = client.socket as any;
-    if (!socket.writable || socket.writableEnded) return;
+    // ERR_STREAM_WRITE_AFTER_END is emitted asynchronously and bypasses the try/catch below.
+    if (!client.socket.writable) return;
 
     // unhandled exceptions completely destroy Rx.Observable subscription
     try {

--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -243,8 +243,8 @@ export class TcpServerService
       this.onDisconnectHandler(client);
     });
 
-    socket.on('error', e => {
-      if (e.code === 'EPIPE') {
+    socket.on('error', (e: NodeJS.ErrnoException) => {
+      if (e.code === 'EPIPE' || e.code === 'ERR_STREAM_WRITE_AFTER_END') {
         // Client has silently disconnected
         console.debug('TCP Server: Socket was disconnected', e);
         this.onDisconnectHandler(client);
@@ -430,6 +430,11 @@ export class TcpServerService
     if (this.isRequestsHandlingStopped && !force) return;
 
     this.log('send response', response);
+
+    // Node.js emits ERR_STREAM_WRITE_AFTER_END asynchronously when writing to an ended socket,
+    // so the try/catch below can't catch it. Skip write if the socket is already closed.
+    const socket = client.socket as any;
+    if (!socket.writable || socket.writableEnded) return;
 
     // unhandled exceptions completely destroy Rx.Observable subscription
     try {


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry N-AIR-APP-FX3: TCP API クライアントが接続を切断する際に `ERR_STREAM_WRITE_AFTER_END` が未捕捉例外となりアプリがクラッシュする問題を修正します。

リリース `1.1.20260513-1` で 51 events / 18 users に影響が確認されています。

## 背景

`TcpServerService` は Named Pipe `\.\pipe\n-air-app` / TCP port 28194 (localhost) 経由で JSON-RPC API を提供するサーバーです（`docs/README.md` に仕様公開）。シーン切り替えや音声管理などをスクリプトや自動化ツールでリモート操作するために使われます。E2E テストも同じ API 経由で接続しています。

クライアントが接続を切断する際に以下の競合が発生していました。

1. クライアントから FIN パケット受信 → Node.js が `allowHalfOpen=false` のため writable 側も自動的に `socket.end()` する
2. バッファリング済みの `data` イベントが発火し `sendResponse` が `socket.write()` を呼ぶ
3. Node.js の `Writable._write` が `ERR_STREAM_WRITE_AFTER_END` を **非同期** に emit する
4. `socket.on('error', ...)` ハンドラが発火。`EPIPE` 以外は `throw e` していたため `ERR_STREAM_WRITE_AFTER_END` が未捕捉例外になる

`sendResponse` にある `try/catch` は `write()` からの非同期 emit を捕捉できないため、この経路でのエラーが握れていませんでした。

## 変更内容

`app/services/api/tcp-server/tcp-server.ts` の 2 箇所を修正:

### 1. `sendResponse` で writable 状態をプリチェック

```typescript
// ERR_STREAM_WRITE_AFTER_END is emitted asynchronously and bypasses the try/catch below.
if (!client.socket.writable) return;
```

`WritableStream.writable` が `false` になるのは `end()` 呼び出し直後なので、`writableEnded` の別チェックは不要。

### 2. `socket.on('error')` で `ERR_STREAM_WRITE_AFTER_END` も既知エラーとして処理

```typescript
if (e.code === 'EPIPE' || e.code === 'ERR_STREAM_WRITE_AFTER_END') {
  // Expected errors from closed/ended connections
```

プリチェックと書き込みの間でソケットが end されるレースに対する保険。

## テスト

- [x] `pnpm run test:unit:app` 全 845 テスト通過
- [x] `pnpm lint` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
