### PR TITLE
開発: N-AIR-APP-FX1/FX2 IPC request failed に service/method 診断情報を追加

### DIFF
--- a/app/services/api/internal-api-client.ts
+++ b/app/services/api/internal-api-client.ts
@@ -2,6 +2,7 @@ import electron from 'electron';
 import { Observable, Subject } from 'rxjs';
 import { IJsonRpcEvent, IJsonRpcResponse, IMutation, JsonrpcService } from 'services/api/jsonrpc';
 import * as traverse from 'traverse';
+import { captureIpcRequestError } from 'util/sentry-ipc-request';
 
 import { ServicesManager } from '../../services-manager';
 import { commitMutation } from '../../store';
@@ -80,7 +81,13 @@ export class InternalApiClient {
           );
 
           if (response.error) {
-            throw Error('IPC request failed: check the errors in the main window');
+            throw captureIpcRequestError(
+              serviceName,
+              methodName,
+              isHelper,
+              isHelper ? target['_resourceId'] : undefined,
+              response.error,
+            );
           }
 
           const result = response.result;

--- a/app/util/ipc-request-error.test.ts
+++ b/app/util/ipc-request-error.test.ts
@@ -1,0 +1,27 @@
+import { IpcRequestError } from './ipc-request-error';
+
+describe('IpcRequestError', () => {
+  test('message に serviceName.methodName が含まれる', () => {
+    const err = new IpcRequestError('FooService', 'barMethod', { code: -32603, message: 'original error' });
+    expect(err.message).toBe('IPC request failed: FooService.barMethod');
+  });
+
+  test('name が IpcRequestError である', () => {
+    const err = new IpcRequestError('FooService', 'barMethod', { code: -32603 });
+    expect(err.name).toBe('IpcRequestError');
+  });
+
+  test('rpcError / serviceName / methodName が保持される', () => {
+    const rpcError = { code: -32603, message: 'test error' };
+    const err = new IpcRequestError('FooService', 'barMethod', rpcError);
+    expect(err.rpcError).toBe(rpcError);
+    expect(err.serviceName).toBe('FooService');
+    expect(err.methodName).toBe('barMethod');
+  });
+
+  test('instanceof Error / IpcRequestError がともに true', () => {
+    const err = new IpcRequestError('FooService', 'barMethod', { code: -32603 });
+    expect(err instanceof Error).toBe(true);
+    expect(err instanceof IpcRequestError).toBe(true);
+  });
+});

--- a/app/util/ipc-request-error.ts
+++ b/app/util/ipc-request-error.ts
@@ -1,0 +1,11 @@
+export class IpcRequestError extends Error {
+  constructor(
+    public readonly serviceName: string,
+    public readonly methodName: string,
+    public readonly rpcError: { code: number; message?: string },
+  ) {
+    super(`IPC request failed: ${serviceName}.${methodName}`);
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/app/util/sentry-ipc-request.test.ts
+++ b/app/util/sentry-ipc-request.test.ts
@@ -1,0 +1,98 @@
+import * as Sentry from '@sentry/vue';
+
+import { IpcRequestError } from './ipc-request-error';
+import { captureIpcRequestError } from './sentry-ipc-request';
+
+jest.mock('@sentry/vue', () => ({
+  addBreadcrumb: jest.fn(),
+  withScope: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+describe('captureIpcRequestError', () => {
+  let mockScope: {
+    setTag: jest.Mock;
+    setExtra: jest.Mock;
+    setFingerprint: jest.Mock;
+    captureException: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockScope = {
+      setTag: jest.fn(),
+      setExtra: jest.fn(),
+      setFingerprint: jest.fn(),
+      captureException: jest.fn(),
+    };
+    (Sentry.withScope as jest.Mock).mockImplementation((cb) => cb(mockScope));
+  });
+
+  test('IpcRequestError を返す', () => {
+    const rpcError = { code: -32603, message: 'main error' };
+    const result = captureIpcRequestError('FooService', 'barMethod', false, undefined, rpcError);
+    expect(result).toBeInstanceOf(IpcRequestError);
+    expect(result.message).toBe('IPC request failed: FooService.barMethod');
+  });
+
+  test('breadcrumb に service/method/code が記録される', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'ipc.request',
+      message: 'FooService.barMethod failed (code: -32603)',
+      level: 'error',
+    });
+  });
+
+  test('scope に service / method タグがセットされる', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
+    expect(mockScope.setTag).toHaveBeenCalledWith('service', 'FooService');
+    expect(mockScope.setTag).toHaveBeenCalledWith('method', 'barMethod');
+  });
+
+  test('helper 時は resourceId タグがセットされる', () => {
+    captureIpcRequestError('FooService', 'barMethod', true, 'resource-123', { code: -32603 });
+    expect(mockScope.setTag).toHaveBeenCalledWith('isHelper', 'true');
+    expect(mockScope.setTag).toHaveBeenCalledWith('resourceId', 'resource-123');
+  });
+
+  test('helper でない場合は resourceId タグがセットされない', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
+    const resourceIdCall = (mockScope.setTag as jest.Mock).mock.calls.find(
+      ([key]) => key === 'resourceId',
+    );
+    expect(resourceIdCall).toBeUndefined();
+  });
+
+  test('mainError extra に rpcError.message がセットされる', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, {
+      code: -32603,
+      message: 'original stack',
+    });
+    expect(mockScope.setExtra).toHaveBeenCalledWith('mainError', 'original stack');
+  });
+
+  test('rpcError.message がない場合は (no message) がセットされる', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
+    expect(mockScope.setExtra).toHaveBeenCalledWith('mainError', '(no message)');
+  });
+
+  test('fingerprint が err.name + service.method で分割される', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'FooService', 'barMethod']);
+  });
+
+  test('captureException が呼ばれる', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
+    expect(Sentry.captureException).toHaveBeenCalled();
+    const captured = (Sentry.captureException as jest.Mock).mock.calls[0][0];
+    expect(captured).toBeInstanceOf(IpcRequestError);
+  });
+
+  test('symbol の methodName も文字列に変換される', () => {
+    const sym = Symbol('myMethod');
+    const result = captureIpcRequestError('FooService', sym, false, undefined, { code: -32603 });
+    expect(result.methodName).toBe('Symbol(myMethod)');
+    expect(mockScope.setTag).toHaveBeenCalledWith('method', 'Symbol(myMethod)');
+  });
+});

--- a/app/util/sentry-ipc-request.ts
+++ b/app/util/sentry-ipc-request.ts
@@ -1,0 +1,33 @@
+import * as Sentry from '@sentry/vue';
+
+import { IpcRequestError } from './ipc-request-error';
+
+export function captureIpcRequestError(
+  serviceName: string,
+  methodName: string | symbol,
+  isHelper: boolean,
+  resourceId: string | undefined,
+  rpcError: { code: number; message?: string },
+): IpcRequestError {
+  const method = String(methodName);
+  const err = new IpcRequestError(serviceName, method, rpcError);
+
+  Sentry.addBreadcrumb({
+    category: 'ipc.request',
+    message: `${serviceName}.${method} failed (code: ${rpcError.code})`,
+    level: 'error',
+  });
+
+  Sentry.withScope((scope) => {
+    scope.setTag('service', serviceName);
+    scope.setTag('method', method);
+    scope.setTag('isHelper', String(isHelper));
+    scope.setTag('rpc.code', String(rpcError.code));
+    if (isHelper && resourceId) scope.setTag('resourceId', resourceId);
+    scope.setExtra('mainError', rpcError.message ?? '(no message)');
+    scope.setFingerprint([err.name, serviceName, method]);
+    Sentry.captureException(err);
+  });
+
+  return err;
+}


### PR DESCRIPTION
## 背景

Sentry issue N-AIR-APP-FX1・FX2（`Error: IPC request failed: check the errors in the main window`）が断続的に発生しているが、現状のエラーメッセージには **どのサービス・メソッドで失敗したか** の情報が含まれておらず、全イベントが1つの Sentry イシューに集約されてしまっている。

## 変更の趣旨

バグ修正ではなく、**次回発生時に原因を絞り込めるよう Sentry への情報出力を強化する**。

具体的には以下を追加する：

1. **専用エラークラス `IpcRequestError`** — メッセージを `IPC request failed: ${service}.${method}` 形式に変更し、Sentry のデフォルトグルーピングをサービス・メソッド別に自動分割する
2. **Sentry タグ** — `service`、`method`、`isHelper`、`rpc.code`（helper 時は `resourceId` も）をセット
3. **Sentry extra** — `mainError` に main プロセス側の元エラーメッセージ（スタックトレース含む）を添付
4. **Breadcrumb** — throw 直前に `category: 'ipc.request'` として記録
5. **Fingerprint** — `[err.name, service, method]` でグルーピングを確実に分割

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/util/ipc-request-error.ts` | `IpcRequestError` クラス（新規） |
| `app/util/sentry-ipc-request.ts` | `captureIpcRequestError()` ヘルパ（新規） |
| `app/services/api/internal-api-client.ts` | L82-84 の throw を上記ヘルパ呼び出しに置き換え |
| `app/util/ipc-request-error.test.ts` | `IpcRequestError` のユニットテスト（新規） |
| `app/util/sentry-ipc-request.test.ts` | `captureIpcRequestError` のユニットテスト（新規） |

## テスト

- `app/util/ipc-request-error.test.ts`・`app/util/sentry-ipc-request.test.ts` を追加（全 14 件 pass）
- 既存 `app/services/api/internal-api-client.ts` の挙動変更は**エラーパスのみ**（正常系は無変更）

## 関連

関連: N-AIR-APP-FX1
関連: N-AIR-APP-FX2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
