### PR TITLE
開発: Sentry ノイズ系イベントの送信を抑制

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -89,13 +89,19 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !remote.process.env.N
       sampleRate: /* isPreview ? */ 1.0 /* : 0.1 */,
       Vue,
       beforeSend(event) {
-        // 一度出始めると大量に送信しつづける IPC error のSentry送信を削減する(quota対策)
-        if (event.exception && event.exception.values) {
-          const value = event.exception.values[0].value;
-          if (value?.match(/Failed to make IPC call/)) {
-            console.log(`skip send to Sentry(IPC): ${value}`, event);
-            return null;
-          }
+        // quota 対策: ユーザー側ネット環境起因またはアプリバグに起因しないノイズを除外する
+        const NOISE_PATTERNS = [
+          /Failed to make IPC call/,
+          /ERR_ABORTED/,
+          /ERR_FAILED/,
+          /read ECONNRESET/,
+          /network error/i,
+          /Failed to fetch/,
+        ];
+        const messageText =
+          (event.exception?.values?.[0]?.value) ?? event.message ?? '';
+        if (NOISE_PATTERNS.some((re) => re.test(messageText))) {
+          return null;
         }
         return event;
       },

--- a/app/services/nicolive-program/NicoliveFailure.test.ts
+++ b/app/services/nicolive-program/NicoliveFailure.test.ts
@@ -22,11 +22,16 @@ function prepare(codeExists: string) {
     }),
   }));
 
+  const sentryMessage = jest.fn();
+  jest.doMock('util/sentry-report', () => ({
+    SentryReport: { message: sentryMessage },
+  }));
+
   const m = require('./NicoliveFailure');
   const NicoliveFailure = m.NicoliveFailure as NicoliveFailureType;
   const openErrorDialogFromFailure = m.openErrorDialogFromFailure;
 
-  return { showMessageBox, NicoliveFailure, openErrorDialogFromFailure };
+  return { showMessageBox, sentryMessage, NicoliveFailure, openErrorDialogFromFailure };
 }
 
 test('4xxで未定義文言だったら400にフォールバックする', async () => {
@@ -88,4 +93,34 @@ test('errorCodeがなかったらstatusCode さらに x00 を使う', async () =
   await openErrorDialogFromFailure(failure);
   expect(showMessageBox.mock.calls[0][1].title).toBe('title');
   expect(showMessageBox.mock.calls[0][1].message).toBe('message');
+});
+
+test('network_error タイプの場合は Sentry に送信しないが dialog は表示する', async () => {
+  jest.doMock('./NicoliveClient', () => ({ NotLoggedInError: class {} }));
+  const { showMessageBox, sentryMessage, NicoliveFailure, openErrorDialogFromFailure } = prepare('network_error');
+  const failure = NicoliveFailure.fromClientError('method', {
+    ok: false,
+    value: new Error('network error'),
+  });
+
+  await openErrorDialogFromFailure(failure);
+  expect(sentryMessage).not.toHaveBeenCalled();
+  expect(showMessageBox).toHaveBeenCalled();
+});
+
+test('http_error タイプの場合は Sentry に送信する', async () => {
+  jest.doMock('./NicoliveClient', () => ({ NotLoggedInError: class {} }));
+  const { sentryMessage, NicoliveFailure, openErrorDialogFromFailure } = prepare('500');
+  const failure = NicoliveFailure.fromClientError('method', {
+    ok: false,
+    value: { meta: { status: 500 } },
+  });
+
+  await openErrorDialogFromFailure(failure);
+  expect(sentryMessage).toHaveBeenCalledWith(
+    'NicoliveProgram',
+    'openErrorDialogFromFailure',
+    'openErrorDialogFromFailure',
+    expect.objectContaining({ level: 'warning' }),
+  );
 });

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -66,16 +66,18 @@ function fallbackToX00(reason: string): string {
 }
 
 export async function openErrorDialogFromFailure(failure: NicoliveFailure): Promise<void> {
-  SentryReport.message('NicoliveProgram', 'openErrorDialogFromFailure', 'openErrorDialogFromFailure', {
-    level: 'warning',
-    extra: { failure },
-    tags: {
-      'failure.type': failure.type,
-      'failure.method': failure.method,
-      'failure.reason': failure.reason,
-    },
-    fingerprint: ['openErrorDialogFromFailure'],
-  });
+  if (failure.type !== 'network_error') {
+    SentryReport.message('NicoliveProgram', 'openErrorDialogFromFailure', 'openErrorDialogFromFailure', {
+      level: 'warning',
+      extra: { failure },
+      tags: {
+        'failure.type': failure.type,
+        'failure.method': failure.method,
+        'failure.reason': failure.reason,
+      },
+      fingerprint: ['openErrorDialogFromFailure'],
+    });
+  }
 
   if (failure.type === 'logic') {
     return openErrorDialog({

--- a/app/services/nicolive-program/speech/WebSpeechSynthesizer.ts
+++ b/app/services/nicolive-program/speech/WebSpeechSynthesizer.ts
@@ -40,16 +40,18 @@ export class WebSpeechSynthesizer implements ISpeechSynthesizer {
         onend();
       };
       uttr.onerror = (e) => {
-        Sentry.captureEvent({
-          message: 'speechSynthesis.onerror',
-          level: ['interrupted', 'canceled'].includes(e.error) ? 'info' : 'warning',
-          tags: {
-            error: e.error,
-          },
-          extra: {
-            speech,
-          },
-        });
+        if (!['interrupted', 'canceled'].includes(e.error)) {
+          Sentry.captureEvent({
+            message: 'speechSynthesis.onerror',
+            level: 'warning',
+            tags: {
+              error: e.error,
+            },
+            extra: {
+              speech,
+            },
+          });
+        }
         if (Utils.isDevMode()) {
           console.warn('speechSynthesis.onerror', e.error);
         }


### PR DESCRIPTION
## 概要

Sentry の quota を圧迫しているノイズ系イベントを送信しないように変更します。

## 背景・動機

リリース `1.1.20260513-1` のトリアージで、以下のノイズイベントが大量に生成していることが判明しました。

- **ニコ生 API のネットワークエラー (約95,000件/期間)**: `openErrorDialogFromFailure` がエラーダイアログを表示するたびに Sentry へ warning を送信していたが、ユーザー側ネット切断 (`network_error`) とサーバ起因エラー (`http_error`) を区別せず全件送っていた。大半はユーザー側の切断によるもので、アプリのバグではない。
- **Web Speech API の発話キャンセル/割り込み**: `speechSynthesis.onerror` の `interrupted`/`canceled` は連投コメントを読み上げ中に次のコメントで切り替えるたびに発火する正常動作で、エラーではない。
- **ネット起因の例外**: `ERR_ABORTED`, `ERR_FAILED` などのネット系エラーが `beforeSend` フィルタの対象外だった。

## 変更内容

### `app/services/nicolive-program/NicoliveFailure.ts`
- `openErrorDialogFromFailure` で `failure.type === 'network_error'` の場合は Sentry に送信しない
- `http_error` (サーバ 4xx/5xx) と `logic` (クライアントロジック) は分類情報維持のため送信継続
- UX への影響なし: dialog (`showMessageBox`) は `failure.type` に関係なく表示し続ける

### `app/services/nicolive-program/speech/WebSpeechSynthesizer.ts`
- `speechSynthesis.onerror` で `e.error` が `interrupted` または `canceled` の場合は Sentry に送信しない (early return)
- その他のエラー (`synthesis-unavailable` 等) は warning で送信継続

### `app/app.ts`
- `beforeSend` を強化し、ユーザー側ネット環境起因のノイズパターンを一括除外
  - 既存: `Failed to make IPC call`
  - 追加: `ERR_ABORTED`, `ERR_FAILED`, `read ECONNRESET`, `network error` (大小文字無視), `Failed to fetch`
- `exception.values[0].value` と `event.message` の両方をチェック (captureMessage 経路もカバー)

### `app/services/nicolive-program/NicoliveFailure.test.ts`
- `network_error` タイプで Sentry に送信しないことのテストを追加
- `http_error` タイプで Sentry に送信することのテストを追加
- 既存テストすべて引き続きパス

## テスト

`NicoliveFailure.test.ts` 7件 pass、TypeScript 型チェック・ESLint エラーなし (いずれも CI 確認)

手動確認:
- [ ] ニコ生番組でネット切断時に dialog が表示されること (Sentry には送らない)
- [ ] VOICEVOX/Web Speech で発話中断時に Sentry に `interrupted` が送られないこと

Sentry-Resolves: N-AIR-APP-DES, N-AIR-APP-BSV