### PR TITLE
開発: pnpm compile 時の webpack 非推奨警告を解消

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -306,9 +306,7 @@ module.exports = function (env, argv) {
 
       plugins,
 
-      stats: {
-        warningsFilter: ["Can't resolve 'osx-temperature-sensor'"],
-      },
+      ignoreWarnings: [{ message: /Can't resolve 'osx-temperature-sensor'/ }],
     },
     {
       ...common,


### PR DESCRIPTION
## このpull requestが解決する内容
webpack.config.js で使用していた非推奨の `stats.warningsFilter` を、Webpack 5 推奨の `ignoreWarnings` に移行します。

## 背景
`pnpm compile` 実行時に以下のような非推奨警告が表示されていました:

```
(node:XXXX) [DEP_WEBPACK_STATS_WARNINGS_FILTER] DeprecationWarning:
config.stats.warningsFilter is deprecated in favor of config.ignoreWarnings
```

`stats.warningsFilter` は Webpack 4 時代の設定で、Webpack 5 では `ignoreWarnings` に置き換えられています。現在は互換動作しますが、将来のバージョンで削除される予定のため修正します。

## 変更内容

- `webpack.config.js`: `stats.warningsFilter` を `ignoreWarnings` に置き換え

```js
// 変更前
stats: {
  warningsFilter: ["Can't resolve 'osx-temperature-sensor'"],
},

// 変更後
ignoreWarnings: [{ message: /Can't resolve 'osx-temperature-sensor'/ }],
```

`osx-temperature-sensor` は macOS 専用のネイティブモジュールです。N Air は現在 macOS 非対応ですが、upstream の Streamlabs Desktop に由来する設定が残っており、将来 macOS 対応が実現した際に意味を持つ設定です。この変更は警告の出力形式を新しい API に移行するだけで、動作は変わりません。

## テスト
- [x] `pnpm compile` で非推奨警告が出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
