### PR TITLE
開発: 配信異常を検知してSentryに通報する観測を追加

### DIFF
--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -205,6 +205,16 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
       if (stats.streamingBandwidth === 0) {
         if (this.zeroBandwidthSamples === 0) {
           this.zeroBandwidthStartedAt = Date.now();
+          Sentry.addBreadcrumb({
+            category: 'streaming',
+            message: 'bandwidth dropped to 0',
+            level: 'warning',
+            data: {
+              CPU: stats.CPU,
+              droppedFrames: stats.numberDroppedFrames,
+              percentageDroppedFrames: stats.percentageDroppedFrames,
+            },
+          });
         }
         this.zeroBandwidthSamples++;
         if (

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -59,6 +59,11 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
   private intervalId: number;
   private statsFailed: boolean = false;
 
+  private zeroBandwidthSamples = 0;
+  private zeroBandwidthAlertSent = false;
+  private zeroBandwidthStartedAt: number | null = null;
+  private readonly ZERO_BANDWIDTH_THRESHOLD = 8; // 8 × 2s = 16s
+
   // 移動平均用の履歴配列
   private historicalDroppedFrames: number[] = [];
   private historicalSkippedFrames: number[] = [];
@@ -81,6 +86,13 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
         this.historicalDroppedFrames = [];
         this.historicalLaggedFrames = [];
         this.historicalSkippedFrames = [];
+        this.zeroBandwidthSamples = 0;
+        this.zeroBandwidthAlertSent = false;
+        this.zeroBandwidthStartedAt = null;
+      } else if (status === EStreamingState.Offline) {
+        this.zeroBandwidthSamples = 0;
+        this.zeroBandwidthAlertSent = false;
+        this.zeroBandwidthStartedAt = null;
       }
     });
   }
@@ -188,6 +200,59 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
       percentageSkippedFrames: skippedFactor * 100,
       streamQuality,
     });
+
+    if (this.streamingService.state.streamingStatus === EStreamingState.Live) {
+      if (stats.streamingBandwidth === 0) {
+        if (this.zeroBandwidthSamples === 0) {
+          this.zeroBandwidthStartedAt = Date.now();
+        }
+        this.zeroBandwidthSamples++;
+        if (
+          this.zeroBandwidthSamples === this.ZERO_BANDWIDTH_THRESHOLD &&
+          !this.zeroBandwidthAlertSent
+        ) {
+          const streamElapsedSec = this.streamingService.state.streamingStatusTime
+            ? Math.round(
+              (Date.now() -
+                  new Date(this.streamingService.state.streamingStatusTime).getTime()) /
+                  1000,
+            )
+            : -1;
+          Sentry.withScope((scope) => {
+            scope.setLevel('warning');
+            scope.setTag('service', 'PerformanceService');
+            scope.setTag('method', 'update');
+            scope.setTag('condition', 'bandwidthZero');
+            scope.setFingerprint(['PerformanceService', 'bandwidthZero']);
+            scope.setExtra(
+              'zeroDurationSec',
+              this.zeroBandwidthSamples * (STATS_UPDATE_INTERVAL / 1000),
+            );
+            scope.setExtra('CPU', stats.CPU);
+            scope.setExtra('droppedFrames', stats.numberDroppedFrames);
+            scope.setExtra('percentageDroppedFrames', stats.percentageDroppedFrames);
+            scope.setExtra('streamElapsedSec', streamElapsedSec);
+            Sentry.captureMessage('streaming bandwidth stuck at 0kbps');
+          });
+          this.zeroBandwidthAlertSent = true;
+        }
+      } else {
+        if (this.zeroBandwidthAlertSent) {
+          Sentry.addBreadcrumb({
+            category: 'streaming',
+            message: 'bandwidth recovered',
+            data: {
+              recoveryDurationSec: this.zeroBandwidthStartedAt
+                ? Math.round((Date.now() - this.zeroBandwidthStartedAt) / 1000)
+                : -1,
+            },
+          });
+        }
+        this.zeroBandwidthSamples = 0;
+        this.zeroBandwidthAlertSent = false;
+        this.zeroBandwidthStartedAt = null;
+      }
+    }
   }
 
   stop() {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -844,6 +844,11 @@ export class StreamingService
 
   private outputErrorOpen = false;
 
+  private reconnectStartedAt: number | null = null;
+  private reconnectCount = 0;
+  private lastReconnectSentAt = 0;
+  private readonly RECONNECT_RATE_LIMIT_MS = 30_000;
+
   private handleOBSOutputSignal(info: IOBSOutputSignalInfo) {
     console.debug('OBS Output signal: ', info);
 
@@ -853,6 +858,8 @@ export class StreamingService
       const time = new Date().toISOString();
 
       if (info.signal === EOBSOutputSignal.Start) {
+        this.reconnectCount = 0;
+        this.reconnectStartedAt = null;
         this.SET_STREAMING_STATUS(EStreamingState.Live, time);
         this.streamingStatusChange.next(EStreamingState.Live);
 
@@ -879,11 +886,57 @@ export class StreamingService
         this.streamingStatusChange.next(EStreamingState.Ending);
         void this.logStreamEnd(); // fire-and-forget: シグナルコールバックはawaitできないため
       } else if (info.signal === EOBSOutputSignal.Reconnect) {
+        this.reconnectStartedAt = Date.now();
+        this.reconnectCount++;
         this.SET_STREAMING_STATUS(EStreamingState.Reconnecting);
         this.streamingStatusChange.next(EStreamingState.Reconnecting);
+        Sentry.addBreadcrumb({
+          category: 'streaming.signal',
+          message: 'reconnect',
+          level: 'warning',
+          data: { code: info.code, error: info.error, reconnectCount: this.reconnectCount },
+        });
+        if (Date.now() - this.lastReconnectSentAt >= this.RECONNECT_RATE_LIMIT_MS) {
+          this.lastReconnectSentAt = Date.now();
+          const streamElapsedSec = this.state.streamingStatusTime
+            ? Math.round(
+              (Date.now() - new Date(this.state.streamingStatusTime).getTime()) / 1000,
+            )
+            : -1;
+          Sentry.withScope((scope) => {
+            scope.setLevel('warning');
+            scope.setTag('service', 'StreamingService');
+            scope.setTag('method', 'handleOBSOutputSignal');
+            scope.setTag('signal', 'Reconnect');
+            scope.setFingerprint(['StreamingService', 'reconnect', String(info.code ?? 0)]);
+            scope.setExtra('info', info);
+            scope.setExtra('streamElapsedSec', streamElapsedSec);
+            scope.setExtra('reconnectCount', this.reconnectCount);
+            Sentry.captureMessage('streaming reconnect started');
+          });
+        }
       } else if (info.signal === EOBSOutputSignal.ReconnectSuccess) {
+        const durationMs =
+          this.reconnectStartedAt != null ? Date.now() - this.reconnectStartedAt : -1;
+        this.reconnectStartedAt = null;
         this.SET_STREAMING_STATUS(EStreamingState.Live);
         this.streamingStatusChange.next(EStreamingState.Live);
+        Sentry.addBreadcrumb({
+          category: 'streaming.signal',
+          message: 'reconnect_success',
+          level: 'info',
+          data: { durationMs, reconnectCount: this.reconnectCount },
+        });
+        Sentry.withScope((scope) => {
+          scope.setLevel('info');
+          scope.setTag('service', 'StreamingService');
+          scope.setTag('method', 'handleOBSOutputSignal');
+          scope.setTag('signal', 'ReconnectSuccess');
+          scope.setFingerprint(['StreamingService', 'reconnectSuccess']);
+          scope.setExtra('durationMs', durationMs);
+          scope.setExtra('reconnectCount', this.reconnectCount);
+          Sentry.captureMessage('streaming reconnect succeeded');
+        });
       }
     } else if (info.type === EOBSOutputType.Recording) {
       const nextState = (
@@ -923,6 +976,22 @@ export class StreamingService
     }
 
     if (info.code) {
+      if (
+        info.signal !== EOBSOutputSignal.Reconnect &&
+        info.signal !== EOBSOutputSignal.ReconnectSuccess
+      ) {
+        Sentry.withScope((scope) => {
+          scope.setLevel('error');
+          scope.setTag('service', 'StreamingService');
+          scope.setTag('method', 'handleOBSOutputSignal');
+          scope.setTag('signal', info.signal);
+          scope.setTag('outputType', info.type);
+          scope.setFingerprint(['StreamingService', 'outputCode', String(info.code)]);
+          scope.setExtra('info', info);
+          scope.setExtra('reconnectCount', this.reconnectCount);
+          Sentry.captureMessage(`OBS output error code: ${info.code}`);
+        });
+      }
       if (this.outputErrorOpen) {
         console.warn('Not showing error message because existing window is open.', info);
         return;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -24,6 +24,7 @@ import * as obs from '../../../obs-api';
 import { RtvcStateService } from '../../services/rtvcStateService';
 import { CustomcastUsageService } from '../custom-cast-usage';
 import { NVoiceCharacterUsageService } from '../nvoice-character-usage';
+import { PerformanceService } from '../performance';
 import { IStreamingSetting } from '../platforms';
 import { SoundDetectorService } from '../sound-detector/sound-detector';
 import { SubStreamService } from '../substream/SubStreamService';
@@ -860,6 +861,11 @@ export class StreamingService
       if (info.signal === EOBSOutputSignal.Start) {
         this.reconnectCount = 0;
         this.reconnectStartedAt = null;
+        Sentry.addBreadcrumb({
+          category: 'streaming.signal',
+          message: 'start',
+          level: 'info',
+        });
         this.SET_STREAMING_STATUS(EStreamingState.Live, time);
         this.streamingStatusChange.next(EStreamingState.Live);
 
@@ -876,12 +882,28 @@ export class StreamingService
 
         void this.logStreamStart(); // fire-and-forget: シグナルコールバックはawaitできないため
       } else if (info.signal === EOBSOutputSignal.Starting) {
+        Sentry.addBreadcrumb({
+          category: 'streaming.signal',
+          message: 'starting',
+          level: 'info',
+        });
         this.SET_STREAMING_STATUS(EStreamingState.Starting, time);
         this.streamingStatusChange.next(EStreamingState.Starting);
       } else if (info.signal === EOBSOutputSignal.Stop) {
+        Sentry.addBreadcrumb({
+          category: 'streaming.signal',
+          message: 'stop',
+          level: 'info',
+          data: { code: info.code, error: info.error },
+        });
         this.SET_STREAMING_STATUS(EStreamingState.Offline, time);
         this.streamingStatusChange.next(EStreamingState.Offline);
       } else if (info.signal === EOBSOutputSignal.Stopping) {
+        Sentry.addBreadcrumb({
+          category: 'streaming.signal',
+          message: 'stopping',
+          level: 'info',
+        });
         this.SET_STREAMING_STATUS(EStreamingState.Ending, time);
         this.streamingStatusChange.next(EStreamingState.Ending);
         void this.logStreamEnd(); // fire-and-forget: シグナルコールバックはawaitできないため
@@ -903,6 +925,7 @@ export class StreamingService
               (Date.now() - new Date(this.state.streamingStatusTime).getTime()) / 1000,
             )
             : -1;
+          const perfState = PerformanceService.instance.state;
           Sentry.withScope((scope) => {
             scope.setLevel('warning');
             scope.setTag('service', 'StreamingService');
@@ -912,6 +935,9 @@ export class StreamingService
             scope.setExtra('info', info);
             scope.setExtra('streamElapsedSec', streamElapsedSec);
             scope.setExtra('reconnectCount', this.reconnectCount);
+            scope.setExtra('CPU', perfState.CPU);
+            scope.setExtra('streamingBandwidth', perfState.streamingBandwidth);
+            scope.setExtra('percentageDroppedFrames', perfState.percentageDroppedFrames);
             Sentry.captureMessage('streaming reconnect started');
           });
         }


### PR DESCRIPTION
## 背景

ユーザーから「配信中に頻繁に黄色の0kbpsになり、N-Airを再起動するしかない。CPU高負荷時(FF11イベントシーン等)に発生しやすい」という問い合わせがあった。

Sentry でイベントを探しても今回の症状に該当するものが見つからなかった。調査したところ、以下の配信異常がコード上は発生し得るにも関わらず Sentry にイベントが上がっていないことが判明した。

## 変更内容

### 1. OBS Reconnect / ReconnectSuccess シグナルの観測 (`streaming.ts`)

- `EOBSOutputSignal.Reconnect` 受信時: `addBreadcrumb` (毎回) + `captureMessage('streaming reconnect started', 'warning')` (30秒レートリミット付き)
  - extra: `info`, `streamElapsedSec`, `reconnectCount`, `CPU`, `streamingBandwidth`, `percentageDroppedFrames`
- `EOBSOutputSignal.ReconnectSuccess` 受信時: `addBreadcrumb` + `captureMessage('streaming reconnect succeeded', 'info')`
  - extra: `durationMs` (再接続所要時間), `reconnectCount`
- 配信開始 (`Start` シグナル) で `reconnectCount` をリセット

### 2. 配信中の bitrate=0 継続検知 (`performance.ts`)

- 配信 Live 状態で `streamingBandwidth === 0` が 16秒 (8サンプル × 2秒) 継続したとき `captureMessage('streaming bandwidth stuck at 0kbps', 'warning')` を送信。bitrate が一度回復すれば再度0kbpsが続いた場合も送信される
  - extra: `zeroDurationSec`, `CPU`, `droppedFrames`, `percentageDroppedFrames`, `streamElapsedSec`
- 配信再接続成功時・配信終了時にカウンタをリセット
- bitrate が回復した場合は `addBreadcrumb('bandwidth recovered')` で記録

### 3. OBS 出力エラーコードの観測 (`streaming.ts`)

- `info.code != 0` で Stop シグナルが来た場合 (Reconnect/ReconnectSuccess は除外) に `captureMessage('OBS output error code: ...', 'error')` を送信
  - extra: `info`, `reconnectCount`
  - fingerprint: `['StreamingService', 'outputCode', String(info.code)]` でエラーコード別にグルーピング

### 4. 調査用 breadcrumb の拡充 (`streaming.ts`, `performance.ts`)

Sentry イベントが発生したときの「直前までの流れ」がタイムラインとして付随するよう、以下の breadcrumb を追加。イベントが発生しなければ送信されないため、ノイズにならない。

- `Starting` / `Start` / `Stopping` / `Stop` シグナル受信時に breadcrumb を記録
- bitrate が最初に 0 になった瞬間 (`zeroBandwidthSamples === 0`) に `bandwidth dropped to 0` breadcrumb を記録 (CPU・droppedFrames 付き)

既存の `Sentry.withScope` + `setTag` + `setFingerprint` + `addBreadcrumb` パターンに揃えています。

## 次のアクション

このPRをリリース後、ユーザーに再度問題が発生したタイミングを確認し、Sentry でイベントを検索する。
- Reconnect が発生しているが ReconnectSuccess が来ない場合 → OBS Reconnect ループの修正へ
- `bandwidth stuck at 0kbps` イベントが上がる場合 → CPU/droppedFrames の extra から負荷状況を把握

## Test plan

- 開発ビルドで `NAIR_REPORT_TO_SENTRY=1` を有効化し、配信開始後にネット接続を一時切断 → Sentry に `streaming reconnect started` / `streaming reconnect succeeded` が届き、breadcrumb に `starting → start → reconnect` の流れが含まれることを確認
