### PR TITLE
変更: 設定/「一般」ページのキャッシュ管理セクションを最下部に移動

### DIFF
--- a/app/components/settings/ExtraSettings.vue
+++ b/app/components/settings/ExtraSettings.vue
@@ -34,6 +34,16 @@
 
     <div>
       <div class="section">
+        <ObsBoolInput
+          :value="pollingPerformanceStatisticsModel"
+          @input="setPollingPerformanceStatistics"
+        />
+        <p>{{ $t('settings.pollingPerformanceStatisticsDescription') }}</p>
+      </div>
+    </div>
+
+    <div>
+      <div class="section">
         <div class="input-label">
           <label>{{ $t('settings.cacheManagement') }}</label>
         </div>
@@ -71,16 +81,6 @@
             {{ $t('settings.deleteAllCacheAndRestart') }}
           </a>
         </div>
-      </div>
-    </div>
-
-    <div>
-      <div class="section">
-        <ObsBoolInput
-          :value="pollingPerformanceStatisticsModel"
-          @input="setPollingPerformanceStatistics"
-        />
-        <p>{{ $t('settings.pollingPerformanceStatisticsDescription') }}</p>
       </div>
     </div>
   </div>

--- a/app/components/settings/Settings.vue
+++ b/app/components/settings/Settings.vue
@@ -33,7 +33,6 @@
           <p class="notification-message">{{ $t('settings.noticeLoginRequired') }}</p>
         </aside>
 
-        <extra-settings v-if="categoryName === 'General'" />
         <language-settings v-if="categoryName === 'General'" />
         <hotkeys v-if="categoryName === 'Hotkeys'" />
         <comment-settings v-if="categoryName === 'Comment' && isLoggedIn" />
@@ -55,6 +54,7 @@
           :isLoggedIn="isLoggedIn"
           @input="save"
         />
+        <extra-settings v-if="categoryName === 'General'" />
       </div>
     </div>
   </modal-layout>


### PR DESCRIPTION
## このpull requestが解決する内容
設定の「一般」ページで、「キャッシュ管理」セクションをページの最下部に移動します。

## 背景
現在の設定「一般」ページでは「キャッシュ管理」セクションが「コンパクトモード」と「パフォーマンス統計のポーリング」の間に配置されています。キャッシュ管理は日常的な設定項目ではないため、ページの最下部に移動します。

## 変更内容

### 変更後のセクション順序（一般タブ全体）

| 順序 | セクション | 変更 |
|------|-----------|------|
| 1 | 言語設定 | 位置変更（2位→1位） |
| 2 | OBS 一般設定群（GenericFormGroups） | 位置変更（3位→2位） |
| 3 | ニコニコ生放送向け最適化 | 位置変更 |
| 4 | コンパクトモード | 位置変更 |
| 5 | パフォーマンス統計のポーリング | 位置変更 |
| 6 | **キャッシュ管理** | **最下部に移動** |

### ファイル変更
- `app/components/settings/ExtraSettings.vue`: キャッシュ管理セクションを ExtraSettings 内の最下部へ移動
- `app/components/settings/Settings.vue`: `extra-settings` コンポーネントを `GenericFormGroups` の後に移動

## テスト
- [x] 設定「一般」タブを開き、キャッシュ管理が最下部に表示されることを確認
- [x] キャッシュ管理セクション内の各ボタン（フォルダ表示、削除、cacheId 表示/コピー、Cookie 削除）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
