### PR TITLE
変更: 設定/各セクション名の冗長な「設定」という言葉を削減

### DIFF
--- a/app/components/settings/CommentSettings.vue
+++ b/app/components/settings/CommentSettings.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="setting-section">
-    <toc-section title="表示設定">
+    <toc-section title="表示">
       <div class="section">
         <div class="input-label section-heading">
-          <label>表示設定</label>
+          <label>表示</label>
         </div>
         <div class="input-container">
           <div class="input-wrapper">
@@ -60,10 +60,10 @@
       </div>
     </toc-section>
 
-    <toc-section title="HTTP連携設定">
+    <toc-section title="HTTP連携">
       <div class="section">
         <div class="input-label section-heading">
-          <label>HTTP連携設定</label>
+          <label>HTTP連携</label>
         </div>
         <div class="input-container">
           <div class="input-wrapper">

--- a/app/components/settings/CommentSpeechSettings.vue
+++ b/app/components/settings/CommentSpeechSettings.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="setting-section">
-    <toc-section title="読み上げ設定">
+    <toc-section title="読み上げ">
       <div class="section">
         <div class="input-label section-heading">
-          <label>読み上げ設定</label>
+          <label>読み上げ</label>
         </div>
         <div class="input-container">
           <div class="input-wrapper">
@@ -16,10 +16,10 @@
           </div>
         </div>
 
-        <toc-section title="音声設定" :visible="synthesizerEnabled">
+        <toc-section title="音声" :visible="synthesizerEnabled">
           <div class="section" v-if="synthesizerEnabled">
             <div class="input-label section-heading">
-              <label>音声設定</label>
+              <label>音声</label>
             </div>
             <div class="input-container">
               <div class="input-wrapper">
@@ -63,10 +63,10 @@
           </div>
         </toc-section>
 
-        <toc-section title="振り分け設定" :visible="synthesizerEnabled">
+        <toc-section title="振り分け" :visible="synthesizerEnabled">
           <div class="section" v-if="synthesizerEnabled">
             <div class="input-label section-heading">
-              <label>振り分け設定</label>
+              <label>振り分け</label>
             </div>
             <div class="input-container">
               <div v-if="voicevoxInformation" class="banner">

--- a/app/components/settings/SoundDetectorSettings.vue
+++ b/app/components/settings/SoundDetectorSettings.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="setting-section">
-    <toc-section title="読み上げ停止設定" id="sound-detector-settings">
+    <toc-section title="読み上げ停止" id="sound-detector-settings">
       <div class="section">
         <div class="input-label section-heading">
-          <label>読み上げ停止設定</label>
+          <label>読み上げ停止</label>
         </div>
         <p class="section-notice-text">放送者の発声中にコメント読み上げを一時停止する設定です</p>
         <div class="input-container">
@@ -17,10 +17,10 @@
           </div>
         </div>
 
-        <toc-section title="基本設定">
+        <toc-section title="基本">
           <div class="section">
             <div class="input-label section-heading">
-              <label>基本設定</label>
+              <label>基本</label>
             </div>
             <ObsListInput v-model="soundDetectorSourceModel" />
             <p v-if="!sourceAvailable" class="source-unavailable-warning">
@@ -87,10 +87,10 @@
           </div>
         </toc-section>
 
-        <toc-section title="詳細設定">
+        <toc-section title="詳細">
           <div class="section">
             <div class="input-label section-heading--dropdown" :class="{ 'is-collapsed': collapsed }" @click="collapsed = !collapsed">
-              <label>詳細設定</label>
+              <label>詳細</label>
               <i :class="collapsed ? 'icon-arrow-bottom-fill' : 'icon-arrow-top-fill'" />
             </div>
             <div v-if="!collapsed">

--- a/app/components/settings/SpeechEngineSettings.vue
+++ b/app/components/settings/SpeechEngineSettings.vue
@@ -12,7 +12,7 @@
       </div>
       <div class="speech-engine-body">
         <div class="input-label section-heading">
-          <label>音声設定</label>
+          <label>音声</label>
         </div>
         <div class="input-container">
           <div class="row">
@@ -66,7 +66,7 @@
       </div>
       <div class="speech-engine-body">
         <div class="input-label section-heading">
-          <label>音声設定</label>
+          <label>音声</label>
         </div>
         <div class="input-container">
           <div class="row">

--- a/app/components/shared/TableOfContents.vue.test.ts
+++ b/app/components/shared/TableOfContents.vue.test.ts
@@ -75,8 +75,8 @@ describe('TableOfContents', () => {
 
     it('日本語のセクション名を受け取れる', () => {
       const sections: TocSectionData[] = [
-        { id: 'display-settings', title: '表示設定', order: 0, level: 1 },
-        { id: 'audio-settings', title: '音声設定', order: 1, level: 2 },
+        { id: 'display-settings', title: '表示', order: 0, level: 1 },
+        { id: 'audio-settings', title: '音声', order: 1, level: 2 },
       ];
 
       const instance = createInstance(sections);
@@ -146,12 +146,12 @@ describe('TableOfContents', () => {
   describe('integration scenarios', () => {
     it('CommentSettings のような複雑な階層構造を扱える', () => {
       const sections: TocSectionData[] = [
-        { id: 'display', title: '表示設定', order: 0, level: 1 },
-        { id: 'speech', title: '読み上げ設定', order: 1, level: 1 },
-        { id: 'audio', title: '音声設定', order: 2, level: 2 },
-        { id: 'distribution', title: '振り分け設定', order: 3, level: 2 },
+        { id: 'display', title: '表示', order: 0, level: 1 },
+        { id: 'speech', title: '読み上げ', order: 1, level: 1 },
+        { id: 'audio', title: '音声', order: 2, level: 2 },
+        { id: 'distribution', title: '振り分け', order: 3, level: 2 },
         { id: 'onecomme', title: 'わんコメ連携', order: 4, level: 1 },
-        { id: 'http', title: 'HTTP連携設定', order: 5, level: 1 },
+        { id: 'http', title: 'HTTP連携', order: 5, level: 1 },
       ];
 
       const instance = createInstance(sections);

--- a/app/components/shared/TocManager.test.ts
+++ b/app/components/shared/TocManager.test.ts
@@ -407,25 +407,25 @@ describe('TocManager', () => {
     it('複雑な階層構造を正しく管理できる', () => {
       manager.register('Comment', {
         id: 'display',
-        title: '表示設定',
+        title: '表示',
         order: 0,
         level: 1,
       });
       manager.register('Comment', {
         id: 'speech',
-        title: '読み上げ設定',
+        title: '読み上げ',
         order: 0,
         level: 1,
       });
       manager.register('Comment', {
         id: 'audio',
-        title: '音声設定',
+        title: '音声',
         order: 0,
         level: 2,
       });
       manager.register('Comment', {
         id: 'distribution',
-        title: '振り分け設定',
+        title: '振り分け',
         order: 0,
         level: 2,
       });

--- a/app/components/shared/TocSection.vue.test.ts
+++ b/app/components/shared/TocSection.vue.test.ts
@@ -114,10 +114,10 @@ describe('TocSection', () => {
 
     it('同じタイトルでも異なるIDが生成される', () => {
       const instance1 = createInstance({
-        title: '表示設定',
+        title: '表示',
       });
       const instance2 = createInstance({
-        title: '表示設定',
+        title: '表示',
       });
 
       expect(instance1.sectionId).toBe('toc-section-0');

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -523,7 +523,7 @@
     "name": "ショートカットキー"
   },
   "Advanced": {
-    "name": "詳細設定",
+    "name": "詳細",
     "General": {
       "name": "一般",
       "ProcessPriority": {
@@ -645,7 +645,7 @@
     }
   },
   "Comment": {
-    "name": "コメント設定"
+    "name": "コメント"
   },
   "CommentSpeech": {
     "name": "コメント読み上げ"
@@ -699,7 +699,7 @@
   "pollingPerformanceStatisticsDescription": "配信が不安定な場合は無効にしてみてください。",
   "compactMode": "コンパクトモード",
   "autoCompact": {
-    "title": "コンパクトモード自動化設定",
+    "title": "コンパクトモード自動化",
     "message": "番組開始時に自動的にコンパクトモードになり、番組終了時に自動で解除されるように設定できます。\n※設定をOFFにしたい場合は[設定]>[一般]から変更できます",
     "doNotShowAgain": "今後、このダイアログを表示しない",
     "later": "今はONにしない",
@@ -788,20 +788,20 @@
     "downloadVoskModel": "モデルをダウンロードする",
     "cancelVoskModel": "ダウンロードをキャンセルする",
     "deleteVoskModel": "ダウンロードしたモデルを削除する",
-    "audioSettings": "音声設定",
+    "audioSettings": "音声",
     "audioSource": "音声ソース",
     "noAudioSourceFound": "音声ソースが見つかりません",
     "preview": "プレビュー",
-    "displaySettings": "表示設定",
+    "displaySettings": "表示",
     "textFile": {
-      "sectionTitle": "自動文字起こしソース出力設定",
+      "sectionTitle": "自動文字起こしソース出力",
       "enable": "自動文字起こしソース出力を有効にする",
       "path": "テキストファイルパス",
       "maxLine": "テキストの最大行数",
       "lineTimeToLive": "テキスト行の最大表示時間 (ミリ秒)"
     },
     "comment": {
-      "sectionTitle": "ニコニコ生放送コメント設定",
+      "sectionTitle": "ニコニコ生放送コメント",
       "notice1": "ONにすると、AIが発言をリアルタイムで文字起こしし、視聴者のプレーヤーやコメントリストに表示します。",
       "notice2": "プレーヤーに自動的に文字起こし結果のテキストを表示します。",
       "notice3": "ニコニコ生放送の番組放送中に自動的に文字起こし結果をコメントとして投稿します。",

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -452,8 +452,8 @@
     "name": "ボイスチェンジャー",
     "description": "自分の声を変換します。\n琴詠ニア、ずんだもん、春日部つむぎや100種類の声をブレンドした自分だけの声になれます。",
     "nav": {
-      "voice_setting": "ボイス設定",
-      "common_setting": "共通設定",
+      "voice_setting": "ボイス",
+      "common_setting": "共通",
       "preset_voice": "キャラクターボイス",
       "original_voice": "オリジナルボイス",
       "remove_voice": "ボイスを削除",
@@ -468,7 +468,7 @@
     },
     "container": {
       "voice_name": "名前",
-      "voice_setting": "音声設定",
+      "voice_setting": "音声",
       "make_random": {
         "name": "ランダムで生成",
         "description": "ボイス1、ボイス2、割合をランダムで設定して生成します"


### PR DESCRIPTION
## 概要

設定画面で 「〜設定」といった文言が多いため表現が冗長になっていたので、i18nファイル内の各セクション・項目名に付いていた「設定」という語を除去し、簡潔な名称に統一しました。

## 変更内容

### Vue コンポーネント（セクション見出し）
- `表示設定` → `表示`
- `読み上げ設定` → `読み上げ`
- `音声設定` → `音声`
- `振り分け設定` → `振り分け`
- `HTTP連携設定` → `HTTP連携`

### i18n（settings.json）
- `詳細設定` → `詳細`
- `コメント設定` → `コメント`
- `コンパクトモード自動化設定` → `コンパクトモード自動化`
- `音声設定` → `音声`
- `表示設定` → `表示`
- `自動文字起こしソース出力設定` → `自動文字起こしソース出力`
- `ニコニコ生放送コメント設定` → `ニコニコ生放送コメント`

### i18n（source-props.json）
- `ボイス設定` → `ボイス`
- `共通設定` → `共通`
- `音声設定` → `音声`

### テスト
- 上記変更に合わせてテストデータを更新

## 変更種別

表示文字列のみの変更です。処理・ロジックへの影響はありません。


<img width="941" height="701" alt="Monosnap work 2026-05-21 13-41-30" src="https://github.com/user-attachments/assets/6cc12a03-952b-4e68-93cb-97717a296a6a" />
<img width="932" height="762" alt="Monosnap work 2026-05-21 13-42-00" src="https://github.com/user-attachments/assets/ce97d3b2-9865-4d2a-8897-bd497264cffb" />

before

<img width="1884" height="1322" alt="image" src="https://github.com/user-attachments/assets/7431294f-e9df-4edb-a6d9-76f534514194" />
<img width="1844" height="1502" alt="image" src="https://github.com/user-attachments/assets/6d214a6e-e522-4e7f-abb2-3d44191f5725" />



