### PR TITLE
変更: 設定/サブ配信設定のサービス選択をタブからドロップダウンに変更

### DIFF
--- a/app/components/settings/SubStreamSettings.vue
+++ b/app/components/settings/SubStreamSettings.vue
@@ -17,16 +17,17 @@
       </div>
 
       <div class="section" v-if="use">
-        <div class="tab-nav">
-          <button
-            v-for="tab in tabIds"
-            :key="tab"
-            class="button--tab"
-            :class="{ active: selectedTab === tab }"
-            @click="selectTab(tab)"
-          >
-            {{ $t(`settings.substream.tabs.${tab}`) }}
-          </button>
+        <div class="input-wrapper">
+          <div class="input-label">
+            <label>{{ $t('settings.substream.service') }}</label>
+          </div>
+          <dropdown
+            :value="tabOptions.find(o => o.id === selectedTab)"
+            :options="tabOptions"
+            label="name"
+            track-by="id"
+            @input="selectedTab = $event.id"
+          />
         </div>
 
         <div class="input-wrapper">
@@ -269,21 +270,6 @@
 
 .set-url-icon {
   margin-left: 4px;
-}
-
-.tab-nav {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  height: 40px;
-  padding: 0 16px;
-  margin: 0 -16px 8px;
-  border-bottom: 1px solid var(--color-border-light);
-
-  > button {
-    flex: 1;
-    height: 100%;
-  }
 }
 
 .key-input-wrapper {

--- a/app/components/settings/SubStreamSettings.vue
+++ b/app/components/settings/SubStreamSettings.vue
@@ -22,8 +22,8 @@
             <label>{{ $t('settings.substream.service') }}</label>
           </div>
           <dropdown
-            :value="tabOptions.find(o => o.id === selectedTab)"
-            :options="tabOptions"
+            :value="serviceOptions.find(o => o.id === selectedTab)"
+            :options="serviceOptions"
             label="name"
             track-by="id"
             @input="selectedTab = $event.id"

--- a/app/components/settings/SubStreamSettings.vue.ts
+++ b/app/components/settings/SubStreamSettings.vue.ts
@@ -20,10 +20,10 @@ export default class SubStreamSettings extends Vue {
   use: boolean = SubStreamService.defaultState.use;
   selectedTab: SubStreamTabID = SubStreamService.defaultState.selectedTab;
   private _tabSwitching = false;
-  readonly tabIds: SubStreamTabID[] = ['youtube', 'twitch', 'other'];
+  readonly serviceIds: SubStreamTabID[] = ['youtube', 'twitch', 'other'];
 
-  get tabOptions(): { id: SubStreamTabID; name: string }[] {
-    return this.tabIds.map((id) => ({ id, name: $t(`settings.substream.tabs.${id}`) }));
+  get serviceOptions(): { id: SubStreamTabID; name: string }[] {
+    return this.serviceIds.map((id) => ({ id, name: $t(`settings.substream.tabs.${id}`) }));
   }
   url: string = '';
   key: string = '';
@@ -85,10 +85,6 @@ export default class SubStreamSettings extends Vue {
       url: tabSettings.url,
       key: tabSettings.key,
     });
-  }
-
-  selectTab(tab: SubStreamTabID) {
-    this.selectedTab = tab;
   }
 
   setDefaultUrl() {

--- a/app/components/settings/SubStreamSettings.vue.ts
+++ b/app/components/settings/SubStreamSettings.vue.ts
@@ -21,6 +21,10 @@ export default class SubStreamSettings extends Vue {
   selectedTab: SubStreamTabID = SubStreamService.defaultState.selectedTab;
   private _tabSwitching = false;
   readonly tabIds: SubStreamTabID[] = ['youtube', 'twitch', 'other'];
+
+  get tabOptions(): { id: SubStreamTabID; name: string }[] {
+    return this.tabIds.map((id) => ({ id, name: $t(`settings.substream.tabs.${id}`) }));
+  }
   url: string = '';
   key: string = '';
 

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -716,6 +716,7 @@
   "substream": {
     "use": "Use",
     "description": "When this feature is turned ON, you can simultaneously stream\nto other platforms in addition to your main destination.",
+    "service": "Streaming Service",
     "url": "URL",
     "streamKey": "Stream Key",
     "syncWithMainStream": "Sync with main stream start/stop",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -716,6 +716,7 @@
   "substream": {
     "use": "使用する",
     "description": "この機能をONにすると、メインの配信先に加えて、\n他のプラットフォームへも同時に配信できます。",
+    "service": "配信サービス",
     "url": "URL",
     "streamKey": "ストリームキー",
     "syncWithMainStream": "メイン配信の配信開始/終了にあわせる",


### PR DESCRIPTION
## 変更内容

サブ配信設定画面のサービス選択UIをタブボタンから `Dropdown` コンポーネントに変更しました。

- タブナビゲーション → `Dropdown` コンポーネント（他の設定項目と統一）
- `tabOptions` computed を追加（`{ id, name }` 形式）
- i18n キー `settings.substream.service` を追加（ja-JP: 「配信サービス」、en-US: 「Streaming Service」）
- 不要になった `.tab-nav` スタイルを削除

<img width="1374" height="846" alt="image" src="https://github.com/user-attachments/assets/1ef5754e-415d-4468-ac08-0a04ea5f555e" />
