### PR TITLE
追加: 設定/ショートカットキー入力ボックスにプレースホルダーを追加

### DIFF
--- a/app/components/shared/Hotkey.vue
+++ b/app/components/shared/Hotkey.vue
@@ -14,6 +14,9 @@
             type="text"
             class="Hotkey-input"
             :value="getBindingString(binding.binding)"
+            :placeholder="String(focusedIndex === index ? $t('hotkeys.inputPlaceholderFocused') : $t('hotkeys.inputPlaceholder'))"
+            @focus="handleFocus(index)"
+            @blur="handleBlur(index)"
             @keydown="e => handleKeydown(e, index)"
           />
           <i class="Hotkey-control icon-plus" @click="addBinding(index)" />

--- a/app/components/shared/Hotkey.vue.ts
+++ b/app/components/shared/Hotkey.vue.ts
@@ -20,6 +20,7 @@ export default class HotkeyComponent extends Vue {
   // @ts-expect-error: ts2729: use before initialization
   description = this.hotkey.description;
   bindings: IKeyedBinding[] = [];
+  focusedIndex: number | null = null;
 
   created() {
     if (this.hotkey.bindings.length === 0) {
@@ -29,6 +30,14 @@ export default class HotkeyComponent extends Vue {
         return this.createBindingWithKey(binding);
       });
     }
+  }
+
+  handleFocus(index: number) {
+    this.focusedIndex = index;
+  }
+
+  handleBlur(index: number) {
+    if (this.focusedIndex === index) this.focusedIndex = null;
   }
 
   handleKeydown(event: KeyboardEvent, index: number) {

--- a/app/i18n/en-US/hotkeys.json
+++ b/app/i18n/en-US/hotkeys.json
@@ -19,5 +19,7 @@
   "togglePerformanceMode": "Toggle Performance Mode",
   "toggleCompactMode": "Toggle Compact Mode",
   "pushToSourceShow": "Show %{sourcename} (while key held)",
-  "pushToSourceHide": "Hide %{sourcename} (while key held)"
+  "pushToSourceHide": "Hide %{sourcename} (while key held)",
+  "inputPlaceholder": "Click to bind",
+  "inputPlaceholderFocused": "Press any key"
 }

--- a/app/i18n/ja-JP/hotkeys.json
+++ b/app/i18n/ja-JP/hotkeys.json
@@ -19,5 +19,7 @@
   "togglePerformanceMode": "パフォーマンス優先モードを切り替える",
   "toggleCompactMode": "コンパクトモードを切り替える",
   "pushToSourceShow": "%{sourcename} を表示する（押している間）",
-  "pushToSourceHide": "%{sourcename} を非表示にする（押している間）"
+  "pushToSourceHide": "%{sourcename} を非表示にする（押している間）",
+  "inputPlaceholder": "クリックして割り当て",
+  "inputPlaceholderFocused": "キーを押してください"
 }


### PR DESCRIPTION
## 背景

ホットキー設定画面の入力ボックスは、キーが未割り当ての場合に何も表示されない。
そのため、初めて使うユーザーがボックスをクリックすればキーを入力できることに気づきにくい状態だったのでプレースホルダなどの表示を追加しました。

## 変更内容

 Hotkey.vue  の入力ボックスにプレースホルダーテキストを追加。

| 状態 | 表示テキスト |
|------|-------------|
| 未フォーカス（未割り当て） | クリックして割り当て / Click to bind |
| フォーカス中 | キーを押してください / Press any key  |

<img width="1346" height="498" alt="image" src="https://github.com/user-attachments/assets/7e0611b1-9ee9-4f78-91a8-05506e4210f5" />
