### PR TITLE
変更: 色指定のコンポーネントを変更

### DIFF
--- a/app/components/obs/inputs/ColorPicker.vue
+++ b/app/components/obs/inputs/ColorPicker.vue
@@ -70,7 +70,7 @@
         <input
           class="color-picker__input"
           :value="rgba[ch.key]"
-          @change="onRgbChange(ch.key, $event)"
+          @input="onRgbInput(ch.key, $event)"
           type="number"
           min="0"
           max="255"
@@ -81,7 +81,7 @@
         <input
           class="color-picker__input"
           :value="alphaInput"
-          @change="onAlphaChange"
+          @input="onAlphaInput"
           type="number"
           min="0"
           max="1"

--- a/app/components/obs/inputs/ColorPicker.vue
+++ b/app/components/obs/inputs/ColorPicker.vue
@@ -54,9 +54,10 @@
       <div class="color-picker__field color-picker__field--hex">
         <input
           class="color-picker__input"
+          type="text"
           :value="hexInput"
-          @change="onHexChange"
-          maxlength="7"
+          @input="onHexInput"
+          maxlength="8"
           spellcheck="false"
         />
         <label class="color-picker__label">HEX</label>
@@ -79,11 +80,12 @@
       <div class="color-picker__field">
         <input
           class="color-picker__input"
-          :value="alphaPercent"
+          :value="alphaInput"
           @change="onAlphaChange"
           type="number"
           min="0"
-          max="100"
+          max="1"
+          step="0.01"
         />
         <label class="color-picker__label">A</label>
       </div>
@@ -253,8 +255,8 @@
 /* Input fields */
 .color-picker__fields {
   display: flex;
-  gap: 4px;
-  margin-top: 8px;
+  gap: 3px;
+  margin-top: 6px;
 }
 
 .color-picker__field {
@@ -264,21 +266,31 @@
   align-items: center;
 
   &--hex {
-    flex: 2;
+    flex: 1.6;
   }
 }
 
-.color-picker__input {
+.color-picker__fields .color-picker__input {
   box-sizing: border-box;
   width: 100%;
-  padding: 2px 0;
-  font-size: 10px;
-  color: @text-primary;
+  height: 26px;
+  padding: 1px 0;
+  font-size: 11px;
+  color: var(--color-text);
   text-align: center;
   background-color: @bg-primary;
-  border: none;
+  border: solid 1px var(--color-white);
   border-radius: 2px;
-  box-shadow: inset 0 0 0 1px @border;
+
+  &:hover {
+    border-color: var(--color-white);
+  }
+
+  &:focus {
+    color: var(--color-text);
+    border-color: var(--color-white);
+    box-shadow: none;
+  }
 
   /* Hide number input arrows */
   &[type='number'] {
@@ -294,9 +306,9 @@
 
 .color-picker__label {
   display: block;
-  margin-top: 3px;
-  font-size: 10px;
-  color: @grey;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--color-text-active);
   text-align: center;
   text-transform: uppercase;
 }

--- a/app/components/obs/inputs/ColorPicker.vue
+++ b/app/components/obs/inputs/ColorPicker.vue
@@ -90,6 +90,20 @@
         <label class="color-picker__label">A</label>
       </div>
     </div>
+
+    <!-- Preset colors -->
+    <div class="color-picker__presets">
+      <div
+        v-for="color in presetColors"
+        :key="color"
+        class="color-picker__preset"
+        :class="{ 'color-picker__preset--transparent': color === 'transparent' }"
+        :style="color !== 'transparent' ? { background: color } : {}"
+        @click="applyPreset(color)"
+      >
+        <div v-if="color === 'transparent'" class="color-picker__preset-checker" />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -311,5 +325,40 @@
   color: var(--color-text-active);
   text-align: center;
   text-transform: uppercase;
+}
+
+/* Preset colors */
+.color-picker__presets {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 4px;
+  padding-top: 8px;
+  margin-top: 6px;
+  border-top: 1px solid @border;
+}
+
+.color-picker__preset {
+  width: 100%;
+  aspect-ratio: 1;
+  overflow: hidden;
+  cursor: pointer;
+  border-radius: 3px;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 15%);
+
+  &:hover {
+    box-shadow: inset 0 0 0 1px rgb(0 0 0 / 40%);
+  }
+}
+
+.color-picker__preset-checker {
+  width: 100%;
+  height: 100%;
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+  background-size: 8px 8px;
 }
 </style>

--- a/app/components/obs/inputs/ColorPicker.vue
+++ b/app/components/obs/inputs/ColorPicker.vue
@@ -56,54 +56,31 @@
           class="color-picker__input"
           :value="hexInput"
           @change="onHexChange"
-          @keydown.enter="onHexChange"
           maxlength="7"
           spellcheck="false"
         />
         <label class="color-picker__label">HEX</label>
       </div>
-      <div class="color-picker__field">
+      <div
+        v-for="ch in rgbChannels"
+        :key="ch.key"
+        class="color-picker__field"
+      >
         <input
           class="color-picker__input"
-          :value="rgba.r"
-          @change="onRgbChange('r', $event)"
-          @keydown.enter="onRgbChange('r', $event)"
+          :value="rgba[ch.key]"
+          @change="onRgbChange(ch.key, $event)"
           type="number"
           min="0"
           max="255"
         />
-        <label class="color-picker__label">R</label>
-      </div>
-      <div class="color-picker__field">
-        <input
-          class="color-picker__input"
-          :value="rgba.g"
-          @change="onRgbChange('g', $event)"
-          @keydown.enter="onRgbChange('g', $event)"
-          type="number"
-          min="0"
-          max="255"
-        />
-        <label class="color-picker__label">G</label>
-      </div>
-      <div class="color-picker__field">
-        <input
-          class="color-picker__input"
-          :value="rgba.b"
-          @change="onRgbChange('b', $event)"
-          @keydown.enter="onRgbChange('b', $event)"
-          type="number"
-          min="0"
-          max="255"
-        />
-        <label class="color-picker__label">B</label>
+        <label class="color-picker__label">{{ ch.label }}</label>
       </div>
       <div class="color-picker__field">
         <input
           class="color-picker__input"
           :value="alphaPercent"
           @change="onAlphaChange"
-          @keydown.enter="onAlphaChange"
           type="number"
           min="0"
           max="100"

--- a/app/components/obs/inputs/ColorPicker.vue
+++ b/app/components/obs/inputs/ColorPicker.vue
@@ -1,0 +1,326 @@
+<template>
+  <div class="color-picker" @mousedown.stop @click.stop>
+    <!-- Saturation/Brightness 2D picker -->
+    <div
+      class="color-picker__saturation"
+      :style="{ background: hueBackground }"
+      ref="saturation"
+      @mousedown="onSaturationMouseDown"
+    >
+      <div class="color-picker__saturation-white" />
+      <div class="color-picker__saturation-black" />
+      <div
+        class="color-picker__saturation-pointer"
+        :style="{ top: satPointerTop, left: satPointerLeft }"
+      >
+        <div class="color-picker__saturation-circle" />
+      </div>
+    </div>
+
+    <div class="color-picker__controls">
+      <!-- Hue slider -->
+      <div class="color-picker__sliders">
+        <div class="color-picker__hue" ref="hue" @mousedown="onHueMouseDown">
+          <div class="color-picker__hue-gradient" />
+          <div
+            class="color-picker__slider-pointer"
+            :style="{ left: huePointerLeft }"
+          />
+        </div>
+
+        <!-- Alpha slider -->
+        <div class="color-picker__alpha" ref="alpha" @mousedown="onAlphaMouseDown">
+          <div class="color-picker__alpha-checkerboard" />
+          <div
+            class="color-picker__alpha-gradient"
+            :style="{ background: alphaGradient }"
+          />
+          <div
+            class="color-picker__slider-pointer"
+            :style="{ left: alphaPointerLeft }"
+          />
+        </div>
+      </div>
+
+      <!-- Color preview -->
+      <div class="color-picker__preview">
+        <div class="color-picker__preview-checkerboard" />
+        <div class="color-picker__preview-color" :style="{ background: previewColor }" />
+      </div>
+    </div>
+
+    <!-- Input fields -->
+    <div class="color-picker__fields">
+      <div class="color-picker__field color-picker__field--hex">
+        <input
+          class="color-picker__input"
+          :value="hexInput"
+          @change="onHexChange"
+          @keydown.enter="onHexChange"
+          maxlength="7"
+          spellcheck="false"
+        />
+        <label class="color-picker__label">HEX</label>
+      </div>
+      <div class="color-picker__field">
+        <input
+          class="color-picker__input"
+          :value="rgba.r"
+          @change="onRgbChange('r', $event)"
+          @keydown.enter="onRgbChange('r', $event)"
+          type="number"
+          min="0"
+          max="255"
+        />
+        <label class="color-picker__label">R</label>
+      </div>
+      <div class="color-picker__field">
+        <input
+          class="color-picker__input"
+          :value="rgba.g"
+          @change="onRgbChange('g', $event)"
+          @keydown.enter="onRgbChange('g', $event)"
+          type="number"
+          min="0"
+          max="255"
+        />
+        <label class="color-picker__label">G</label>
+      </div>
+      <div class="color-picker__field">
+        <input
+          class="color-picker__input"
+          :value="rgba.b"
+          @change="onRgbChange('b', $event)"
+          @keydown.enter="onRgbChange('b', $event)"
+          type="number"
+          min="0"
+          max="255"
+        />
+        <label class="color-picker__label">B</label>
+      </div>
+      <div class="color-picker__field">
+        <input
+          class="color-picker__input"
+          :value="alphaPercent"
+          @change="onAlphaChange"
+          @keydown.enter="onAlphaChange"
+          type="number"
+          min="0"
+          max="100"
+        />
+        <label class="color-picker__label">A</label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" src="./ColorPicker.vue.ts"></script>
+
+<style lang="less">
+@import url('../../../styles/index');
+
+.color-picker {
+  position: relative;
+  box-sizing: border-box;
+  width: 220px;
+  padding: 10px;
+  font-family: Menlo, Consolas, 'Courier New', monospace;
+  user-select: none;
+  background: @bg-secondary;
+  border-radius: @radius;
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 15%), 0 8px 16px rgb(0 0 0 / 15%);
+}
+
+/* Saturation/Brightness picker */
+.color-picker__saturation {
+  position: relative;
+  width: 100%;
+  padding-bottom: 75%;
+  overflow: hidden;
+  cursor: crosshair;
+  border-radius: 2px;
+}
+
+.color-picker__saturation-white {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to right, #fff, rgb(255 255 255 / 0%));
+}
+
+.color-picker__saturation-black {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, #000, rgb(0 0 0 / 0%));
+}
+
+.color-picker__saturation-pointer {
+  position: absolute;
+  cursor: move;
+  transform: translate(-50%, -50%);
+}
+
+.color-picker__saturation-circle {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1.5px #fff, inset 0 0 1px 1px rgb(0 0 0 / 30%), 0 0 1px 2px rgb(0 0 0 / 40%);
+}
+
+/* Controls row */
+.color-picker__controls {
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.color-picker__sliders {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Hue slider */
+.color-picker__hue {
+  position: relative;
+  height: 10px;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.color-picker__hue-gradient {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to right,
+    #f00 0%,
+    #ff0 17%,
+    #0f0 33%,
+    #0ff 50%,
+    #00f 67%,
+    #f0f 83%,
+    #f00 100%
+  );
+  border-radius: 2px;
+}
+
+/* Alpha slider */
+.color-picker__alpha {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.color-picker__alpha-checkerboard {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-position: 0 0, 0 3px, 3px -3px, -3px 0;
+  background-size: 6px 6px;
+}
+
+.color-picker__alpha-gradient {
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+}
+
+/* Slider pointer (shared for hue and alpha) */
+.color-picker__slider-pointer {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  cursor: pointer;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 37%);
+  transform: translate(-50%, -50%);
+}
+
+/* Color preview */
+.color-picker__preview {
+  position: relative;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-left: 8px;
+  overflow: hidden;
+  border-radius: 2px;
+}
+
+.color-picker__preview-checkerboard {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+  background-size: 8px 8px;
+}
+
+.color-picker__preview-color {
+  position: absolute;
+  inset: 0;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 15%);
+}
+
+/* Input fields */
+.color-picker__fields {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.color-picker__field {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+
+  &--hex {
+    flex: 2;
+  }
+}
+
+.color-picker__input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 2px 0;
+  font-size: 10px;
+  color: @text-primary;
+  text-align: center;
+  background-color: @bg-primary;
+  border: none;
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px @border;
+
+  /* Hide number input arrows */
+  &[type='number'] {
+    appearance: textfield;
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      margin: 0;
+      appearance: none;
+    }
+  }
+}
+
+.color-picker__label {
+  display: block;
+  margin-top: 3px;
+  font-size: 10px;
+  color: @grey;
+  text-align: center;
+  text-transform: uppercase;
+}
+</style>

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -56,6 +56,25 @@ function clamp(v: number, min: number, max: number) {
   return Math.min(Math.max(v, min), max);
 }
 
+interface IDragContext {
+  dragging: boolean;
+  $emit(event: string, ...args: unknown[]): void;
+}
+
+function startDrag(ctx: IDragContext, e: MouseEvent, onMove: (e: MouseEvent) => void) {
+  ctx.dragging = true;
+  ctx.$emit('dragging-change', true);
+  onMove(e);
+  const onMouseUp = () => {
+    ctx.dragging = false;
+    ctx.$emit('dragging-change', false);
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('mouseup', onMouseUp);
+  };
+  window.addEventListener('mousemove', onMove);
+  window.addEventListener('mouseup', onMouseUp);
+}
+
 export default defineComponent({
   name: 'ColorPicker',
 
@@ -116,22 +135,8 @@ export default defineComponent({
   },
 
   methods: {
-    startDrag(e: MouseEvent, onMove: (e: MouseEvent) => void) {
-      this.dragging = true;
-      this.$emit('dragging-change', true);
-      onMove(e);
-      const onMouseUp = () => {
-        this.dragging = false;
-        this.$emit('dragging-change', false);
-        window.removeEventListener('mousemove', onMove);
-        window.removeEventListener('mouseup', onMouseUp);
-      };
-      window.addEventListener('mousemove', onMove);
-      window.addEventListener('mouseup', onMouseUp);
-    },
-
     onSaturationMouseDown(e: MouseEvent) {
-      this.startDrag(e, (ev) => {
+      startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.saturation as HTMLElement;
         const rect = el.getBoundingClientRect();
         this.hsv = {
@@ -144,7 +149,7 @@ export default defineComponent({
     },
 
     onHueMouseDown(e: MouseEvent) {
-      this.startDrag(e, (ev) => {
+      startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.hue as HTMLElement;
         const rect = el.getBoundingClientRect();
         this.hsv = { ...this.hsv, h: clamp((ev.clientX - rect.left) / rect.width, 0, 1) * 360 };
@@ -153,7 +158,7 @@ export default defineComponent({
     },
 
     onAlphaMouseDown(e: MouseEvent) {
-      this.startDrag(e, (ev) => {
+      startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.alpha as HTMLElement;
         const rect = el.getBoundingClientRect();
         this.internalAlpha = clamp((ev.clientX - rect.left) / rect.width, 0, 1);

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -1,0 +1,284 @@
+import Vue from 'vue';
+import { Component, Prop, Watch } from 'vue-property-decorator';
+
+interface IColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number; // 0.0 - 1.0
+}
+
+interface IHsv {
+  h: number; // 0 - 360
+  s: number; // 0 - 1
+  v: number; // 0 - 1
+}
+
+function rgbToHsv(r: number, g: number, b: number): IHsv {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const d = max - min;
+
+  let h = 0;
+  const s = max === 0 ? 0 : d / max;
+  const v = max;
+
+  if (d !== 0) {
+    if (max === rn) {
+      h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6;
+    } else if (max === gn) {
+      h = ((bn - rn) / d + 2) / 6;
+    } else {
+      h = ((rn - gn) / d + 4) / 6;
+    }
+  }
+
+  return { h: h * 360, s, v };
+}
+
+function hsvToRgb(h: number, s: number, v: number): { r: number; g: number; b: number } {
+  const hn = h / 360;
+  const i = Math.floor(hn * 6);
+  const f = hn * 6 - i;
+  const p = v * (1 - s);
+  const q = v * (1 - f * s);
+  const t = v * (1 - (1 - f) * s);
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  switch (i % 6) {
+    case 0: r = v; g = t; b = p; break;
+    case 1: r = q; g = v; b = p; break;
+    case 2: r = p; g = v; b = t; break;
+    case 3: r = p; g = q; b = v; break;
+    case 4: r = t; g = p; b = v; break;
+    case 5: r = v; g = p; b = q; break;
+  }
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+@Component({})
+export default class ColorPicker extends Vue {
+  /** rgba value: r/g/b in 0-255, a in 0.0-1.0 */
+  @Prop({ required: true })
+    value: IColor;
+
+  // Internal HSV state (avoids rounding issues when dragging)
+  private hsv: IHsv = { h: 0, s: 0, v: 1 };
+  private internalAlpha: number = 1;
+
+  // Dragging state
+  private draggingSat = false;
+  private draggingHue = false;
+  private draggingAlpha = false;
+
+  created() {
+    this.syncFromValue();
+  }
+
+  @Watch('value')
+  onValueChanged() {
+    // Only sync from outside if we're not currently dragging
+    if (!this.draggingSat && !this.draggingHue && !this.draggingAlpha) {
+      this.syncFromValue();
+    }
+  }
+
+  private syncFromValue() {
+    const { r, g, b, a } = this.value;
+    this.hsv = rgbToHsv(r, g, b);
+    this.internalAlpha = a;
+  }
+
+  // ─── Computed ────────────────────────────────────────────────────────────
+
+  get rgba(): IColor {
+    const { r, g, b } = hsvToRgb(this.hsv.h, this.hsv.s, this.hsv.v);
+    return { r, g, b, a: this.internalAlpha };
+  }
+
+  get hueBackground(): string {
+    return `hsl(${this.hsv.h}, 100%, 50%)`;
+  }
+
+  get satPointerTop(): string {
+    return `${(1 - this.hsv.v) * 100}%`;
+  }
+
+  get satPointerLeft(): string {
+    return `${this.hsv.s * 100}%`;
+  }
+
+  get huePointerLeft(): string {
+    return `${(this.hsv.h / 360) * 100}%`;
+  }
+
+  get alphaPointerLeft(): string {
+    return `${this.internalAlpha * 100}%`;
+  }
+
+  get alphaGradient(): string {
+    const { r, g, b } = this.rgba;
+    return `linear-gradient(to right, rgba(${r},${g},${b},0), rgb(${r},${g},${b}))`;
+  }
+
+  get previewColor(): string {
+    const { r, g, b, a } = this.rgba;
+    return `rgba(${r},${g},${b},${a})`;
+  }
+
+  get hexInput(): string {
+    const { r, g, b } = this.rgba;
+    return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+  }
+
+  get alphaPercent(): number {
+    return Math.round(this.internalAlpha * 100);
+  }
+
+  // ─── Saturation/Brightness drag ──────────────────────────────────────────
+
+  onSaturationMouseDown(e: MouseEvent) {
+    this.draggingSat = true;
+    this.updateSaturation(e);
+    window.addEventListener('mousemove', this.onSaturationMouseMove);
+    window.addEventListener('mouseup', this.onSaturationMouseUp);
+  }
+
+  private onSaturationMouseMove = (e: MouseEvent) => {
+    this.updateSaturation(e);
+  };
+
+  private onSaturationMouseUp = () => {
+    this.draggingSat = false;
+    window.removeEventListener('mousemove', this.onSaturationMouseMove);
+    window.removeEventListener('mouseup', this.onSaturationMouseUp);
+    this.emitColor();
+  };
+
+  private updateSaturation(e: MouseEvent) {
+    const el = this.$refs.saturation as HTMLElement;
+    const rect = el.getBoundingClientRect();
+    const s = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    const v = clamp(1 - (e.clientY - rect.top) / rect.height, 0, 1);
+    this.hsv = { ...this.hsv, s, v };
+    this.emitColor();
+  }
+
+  // ─── Hue drag ────────────────────────────────────────────────────────────
+
+  onHueMouseDown(e: MouseEvent) {
+    this.draggingHue = true;
+    this.updateHue(e);
+    window.addEventListener('mousemove', this.onHueMouseMove);
+    window.addEventListener('mouseup', this.onHueMouseUp);
+  }
+
+  private onHueMouseMove = (e: MouseEvent) => {
+    this.updateHue(e);
+  };
+
+  private onHueMouseUp = () => {
+    this.draggingHue = false;
+    window.removeEventListener('mousemove', this.onHueMouseMove);
+    window.removeEventListener('mouseup', this.onHueMouseUp);
+    this.emitColor();
+  };
+
+  private updateHue(e: MouseEvent) {
+    const el = this.$refs.hue as HTMLElement;
+    const rect = el.getBoundingClientRect();
+    const h = clamp((e.clientX - rect.left) / rect.width, 0, 1) * 360;
+    this.hsv = { ...this.hsv, h };
+    this.emitColor();
+  }
+
+  // ─── Alpha drag ──────────────────────────────────────────────────────────
+
+  onAlphaMouseDown(e: MouseEvent) {
+    this.draggingAlpha = true;
+    this.updateAlpha(e);
+    window.addEventListener('mousemove', this.onAlphaMouseMove);
+    window.addEventListener('mouseup', this.onAlphaMouseUp);
+  }
+
+  private onAlphaMouseMove = (e: MouseEvent) => {
+    this.updateAlpha(e);
+  };
+
+  private onAlphaMouseUp = () => {
+    this.draggingAlpha = false;
+    window.removeEventListener('mousemove', this.onAlphaMouseMove);
+    window.removeEventListener('mouseup', this.onAlphaMouseUp);
+    this.emitColor();
+  };
+
+  private updateAlpha(e: MouseEvent) {
+    const el = this.$refs.alpha as HTMLElement;
+    const rect = el.getBoundingClientRect();
+    this.internalAlpha = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    this.emitColor();
+  }
+
+  // ─── Input field handlers ────────────────────────────────────────────────
+
+  onHexChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const hex = input.value.trim().replace(/^#/, '');
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+      // Reset to current value
+      input.value = this.hexInput;
+      return;
+    }
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    this.hsv = rgbToHsv(r, g, b);
+    this.emitColor();
+  }
+
+  onRgbChange(channel: 'r' | 'g' | 'b', e: Event) {
+    const input = e.target as HTMLInputElement;
+    const val = clamp(parseInt(input.value, 10) || 0, 0, 255);
+    const current = this.rgba;
+    const updated = { ...current, [channel]: val };
+    this.hsv = rgbToHsv(updated.r, updated.g, updated.b);
+    this.emitColor();
+  }
+
+  onAlphaChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const val = clamp(parseInt(input.value, 10) || 0, 0, 100);
+    this.internalAlpha = val / 100;
+    this.emitColor();
+  }
+
+  // ─── Emit ────────────────────────────────────────────────────────────────
+
+  private emitColor() {
+    this.$emit('input', { ...this.rgba });
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('mousemove', this.onSaturationMouseMove);
+    window.removeEventListener('mouseup', this.onSaturationMouseUp);
+    window.removeEventListener('mousemove', this.onHueMouseMove);
+    window.removeEventListener('mouseup', this.onHueMouseUp);
+    window.removeEventListener('mousemove', this.onAlphaMouseMove);
+    window.removeEventListener('mouseup', this.onAlphaMouseUp);
+  }
+}

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -127,10 +127,13 @@ export default defineComponent({
     },
     hexInput(): string {
       const { r, g, b } = this.rgba;
-      return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+      const rgbHex = [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+      const alphaInt = Math.round(this.internalAlpha * 255);
+      if (alphaInt === 255) return rgbHex;
+      return rgbHex + alphaInt.toString(16).padStart(2, '0');
     },
-    alphaPercent(): number {
-      return Math.round(this.internalAlpha * 100);
+    alphaInput(): string {
+      return Number(this.internalAlpha.toFixed(2)).toString();
     },
   },
 
@@ -166,10 +169,20 @@ export default defineComponent({
       });
     },
 
-    onHexChange(e: Event) {
+    onHexInput(e: Event) {
       const input = e.target as HTMLInputElement;
       const hex = input.value.trim().replace(/^#/, '');
-      if (!/^[0-9a-fA-F]{6}$/.test(hex)) { input.value = this.hexInput; return; }
+      if (!/^[0-9a-fA-F]{0,8}$/.test(hex)) {
+        input.value = this.hexInput;
+        return;
+      }
+
+      if (hex.length !== 6 && hex.length !== 8) {
+        return;
+      }
+
+      this.internalAlpha = hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1;
+
       this.hsv = rgbToHsv(
         parseInt(hex.substring(0, 2), 16),
         parseInt(hex.substring(2, 4), 16),
@@ -186,7 +199,14 @@ export default defineComponent({
     },
 
     onAlphaChange(e: Event) {
-      this.internalAlpha = clamp(parseInt((e.target as HTMLInputElement).value, 10) || 0, 0, 100) / 100;
+      const input = e.target as HTMLInputElement;
+      const parsed = parseFloat(input.value);
+      if (Number.isNaN(parsed)) {
+        input.value = this.alphaInput;
+        return;
+      }
+
+      this.internalAlpha = clamp(parsed, 0, 1);
       this.$emit('input', { ...this.rgba });
     },
   },

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -85,17 +85,21 @@ export default defineComponent({
   data() {
     const { r, g, b, a } = this.value as IColor;
     return {
-      hsv: rgbToHsv(r, g, b) as IHsv,
-      internalAlpha: a as number,
+      rgba: { r, g, b, a } as IColor,
       dragging: false,
+      presetColors: [
+        '#D0021B', '#F5A623', '#F8E71C', '#8B572A', '#7ED321',
+        '#417505', '#BD10E0', '#9013FE', '#4A90E2', '#50E3C2',
+        '#B8E986', '#000000', '#4A4A4A', '#9B9B9B', '#FFFFFF',
+        'transparent',
+      ] as string[],
     };
   },
 
   watch: {
     value(val: IColor) {
       if (!this.dragging) {
-        this.hsv = rgbToHsv(val.r, val.g, val.b);
-        this.internalAlpha = val.a;
+        this.rgba = { ...val };
       }
     },
   },
@@ -106,9 +110,8 @@ export default defineComponent({
       { key: 'g' as const, label: 'G' },
       { key: 'b' as const, label: 'B' },
     ],
-    rgba(): IColor {
-      const { r, g, b } = hsvToRgb(this.hsv.h, this.hsv.s, this.hsv.v);
-      return { r, g, b, a: this.internalAlpha };
+    hsv(): IHsv {
+      return rgbToHsv(this.rgba.r, this.rgba.g, this.rgba.b);
     },
     hueBackground(): string {
       return `hsl(${this.hsv.h}, 100%, 50%)`;
@@ -116,7 +119,7 @@ export default defineComponent({
     satPointerTop(): string { return `${(1 - this.hsv.v) * 100}%`; },
     satPointerLeft(): string { return `${this.hsv.s * 100}%`; },
     huePointerLeft(): string { return `${(this.hsv.h / 360) * 100}%`; },
-    alphaPointerLeft(): string { return `${this.internalAlpha * 100}%`; },
+    alphaPointerLeft(): string { return `${this.rgba.a * 100}%`; },
     alphaGradient(): string {
       const { r, g, b } = this.rgba;
       return `linear-gradient(to right, rgba(${r},${g},${b},0), rgb(${r},${g},${b}))`;
@@ -128,26 +131,32 @@ export default defineComponent({
     hexInput(): string {
       const { r, g, b } = this.rgba;
       const rgbHex = [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
-      const alphaInt = Math.round(this.internalAlpha * 255);
+      const alphaInt = Math.round(this.rgba.a * 255);
       if (alphaInt === 255) return rgbHex;
       return rgbHex + alphaInt.toString(16).padStart(2, '0');
     },
     alphaInput(): string {
-      return Number(this.internalAlpha.toFixed(2)).toString();
+      return Number(this.rgba.a.toFixed(2)).toString();
     },
   },
 
   methods: {
+    emitColor() {
+      this.$emit('input', this.rgba);
+    },
+
     onSaturationMouseDown(e: MouseEvent) {
       startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.saturation as HTMLElement;
         const rect = el.getBoundingClientRect();
-        this.hsv = {
+        const newHsv = {
           ...this.hsv,
           s: clamp((ev.clientX - rect.left) / rect.width, 0, 1),
           v: clamp(1 - (ev.clientY - rect.top) / rect.height, 0, 1),
         };
-        this.$emit('input', { ...this.rgba });
+        const { r, g, b } = hsvToRgb(newHsv.h, newHsv.s, newHsv.v);
+        this.rgba = { r, g, b, a: this.rgba.a };
+        this.emitColor();
       });
     },
 
@@ -155,8 +164,10 @@ export default defineComponent({
       startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.hue as HTMLElement;
         const rect = el.getBoundingClientRect();
-        this.hsv = { ...this.hsv, h: clamp((ev.clientX - rect.left) / rect.width, 0, 1) * 360 };
-        this.$emit('input', { ...this.rgba });
+        const newHsv = { ...this.hsv, h: clamp((ev.clientX - rect.left) / rect.width, 0, 1) * 360 };
+        const { r, g, b } = hsvToRgb(newHsv.h, newHsv.s, newHsv.v);
+        this.rgba = { r, g, b, a: this.rgba.a };
+        this.emitColor();
       });
     },
 
@@ -164,8 +175,9 @@ export default defineComponent({
       startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.alpha as HTMLElement;
         const rect = el.getBoundingClientRect();
-        this.internalAlpha = clamp((ev.clientX - rect.left) / rect.width, 0, 1);
-        this.$emit('input', { ...this.rgba });
+        const a = clamp((ev.clientX - rect.left) / rect.width, 0, 1);
+        this.rgba = { ...this.rgba, a };
+        this.emitColor();
       });
     },
 
@@ -176,19 +188,16 @@ export default defineComponent({
         input.value = this.hexInput;
         return;
       }
-
       if (hex.length !== 6 && hex.length !== 8) {
         return;
       }
 
-      this.internalAlpha = hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1;
-
-      this.hsv = rgbToHsv(
-        parseInt(hex.substring(0, 2), 16),
-        parseInt(hex.substring(2, 4), 16),
-        parseInt(hex.substring(4, 6), 16),
-      );
-      this.$emit('input', { ...this.rgba });
+      const a = hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1;
+      const r = parseInt(hex.substring(0, 2), 16);
+      const g = parseInt(hex.substring(2, 4), 16);
+      const b = parseInt(hex.substring(4, 6), 16);
+      this.rgba = { r, g, b, a };
+      this.emitColor();
     },
 
     onRgbInput(channel: 'r' | 'g' | 'b', e: Event) {
@@ -198,10 +207,8 @@ export default defineComponent({
         return;
       }
 
-      const val = clamp(parsed, 0, 255);
-      const c = { ...this.rgba, [channel]: val };
-      this.hsv = rgbToHsv(c.r, c.g, c.b);
-      this.$emit('input', { ...this.rgba });
+      this.rgba = { ...this.rgba, [channel]: clamp(parsed, 0, 255) };
+      this.emitColor();
     },
 
     onAlphaInput(e: Event) {
@@ -212,8 +219,22 @@ export default defineComponent({
         return;
       }
 
-      this.internalAlpha = clamp(parsed, 0, 1);
-      this.$emit('input', { ...this.rgba });
+      this.rgba = { ...this.rgba, a: clamp(parsed, 0, 1) };
+      this.emitColor();
+    },
+
+    applyPreset(color: string) {
+      if (color === 'transparent') {
+        this.rgba = { ...this.rgba, a: 0 };
+        this.emitColor();
+        return;
+      }
+      const hex = color.replace(/^#/, '');
+      const r = parseInt(hex.substring(0, 2), 16);
+      const g = parseInt(hex.substring(2, 4), 16);
+      const b = parseInt(hex.substring(4, 6), 16);
+      this.rgba = { r, g, b, a: 1 };
+      this.emitColor();
     },
   },
 });

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -191,14 +191,20 @@ export default defineComponent({
       this.$emit('input', { ...this.rgba });
     },
 
-    onRgbChange(channel: 'r' | 'g' | 'b', e: Event) {
-      const val = clamp(parseInt((e.target as HTMLInputElement).value, 10) || 0, 0, 255);
+    onRgbInput(channel: 'r' | 'g' | 'b', e: Event) {
+      const input = e.target as HTMLInputElement;
+      const parsed = parseInt(input.value, 10);
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+
+      const val = clamp(parsed, 0, 255);
       const c = { ...this.rgba, [channel]: val };
       this.hsv = rgbToHsv(c.r, c.g, c.b);
       this.$emit('input', { ...this.rgba });
     },
 
-    onAlphaChange(e: Event) {
+    onAlphaInput(e: Event) {
       const input = e.target as HTMLInputElement;
       const parsed = parseFloat(input.value);
       if (Number.isNaN(parsed)) {

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -1,5 +1,4 @@
-import Vue from 'vue';
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
 interface IColor {
   r: number;
@@ -14,271 +13,176 @@ interface IHsv {
   v: number; // 0 - 1
 }
 
+// r/g/b: 0-255 → h: 0-360, s/v: 0-1
 function rgbToHsv(r: number, g: number, b: number): IHsv {
   const rn = r / 255;
   const gn = g / 255;
   const bn = b / 255;
   const max = Math.max(rn, gn, bn);
-  const min = Math.min(rn, gn, bn);
-  const d = max - min;
-
-  let h = 0;
+  const d = max - Math.min(rn, gn, bn);
   const s = max === 0 ? 0 : d / max;
-  const v = max;
-
+  let h = 0;
   if (d !== 0) {
-    if (max === rn) {
-      h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6;
-    } else if (max === gn) {
-      h = ((bn - rn) / d + 2) / 6;
-    } else {
-      h = ((rn - gn) / d + 4) / 6;
-    }
+    if (max === rn) h = (gn - bn) / d + (gn < bn ? 6 : 0);
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h *= 60;
   }
-
-  return { h: h * 360, s, v };
+  return { h, s, v: max };
 }
 
-function hsvToRgb(h: number, s: number, v: number): { r: number; g: number; b: number } {
-  const hn = h / 360;
-  const i = Math.floor(hn * 6);
-  const f = hn * 6 - i;
+// h: 0-360, s/v: 0-1 → r/g/b: 0-255
+function hsvToRgb(h: number, s: number, v: number) {
+  const i = Math.floor(h / 60) % 6;
+  const f = (h / 60) - Math.floor(h / 60);
   const p = v * (1 - s);
   const q = v * (1 - f * s);
   const t = v * (1 - (1 - f) * s);
-
-  let r = 0;
-  let g = 0;
-  let b = 0;
-
-  switch (i % 6) {
+  let r: number;
+  let g: number;
+  let b: number;
+  switch (i) {
     case 0: r = v; g = t; b = p; break;
     case 1: r = q; g = v; b = p; break;
     case 2: r = p; g = v; b = t; break;
     case 3: r = p; g = q; b = v; break;
     case 4: r = t; g = p; b = v; break;
-    case 5: r = v; g = p; b = q; break;
+    default: r = v; g = p; b = q; break;
   }
-
-  return {
-    r: Math.round(r * 255),
-    g: Math.round(g * 255),
-    b: Math.round(b * 255),
-  };
+  return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
+function clamp(v: number, min: number, max: number) {
+  return Math.min(Math.max(v, min), max);
 }
 
-@Component({})
-export default class ColorPicker extends Vue {
-  /** rgba value: r/g/b in 0-255, a in 0.0-1.0 */
-  @Prop({ required: true })
-    value: IColor;
+export default defineComponent({
+  name: 'ColorPicker',
 
-  // Internal HSV state (avoids rounding issues when dragging)
-  private hsv: IHsv = { h: 0, s: 0, v: 1 };
-  private internalAlpha: number = 1;
+  props: {
+    value: { type: Object as () => IColor, required: true },
+  },
 
-  // Dragging state
-  private draggingSat = false;
-  private draggingHue = false;
-  private draggingAlpha = false;
+  data() {
+    const { r, g, b, a } = this.value as IColor;
+    return {
+      hsv: rgbToHsv(r, g, b) as IHsv,
+      internalAlpha: a as number,
+      dragging: false,
+    };
+  },
 
-  created() {
-    this.syncFromValue();
-  }
+  watch: {
+    value(val: IColor) {
+      if (!this.dragging) {
+        this.hsv = rgbToHsv(val.r, val.g, val.b);
+        this.internalAlpha = val.a;
+      }
+    },
+  },
 
-  @Watch('value')
-  onValueChanged() {
-    // Only sync from outside if we're not currently dragging
-    if (!this.draggingSat && !this.draggingHue && !this.draggingAlpha) {
-      this.syncFromValue();
-    }
-  }
+  computed: {
+    rgbChannels: () => [
+      { key: 'r' as const, label: 'R' },
+      { key: 'g' as const, label: 'G' },
+      { key: 'b' as const, label: 'B' },
+    ],
+    rgba(): IColor {
+      const { r, g, b } = hsvToRgb(this.hsv.h, this.hsv.s, this.hsv.v);
+      return { r, g, b, a: this.internalAlpha };
+    },
+    hueBackground(): string {
+      return `hsl(${this.hsv.h}, 100%, 50%)`;
+    },
+    satPointerTop(): string { return `${(1 - this.hsv.v) * 100}%`; },
+    satPointerLeft(): string { return `${this.hsv.s * 100}%`; },
+    huePointerLeft(): string { return `${(this.hsv.h / 360) * 100}%`; },
+    alphaPointerLeft(): string { return `${this.internalAlpha * 100}%`; },
+    alphaGradient(): string {
+      const { r, g, b } = this.rgba;
+      return `linear-gradient(to right, rgba(${r},${g},${b},0), rgb(${r},${g},${b}))`;
+    },
+    previewColor(): string {
+      const { r, g, b, a } = this.rgba;
+      return `rgba(${r},${g},${b},${a})`;
+    },
+    hexInput(): string {
+      const { r, g, b } = this.rgba;
+      return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+    },
+    alphaPercent(): number {
+      return Math.round(this.internalAlpha * 100);
+    },
+  },
 
-  private syncFromValue() {
-    const { r, g, b, a } = this.value;
-    this.hsv = rgbToHsv(r, g, b);
-    this.internalAlpha = a;
-  }
+  methods: {
+    startDrag(e: MouseEvent, onMove: (e: MouseEvent) => void) {
+      this.dragging = true;
+      this.$emit('dragging-change', true);
+      onMove(e);
+      const onMouseUp = () => {
+        this.dragging = false;
+        this.$emit('dragging-change', false);
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onMouseUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onMouseUp);
+    },
 
-  // ─── Computed ────────────────────────────────────────────────────────────
+    onSaturationMouseDown(e: MouseEvent) {
+      this.startDrag(e, (ev) => {
+        const el = this.$refs.saturation as HTMLElement;
+        const rect = el.getBoundingClientRect();
+        this.hsv = {
+          ...this.hsv,
+          s: clamp((ev.clientX - rect.left) / rect.width, 0, 1),
+          v: clamp(1 - (ev.clientY - rect.top) / rect.height, 0, 1),
+        };
+        this.$emit('input', { ...this.rgba });
+      });
+    },
 
-  get rgba(): IColor {
-    const { r, g, b } = hsvToRgb(this.hsv.h, this.hsv.s, this.hsv.v);
-    return { r, g, b, a: this.internalAlpha };
-  }
+    onHueMouseDown(e: MouseEvent) {
+      this.startDrag(e, (ev) => {
+        const el = this.$refs.hue as HTMLElement;
+        const rect = el.getBoundingClientRect();
+        this.hsv = { ...this.hsv, h: clamp((ev.clientX - rect.left) / rect.width, 0, 1) * 360 };
+        this.$emit('input', { ...this.rgba });
+      });
+    },
 
-  get hueBackground(): string {
-    return `hsl(${this.hsv.h}, 100%, 50%)`;
-  }
+    onAlphaMouseDown(e: MouseEvent) {
+      this.startDrag(e, (ev) => {
+        const el = this.$refs.alpha as HTMLElement;
+        const rect = el.getBoundingClientRect();
+        this.internalAlpha = clamp((ev.clientX - rect.left) / rect.width, 0, 1);
+        this.$emit('input', { ...this.rgba });
+      });
+    },
 
-  get satPointerTop(): string {
-    return `${(1 - this.hsv.v) * 100}%`;
-  }
+    onHexChange(e: Event) {
+      const input = e.target as HTMLInputElement;
+      const hex = input.value.trim().replace(/^#/, '');
+      if (!/^[0-9a-fA-F]{6}$/.test(hex)) { input.value = this.hexInput; return; }
+      this.hsv = rgbToHsv(
+        parseInt(hex.substring(0, 2), 16),
+        parseInt(hex.substring(2, 4), 16),
+        parseInt(hex.substring(4, 6), 16),
+      );
+      this.$emit('input', { ...this.rgba });
+    },
 
-  get satPointerLeft(): string {
-    return `${this.hsv.s * 100}%`;
-  }
+    onRgbChange(channel: 'r' | 'g' | 'b', e: Event) {
+      const val = clamp(parseInt((e.target as HTMLInputElement).value, 10) || 0, 0, 255);
+      const c = { ...this.rgba, [channel]: val };
+      this.hsv = rgbToHsv(c.r, c.g, c.b);
+      this.$emit('input', { ...this.rgba });
+    },
 
-  get huePointerLeft(): string {
-    return `${(this.hsv.h / 360) * 100}%`;
-  }
-
-  get alphaPointerLeft(): string {
-    return `${this.internalAlpha * 100}%`;
-  }
-
-  get alphaGradient(): string {
-    const { r, g, b } = this.rgba;
-    return `linear-gradient(to right, rgba(${r},${g},${b},0), rgb(${r},${g},${b}))`;
-  }
-
-  get previewColor(): string {
-    const { r, g, b, a } = this.rgba;
-    return `rgba(${r},${g},${b},${a})`;
-  }
-
-  get hexInput(): string {
-    const { r, g, b } = this.rgba;
-    return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
-  }
-
-  get alphaPercent(): number {
-    return Math.round(this.internalAlpha * 100);
-  }
-
-  // ─── Saturation/Brightness drag ──────────────────────────────────────────
-
-  onSaturationMouseDown(e: MouseEvent) {
-    this.draggingSat = true;
-    this.updateSaturation(e);
-    window.addEventListener('mousemove', this.onSaturationMouseMove);
-    window.addEventListener('mouseup', this.onSaturationMouseUp);
-  }
-
-  private onSaturationMouseMove = (e: MouseEvent) => {
-    this.updateSaturation(e);
-  };
-
-  private onSaturationMouseUp = () => {
-    this.draggingSat = false;
-    window.removeEventListener('mousemove', this.onSaturationMouseMove);
-    window.removeEventListener('mouseup', this.onSaturationMouseUp);
-    this.emitColor();
-  };
-
-  private updateSaturation(e: MouseEvent) {
-    const el = this.$refs.saturation as HTMLElement;
-    const rect = el.getBoundingClientRect();
-    const s = clamp((e.clientX - rect.left) / rect.width, 0, 1);
-    const v = clamp(1 - (e.clientY - rect.top) / rect.height, 0, 1);
-    this.hsv = { ...this.hsv, s, v };
-    this.emitColor();
-  }
-
-  // ─── Hue drag ────────────────────────────────────────────────────────────
-
-  onHueMouseDown(e: MouseEvent) {
-    this.draggingHue = true;
-    this.updateHue(e);
-    window.addEventListener('mousemove', this.onHueMouseMove);
-    window.addEventListener('mouseup', this.onHueMouseUp);
-  }
-
-  private onHueMouseMove = (e: MouseEvent) => {
-    this.updateHue(e);
-  };
-
-  private onHueMouseUp = () => {
-    this.draggingHue = false;
-    window.removeEventListener('mousemove', this.onHueMouseMove);
-    window.removeEventListener('mouseup', this.onHueMouseUp);
-    this.emitColor();
-  };
-
-  private updateHue(e: MouseEvent) {
-    const el = this.$refs.hue as HTMLElement;
-    const rect = el.getBoundingClientRect();
-    const h = clamp((e.clientX - rect.left) / rect.width, 0, 1) * 360;
-    this.hsv = { ...this.hsv, h };
-    this.emitColor();
-  }
-
-  // ─── Alpha drag ──────────────────────────────────────────────────────────
-
-  onAlphaMouseDown(e: MouseEvent) {
-    this.draggingAlpha = true;
-    this.updateAlpha(e);
-    window.addEventListener('mousemove', this.onAlphaMouseMove);
-    window.addEventListener('mouseup', this.onAlphaMouseUp);
-  }
-
-  private onAlphaMouseMove = (e: MouseEvent) => {
-    this.updateAlpha(e);
-  };
-
-  private onAlphaMouseUp = () => {
-    this.draggingAlpha = false;
-    window.removeEventListener('mousemove', this.onAlphaMouseMove);
-    window.removeEventListener('mouseup', this.onAlphaMouseUp);
-    this.emitColor();
-  };
-
-  private updateAlpha(e: MouseEvent) {
-    const el = this.$refs.alpha as HTMLElement;
-    const rect = el.getBoundingClientRect();
-    this.internalAlpha = clamp((e.clientX - rect.left) / rect.width, 0, 1);
-    this.emitColor();
-  }
-
-  // ─── Input field handlers ────────────────────────────────────────────────
-
-  onHexChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const hex = input.value.trim().replace(/^#/, '');
-    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
-      // Reset to current value
-      input.value = this.hexInput;
-      return;
-    }
-    const r = parseInt(hex.substring(0, 2), 16);
-    const g = parseInt(hex.substring(2, 4), 16);
-    const b = parseInt(hex.substring(4, 6), 16);
-    this.hsv = rgbToHsv(r, g, b);
-    this.emitColor();
-  }
-
-  onRgbChange(channel: 'r' | 'g' | 'b', e: Event) {
-    const input = e.target as HTMLInputElement;
-    const val = clamp(parseInt(input.value, 10) || 0, 0, 255);
-    const current = this.rgba;
-    const updated = { ...current, [channel]: val };
-    this.hsv = rgbToHsv(updated.r, updated.g, updated.b);
-    this.emitColor();
-  }
-
-  onAlphaChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const val = clamp(parseInt(input.value, 10) || 0, 0, 100);
-    this.internalAlpha = val / 100;
-    this.emitColor();
-  }
-
-  // ─── Emit ────────────────────────────────────────────────────────────────
-
-  private emitColor() {
-    this.$emit('input', { ...this.rgba });
-  }
-
-  beforeDestroy() {
-    window.removeEventListener('mousemove', this.onSaturationMouseMove);
-    window.removeEventListener('mouseup', this.onSaturationMouseUp);
-    window.removeEventListener('mousemove', this.onHueMouseMove);
-    window.removeEventListener('mouseup', this.onHueMouseUp);
-    window.removeEventListener('mousemove', this.onAlphaMouseMove);
-    window.removeEventListener('mouseup', this.onAlphaMouseUp);
-  }
-}
+    onAlphaChange(e: Event) {
+      this.internalAlpha = clamp(parseInt((e.target as HTMLInputElement).value, 10) || 0, 0, 100) / 100;
+      this.$emit('input', { ...this.rgba });
+    },
+  },
+});

--- a/app/components/obs/inputs/ColorPicker.vue.ts
+++ b/app/components/obs/inputs/ColorPicker.vue.ts
@@ -141,10 +141,6 @@ export default defineComponent({
   },
 
   methods: {
-    emitColor() {
-      this.$emit('input', this.rgba);
-    },
-
     onSaturationMouseDown(e: MouseEvent) {
       startDrag(this, e, (ev: MouseEvent) => {
         const el = this.$refs.saturation as HTMLElement;
@@ -156,7 +152,7 @@ export default defineComponent({
         };
         const { r, g, b } = hsvToRgb(newHsv.h, newHsv.s, newHsv.v);
         this.rgba = { r, g, b, a: this.rgba.a };
-        this.emitColor();
+        this.$emit('input', this.rgba);
       });
     },
 
@@ -167,7 +163,7 @@ export default defineComponent({
         const newHsv = { ...this.hsv, h: clamp((ev.clientX - rect.left) / rect.width, 0, 1) * 360 };
         const { r, g, b } = hsvToRgb(newHsv.h, newHsv.s, newHsv.v);
         this.rgba = { r, g, b, a: this.rgba.a };
-        this.emitColor();
+        this.$emit('input', this.rgba);
       });
     },
 
@@ -177,7 +173,7 @@ export default defineComponent({
         const rect = el.getBoundingClientRect();
         const a = clamp((ev.clientX - rect.left) / rect.width, 0, 1);
         this.rgba = { ...this.rgba, a };
-        this.emitColor();
+        this.$emit('input', this.rgba);
       });
     },
 
@@ -197,7 +193,7 @@ export default defineComponent({
       const g = parseInt(hex.substring(2, 4), 16);
       const b = parseInt(hex.substring(4, 6), 16);
       this.rgba = { r, g, b, a };
-      this.emitColor();
+      this.$emit('input', this.rgba);
     },
 
     onRgbInput(channel: 'r' | 'g' | 'b', e: Event) {
@@ -208,7 +204,7 @@ export default defineComponent({
       }
 
       this.rgba = { ...this.rgba, [channel]: clamp(parsed, 0, 255) };
-      this.emitColor();
+      this.$emit('input', this.rgba);
     },
 
     onAlphaInput(e: Event) {
@@ -220,13 +216,13 @@ export default defineComponent({
       }
 
       this.rgba = { ...this.rgba, a: clamp(parsed, 0, 1) };
-      this.emitColor();
+      this.$emit('input', this.rgba);
     },
 
     applyPreset(color: string) {
       if (color === 'transparent') {
         this.rgba = { ...this.rgba, a: 0 };
-        this.emitColor();
+        this.$emit('input', this.rgba);
         return;
       }
       const hex = color.replace(/^#/, '');
@@ -234,7 +230,7 @@ export default defineComponent({
       const g = parseInt(hex.substring(2, 4), 16);
       const b = parseInt(hex.substring(4, 6), 16);
       this.rgba = { r, g, b, a: 1 };
-      this.emitColor();
+      this.$emit('input', this.rgba);
     },
   },
 });

--- a/app/components/obs/inputs/ObsColorInput.vue
+++ b/app/components/obs/inputs/ObsColorInput.vue
@@ -13,15 +13,14 @@
           <button class="colorpicker__eyedropper" @click="startEyedropper" title="Color picker">
             <i class="icon-eyedropper-fill" />
           </button>
-          <template v-if="pickerVisible">
-            <div class="colorpicker-overlay" @mousedown="closePicker" />
-            <color-picker
-              :value="obsColor"
-              @input="handleColorChange"
-              @dragging-change="handleDraggingChange"
-              class="colorpicker-menu"
-            />
-          </template>
+          <color-picker
+            v-if="pickerVisible"
+            :value="obsColor"
+            @input="handleColorChange"
+            @dragging-change="handleDraggingChange"
+            class="colorpicker-menu"
+            ref="colorPickerMenu"
+          />
         </div>
       </div>
     </div>
@@ -74,12 +73,6 @@
   &:hover {
     opacity: 1;
   }
-}
-
-.colorpicker-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 9;
 }
 
 .colorpicker-menu {

--- a/app/components/obs/inputs/ObsColorInput.vue
+++ b/app/components/obs/inputs/ObsColorInput.vue
@@ -13,12 +13,14 @@
           <button class="colorpicker__eyedropper" @click="startEyedropper" title="Color picker">
             <i class="icon-eyedropper-fill" />
           </button>
-          <color-picker
-            :value="obsColor"
-            @input="handleColorChange"
-            v-if="pickerVisible"
-            class="colorpicker-menu"
-          />
+          <template v-if="pickerVisible">
+            <div class="colorpicker-overlay" @mousedown="closePicker" />
+            <color-picker
+              :value="obsColor"
+              @input="handleColorChange"
+              class="colorpicker-menu"
+            />
+          </template>
         </div>
       </div>
     </div>
@@ -73,25 +75,15 @@
   }
 }
 
-.colorpicker-menu {
-  top: 6px;
-  z-index: 10;
-  .radius() !important;
-
-  background: @bg-secondary !important;
-  border-color: @bg-secondary !important;
-  box-shadow: none !important;
-
-  .vc-sketch-field .vc-input__input {
-    background-color: @bg-primary !important;
-  }
-
-  .vc-input__label {
-    color: @text-primary !important;
-  }
+.colorpicker-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9;
 }
 
-.vue-color__sketch__presets {
-  border-color: @border;
+.colorpicker-menu {
+  position: absolute;
+  top: @item-generic-size + 4px;
+  z-index: 10;
 }
 </style>

--- a/app/components/obs/inputs/ObsColorInput.vue
+++ b/app/components/obs/inputs/ObsColorInput.vue
@@ -18,6 +18,7 @@
             <color-picker
               :value="obsColor"
               @input="handleColorChange"
+              @dragging-change="handleDraggingChange"
               class="colorpicker-menu"
             />
           </template>

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -1,4 +1,3 @@
-import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import Utils from 'services/utils';
 import { Component, Prop } from 'vue-property-decorator';
@@ -67,11 +66,7 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
   }
 
   handleColorChange(color: IColor) {
-    if (this.isDragging) {
-      this.setValueImpl(color);
-    } else {
-      this.setValue(color);
-    }
+    this.setValueImpl(color);
   }
 
   startEyedropper() {
@@ -115,18 +110,12 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
     }
   }
 
-  private debouncedSetValue = debounce(this.setValueImpl, 500);
-
   setValue(rgba: IColor) {
-    this.debouncedSetValue(rgba);
+    this.setValueImpl(rgba);
   }
 
   mounted() {
     this.setValue(this.obsColor);
-  }
-
-  beforeDestroy() {
-    this.debouncedSetValue.cancel();
   }
 
   get hexAlpha() {

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -53,10 +53,30 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
 
   togglePicker() {
     this.pickerVisible = !this.pickerVisible;
+    if (this.pickerVisible) {
+      this.$nextTick(() => {
+        document.addEventListener('mousedown', this.onDocumentMouseDown);
+      });
+    } else {
+      document.removeEventListener('mousedown', this.onDocumentMouseDown);
+    }
   }
 
   closePicker() {
     this.pickerVisible = false;
+    document.removeEventListener('mousedown', this.onDocumentMouseDown);
+  }
+
+  onDocumentMouseDown(event: MouseEvent) {
+    const menu = this.$refs.colorPickerMenu as Vue | undefined;
+    if (menu && menu.$el && menu.$el.contains(event.target as Node)) {
+      return;
+    }
+    const el = this.$el as HTMLElement;
+    if (el && el.contains(event.target as Node)) {
+      return;
+    }
+    this.closePicker();
   }
 
   isDragging = false;
@@ -116,6 +136,10 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
 
   mounted() {
     this.setValue(this.obsColor);
+  }
+
+  beforeDestroy() {
+    document.removeEventListener('mousedown', this.onDocumentMouseDown);
   }
 
   get hexAlpha() {

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -60,8 +60,18 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
     this.pickerVisible = false;
   }
 
+  isDragging = false;
+
+  handleDraggingChange(dragging: boolean) {
+    this.isDragging = dragging;
+  }
+
   handleColorChange(color: IColor) {
-    this.setValue(color);
+    if (this.isDragging) {
+      this.setValueImpl(color);
+    } else {
+      this.setValue(color);
+    }
   }
 
   startEyedropper() {

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -1,9 +1,9 @@
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import Utils from 'services/utils';
-import VueColor from 'vue-color';
 import { Component, Prop } from 'vue-property-decorator';
 
+import ColorPicker from './ColorPicker.vue';
 import { IObsInput, ObsInput, TObsType } from './ObsInput';
 
 interface IColorPickerOptions {
@@ -41,7 +41,7 @@ interface IColor {
 }
 
 @Component({
-  components: { ColorPicker: VueColor.Sketch },
+  components: { ColorPicker },
 })
 class ObsColorInput extends ObsInput<IObsInput<number>> {
   static obsType: TObsType;
@@ -56,8 +56,12 @@ class ObsColorInput extends ObsInput<IObsInput<number>> {
     this.pickerVisible = !this.pickerVisible;
   }
 
-  handleColorChange(color: any) {
-    this.setValue(color.rgba);
+  closePicker() {
+    this.pickerVisible = false;
+  }
+
+  handleColorChange(color: IColor) {
+    this.setValue(color);
   }
 
   startEyedropper() {

--- a/app/index.d.ts
+++ b/app/index.d.ts
@@ -43,7 +43,6 @@ declare module 'raven-js/*';
 declare module 'traverse';
 declare module 'node-fontinfo';
 declare module '@xkeshi/vue-qrcode';
-declare module 'vue-color';
 
 declare module 'font-manager';
 declare module 'recursive-readdir';

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "unzip-stream": "^0.3.4",
     "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
     "vue": "2.7.14",
-    "vue-color": "2.8.1",
     "vue-i18n": "7.8.1",
     "vue-property-decorator": "7.3.0",
     "vuex": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       vue:
         specifier: 2.7.14
         version: 2.7.14
-      vue-color:
-        specifier: 2.8.1
-        version: 2.8.1
       vue-i18n:
         specifier: 7.8.1
         version: 7.8.1(vue@2.7.14)
@@ -2712,12 +2709,6 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
-  cjs-module-lexer@2.2.0:
-    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
-
-  clamp@1.0.1:
-    resolution: {integrity: sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==}
-
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -5033,9 +5024,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash.throttle@4.1.1:
-    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
-
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
@@ -5127,9 +5115,6 @@ packages:
   matcher@5.0.0:
     resolution: {integrity: sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  material-colors@1.2.6:
-    resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6753,9 +6738,6 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -7060,9 +7042,6 @@ packages:
 
   vue-class-component@6.3.2:
     resolution: {integrity: sha512-cH208IoM+jgZyEf/g7mnFyofwPDJTM/QvBNhYMjqGB8fCsRyTf68rH2ISw/G20tJv+5mIThQ3upKwoL4jLTr1A==}
-
-  vue-color@2.8.1:
-    resolution: {integrity: sha512-BoLCEHisXi2QgwlhZBg9UepvzZZmi4176vbr+31Shen5WWZwSLVgdScEPcB+yrAtuHAz42309C0A4+WiL9lNBw==}
 
   vue-eslint-parser@9.4.3:
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
@@ -10602,10 +10581,6 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  cjs-module-lexer@2.2.0: {}
-
-  clamp@1.0.1: {}
-
   clean-stack@2.2.0: {}
 
   cli-cursor@3.1.0:
@@ -13196,8 +13171,6 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash.throttle@4.1.1: {}
-
   lodash.truncate@4.4.2: {}
 
   lodash.union@4.6.0: {}
@@ -13302,8 +13275,6 @@ snapshots:
   matcher@5.0.0:
     dependencies:
       escape-string-regexp: 5.0.0
-
-  material-colors@1.2.6: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -15025,8 +14996,6 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
-  tinycolor2@1.6.0: {}
-
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15313,13 +15282,6 @@ snapshots:
   vosk-cli@https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz: {}
 
   vue-class-component@6.3.2: {}
-
-  vue-color@2.8.1:
-    dependencies:
-      clamp: 1.0.1
-      lodash.throttle: 4.1.1
-      material-colors: 1.2.6
-      tinycolor2: 1.6.0
 
   vue-eslint-parser@9.4.3(eslint@9.39.2(jiti@2.6.1)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2709,6 +2709,9 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -10580,6 +10583,8 @@ snapshots:
   ci-parallel-vars@1.0.1: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   clean-stack@2.2.0: {}
 


### PR DESCRIPTION
## 概要

OBSプロパティのカラー入力で使用していた `vue-color` ライブラリを削除し、
自前実装の `ColorPicker` コンポーネントに置き換えました。

## 背景・動機

`vue-color` は Vue 2 向けのライブラリで、Vue 3 には対応していません。
Vue 3 向けのフォークも存在しますが、API の差異があるためそのままでは移行できず、
結局ある程度の改修が必要になります。

Vue 3 移行時にいずれ改修コストが発生するため、このタイミングで外部依存を解消し
自前実装に切り替えます。

- **Vue バージョンに依存しない**: `defineComponent` (Options API) で実装しており、
  Vue 2.7 と Vue 3 の両方でそのまま動作します
- **メンテナンスコストが低い**: ライブラリのアップデート追従や
  破壊的変更への対応が不要になります
- **依存パッケージが減る**: `vue-color` の推移的依存である
  `clamp`・`material-colors`・`tinycolor2` 等も合わせて削除されます
- **機能を必要最小限に絞れる**: アプリで実際に使う機能だけを実装しており、
  不要な依存コードを抱えません

## 変更内容

### 追加
- `app/components/obs/inputs/ColorPicker.vue` / `.vue.ts`
  - HSVベースのカラーピッカーUIコンポーネント（新規作成）
  - サチュレーション/ブライトネス 2Dピッカー、色相スライダー、アルファスライダー
  - HEX / R / G / B / A の数値入力フィールド
  - `defineComponent` (Options API) で実装、Vue 2.7 / Vue 3 両対応

### 変更
- `app/components/obs/inputs/ObsColorInput.vue` / `.vue.ts`
  - `vue-color` の `Sketch` コンポーネントを自前 `ColorPicker` に差し替え
  - ピッカーの外側クリックで閉じる処理を透明オーバーレイ方式に変更
  - ドラッグ中は debounce なしで即時反映、ドラッグ終了後は debounce 経由に切り替え

### 削除
- `vue-color` パッケージ（および推移的依存 `clamp`・`lodash.throttle`・`material-colors`・`tinycolor2`）を削除
- `app/index.d.ts` の `declare module 'vue-color'` を削除
