### PR TITLE
修正: ソースプロパティなどのウィンドウを開いた状態でアプリを終了するとクラッシュする問題を修正 (N-AIR-APP-EKB)

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -370,7 +370,16 @@ export class WindowsService extends StatefulService<IWindowsState> {
       this.windows[windowId].close();
       await this.waitWindowCleanup(windowId);
       // 念のため destroy も残す
-      this.windows[windowId]?.destroy();
+      if (this.windows[windowId]) {
+        this.windows[windowId].destroy();
+      } else {
+        // closed イベントハンドラが先に delete this.windows[windowId] を実行したケース
+        Sentry.captureMessage('closeOneOffWindow: window already deleted before destroy()', {
+          level: 'warning',
+          extra: { windowId },
+          tags: { module: 'windows', function: 'closeOneOffWindow' },
+        });
+      }
     });
   }
 

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -358,7 +358,6 @@ export class WindowsService extends StatefulService<IWindowsState> {
     Object.keys(this.windows).forEach((windowId) => {
       if (windowId === 'main') return;
       if (windowId === 'child') return;
-      this.closeOneOffWindow(windowId);
       closingPromises.push(this.closeOneOffWindow(windowId));
     });
     return Promise.all(closingPromises);
@@ -371,7 +370,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
       this.windows[windowId].close();
       await this.waitWindowCleanup(windowId);
       // 念のため destroy も残す
-      this.windows[windowId].destroy();
+      this.windows[windowId]?.destroy();
     });
   }
 

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -369,17 +369,6 @@ export class WindowsService extends StatefulService<IWindowsState> {
       this.windows[windowId].on('closed', resolve);
       this.windows[windowId].close();
       await this.waitWindowCleanup(windowId);
-      // 念のため destroy も残す
-      if (this.windows[windowId]) {
-        this.windows[windowId].destroy();
-      } else {
-        // closed イベントハンドラが先に delete this.windows[windowId] を実行したケース
-        Sentry.captureMessage('closeOneOffWindow: window already deleted before destroy()', {
-          level: 'warning',
-          extra: { windowId },
-          tags: { module: 'windows', function: 'closeOneOffWindow' },
-        });
-      }
     });
   }
 


### PR DESCRIPTION
## このpull requestが解決する内容

アプリ終了時にone-offウィンドウ（ソースプロパティなど）を `close()` した際に `@electron/remote` 経由で `TypeError: Could not call remote method 'close'. Object has been destroyed` が発生する問題を修正します。

## 背景

N-AIR-APP-EKB: 384 events / 63 users

Sentry のスタックトレース・breadcrumbs を解析したところ、アプリ終了時に one-off ウィンドウを閉じる `WindowsService.closeAllOneOffs()` で同一ウィンドウに対して `closeOneOffWindow()` が2回呼び出されていることが原因と特定しました。

## 変更内容

### ファイル変更

- `app/services/windows.ts`: 2箇所を修正

### バグ1: `closeAllOneOffs()` の二重呼び出し（根本原因）

```typescript
// Before（バグあり）
Object.keys(this.windows).forEach((windowId) => {
  if (windowId === 'main') return;
  if (windowId === 'child') return;
  this.closeOneOffWindow(windowId);                        // ← 結果を捨てる重複呼び出し
  closingPromises.push(this.closeOneOffWindow(windowId)); // ← 同じウィンドウを2回close
});

// After（修正後）
Object.keys(this.windows).forEach((windowId) => {
  if (windowId === 'main') return;
  if (windowId === 'child') return;
  closingPromises.push(this.closeOneOffWindow(windowId)); // ← 1回だけ
});
```

2行が並んで存在し、同じウィンドウを2回クローズしようとしていました。`closeOneOffWindow()` は最初に `isDestroyed()` チェックを行いますが、この2呼び出しは同期的に評価されるため、両方のチェックが通過して `window.close()` が2回呼ばれます。

### バグ2: `closeOneOffWindow()` の不要な `destroy()` 呼び出しを削除

```typescript
// Before
await this.waitWindowCleanup(windowId);
// 念のため destroy も残す
this.windows[windowId].destroy();  // ← closed イベント後は undefined になっている可能性あり

// After
await this.waitWindowCleanup(windowId);
// close() + waitWindowCleanup() で十分なため destroy() は不要
```

`closed` イベント発火時のハンドラが `delete this.windows[windowId]` を行うため、`await this.waitWindowCleanup()` 完了後には `this.windows[windowId]` が `undefined` になっている可能性があります。`close()` と `waitWindowCleanup()` で既に十分なクリーンアップが行われるため、`destroy()` 自体を削除しました。

## テスト

- ソースプロパティウィンドウやシーントランジションウィンドウを開いた状態でアプリを終了し、クラッシュが発生しないことを確認
- リリース後、Sentry N-AIR-APP-EKB のイベント数が減少することを観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)
