### PR TITLE
修正: ソースプロパティなどの子ウィンドウを素早く開閉するとアプリがクラッシュする問題を修正 (N-AIR-APP-EK3)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1067,14 +1067,18 @@ function initialize(crashHandler) {
 
         // setBounds の適用後に最小サイズを設定（遅延させることで確実に反映）
         setTimeout(() => {
-          childWindow.setMinimumSize(windowOptions.size.width, windowOptions.size.height);
+          if (!childWindow.isDestroyed()) {
+            childWindow.setMinimumSize(windowOptions.size.width, windowOptions.size.height);
+          }
         }, 10);
       } catch (err) {
         console.log('Recovering from error:', err);
 
-        childWindow.setMinimumSize(windowOptions.size.width, windowOptions.size.height);
-        childWindow.setSize(windowOptions.size.width, windowOptions.size.height);
-        childWindow.center();
+        if (!childWindow.isDestroyed()) {
+          childWindow.setMinimumSize(windowOptions.size.width, windowOptions.size.height);
+          childWindow.setSize(windowOptions.size.width, windowOptions.size.height);
+          childWindow.center();
+        }
       }
 
       childWindow.focus();


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue [N-AIR-APP-EK3](https://n-air-app2.sentry.io/issues/6709292688/) を修正します。

- 184 events / 16 users に影響、fatal (unhandled)、継続発生中

## 原因

`ipcMain.on('window-showChildWindow', ...)` ハンドラ内の 2 箇所で、`childWindow` が破棄済み（`isDestroyed() === true`）の状態でメソッドを呼び出す可能性がありました。

### 発生シナリオ

Sentry の breadcrumbs に `window.close → renderer.destroyed → window.closed` の流れが記録されており、**子ウィンドウ（ソースプロパティ等）を素早く開閉する操作**でタイミング問題が起きていたと考えられます。

1. ソースプロパティ等の子ウィンドウを開く `window-showChildWindow` IPC メッセージが送られる
2. ウィンドウを開く処理中に何らかの理由（素早い閉じ操作など）でウィンドウが破棄される
3. `try` ブロック内で `childWindow` の操作（`setBounds` など）が失敗し `catch` に入る
4. `catch` の復旧コードも同じ破棄済み `childWindow` を操作しようとして `TypeError: Object has been destroyed`

また、`setTimeout` 側の経路でも：
- `childWindow.show()` の直後、10ms の遅延中にウィンドウが閉じられた場合、遅延コールバックで `setMinimumSize` が失敗する

**1. `setTimeout` コールバック（10ms 遅延）**

```js
// 修正前
setTimeout(() => {
  childWindow.setMinimumSize(windowOptions.size.width, windowOptions.size.height);
}, 10);
```

**2. `catch` ブロック（エラー復旧コード）**

```js
// 修正前
} catch (err) {
  console.log('Recovering from error:', err);
  childWindow.setMinimumSize(...);  // ← ここで throw
  childWindow.setSize(...);
  childWindow.center();
}
```

## 変更内容

### `main.js`

両箇所に `!childWindow.isDestroyed()` ガードを追加:

```js
// setTimeout コールバック
setTimeout(() => {
  if (!childWindow.isDestroyed()) {
    childWindow.setMinimumSize(windowOptions.size.width, windowOptions.size.height);
  }
}, 10);

// catch ブロック
} catch (err) {
  console.log('Recovering from error:', err);
  if (!childWindow.isDestroyed()) {
    childWindow.setMinimumSize(...);
    childWindow.setSize(...);
    childWindow.center();
  }
}
```

同ファイル内の他のガード（line 601, 936, 1114）と同じパターン。

## テスト

- [x] ローカルでアプリ起動、子ウィンドウ（Source Properties 等）の開閉が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)