### PR TITLE
開発: N-AIR-APP-FY9/FWM Lost IPC Connection に OBS 操作 breadcrumb を追加

### DIFF
--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -6,6 +6,7 @@ import { CustomizationService } from 'services/customization';
 import { VideoSettingsService } from 'services/settings-v2/video';
 import { EStreamingState, StreamingService } from 'services/streaming';
 import { getKeys } from 'util/getKeys';
+import { getLastObsOp } from 'util/sentry-obs-breadcrumb';
 import Vue from 'vue';
 
 import * as obs from '../../../obs-api';
@@ -136,7 +137,13 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
           level: 'warning',
         });
       } else {
-        Sentry.captureException(e);
+        Sentry.withScope((scope) => {
+          scope.setTag('service', 'PerformanceService');
+          scope.setTag('method', 'getState');
+          scope.setExtra('streamingStatus', this.streamingService.state.streamingStatus);
+          scope.setExtra('lastObsOp', getLastObsOp());
+          Sentry.captureException(e);
+        });
       }
       return null;
     }

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -9,6 +9,7 @@ import { TransitionsService } from 'services/transitions';
 import { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import namingHelpers from 'util/NamingHelpers';
+import { markObsOp } from 'util/sentry-obs-breadcrumb';
 import Vue from 'vue';
 
 import * as obs from '../../../obs-api';
@@ -187,6 +188,7 @@ export class ScenesService extends StatefulService<IScenesState> {
   }
 
   createScene(name: string, options: ISceneCreateOptions = {}) {
+    markObsOp('ScenesService', 'createScene');
     // Get an id to identify the scene on the frontend
     const id = options.sceneId || `scene_${uuidv4()}`;
     this.ADD_SCENE(id, name);
@@ -221,6 +223,7 @@ export class ScenesService extends StatefulService<IScenesState> {
     if (!scene) {
       return null;
     }
+    markObsOp('ScenesService', 'removeScene', { sceneId: id });
     const sceneModel = this.state.scenes[id];
 
     if (!force) this.rtvcStateService.didRemoveScene(id);
@@ -270,6 +273,7 @@ export class ScenesService extends StatefulService<IScenesState> {
     if (!scene) return false;
 
     const activeScene = this.activeScene;
+    markObsOp('ScenesService', 'makeSceneActive', { sceneId: id });
 
     this.transitionsService.transition(activeScene && activeScene.id, scene.id);
 

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -21,6 +21,7 @@ import { SoundDetectorService } from 'services/sound-detector';
 import { SourcesService } from 'services/sources';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
+import { markObsOp } from 'util/sentry-obs-breadcrumb';
 
 import * as obs from '../../../obs-api';
 import { Inject } from '../core/injector';
@@ -763,6 +764,9 @@ export class SettingsService
   }
 
   setSettings(categoryName: SettingsCategory, settingsData: ISettingsSubCategory[]) {
+    if (categoryName === 'Output' || categoryName === 'Video' || categoryName === 'Stream') {
+      markObsOp('SettingsService', 'setSettings', { category: categoryName });
+    }
     if (categoryName === 'Audio') this.setAudioSettings([settingsData.pop()]);
     if (categoryName === 'Developer') return this.setDeveloperSettings(settingsData);
 

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -16,6 +16,7 @@ import { uuidv4 } from 'services/utils';
 import { IWindowOptions, WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
 import namingHelpers from 'util/NamingHelpers';
+import { markObsOp } from 'util/sentry-obs-breadcrumb';
 import Vue from 'vue';
 
 import * as obs from '../../../obs-api';
@@ -164,6 +165,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     settings: Dictionary<any> = {},
     options: ISourceAddOptions = {},
   ): Source {
+    markObsOp('SourcesService', 'createSource', { type });
     const id: string = options.sourceId || `${type}_${uuidv4()}`;
     const obsInputSettings = this.getObsSourceCreateSettings(type, settings);
     const obsInput = obs.InputFactory.create(type, id, obsInputSettings);
@@ -215,6 +217,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   removeSource(id: string) {
+    markObsOp('SourcesService', 'removeSource');
     const source = this.getSource(id);
 
     if (!source) throw new Error(`Source ${id} not found`);

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -19,6 +19,7 @@ import { TUsageEvent, UsageStatisticsService } from 'services/usage-statistics';
 import { UserService } from 'services/user';
 import Utils from 'services/utils';
 import { WindowsService } from 'services/windows';
+import { markObsOp } from 'util/sentry-obs-breadcrumb';
 
 import * as obs from '../../../obs-api';
 import { RtvcStateService } from '../../services/rtvcStateService';
@@ -340,6 +341,7 @@ export class StreamingService
 
       if (shouldConfirm && !confirm(confirmText)) return;
 
+      markObsOp('StreamingService', 'toggleStreaming', { action: 'start' });
       this.powerSaveId = remote.powerSaveBlocker.start('prevent-display-sleep');
       try {
         Sentry.addBreadcrumb({
@@ -372,6 +374,7 @@ export class StreamingService
 
       if (shouldConfirm && !confirm(confirmText)) return;
 
+      markObsOp('StreamingService', 'toggleStreaming', { action: 'stop' });
       if (this.powerSaveId) {
         remote.powerSaveBlocker.stop(this.powerSaveId);
       }
@@ -525,6 +528,7 @@ export class StreamingService
   }
 
   toggleRecording() {
+    markObsOp('StreamingService', 'toggleRecording');
     if (this.state.recordingStatus === ERecordingState.Recording) {
       try {
         Sentry.addBreadcrumb({

--- a/app/util/sentry-obs-breadcrumb.test.ts
+++ b/app/util/sentry-obs-breadcrumb.test.ts
@@ -1,0 +1,54 @@
+import * as Sentry from '@sentry/vue';
+
+import { getLastObsOp, markObsOp } from './sentry-obs-breadcrumb';
+
+jest.mock('@sentry/vue', () => ({
+  addBreadcrumb: jest.fn(),
+  setTag: jest.fn(),
+}));
+
+describe('sentry-obs-breadcrumb', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('markObsOp が breadcrumb を追加する', () => {
+    markObsOp('ScenesService', 'makeSceneActive');
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'obs',
+      message: 'ScenesService.makeSceneActive',
+      level: 'info',
+      data: undefined,
+    });
+  });
+
+  test('markObsOp が obs.lastOp タグをセットする', () => {
+    markObsOp('ScenesService', 'makeSceneActive');
+    expect(Sentry.setTag).toHaveBeenCalledWith('obs.lastOp', 'ScenesService.makeSceneActive');
+  });
+
+  test('data が渡された場合は breadcrumb に含まれる', () => {
+    markObsOp('SourcesService', 'createSource', { type: 'video_capture_device' });
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'obs',
+      message: 'SourcesService.createSource',
+      level: 'info',
+      data: { type: 'video_capture_device' },
+    });
+  });
+
+  test('getLastObsOp は最後に呼んだ markObsOp の op を返す', () => {
+    markObsOp('ScenesService', 'createScene');
+    expect(getLastObsOp()).toBe('ScenesService.createScene');
+
+    markObsOp('StreamingService', 'toggleStreaming');
+    expect(getLastObsOp()).toBe('StreamingService.toggleStreaming');
+  });
+
+  test('初期値は空文字', () => {
+    // module-scope なので他テストの後でも初期値は確認できないが
+    // markObsOp を呼んだ後は上書きされることを確認
+    markObsOp('ScenesService', 'removeScene', { sceneId: 'abc' });
+    expect(getLastObsOp()).toBe('ScenesService.removeScene');
+  });
+});

--- a/app/util/sentry-obs-breadcrumb.ts
+++ b/app/util/sentry-obs-breadcrumb.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/vue';
+
+let lastObsOp = '';
+
+export function getLastObsOp(): string {
+  return lastObsOp;
+}
+
+export function markObsOp(
+  serviceName: string,
+  methodName: string,
+  data?: Record<string, string | number | boolean>,
+): void {
+  const op = `${serviceName}.${methodName}`;
+  lastObsOp = op;
+
+  Sentry.addBreadcrumb({
+    category: 'obs',
+    message: op,
+    level: 'info',
+    data,
+  });
+
+  Sentry.setTag('obs.lastOp', op);
+}


### PR DESCRIPTION
## 背景

Sentry issue N-AIR-APP-FY9・FWM（`Error: Lost IPC Connection`）が断続的に発生しているが、OBS バックエンドプロセスが死亡するタイミングを `PerformanceService` の 2 秒ポーリングが検知するだけで、**直前にどの OBS 操作が実行されていたか**の情報がない。breadcrumb には `window.focus/blur` 等の Electron 既定イベントのみで、誘発操作が特定できない。

## 変更の趣旨

バグ修正ではなく、**次回発生時に誘発操作を絞り込めるよう Sentry への情報出力を強化する**。

1. **`markObsOp` ユーティリティ** (`app/util/sentry-obs-breadcrumb.ts`) を新規作成
   - OBS に関わる主要操作の入口で `category: 'obs'` の breadcrumb を記録
   - `Sentry.setTag('obs.lastOp', op)` で直近操作をセッション全体のタグとして保持
   - モジュールスコープの `lastObsOp` で `PerformanceService` から参照可能にする
2. **`PerformanceService.getState()` の捕捉を強化**
   - 初回例外キャプチャに `withScope` を追加し、`service`/`method` タグ + `streamingStatus`/`lastObsOp` extra を付与

## 計装対象

| サービス | メソッド | 備考 |
|---|---|---|
| `ScenesService` | `makeSceneActive` | sceneId 付き |
| `ScenesService` | `createScene` | |
| `ScenesService` | `removeScene` | ガード通過後のみ記録 |
| `SourcesService` | `createSource` | type 付き |
| `SourcesService` | `removeSource` | |
| `StreamingService` | `toggleStreaming` | start/stop を action で区別 |
| `StreamingService` | `toggleRecording` | |
| `SettingsService` | `setSettings` | Output/Video/Stream カテゴリのみ |

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/util/sentry-obs-breadcrumb.ts` | `markObsOp` / `getLastObsOp` ユーティリティ（新規） |
| `app/util/sentry-obs-breadcrumb.test.ts` | ユニットテスト（新規） |
| `app/services/performance/performance.ts` | `captureException` を `withScope` で包み tags/extras を追加 |
| `app/services/scenes/scenes.ts` | `markObsOp` 追加（3 メソッド） |
| `app/services/sources/sources.ts` | `markObsOp` 追加（2 メソッド） |
| `app/services/streaming/streaming.ts` | `markObsOp` 追加（2 メソッド） |
| `app/services/settings/settings.ts` | `markObsOp` 追加（encoder 系カテゴリのみ） |

## 注意

- `scenes.ts` は PR #1278 と同ファイルを修正しています。PR #1278 マージ後に rebase が必要です
- 既存の `Sentry.addBreadcrumb({ category: 'obs', ... })` は OBS API レベルの記録であり、`markObsOp` はサービス操作レベルの記録です。意図的に共存します

## テスト

- `app/util/sentry-obs-breadcrumb.test.ts` を追加（全 5 件 pass）
- 挙動変更はなく診断データ追加のみ

## 関連

関連: N-AIR-APP-FY9
関連: N-AIR-APP-FWM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
