### PR TITLE
開発: @n-air-app/nicolive-comment-protobuf を 2026.116.121242 に更新し protobufjs を v8 に対応

### DIFF
--- a/app/services/nicolive-program/NdgrClient.test.ts
+++ b/app/services/nicolive-program/NdgrClient.test.ts
@@ -103,6 +103,17 @@ function encodeMessages<T>(encoder: (message: T) => Writer, messages: T[]): Uint
     .reduce((a, b) => new Uint8Array([...a, ...b]), new Uint8Array([]));
 }
 
+// proto3 ではデフォルト値 (enum 0 等) が wire format に乗らないため、
+// 期待値も同じ encode/decode を経由させて正規化してから比較する
+function normalizeChunkedMessage(
+  msg: dwango.nicolive.chat.service.edge.IChunkedMessage,
+): dwango.nicolive.chat.service.edge.IChunkedMessage {
+  const ChunkedMessage = dwango.nicolive.chat.service.edge.ChunkedMessage;
+  return ChunkedMessage.decode(
+    ChunkedMessage.encode(ChunkedMessage.fromObject(msg)).finish(),
+  ).toJSON();
+}
+
 describe('ChunkedEntry', () => {
   test('EncodeDelimited して DecodeDelimited すると元のオブジェクトに戻る', () => {
     const buf = encodeMessages(
@@ -232,7 +243,10 @@ describe('NdgrClient', () => {
     const expectedMessages = [...prevMessages, ...messages];
     expect(onReceived).toHaveBeenCalledTimes(expectedMessages.length);
     for (let i = 0; i < expectedMessages.length; i++) {
-      expect(onReceived).toHaveBeenNthCalledWith(i + 1, { message: expectedMessages[i] });
+      expect(onReceived).toHaveBeenNthCalledWith(
+        i + 1,
+        normalizeChunkedMessage({ message: expectedMessages[i] }),
+      );
     }
     target.dispose();
     expect(onCompleted).toHaveBeenCalledTimes(1);
@@ -263,7 +277,10 @@ describe('NdgrClient', () => {
     const expectedMessages = [...backwards, ...prevMessages, ...messages];
     expect(onReceived).toHaveBeenCalledTimes(expectedMessages.length);
     for (let i = 0; i < expectedMessages.length; i++) {
-      expect(onReceived).toHaveBeenNthCalledWith(i + 1, { message: expectedMessages[i] });
+      expect(onReceived).toHaveBeenNthCalledWith(
+        i + 1,
+        normalizeChunkedMessage({ message: expectedMessages[i] }),
+      );
     }
     target.dispose();
     expect(onCompleted).toHaveBeenCalledTimes(1);

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -1,6 +1,5 @@
 import { dwango } from '@n-air-app/nicolive-comment-protobuf';
 import { Observable, Subject, Subscription } from 'rxjs';
-import { getKeys } from 'util/getKeys';
 
 import { MessageResponse, NotificationType, NotificationTypeTable } from './ChatMessage';
 import { IMessageServerClient } from './MessageServerClient';
@@ -132,16 +131,22 @@ function convertSimpleNotificationToMessageResponse(
   common: CommonComponent,
   notification: dwango.nicolive.chat.data.ISimpleNotification,
 ): MessageResponse | undefined {
-  const key = getKeys(notification)[0];
-  let type = key as NotificationType;
-  if (!NotificationTypeTable.includes(key)) {
-    type = 'unknown';
-  }
+  // protobufjs 8 のデコード結果では `message` が oneof の discriminator として設定される。
+  // プレーンオブジェクトとして渡された場合はフォールバックとして Object.keys で探す。
+  const key = notification.message
+    ?? (Object.keys(notification).find((k) => k !== '$unknowns' && k !== 'message') as
+        typeof notification.message | string | undefined);
+  const type: NotificationType =
+    key != null && (NotificationTypeTable as readonly string[]).includes(key)
+      ? (key as NotificationType)
+      : 'unknown';
   return {
     notification: {
       ...common,
       type,
-      message: notification[key],
+      message: key != null
+        ? ((notification[key as keyof typeof notification] as string) ?? '')
+        : '',
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@electron/remote": "2.1.3",
     "@n-air-app/n-voice-package": "^1.0.2",
-    "@n-air-app/nicolive-comment-protobuf": "2025.1117.170000",
+    "@n-air-app/nicolive-comment-protobuf": "2026.116.121242",
     "@sentry/electron": "7.4.0",
     "@sentry/vue": "10.27.0",
     "color-picker": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/color-picker-1.3.11-win64.tar.gz",
@@ -74,7 +74,7 @@
     "node-fontinfo": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/node-fontinfo-1.1.12-win64.tar.gz",
     "node-libuiohook": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/node-libuiohook-1.1.17-win64.tar.gz",
     "obs-studio-node": "https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz",
-    "protobufjs": "^7.5.3",
+    "protobufjs": "^8.4.0",
     "rxjs": "^7.8.1",
     "semver": "^7.5.4",
     "socket.io": "4.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@babel/core@7.28.6)(@types/babel__core@7.20.5)
       '@n-air-app/nicolive-comment-protobuf':
-        specifier: 2025.1117.170000
-        version: 2025.1117.170000
+        specifier: 2026.116.121242
+        version: 2026.116.121242
       '@sentry/electron':
         specifier: 7.4.0
         version: 7.4.0
@@ -67,8 +67,8 @@ importers:
         specifier: https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz
         version: '@streamlabs/obs-studio-node@https://github.com/n-air-app/native-deps/releases/download/osn0.25.56/osn-0.25.56-release-win64.tar.gz'
       protobufjs:
-        specifier: ^7.5.3
-        version: 7.5.5
+        specifier: ^8.4.0
+        version: 8.4.0
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1352,8 +1352,8 @@ packages:
   '@n-air-app/n-voice-package@1.0.2':
     resolution: {integrity: sha512-E9TsrIhqoX8p6ZGeg9j0s3+fIZMoQONxlPt2nw1ctZGpMnK4O5IO6hug9wWg5oLG4C3gYV763Yem7p8NIb2EqQ==, tarball: https://npm.pkg.github.com/download/@n-air-app/n-voice-package/1.0.2/3ad9bb4da017848de7a399c171bb971a5f987e52}
 
-  '@n-air-app/nicolive-comment-protobuf@2025.1117.170000':
-    resolution: {integrity: sha512-DYhbJ8n1LoyCBDbt7ZKGzBl0qBmNZDFkprLmnq7GsYOH2W5SfNe7hQhHs6ys9rTj1HjSHiGWDaahLRSlVVwOgA==, tarball: https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2025.1117.170000/73b1c2f30f2df49ea6912dda6775236d059304da}
+  '@n-air-app/nicolive-comment-protobuf@2026.116.121242':
+    resolution: {integrity: sha512-KF8t1jNeETZOSpp50UhHkdAcq2LNgOWtqIyW9mKT2HnIKdN/Sw/EHEqI9csGK1/pbtPHjjt2MosunUvteUO5PA==, tarball: https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2026.116.121242/36407e5ae0a52bebe93c8f581aa46c886054721f}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1576,36 +1576,6 @@ packages:
     resolution: {integrity: sha512-QcuYy25pkXM8BJ37wVFBO7Zh34nyRV1GOb2n3lPkkbRYfl4hWl3PTcImP41P0KrzVXfa/45p6eVCos27x3exIg==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
-
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
-
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
-
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
-
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rollup/plugin-babel@6.1.0':
     resolution: {integrity: sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==}
@@ -5970,8 +5940,8 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@8.4.0:
+    resolution: {integrity: sha512-iriNhQ57SYA5Jbdi+41AyPdx6jPPkFO7DODzkOBmqFhgYn/JzX2HxgxYPY18eQAs3CP/AWqtPvkWn8rclRAxdQ==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -8854,9 +8824,9 @@ snapshots:
       - '@types/babel__core'
       - supports-color
 
-  '@n-air-app/nicolive-comment-protobuf@2025.1117.170000':
+  '@n-air-app/nicolive-comment-protobuf@2026.116.121242':
     dependencies:
-      protobufjs: 7.5.5
+      protobufjs: 8.4.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9124,29 +9094,6 @@ snapshots:
       '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.4': {}
-
-  '@protobufjs/eventemitter@1.1.0': {}
-
-  '@protobufjs/fetch@1.1.0':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
-
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.0': {}
 
   '@rollup/plugin-babel@6.1.0(@babel/core@7.28.6)(@types/babel__core@7.20.5)(rollup@3.29.5)':
     dependencies:
@@ -14115,19 +14062,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  protobufjs@7.5.5:
+  protobufjs@8.4.0:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.27
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
## このpull requestが解決する内容
`@n-air-app/nicolive-comment-protobuf` を `2026.116.121242` に更新します。このバージョンから `protobufjs` の依存が v7 → v8 に変わるため、本体側の `protobufjs` も合わせて更新します。

protobufjs v8 への更新により、多数の dependabot security alert が解消される見込みです（`@protobufjs/*` サブパッケージ群が v8 で統合・削除されたため）。

## 変更内容

| package | before | after | 備考 |
|---------|--------|-------|------|
| @n-air-app/nicolive-comment-protobuf | 2025.1117.170000 | 2026.116.121242 | |
| protobufjs | ^7.5.3 (7.5.5) | ^8.4.0 (8.4.0) | メジャーバージョンアップ |

### ファイル変更
- `package.json`: 2パッケージのバージョン更新
- `pnpm-lock.yaml`: 依存関係の更新（`@protobufjs/*` サブパッケージ9個が削除）
- `app/services/nicolive-program/NdgrClient.test.ts`: テスト修正
- `app/services/nicolive-program/NdgrCommentReceiver.ts`: 型修正

### protobufjs v7 → v8 の変更点と対応

**変更1: proto3 デフォルト値が `toJSON()` で省略されるようになった**

- **アプリコードへの影響なし**: インスタンスへのプロパティアクセス（`msg.operation` 等）はプロトタイプ経由でデフォルト値 `0` を返すため、`nicolive-moderators.ts` の switch 文は正常動作する
- **テストの修正**: `NdgrClient.test.ts` で `msg.toJSON()` の結果を比較しているテスト2件で、期待値を同じ encode/decode パスで正規化する `normalizeChunkedMessage()` ヘルパーを追加（`nicolive-comment-protobuf` パッケージ側の PR #101 と同じアプローチ）

**変更2: `SimpleNotification.$Properties` に oneof discriminator と `$unknowns` フィールドが追加された**

- `message?: ("ichiba"|"quote"|...)`: oneof のどのケースがセットされているかを示す discriminator
- `$unknowns?: Uint8Array[]`: 未知フィールドの保存用
- **修正**: `NdgrCommentReceiver.ts` の `convertSimpleNotificationToMessageResponse` を、`notification.message` discriminatorを優先して使い、プレーンオブジェクトの場合は `Object.keys` フォールバックで対応するよう修正
- **不要になった `getKeys` import を削除**

## 関連
- 関連: n-air-app/nicolive-comment-protobuf#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
