### PR TITLE
修正: お知らせウィンドウの左右の余分な余白を修正

### DIFF
--- a/app/components/settings/Informations.vue
+++ b/app/components/settings/Informations.vue
@@ -1,5 +1,5 @@
 <template>
-  <modal-layout :showControls="false">
+  <modal-layout :showControls="false" :bareContent="true">
     <div class="informations" slot="content" data-test="Informations">
       <ul class="information-list" v-if="!fetching && !hasError">
         <li
@@ -39,12 +39,13 @@
 .informations {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   height: 100%;
 }
 
 .information-list {
-  margin: -16px;
+  padding: 0;
+  margin: 0;
   list-style: none;
   background: var(--color-background); // TODO: .modal-layoutの背景色を一括で変えるまでの暫定対応
 }


### PR DESCRIPTION
## 変更内容

情報ウィンドウ（`Informations.vue`）のレイアウトを修正し、コンテンツの表示を改善しました。

### 修正箇所

- `modal-layout` に `:bareContent="true"` を追加し、余分なパディングを除去
- `.informations` の `align-items` を `center` から `stretch` に変更し、リストが横幅いっぱいに広がるよう修正
- `.information-list` のマージンを `-16px` から `0` に変更し、`padding: 0` を追加

before
<img width="731" height="493" alt="Monosnap work 2026-06-01 15-17-19" src="https://github.com/user-attachments/assets/555c1685-c96e-40de-8ad1-a3ef7a3c6dcb" />

after
<img width="731" height="492" alt="Monosnap work 2026-06-01 15-18-54" src="https://github.com/user-attachments/assets/b4852ee5-2523-4696-9c6a-c7e4600a0d5e" />
