### PR TITLE
開発: 番組終了メッセージ受信時にrefreshProgramのNicoliveFailureがunhandledになる問題を修正 (N-AIR-APP-FF4)

### DIFF
--- a/app/services/nicolive-program/nicolive-comment-viewer.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.test.ts
@@ -191,6 +191,40 @@ test('status=endedが流れてきたらunsubscribeし、refreshProgramも呼ぶ'
   expect(refreshProgram).toHaveBeenCalledTimes(1);
 });
 
+test('status=endedでrefreshProgramがNicoliveFailureを投げてもunhandledにならない', async () => {
+  const stateChange = new Subject();
+  const clientSubject = new Subject<MessageResponse>();
+  jest.doMock('./NdgrCommentReceiver', () => {
+    return {
+      ...(jest.requireActual('./NdgrCommentReceiver') as {}),
+      NdgrCommentReceiver: class NdgrCommentReceiver {
+        connect() {
+          return clientSubject;
+        }
+      },
+    };
+  });
+  jest.spyOn(window, 'setTimeout').mockImplementation((callback) => callback() as any);
+  const { NicoliveFailure } = require('./NicoliveFailure');
+  const failure = new NicoliveFailure('network_error', 'fetchProgram', 'network_error');
+  const refreshProgram = jest.fn().mockRejectedValue(failure);
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  setup({ injectee: { NicoliveProgramService: { stateChange, refreshProgram } } });
+
+  const { NicoliveCommentViewerService } = require('./nicolive-comment-viewer');
+  const instance = NicoliveCommentViewerService.instance as NicoliveCommentViewerService;
+  (instance as any).unsubscribe = jest.fn();
+
+  stateChange.next({ viewUri: 'https://example.com' });
+  clientSubject.next({ state: { state: 'ended' } });
+
+  // .catch() の非同期処理が完了するまで待つ
+  await Promise.resolve();
+
+  expect(warnSpy).toHaveBeenCalledWith('refreshProgram failed:', failure);
+  warnSpy.mockRestore();
+});
+
 const MODERATOR_ID = '123';
 const NOT_MODERATOR_ID = '456';
 

--- a/app/services/nicolive-program/nicolive-comment-viewer.ts
+++ b/app/services/nicolive-program/nicolive-comment-viewer.ts
@@ -45,6 +45,7 @@ import { NicoliveCommentLocalFilterService } from './nicolive-comment-local-filt
 import { NicoliveCommentSynthesizerService } from './nicolive-comment-synthesizer';
 import { NicoliveModeratorsService } from './nicolive-moderators';
 import { NicoliveSupportersService } from './nicolive-supporters';
+import { NicoliveFailure } from './NicoliveFailure';
 import { FilterRecord } from './ResponseTypes';
 import { NicoliveProgramStateService } from './state';
 import {
@@ -442,7 +443,13 @@ export class NicoliveCommentViewerService extends StatefulService<INicoliveComme
                     // `/disconnect` の代わりのメッセージは出さない仕様なので問題ない
                     this.unsubscribe();
                     // 番組情報を更新する
-                    this.nicoliveProgramService.refreshProgram();
+                    this.nicoliveProgramService.refreshProgram().catch((caught) => {
+                      if (caught instanceof NicoliveFailure) {
+                        console.warn('refreshProgram failed:', caught);
+                      } else {
+                        throw new Error('refreshProgram failed unexpectedly', { cause: caught });
+                      }
+                    });
                   }
                 }),
                 ignoreElements(),


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue [N-AIR-APP-FF4](https://n-air-app2.sentry.io/issues/7122684421/) の残存経路を修正します。

- 628 events / 184 users に影響、High優先度、継続発生中（最終 2026/5/18）
- PR #1236 で `refreshProgramTimer` の fire-and-forget は修正済みでしたが、別の経路でまだ発生していました

## 原因

`NicoliveCommentViewerService` 内の RxJS `tap()` ハンドラで、サーバーから `state: 'ended'` メッセージを受信した際に `refreshProgram()` を fire-and-forget で呼び出していました。

```typescript
// 修正前: .catch() なし
this.nicoliveProgramService.refreshProgram();
```

`refreshProgram()` はネットワークエラー時に `NicoliveFailure` を throw しますが（`NicoliveFailure` は `Error` を継承していないため Sentry では `<unknown>` として記録）、これが未捕捉のまま `UnhandledRejection` になっていました。

## 変更内容

### `app/services/nicolive-program/nicolive-comment-viewer.ts`

PR #1236 と同じパターンで `.catch()` を追加:

```typescript
// 修正後: NicoliveFailure を catch してログ
this.nicoliveProgramService.refreshProgram().catch(caught => {
  if (caught instanceof NicoliveFailure) {
    console.warn('refreshProgram failed:', caught);
  } else {
    throw new Error('refreshProgram failed unexpectedly', { cause: caught });
  }
});
```

### `app/services/nicolive-program/nicolive-comment-viewer.test.ts`

`refreshProgram` が `NicoliveFailure` を reject しても unhandled rejection にならないことを確認するテストを追加。

## テスト

- [x] `pnpm run test:unit:app`: 全54スイート / 850テスト通過

関連: #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)