### PR TITLE
開発: Vue 3移行対応 - スロット記法をテンプレート構文に変更

### DIFF
--- a/app/components/nicolive-area/AreaSwitcher.vue
+++ b/app/components/nicolive-area/AreaSwitcher.vue
@@ -20,10 +20,12 @@
           </ul>
         </div>
 
-        <div class="indicator" slot="reference">
-          {{ activeContent.name }}
-          <i class="icon-drop-down-arrow"></i>
-        </div>
+        <template #reference>
+          <div class="indicator">
+            {{ activeContent.name }}
+            <i class="icon-drop-down-arrow"></i>
+          </div>
+        </template>
       </popper>
     </div>
   </div>

--- a/app/components/nicolive-area/CommentFilter.vue
+++ b/app/components/nicolive-area/CommentFilter.vue
@@ -39,9 +39,11 @@
             </ul>
           </div>
 
-          <div class="indicator" :class="{ 'is-show': showPopupMenu }" slot="reference">
-            <i class="icon-adjuster icon-btn" v-tooltip.bottom="adjusterTooltip"></i>
-          </div>
+          <template #reference>
+            <div class="indicator" :class="{ 'is-show': showPopupMenu }">
+              <i class="icon-adjuster icon-btn" v-tooltip.bottom="adjusterTooltip"></i>
+            </div>
+          </template>
         </popper>
 
         <button

--- a/app/components/nicolive-area/ModeratorConfirmDialog.vue
+++ b/app/components/nicolive-area/ModeratorConfirmDialog.vue
@@ -1,28 +1,30 @@
 <template>
   <modal-layout :show-controls="false" :customControls="true">
-    <div class="content" slot="content">
-      <div v-if="operation === 'add'">
-        <p class="confirm-title">
-          <span class="text-ellipsis">{{ userName }}</span
-          ><span class="text-suffix">さんをモデレーターに追加しますか？</span>
-        </p>
-        <p class="confirm-description">
-          追加すると視聴中または視聴を開始した追加対象のユーザーに通知されます
-        </p>
-        <a @click="openModeratorHelpPage" class="text-link">
-          <i class="icon-question"></i>
-          <span>モデレーターとは</span>
-        </a>
+    <template #content>
+      <div class="content">
+        <div v-if="operation === 'add'">
+          <p class="confirm-title">
+            <span class="text-ellipsis">{{ userName }}</span
+            ><span class="text-suffix">さんをモデレーターに追加しますか？</span>
+          </p>
+          <p class="confirm-description">
+            追加すると視聴中または視聴を開始した追加対象のユーザーに通知されます
+          </p>
+          <a @click="openModeratorHelpPage" class="text-link">
+            <i class="icon-question"></i>
+            <span>モデレーターとは</span>
+          </a>
+        </div>
+        <div v-else-if="operation === 'remove'">
+          <p class="confirm-title">
+            <span class="text-ellipsis">{{ userName }}</span
+            ><span class="text-suffix">さんをモデレーターから削除しますか？</span>
+          </p>
+          <p class="confirm-description">削除されたことは削除対象のユーザーに通知されません</p>
+        </div>
       </div>
-      <div v-else-if="operation === 'remove'">
-        <p class="confirm-title">
-          <span class="text-ellipsis">{{ userName }}</span
-          ><span class="text-suffix">さんをモデレーターから削除しますか？</span>
-        </p>
-        <p class="confirm-description">削除されたことは削除対象のユーザーに通知されません</p>
-      </div>
-    </div>
-    <div slot="controls">
+    </template>
+    <template #controls>
       <button class="button button--secondary" :disabled="isClosing" @click="cancel">
         {{ $t('common.cancel') }}
       </button>
@@ -34,7 +36,7 @@
       >
         {{ operation === 'add' ? '追加する' : operation === 'remove' ? '削除する' : operation }}
       </button>
-    </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/nicolive-area/NicoliveProgramSelector.vue
+++ b/app/components/nicolive-area/NicoliveProgramSelector.vue
@@ -1,22 +1,23 @@
 <template>
   <modal-layout bare-content :show-controls="false" :custom-controls="true">
-    <div slot="content" class="nicolive-program-selector">
-      <NavMenu v-model="currentStep" class="side-menu" data-test="SideMenu">
-        <NavItem
-          v-for="step in steps"
-          :enabled="shouldEnableNavItem(step)"
-          :key="step"
-          :to="step"
-          :ico="isCompletedStep(step) ? 'icon-check' : undefined"
-          :data-test="step"
-          :class="'step-item'"
-        >
-          <h3 class="step-item-title">{{ getStepTitleForMenu(step) }}</h3>
-          <p class="step-item-selected-item" v-if="isCompletedStep(step)">
-            {{ getSelectedValueForDisplay(step) }}
-          </p>
-        </NavItem>
-      </NavMenu>
+    <template #content>
+      <div class="nicolive-program-selector">
+        <NavMenu v-model="currentStep" class="side-menu" data-test="SideMenu">
+          <NavItem
+            v-for="step in steps"
+            :enabled="shouldEnableNavItem(step)"
+            :key="step"
+            :to="step"
+            :ico="isCompletedStep(step) ? 'icon-check' : undefined"
+            :data-test="step"
+            :class="'step-item'"
+          >
+            <h3 class="step-item-title">{{ getStepTitleForMenu(step) }}</h3>
+            <p class="step-item-selected-item" v-if="isCompletedStep(step)">
+              {{ getSelectedValueForDisplay(step) }}
+            </p>
+          </NavItem>
+        </NavMenu>
       <div class="nicolive-program-selector-container">
         <Step
           v-if="currentStep === 'providerTypeSelect'"
@@ -85,11 +86,14 @@
         </Step>
       </div>
     </div>
-    <div slot="controls" v-if="currentStep === 'confirm'">
-      <button class="button button--primary" @click="ok" data-test="Done">
-        {{ $t('streaming.nicoliveProgramSelector.done') }}
-      </button>
-    </div>
+    </template>
+    <template #controls>
+      <template v-if="currentStep === 'confirm'">
+        <button class="button button--primary" @click="ok" data-test="Done">
+          {{ $t('streaming.nicoliveProgramSelector.done') }}
+        </button>
+      </template>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/nicolive-area/ProgramInfo.vue
+++ b/app/components/nicolive-area/ProgramInfo.vue
@@ -83,9 +83,11 @@
           </li>
         </ul>
       </div>
-      <div class="indicator" :class="{ 'is-show': showPopupMenu }" slot="reference">
-        <i class="icon-drop-down-arrow"></i>
-      </div>
+      <template #reference>
+        <div class="indicator" :class="{ 'is-show': showPopupMenu }">
+          <i class="icon-drop-down-arrow"></i>
+        </div>
+      </template>
     </popper>
   </div>
 </template>

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -46,14 +46,15 @@
             </li>
           </ul>
         </div>
-        <button
-          class="button--circle button--secondary button--extension"
-          v-tooltip.bottom="extensionTooltip"
-          :class="{ 'is-show': showPopupMenu, active: autoExtensionEnabled }"
-          slot="reference"
-        >
-          <i class="icon-extension"></i>
-        </button>
+        <template #reference>
+          <button
+            class="button--circle button--secondary button--extension"
+            v-tooltip.bottom="extensionTooltip"
+            :class="{ 'is-show': showPopupMenu, active: autoExtensionEnabled }"
+          >
+            <i class="icon-extension"></i>
+          </button>
+        </template>
       </popper>
 
       <button
@@ -118,22 +119,23 @@
               </li>
             </ul>
           </div>
-          <button
-            class="button button--select-menu"
-            v-tooltip.bottom="startButtonSelectorTooltip"
-            v-show="programStatus !== 'onAir'"
-            :class="{
-              'is-show': showPopupMenu,
-              active: showButtonSelector,
-              'button--action': selectedButton === 'start',
-              'button--end-program button--live': selectedButton === 'end',
-              'button--primary': selectedButton === 'create',
-              'button--secondary': selectedButton === 'release',
-            }"
-            slot="reference"
-          >
-            <i class="icon-drop-down-arrow"></i>
-          </button>
+          <template #reference>
+            <button
+              class="button button--select-menu"
+              v-tooltip.bottom="startButtonSelectorTooltip"
+              v-show="programStatus !== 'onAir'"
+              :class="{
+                'is-show': showPopupMenu,
+                active: showButtonSelector,
+                'button--action': selectedButton === 'start',
+                'button--end-program button--live': selectedButton === 'end',
+                'button--primary': selectedButton === 'create',
+                'button--secondary': selectedButton === 'release',
+              }"
+            >
+              <i class="icon-drop-down-arrow"></i>
+            </button>
+          </template>
         </popper>
       </div>
     </div>

--- a/app/components/nicolive-area/UserInfo.vue
+++ b/app/components/nicolive-area/UserInfo.vue
@@ -1,6 +1,7 @@
 <template>
   <modal-layout :showControls="false">
-    <div class="user-info" slot="content">
+    <template #content>
+      <div class="user-info">
       <div class="user-detail">
         <img
           :src="userIconURL"
@@ -97,14 +98,15 @@
                 </li>
               </ul>
             </div>
-            <div
-              class="button--circle button--secondary"
-              v-tooltip.bottom="otherMenuTooltip"
-              :class="{ 'is-show': showPopupMenu }"
-              slot="reference"
-            >
-              <i class="icon-ellipsis-horizontal"></i>
-            </div>
+            <template #reference>
+              <div
+                class="button--circle button--secondary"
+                v-tooltip.bottom="otherMenuTooltip"
+                :class="{ 'is-show': showPopupMenu }"
+              >
+                <i class="icon-ellipsis-horizontal"></i>
+              </div>
+            </template>
           </popper>
         </div>
       </div>
@@ -162,7 +164,8 @@
           </div>
         </div>
       </div>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/scenes/ManageSceneCollections.vue
+++ b/app/components/scenes/ManageSceneCollections.vue
@@ -1,6 +1,6 @@
 <template>
   <modal-layout :show-cancel="false" :done-handler="close" :customControls="true">
-    <div slot="content">
+    <template #content>
       <div class="manage-scene-collections__header">
         <div class="input-wrapper input-wrapper--search">
           <input
@@ -22,12 +22,12 @@
           :collection-id="collection.id"
         />
       </div>
-    </div>
-    <div slot="controls">
+    </template>
+    <template #controls>
       <button class="button button--secondary" @click="importFromOBS" :disabled="!canImportFromOBS">
         {{ $t('onboarding.importFromObs') }}
       </button>
-    </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/scenes/NameFolder.vue
+++ b/app/components/scenes/NameFolder.vue
@@ -1,14 +1,16 @@
 <template>
   <modal-layout :done-handler="submit">
-    <form slot="content" @submit.prevent="submit">
-      <p v-if="!error" class="NameSource-label">
-        {{ $t('sources.enterTheNameOfFolder') }}
-      </p>
-      <p v-if="error" class="NameSource-label NameSource-label__error">
-        {{ error }}
-      </p>
-      <input autofocus type="text" v-model="name" />
-    </form>
+    <template #content>
+      <form @submit.prevent="submit">
+        <p v-if="!error" class="NameSource-label">
+          {{ $t('sources.enterTheNameOfFolder') }}
+        </p>
+        <p v-if="error" class="NameSource-label NameSource-label__error">
+          {{ error }}
+        </p>
+        <input autofocus type="text" v-model="name" />
+      </form>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/scenes/NameScene.vue
+++ b/app/components/scenes/NameScene.vue
@@ -1,14 +1,16 @@
 <template>
   <modal-layout :done-handler="submit">
-    <form slot="content" @submit.prevent="submit">
-      <p v-if="!error" class="NameScene-label">
-        {{ $t('scenes.enterTheNameOfTheScene') }}
-      </p>
-      <p v-if="error" class="NameScene-label NameScene-label__error">
-        {{ error }}
-      </p>
-      <input autofocus type="text" v-model="name" />
-    </form>
+    <template #content>
+      <form @submit.prevent="submit">
+        <p v-if="!error" class="NameScene-label">
+          {{ $t('scenes.enterTheNameOfTheScene') }}
+        </p>
+        <p v-if="error" class="NameScene-label NameScene-label__error">
+          {{ error }}
+        </p>
+        <input autofocus type="text" v-model="name" />
+      </form>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/scenes/NameSceneCollection.vue
+++ b/app/components/scenes/NameSceneCollection.vue
@@ -1,14 +1,16 @@
 <template>
   <modal-layout :done-handler="submit">
-    <form slot="content" @submit.prevent="submit">
-      <p v-if="!error" class="NameScene-label">
-        {{ $t('scenes.enterTheNameOfTheSceneCollection') }}
-      </p>
-      <p v-if="error" class="NameScene-label NameScene-label__error">
-        {{ error }}
-      </p>
-      <input autofocus type="text" v-model="name" />
-    </form>
+    <template #content>
+      <form @submit.prevent="submit">
+        <p v-if="!error" class="NameScene-label">
+          {{ $t('scenes.enterTheNameOfTheSceneCollection') }}
+        </p>
+        <p v-if="error" class="NameScene-label NameScene-label__error">
+          {{ error }}
+        </p>
+        <input autofocus type="text" v-model="name" />
+      </form>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/settings/AdvancedAudio.vue
+++ b/app/components/settings/AdvancedAudio.vue
@@ -1,34 +1,36 @@
 <template>
   <modal-layout :show-controls="false" no-scroll>
-    <div slot="content" class="table-wrapper section">
-      <table>
-        <thead>
-          <tr>
-            <th class="device">{{ $t('common.name') }}</th>
-            <th class="volume">{{ $t('audio.volumeInPercent') }}</th>
-            <th class="downmix">{{ $t('audio.downmixToMono') }}</th>
-            <th class="syncOffset">{{ $t('audio.syncOffsetInMs') }}</th>
-            <th class="audioMonitor">{{ $t('audio.audioMonitoring') }}</th>
-            <th class="track">{{ $t('audio.tracks') }}</th>
+    <template #content>
+      <div class="table-wrapper section">
+        <table>
+          <thead>
+            <tr>
+              <th class="device">{{ $t('common.name') }}</th>
+              <th class="volume">{{ $t('audio.volumeInPercent') }}</th>
+              <th class="downmix">{{ $t('audio.downmixToMono') }}</th>
+              <th class="syncOffset">{{ $t('audio.syncOffsetInMs') }}</th>
+              <th class="audioMonitor">{{ $t('audio.audioMonitoring') }}</th>
+              <th class="track">{{ $t('audio.tracks') }}</th>
+            </tr>
+          </thead>
+          <tr v-for="audioSource in audioSources" :key="audioSource.sourceId">
+            <td>{{ audioSource.name }}</td>
+            <td
+              v-for="formInput in audioSource.getSettingsForm()"
+              :key="`${audioSource.name}${formInput.name}`"
+              :class="'column-' + formInput.name"
+            >
+              <component
+                v-if="propertyComponentForType(formInput.type)"
+                :is="propertyComponentForType(formInput.type)"
+                :value="formInput"
+                @input="value => onInputHandler(audioSource, formInput.name, value.value)"
+              />
+            </td>
           </tr>
-        </thead>
-        <tr v-for="audioSource in audioSources" :key="audioSource.sourceId">
-          <td>{{ audioSource.name }}</td>
-          <td
-            v-for="formInput in audioSource.getSettingsForm()"
-            :key="`${audioSource.name}${formInput.name}`"
-            :class="'column-' + formInput.name"
-          >
-            <component
-              v-if="propertyComponentForType(formInput.type)"
-              :is="propertyComponentForType(formInput.type)"
-              :value="formInput"
-              @input="value => onInputHandler(audioSource, formInput.name, value.value)"
-            />
-          </td>
-        </tr>
-      </table>
-    </div>
+        </table>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/settings/Informations.vue
+++ b/app/components/settings/Informations.vue
@@ -1,6 +1,7 @@
 <template>
   <modal-layout :showControls="false">
-    <div class="informations" slot="content" data-test="Informations">
+    <template #content>
+      <div class="informations" data-test="Informations">
       <ul class="information-list" v-if="!fetching && !hasError">
         <li
           class="information-list-item"
@@ -27,7 +28,8 @@
           >
         </i18n>
       </div>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/settings/OptimizeForNiconico.vue
+++ b/app/components/settings/OptimizeForNiconico.vue
@@ -1,6 +1,6 @@
 <template>
   <modal-layout :show-controls="false" :customControls="true">
-    <div slot="content">
+    <template #content>
       <p class="optimize-title">{{ $t('streaming.optimizationForNiconico.description') }}</p>
       <ul class="optimize-category-list">
         <li
@@ -24,15 +24,15 @@
       </ul>
       <BoolInput :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
       <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
-    </div>
-    <div slot="controls">
+    </template>
+    <template #controls>
       <button class="button button--secondary" :disabled="isStarting" @click="skip">
         {{ $t('streaming.skipOptimization') }}
       </button>
       <button class="button button--primary" :disabled="isStarting" @click="optimizeAndGoLive">
         {{ $t('streaming.optimizeAndGoLive') }}
       </button>
-    </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/settings/SceneTransitions.vue
+++ b/app/components/settings/SceneTransitions.vue
@@ -6,12 +6,14 @@
     :show-cancel="false"
     :done-handler="done"
   >
-    <div slot="content">
+    <template #content>
+      <div>
       <div v-if="!transitionsEnabled" class="transition-blank">
         {{ $t('transitions.mustHaveLeastTwoScenes') }}
       </div>
       <tabs :tabs="tabs" v-model="selectedTab" v-else>
-        <div slot="transitions" class="transition-tab">
+        <template #transitions>
+          <div class="transition-tab">
           <button class="button button--primary" @click="addTransition">
             {{ $t('transitions.addTransition') }}
           </button>
@@ -43,8 +45,10 @@
               </tr>
             </table>
           </div>
-        </div>
-        <div slot="connections" class="transition-tab">
+          </div>
+        </template>
+        <template #connections>
+          <div class="transition-tab">
           <button class="button button--primary" @click="addConnection">
             {{ $t('transitions.addConnection') }}
           </button>
@@ -76,7 +80,8 @@
               </tr>
             </table>
           </div>
-        </div>
+          </div>
+        </template>
       </tabs>
       <transition name="modal-fade">
         <div v-if="showTransitionSettings" class="modal-backdrop" @click.self="dismissModal('transition-settings')">
@@ -118,7 +123,8 @@
           </div>
         </div>
       </transition>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/settings/Settings.vue
+++ b/app/components/settings/Settings.vue
@@ -1,6 +1,7 @@
 <template>
   <modal-layout bare-content :show-cancel="false" :done-handler="done">
-    <div slot="content" class="settings" data-test="Settings">
+    <template #content>
+      <div class="settings" data-test="Settings">
       <NavMenu :value="categoryName" class="side-menu" data-test="SideMenu">
         <template v-for="category in categoryNames">
           <NavItem
@@ -56,7 +57,8 @@
         />
         <extra-settings v-if="categoryName === 'General'" />
       </div>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/shared/Login.vue
+++ b/app/components/shared/Login.vue
@@ -16,8 +16,8 @@
     >
       <i class="icon-log-in"></i>
       <help-tip :dismissable-key="loginHelpTipDismissable" mode="login">
-        <div slot="title" v-text="$t('common.loginHelpTipTitle')"></div>
-        <div slot="content" v-text="$t('common.loginHelpTipContent')"></div>
+        <template #title><div v-text="$t('common.loginHelpTipTitle')"></div></template>
+        <template #content><div v-text="$t('common.loginHelpTipContent')"></div></template>
       </help-tip>
     </a>
   </div>

--- a/app/components/shared/Popper.vue
+++ b/app/components/shared/Popper.vue
@@ -15,7 +15,6 @@
 @import url('../../styles/index');
 
 // Popperの共通スタイル（グローバル）
-// 利用側: <popper width="240px"><div class="popper">コンテンツ</div><button slot="reference">...</button></popper>
 // 幅は width プロパティで指定（例: width="240px"）。未指定の場合はコンテンツ幅に依存
 .popper {
   .shadow();

--- a/app/components/shared/sl-vue-tree/sl-vue-tree.vue
+++ b/app/components/shared/sl-vue-tree/sl-vue-tree.vue
@@ -96,11 +96,11 @@
           :showBranches="showBranches"
           @dragover.prevent
         >
-          <template slot="title" slot-scope="{ node }">
+          <template #title="{ node }">
             <slot name="title" :node="node">{{ node.title }}</slot>
           </template>
 
-          <template slot="toggle" slot-scope="{ node }">
+          <template #toggle="{ node }">
             <slot name="toggle" :node="node">
               <span>
                 {{ !node.isLeaf ? (node.isExpanded ? '-' : '+') : '' }}
@@ -108,11 +108,11 @@
             </slot>
           </template>
 
-          <template slot="sidebar" slot-scope="{ node }">
+          <template #sidebar="{ node }">
             <slot name="sidebar" :node="node"></slot>
           </template>
 
-          <template slot="empty-node" slot-scope="{ node }">
+          <template #empty-node="{ node }">
             <slot name="empty-node" :node="node" v-if="!node.isLeaf && node.children.length == 0 && node.isExpanded">
             </slot>
           </template>

--- a/app/components/sources/AddSource.vue
+++ b/app/components/sources/AddSource.vue
@@ -1,6 +1,7 @@
 <template>
   <modal-layout :showControls="false">
-    <div slot="content" data-test="AddSource">
+    <template #content>
+      <div data-test="AddSource">
       <div v-if="canAddNew">
         <div class="row">
           <div class="column small-12">
@@ -73,7 +74,8 @@
           </button>
         </div>
       </div>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/sources/AddSourceFilter.vue
+++ b/app/components/sources/AddSourceFilter.vue
@@ -1,12 +1,14 @@
 <template>
   <modal-layout :done-handler="done" :cancel-handler="cancel">
-    <div slot="content">
-      <ObsListInput v-model="form.type" @input="setTypeAsName"></ObsListInput>
-      <ObsTextInput v-model="form.name"></ObsTextInput>
-      <p v-if="error" style="color: red">
-        {{ error }}
-      </p>
-    </div>
+    <template #content>
+      <div>
+        <ObsListInput v-model="form.type" @input="setTypeAsName"></ObsListInput>
+        <ObsTextInput v-model="form.name"></ObsTextInput>
+        <p v-if="error" style="color: red">
+          {{ error }}
+        </p>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/sources/AutoCompactConfirmDialog.vue
+++ b/app/components/sources/AutoCompactConfirmDialog.vue
@@ -1,21 +1,21 @@
 <template>
   <modal-layout :show-controls="false" :customControls="true" no-scroll>
-    <div slot="content">
+    <template #content>
       <ul class="confirm-list">
         <li class="confirm-list-item">
           <p class="confirm-message">{{ $t('settings.autoCompact.message') }}</p>
           <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
         </li>
       </ul>
-    </div>
-    <div slot="controls">
+    </template>
+    <template #controls>
       <button class="button button--secondary" @click="skip">
         {{ $t('settings.autoCompact.later') }}
       </button>
       <button class="button button--primary" @click="activate">
         {{ $t('settings.autoCompact.activate') }}
       </button>
-    </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/sources/BrowserSourceInteraction.vue
+++ b/app/components/sources/BrowserSourceInteraction.vue
@@ -1,19 +1,20 @@
 <template>
   <ModalLayout :showControls="false" :contentStyles="{ padding: '0px' }">
-    <div
-      slot="content"
-      @wheel="onWheel"
-      @mousedown="onMousedown"
-      @mouseup="onMouseup"
-      @mousemove="onMousemove"
-      @keydown="onKeydown"
-      @keyup="onKeyup"
-      tabindex="0"
-      style="height: 100%; outline: none"
-      ref="eventDiv"
-    >
-      <Display :sourceId="sourceId" @outputResize="onOutputResize" />
-    </div>
+    <template #content>
+      <div
+        @wheel="onWheel"
+        @mousedown="onMousedown"
+        @mouseup="onMouseup"
+        @mousemove="onMousemove"
+        @keydown="onKeydown"
+        @keyup="onKeyup"
+        tabindex="0"
+        style="height: 100%; outline: none"
+        ref="eventDiv"
+      >
+        <Display :sourceId="sourceId" @outputResize="onOutputResize" />
+      </div>
+    </template>
   </ModalLayout>
 </template>
 

--- a/app/components/sources/RenameSource.vue
+++ b/app/components/sources/RenameSource.vue
@@ -1,14 +1,16 @@
 <template>
   <modal-layout :done-handler="submit">
-    <form slot="content" @submit.prevent="submit">
-      <p v-if="!error" class="NameSource-label">
-        {{ $t('sources.enterTheNameOfSource') }}
-      </p>
-      <p v-if="error" class="NameSource-label NameSource-label__error">
-        {{ error }}
-      </p>
-      <input autofocus type="text" v-model="name" />
-    </form>
+    <template #content>
+      <form @submit.prevent="submit">
+        <p v-if="!error" class="NameSource-label">
+          {{ $t('sources.enterTheNameOfSource') }}
+        </p>
+        <p v-if="error" class="NameSource-label NameSource-label__error">
+          {{ error }}
+        </p>
+        <input autofocus type="text" v-model="name" />
+      </form>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/sources/RtvcSourceProperties.vue
+++ b/app/components/sources/RtvcSourceProperties.vue
@@ -37,7 +37,7 @@
                   <span class="cellicon-label">{{ v.name }}</span>
                 </div>
 
-                <div class="indicator" slot="reference" @click="playSample(v.index)">
+                <div class="indicator" @click="playSample(v.index)">
                   <i
                     class="icon-speaker"
                     v-tooltip.bottom="$t('source-props.nair-rtvc-source.nav.play_sample')"
@@ -94,12 +94,14 @@
                       </li>
                     </ul>
                   </div>
-                  <div class="indicator" :class="{ 'is-show': showPopupMenu }" slot="reference">
-                    <i
-                      class="icon-ellipsis-vertical"
-                      v-tooltip.bottom="$t('source-props.nair-rtvc-source.nav.open_menu')"
-                    ></i>
-                  </div>
+                  <template #reference>
+                    <div class="indicator" :class="{ 'is-show': showPopupMenu }">
+                      <i
+                        class="icon-ellipsis-vertical"
+                        v-tooltip.bottom="$t('source-props.nair-rtvc-source.nav.open_menu')"
+                      ></i>
+                    </div>
+                  </template>
                 </popper>
               </div>
 

--- a/app/components/sources/SourceFilters.vue
+++ b/app/components/sources/SourceFilters.vue
@@ -1,9 +1,9 @@
 <template>
   <modal-layout :show-cancel="false" :done-handler="done" :fixedSectionHeight="250" bare-content>
-    <display slot="fixed" :sourceId="sourceId" />
+    <template #fixed><display :sourceId="sourceId" /></template>
 
-    <div slot="content" class="container" data-test="SourceFilters">
-      <NavMenu v-model="selectedFilterName" class="side-menu">
+    <template #content>
+      <div class="container" data-test="SourceFilters">
         <div class="controls">
           <i class="icon-add icon-btn" @click="addFilter" data-test="Add"></i>
           <i
@@ -21,7 +21,7 @@
           @drop="handleSort"
           :allowMultiselect="false"
         >
-          <template slot="title" slot-scope="{ node }">
+          <template #title="{ node }">
             <div class="title-container">
               <span class="layer-icon">
                 <i
@@ -50,7 +50,8 @@
           {{ $t('filters.noFilterMessage') }}
         </div>
       </div>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/sources/SourceProperties.vue
+++ b/app/components/sources/SourceProperties.vue
@@ -5,8 +5,8 @@
     :cancel-handler="cancel"
     :fixedSectionHeight="200"
   >
-    <display slot="fixed" v-if="source" :sourceId="source.id" />
-    <div slot="content">
+    <template #fixed><display v-if="source" :sourceId="source.id" /></template>
+    <template #content>
       <component
         v-if="propertiesManagerUI"
         :is="propertiesManagerUI"
@@ -14,7 +14,7 @@
         @update="refresh"
       />
       <GenericForm v-model="properties" @input="onInputHandler" />
-    </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/sources/SourcesShowcase.vue
+++ b/app/components/sources/SourcesShowcase.vue
@@ -1,12 +1,13 @@
 <template>
   <modal-layout bare-content :show-controls="false">
-    <div slot="content" class="add-source" data-test="SourcesShowCase">
+    <template #content>
+      <div class="add-source" data-test="SourcesShowCase">
       <add-source-info v-if="inspectedSource === 'image_source'" sourceType="image_source" key="1">
-        <imageSourceIcon slot="media" />
+        <template #media><imageSourceIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'slideshow'" sourceType="slideshow" key="2">
-        <SlideshowIcon slot="media" />
+        <template #media><SlideshowIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -14,7 +15,7 @@
         sourceType="ffmpeg_source"
         key="3"
       >
-        <FfmpegSourceIcon slot="media" />
+        <template #media><FfmpegSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -22,26 +23,18 @@
         sourceType="window_capture"
         key="4"
       >
-        <WindowCaptureIcon slot="media" />
-        <p slot="attention-text" class="attention">
+        <template #media><WindowCaptureIcon /></template>
+        <template #attention-text><p class="attention">
           {{ $t('sources.windowCaptureMessage') }}
-        </p>
+        </p></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'dshow_input'" sourceType="dshow_input" key="5">
-        <MonitorCaptureIcon slot="media" />
-      </add-source-info>
-
-      <add-source-info
-        v-if="inspectedSource === 'wasapi_output_capture'"
-        sourceType="wasapi_output_capture"
-        key="6"
-      >
-        <WasapiOutputIcon slot="media" />
+        <template #media><MonitorCaptureIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'color_source'" sourceType="color_source" key="7">
-        <ColorSourceIcon slot="media" />
+        <template #media><ColorSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -49,11 +42,11 @@
         sourceType="browser_source"
         key="8"
       >
-        <BrowserSourceIcon slot="media" />
+        <template #media><BrowserSourceIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'text_gdiplus'" sourceType="text_gdiplus" key="9">
-        <TextGdiplusIcon slot="media" />
+        <template #media><TextGdiplusIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -61,14 +54,14 @@
         sourceType="monitor_capture"
         key="10"
       >
-        <DshowInputIcon slot="media" />
+        <template #media><DshowInputIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'game_capture'" sourceType="game_capture" key="11">
-        <GameCaptureIcon slot="media" />
-        <p slot="attention-text" class="attention">
+        <template #media><GameCaptureIcon /></template>
+        <template #attention-text><p class="attention">
           {{ $t('sources.gameCaptureMessage') }}
-        </p>
+        </p></template>
       </add-source-info>
 
       <add-source-info
@@ -76,11 +69,11 @@
         sourceType="wasapi_input_capture"
         key="12"
       >
-        <WasapiInputCaptureIcon slot="media" />
+        <template #media><WasapiInputCaptureIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'ndi_source'" sourceType="ndi_source" key="13">
-        <NdiSourceIcon slot="media" />
+        <template #media><NdiSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -88,15 +81,15 @@
         sourceType="decklink-input"
         key="14"
       >
-        <BlackmagicSourceIcon slot="media" />
+        <template #media><BlackmagicSourceIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'scene'" sourceType="scene" key="15">
-        <AddSceneIcon slot="media" />
+        <template #media><AddSceneIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'vlc_source'" sourceType="vlc_source" key="16">
-        <VLCSourceIcon slot="media" />
+        <template #media><VLCSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -104,11 +97,11 @@
         sourceType="wasapi_process_output_capture"
         key="17"
       >
-        <AppAudioCaptureSourceIcon slot="media" />
+        <template #media><AppAudioCaptureSourceIcon /></template>
       </add-source-info>
 
       <add-source-info v-if="inspectedSource === 'near'" sourceType="near" key="18">
-        <CharacterSourceIcon slot="media" />
+        <template #media><CharacterSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -116,7 +109,7 @@
         sourceType="custom_cast_ndi_source"
         key="19"
       >
-        <CharacterSourceIcon slot="media" />
+        <template #media><CharacterSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -124,13 +117,13 @@
         sourceType="custom_cast_ndi_guide"
         key="20"
       >
-        <CharacterSourceIcon slot="media" />
-        <p slot="attention-text" class="attention">
+        <template #media><CharacterSourceIcon /></template>
+        <template #attention-text><p class="attention">
           {{ $t('sources.installNdiMessage') }}
           <button class="button button--secondary" @click="downloadNdiRuntime">
             {{ $t('sources.downloadNdiRuntime') }}
           </button>
-        </p>
+        </p></template>
       </add-source-info>
 
       <add-source-info
@@ -138,7 +131,7 @@
         sourceType="nair-rtvc-source"
         key="21"
       >
-        <SpeechEngineIcon slot="media" />
+        <template #media><SpeechEngineIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -146,7 +139,7 @@
         sourceType="text_transcription"
         key="22"
       >
-        <TextGdiplusIcon slot="media" />
+        <template #media><TextGdiplusIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -154,7 +147,7 @@
         sourceType="ffmpeg_source_replay"
         key="23"
       >
-        <FfmpegSourceIcon slot="media" />
+        <template #media><FfmpegSourceIcon /></template>
       </add-source-info>
 
       <add-source-info
@@ -162,7 +155,7 @@
         sourceType="spout_capture"
         key="24"
       >
-        <MonitorCaptureIcon slot="media" />
+        <template #media><MonitorCaptureIcon /></template>
       </add-source-info>
 
       <div class="source-info" v-if="inspectedSource === null">
@@ -175,7 +168,7 @@
           </ol>
         </div>
         <div class="source-info__media">
-          <AddFileIcon slot="media" />
+          <AddFileIcon />
         </div>
       </div>
 
@@ -207,7 +200,8 @@
           {{ $t('sources.addSourceButton') }}
         </button>
       </div>
-    </div>
+      </div>
+    </template>
   </modal-layout>
 </template>
 

--- a/app/components/studio/SceneSelector.vue
+++ b/app/components/studio/SceneSelector.vue
@@ -27,10 +27,12 @@
             </div>
           </div>
 
-          <button slot="reference" class="scene-collections__toggle">
-            <span class="scene-name">{{ activeCollection.name }}</span
-            ><i class="icon-drop-down-arrow" />
-          </button>
+          <template #reference>
+            <button class="scene-collections__toggle">
+              <span class="scene-name">{{ activeCollection.name }}</span
+              ><i class="icon-drop-down-arrow" />
+            </button>
+          </template>
         </popper>
       </div>
 
@@ -58,7 +60,7 @@
       @sort="handleSort"
       @contextmenu="showContextMenu"
     >
-      <template slot="actions" slot-scope="p">
+      <template #actions="p">
         <i
           class="icon-delete icon-btn"
           v-tooltip.bottom="removeSceneTooltip"
@@ -69,8 +71,8 @@
     </selector>
 
     <help-tip :dismissable-key="helpTipDismissable">
-      <div slot="title" v-text="$t('scenes.sceneCollections')"></div>
-      <div slot="content" v-text="$t('scenes.sceneCollectionSelectionDescription')"></div>
+      <template #title><div v-text="$t('scenes.sceneCollections')"></div></template>
+      <template #content><div v-text="$t('scenes.sceneCollectionSelectionDescription')"></div></template>
     </help-tip>
   </div>
 </template>

--- a/app/components/studio/SideNav.vue
+++ b/app/components/studio/SideNav.vue
@@ -10,8 +10,8 @@
             :dismissable-key="CompactModeToggleHelpTipDismissable"
             mode="compact-mode-toggle"
           >
-            <div slot="title" v-text="$t('common.compactModeToggleHelpTipTitle')"></div>
-            <div slot="content" v-text="$t('common.compactModeToggleHelpTipContent')"></div>
+            <template #title><div v-text="$t('common.compactModeToggleHelpTipTitle')"></div></template>
+            <template #content><div v-text="$t('common.compactModeToggleHelpTipContent')"></div></template>
           </help-tip>
         </a>
       </div>
@@ -71,8 +71,8 @@
         <a @click="openHelp" class="link help_tip_content" :title="$t('common.help')">
           <i class="icon-help" />
           <help-tip :dismissable-key="InitialHelpTipDismissable" mode="login">
-            <div slot="title" v-text="$t('common.initialHelpTipTitle')"></div>
-            <div slot="content" v-text="$t('common.initialHelpTipContent')"></div>
+            <template #title><div v-text="$t('common.initialHelpTipTitle')"></div></template>
+            <template #content><div v-text="$t('common.initialHelpTipContent')"></div></template>
           </help-tip>
         </a>
       </div>

--- a/app/components/studio/SourceSelector.vue
+++ b/app/components/studio/SourceSelector.vue
@@ -32,7 +32,7 @@
       :scrollAreaHeight="50"
       :maxScrollSpeed="15"
     >
-      <template slot="title" slot-scope="{ node }">
+      <template #title="{ node }">
         <div class="title-container">
           <span class="layer-icon">
             <i :class="determineIcon(node.isLeaf, node.data.sourceId)"></i>
@@ -41,40 +41,42 @@
         </div>
       </template>
 
-      <template slot="toggle" slot-scope="{ node }">
+      <template #toggle="{ node }">
         <span v-if="!node.isLeaf && node.children.length">
           <i v-if="node.isExpanded" class="icon-drop-down-arrow" />
           <i v-if="!node.isExpanded" class="icon-drop-down-arrow icon-right" />
         </span>
       </template>
 
-      <template slot="sidebar" slot-scope="{ node }" v-if="canShowActions(node.data.id)">
-        <i
-          class="source-selector-action"
-          :class="lockClassesForSource(node.data.id)"
-          v-tooltip.bottom="lockTooltip"
-          @click.stop="toggleLock(node.data.id)"
-          @dblclick.stop="() => {}"
-        />
-        <i
-          class="source-selector-action"
-          :class="visibilityClassesForSource(node.data.id)"
-          v-tooltip.bottom="visibilityTooltip"
-          @click.stop="toggleVisibility(node.data.id)"
-          @dblclick.stop="() => {}"
-        />
-        <i
-          class="source-selector-action icon-delete"
-          @click="removeItems"
-          v-tooltip.bottom="removeSourcesTooltip"
-          :data-test="`Remove` + node.title"
-        />
-        <i
-          class="source-selector-action icon-settings"
-          @click="sourceProperties"
-          v-tooltip.bottom="openSourcePropertiesTooltip"
-          data-test="Edit"
-        />
+      <template #sidebar="{ node }">
+        <template v-if="canShowActions(node.data.id)">
+          <i
+            class="source-selector-action"
+            :class="lockClassesForSource(node.data.id)"
+            v-tooltip.bottom="lockTooltip"
+            @click.stop="toggleLock(node.data.id)"
+            @dblclick.stop="() => {}"
+          />
+          <i
+            class="source-selector-action"
+            :class="visibilityClassesForSource(node.data.id)"
+            v-tooltip.bottom="visibilityTooltip"
+            @click.stop="toggleVisibility(node.data.id)"
+            @dblclick.stop="() => {}"
+          />
+          <i
+            class="source-selector-action icon-delete"
+            @click="removeItems"
+            v-tooltip.bottom="removeSourcesTooltip"
+            :data-test="`Remove` + node.title"
+          />
+          <i
+            class="source-selector-action icon-settings"
+            @click="sourceProperties"
+            v-tooltip.bottom="openSourcePropertiesTooltip"
+            data-test="Edit"
+          />
+        </template>
       </template>
     </sl-vue-tree>
   </div>

--- a/app/components/studio/StartStreamingButton.vue
+++ b/app/components/studio/StartStreamingButton.vue
@@ -17,8 +17,8 @@
         mode="streaming"
         v-if="showEndStreamHelpTip"
       >
-        <div slot="title" v-text="$t('common.endStreamHelpTipTitle')"></div>
-        <div slot="content" v-text="$t('common.endStreamHelpTipContent')"></div>
+        <template #title><div v-text="$t('common.endStreamHelpTipTitle')"></div></template>
+        <template #content><div v-text="$t('common.endStreamHelpTipContent')"></div></template>
       </help-tip>
     </button>
   </div>

--- a/app/components/windows/Blank.vue
+++ b/app/components/windows/Blank.vue
@@ -1,6 +1,6 @@
 <template>
   <modal-layout :show-controls="false" title="">
-    <div slot="content"></div>
+    <template #content><div></div></template>
   </modal-layout>
 </template>
 

--- a/app/components/windows/Projector.vue
+++ b/app/components/windows/Projector.vue
@@ -4,19 +4,21 @@
       <display :source-id="sourceId" />
     </div>
     <modal-layout v-else bare-content :showControls="false">
-      <div slot="content" class="projector-windowed">
-        <div class="projector-buttons">
-          <button
-            class="button button--trans"
-            v-for="(display, index) in allDisplays"
-            :key="display.id"
-            @click="enterFullscreen(display)"
-          >
-            Fullscreen Display {{ index + 1 }}: {{ display.size.width }}x{{ display.size.height }}
-          </button>
+      <template #content>
+        <div class="projector-windowed">
+          <div class="projector-buttons">
+            <button
+              class="button button--trans"
+              v-for="(display, index) in allDisplays"
+              :key="display.id"
+              @click="enterFullscreen(display)"
+            >
+              Fullscreen Display {{ index + 1 }}: {{ display.size.width }}x{{ display.size.height }}
+            </button>
+          </div>
+          <display :source-id="sourceId" />
         </div>
-        <display :source-id="sourceId" />
-      </div>
+      </template>
     </modal-layout>
   </div>
 </template>


### PR DESCRIPTION
## 開発: Vue 3移行対応 - スロット記法をテンプレート構文に変更

### 概要

Vue 3への移行準備として、各コンポーネントのスロット記法を Vue 2 の `slot` 属性構文から Vue 3 互換のテンプレート構文（`<template #slotName>`）に変換しました。

### 変更内容

34ファイルのVueコンポーネントにおいて、スロット指定の書き方を更新しました。

**対象ディレクトリ:**
- `app/components/nicolive-area/` (6ファイル)
- `app/components/scenes/` (4ファイル)
- `app/components/settings/` (5ファイル)
- `app/components/shared/` (2ファイル)
- `app/components/sources/` (9ファイル)
- `app/components/studio/` (5ファイル)
- `app/components/windows/` (2ファイル)
- その他 (1ファイル)

**変更パターン:**
```html
<!-- 変更前 (Vue 2 旧記法) -->
<template slot="header">...</template>
<span slot="foo">...</span>

<!-- 変更後 (Vue 2.6+/Vue 3 互換記法) -->
<template #header>...</template>
<template #foo><span>...</span></template>
```

### 動機

Vue 2 の旧スロット構文（`slot` 属性）は Vue 3 で削除されています。この変更により Vue 3 への移行がスムーズになります。

### テスト

- ビルド確認済み（`pnpm compile`）

