### PR TITLE
開発: CrashContextService を追加してネイティブクラッシュ時の診断情報を強化

### DIFF
--- a/app/app-services.ts
+++ b/app/app-services.ts
@@ -12,6 +12,7 @@ export { AppService } from 'services/app';
 export { AudioService, AudioSource } from 'services/audio';
 export { ClipboardService } from 'services/clipboard';
 export { CompactModeService } from 'services/compact-mode';
+export { CrashContextService } from 'services/crash-context';
 export { CrashReporterService } from 'services/crash-reporter';
 export { CustomcastUsageService } from 'services/custom-cast-usage';
 export { CustomizationService } from 'services/customization';

--- a/app/services/crash-context.test.ts
+++ b/app/services/crash-context.test.ts
@@ -1,0 +1,164 @@
+import { Subject } from 'rxjs';
+import { createSetupFunction } from 'util/test-setup';
+
+const mockAddExtraParameter = jest.fn();
+const mockIpcSend = jest.fn();
+
+jest.mock('@electron/remote', () => ({
+  crashReporter: {
+    addExtraParameter: mockAddExtraParameter,
+  },
+}));
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    send: mockIpcSend,
+  },
+}));
+
+jest.mock('services/core/stateful-service');
+jest.mock('services/core/injector');
+jest.mock('services/core/service-initialization-observer', () => ({
+  InitAfter: () => () => {},
+}));
+
+function makeScenesMock() {
+  const sceneSwitched = new Subject<any>();
+  const sceneAdded = new Subject<any>();
+  const sceneRemoved = new Subject<any>();
+  return {
+    sceneSwitched,
+    sceneAdded,
+    sceneRemoved,
+    scenes: [{ id: 's1' }, { id: 's2' }],
+    activeScene: {
+      name: 'Scene 1',
+      getItems: () => [
+        { sourceId: 'src1' },
+        { sourceId: 'src2' },
+        { sourceId: 'src3' },
+        { sourceId: 'src4' },
+      ],
+    },
+  };
+}
+
+function makeSourcesMock() {
+  const sourceAdded = new Subject<any>();
+  const sourceRemoved = new Subject<any>();
+  return {
+    sourceAdded,
+    sourceRemoved,
+    getSource: (id: string) => ({ name: `source-${id}` }),
+  };
+}
+
+function makeStreamingMock() {
+  const streamingStatusChange = new Subject<any>();
+  return {
+    streamingStatusChange,
+    state: { streamingStatus: 'offline' },
+  };
+}
+
+function makeSettingsMock() {
+  return {
+    getStreamEncoderSettings: jest.fn().mockReturnValue({
+      encoder: 'obs_x264',
+      outputResolution: '1920x1080',
+      fps: '60',
+      bitrate: 6000,
+      audio: { bitrate: '192' },
+    }),
+  };
+}
+
+const scenesMock = makeScenesMock();
+const sourcesMock = makeSourcesMock();
+const streamingMock = makeStreamingMock();
+const settingsMock = makeSettingsMock();
+
+const setup = createSetupFunction({
+  injectee: {
+    ScenesService: scenesMock,
+    SourcesService: sourcesMock,
+    StreamingService: streamingMock,
+    SettingsService: settingsMock,
+  },
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('init() でシーン名・シーン数・ソースリスト・エンコーダー・ストリーミング状態が設定される', () => {
+  setup();
+  const { CrashContextService } = require('./crash-context');
+  const instance = CrashContextService.instance;
+  instance.init();
+
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.scene', 'Scene 1');
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.scenes.count', '2');
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.streaming', 'offline');
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.encoder.video', 'obs_x264 1920x1080 60fps 6000kbps');
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.encoder.audio', 'aac 192kbps');
+});
+
+test('init() でcrash-context-updateがipcRenderer経由でmainに送信される', () => {
+  setup();
+  const { CrashContextService } = require('./crash-context');
+  const instance = CrashContextService.instance;
+  instance.init();
+
+  expect(mockIpcSend).toHaveBeenCalledWith('crash-context-update', 'nair.scene', 'Scene 1');
+});
+
+test('init() でソースが4件の場合、先頭3件+件数が記録される', () => {
+  setup();
+  const { CrashContextService } = require('./crash-context');
+  const instance = CrashContextService.instance;
+  instance.init();
+
+  expect(mockAddExtraParameter).toHaveBeenCalledWith(
+    'nair.sources',
+    'source-src1,source-src2,source-src3,...(4)',
+  );
+});
+
+test('setLastUserOp() でnair.lastUserOpが設定される', () => {
+  setup();
+  const { CrashContextService } = require('./crash-context');
+  const instance = CrashContextService.instance;
+  instance.init();
+  jest.clearAllMocks();
+
+  instance.setLastUserOp('menu:file.openSceneCollection');
+
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.lastUserOp', 'menu:file.openSceneCollection');
+  expect(mockIpcSend).toHaveBeenCalledWith('crash-context-update', 'nair.lastUserOp', 'menu:file.openSceneCollection');
+});
+
+test('setLastObsOp() でnair.lastObsOpが設定される', () => {
+  setup();
+  const { CrashContextService } = require('./crash-context');
+  const instance = CrashContextService.instance;
+  instance.init();
+  jest.clearAllMocks();
+
+  instance.setLastObsOp('ScenesService.makeSceneActive');
+
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.lastObsOp', 'ScenesService.makeSceneActive');
+});
+
+test('setAppPhase() でnair.appPhaseが設定される', () => {
+  setup();
+  const { CrashContextService } = require('./crash-context');
+  const instance = CrashContextService.instance;
+  instance.init();
+  jest.clearAllMocks();
+
+  instance.setAppPhase('streaming');
+
+  expect(mockAddExtraParameter).toHaveBeenCalledWith('nair.appPhase', 'streaming');
+});

--- a/app/services/crash-context.ts
+++ b/app/services/crash-context.ts
@@ -1,0 +1,123 @@
+import * as remote from '@electron/remote';
+import { debounceTime, merge, Subject, Subscription } from 'rxjs';
+import { Inject } from 'services/core/injector';
+import { InitAfter } from 'services/core/service-initialization-observer';
+import { Service } from 'services/core/service';
+import { ScenesService } from 'services/scenes';
+import { SettingsService } from 'services/settings';
+import { SourcesService } from 'services/sources';
+import { StreamingService } from 'services/streaming';
+import { ipcRenderer } from 'electron';
+
+const DEBOUNCE_MS = 300;
+
+@InitAfter('ScenesService')
+export class CrashContextService extends Service {
+  @Inject() private scenesService: ScenesService;
+  @Inject() private sourcesService: SourcesService;
+  @Inject() private streamingService: StreamingService;
+  @Inject() private settingsService: SettingsService;
+
+  private subscriptions: Subscription[] = [];
+  private encoderUpdateTrigger = new Subject<void>();
+
+  init() {
+    this.subscriptions.push(
+      this.scenesService.sceneSwitched.subscribe((scene) => {
+        this.set('nair.scene', scene.name);
+        this.updateSourcesList();
+      }),
+      merge(
+        this.scenesService.sceneAdded,
+        this.scenesService.sceneRemoved,
+      ).subscribe(() => {
+        this.set('nair.scenes.count', String(this.scenesService.scenes.length));
+      }),
+      merge(
+        this.sourcesService.sourceAdded,
+        this.sourcesService.sourceRemoved,
+      ).pipe(debounceTime(DEBOUNCE_MS)).subscribe(() => {
+        this.updateSourcesList();
+      }),
+      this.streamingService.streamingStatusChange.subscribe((status) => {
+        this.set('nair.streaming', status);
+      }),
+      this.encoderUpdateTrigger
+        .pipe(debounceTime(DEBOUNCE_MS))
+        .subscribe(() => {
+          this.updateEncoderInfoImpl();
+        }),
+    );
+
+    this.snapshotAll();
+  }
+
+  setLastUserOp(name: string) {
+    this.set('nair.lastUserOp', name);
+  }
+
+  setLastObsOp(op: string) {
+    this.set('nair.lastObsOp', op);
+  }
+
+  setAppPhase(phase: string) {
+    this.set('nair.appPhase', phase);
+  }
+
+  triggerEncoderUpdate() {
+    this.encoderUpdateTrigger.next();
+  }
+
+  private snapshotAll() {
+    const activeScene = this.scenesService.activeScene;
+    if (activeScene) {
+      this.set('nair.scene', activeScene.name);
+      this.updateSourcesList();
+    }
+    this.set('nair.scenes.count', String(this.scenesService.scenes.length));
+    this.set('nair.streaming', this.streamingService.state.streamingStatus);
+    this.updateEncoderInfoImpl();
+  }
+
+  private updateSourcesList() {
+    const activeScene = this.scenesService.activeScene;
+    if (!activeScene) return;
+    const items = activeScene.getItems();
+    const names = items.map((item) => {
+      const source = this.sourcesService.getSource(item.sourceId);
+      return source ? source.name : item.sourceId;
+    });
+    const total = names.length;
+    const preview = names.slice(0, 3).join(',');
+    this.set('nair.sources', total > 3 ? `${preview},...(${total})` : preview);
+  }
+
+  private updateEncoderInfoImpl() {
+    try {
+      const enc = this.settingsService.getStreamEncoderSettings();
+      const videoStr = [
+        enc.encoder,
+        enc.outputResolution,
+        enc.fps ? `${enc.fps}fps` : '',
+        enc.bitrate ? `${enc.bitrate}kbps` : '',
+      ].filter(Boolean).join(' ');
+      const audioStr = [
+        'aac',
+        enc.audio.bitrate ? `${enc.audio.bitrate}kbps` : '',
+      ].filter(Boolean).join(' ');
+      this.set('nair.encoder.video', videoStr);
+      this.set('nair.encoder.audio', audioStr);
+    } catch {
+      // Settings may not be ready at startup; silently skip
+    }
+  }
+
+  private set(key: string, value: string) {
+    try {
+      remote.crashReporter.addExtraParameter(key, value);
+    } catch {
+      // Ignore errors if crashReporter is not available
+    }
+    ipcRenderer.send('crash-context-update', key, value);
+  }
+}

--- a/app/services/crash-context.ts
+++ b/app/services/crash-context.ts
@@ -1,13 +1,13 @@
 import * as remote from '@electron/remote';
+import { ipcRenderer } from 'electron';
 import { debounceTime, merge, Subject, Subscription } from 'rxjs';
 import { Inject } from 'services/core/injector';
-import { InitAfter } from 'services/core/service-initialization-observer';
 import { Service } from 'services/core/service';
+import { InitAfter } from 'services/core/service-initialization-observer';
 import { ScenesService } from 'services/scenes';
 import { SettingsService } from 'services/settings';
 import { SourcesService } from 'services/sources';
 import { StreamingService } from 'services/streaming';
-import { ipcRenderer } from 'electron';
 
 const DEBOUNCE_MS = 300;
 

--- a/main.js
+++ b/main.js
@@ -646,6 +646,10 @@ function initialize(crashHandler) {
         processType: 'main',
       },
     });
+
+    ipcMain.on('crash-context-update', (_event, key, value) => {
+      crashReporter.addExtraParameter(key, value);
+    });
   } else {
     console.log('Sentry disabled, SENTRY_DSN = ', sentryDefs.DSN);
   }


### PR DESCRIPTION
## このpull requestが解決する内容

ネイティブクラッシュ（`EXCEPTION_*` 系）が発生した際、minidump に付随するコンテキスト情報が不足していて原因特定ができない問題を改善します。`crashReporter.addExtraParameter()` を使って、クラッシュ時のシーン・ソース・エンコーダー設定・配信状態・直前操作を Sentry の minidump イベントに付与します。

## 背景

現状の minidump イベント（N-AIR-APP-FXK, FXH, FXT, D0C, FYC）には `version` と `processType` しか付いておらず、何をしていてクラッシュしたかが分からない。

## 変更内容

### 新規ファイル

- `app/services/crash-context.ts` — `CrashContextService`
  - `@InitAfter('ScenesService')` で起動時に自動初期化
  - シーン切替・ソース追加削除・配信状態変化を購読し `crashReporter.addExtraParameter()` で更新
  - renderer プロセスと main プロセスの両方に反映（片方のクラッシュでも情報が載るように）
  
- `app/services/crash-context.test.ts` — ユニットテスト（6件）

### 修正ファイル

- `app/app-services.ts` — `CrashContextService` を登録
- `main.js` — `crash-context-update` IPC チャネルを受け取り main プロセスの `crashReporter` に転送

### 付与される情報

| key | 内容 | 例 |
|-----|------|----|
| `nair.scene` | アクティブシーン名 | `"Scene 1"` |
| `nair.scenes.count` | シーン総数 | `"3"` |
| `nair.sources` | ソース一覧（先頭3件＋件数） | `"mic,cam,bgm,...(5)"` |
| `nair.encoder.video` | 映像エンコーダー設定 | `"obs_x264 1920x1080 60fps 6000kbps"` |
| `nair.encoder.audio` | 音声エンコーダー設定 | `"aac 192kbps"` |
| `nair.streaming` | 配信状態 | `"live"` / `"offline"` |
| `nair.lastUserOp` | 最後のユーザー操作 | `"menu:file.openSceneCollection"` |
| `nair.lastObsOp` | 最後の OBS 操作 | `"ScenesService.makeSceneActive"` |
| `nair.appPhase` | アプリのフェーズ | `"streaming"` |

> **注記**: `nair.lastUserOp` は PR #1278 マージ後に `sentry-menu-handler.ts` から呼び出す予定。`nair.lastObsOp` は PR #1281 の `markObsOp()` 内から呼び出す予定。

## 挙動変更

なし。診断データの追加のみ。

## テスト

- ユニットテスト: `app/services/crash-context.test.ts`（6件）

## 関連

関連: N-AIR-APP-FXK, N-AIR-APP-FXH, N-AIR-APP-FXT, N-AIR-APP-D0C, N-AIR-APP-FYC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
