### PR TITLE
開発: 高度な音声設定ウィンドウのレイアウトとスタイルを調整

### DIFF
--- a/app/components/settings/AdvancedAudio.vue
+++ b/app/components/settings/AdvancedAudio.vue
@@ -1,11 +1,11 @@
 <template>
-  <modal-layout :show-controls="false" no-scroll>
+  <modal-layout :show-controls="false" :bare-content="true" no-scroll>
     <div slot="content" class="content">
       <div
-        v-for="(audioSource, index) in audioSources"
+        v-for="audioSource in audioSources"
         :key="audioSource.sourceId"
+        class="source-card"
       >
-        <div v-if="index > 0" class="divider" />
         <div class="source-row">
           <div class="source-name">{{ sourceName(audioSource) }}</div>
           <div class="controls">
@@ -36,14 +36,17 @@
 .content {
   display: flex;
   flex-direction: column;
+  gap: var(--spacing-xs);
   height: 100%;
+  padding: var(--spacing-md);
   overflow-y: auto;
-  background-color: var(--color-background);
+  background-color: var(--color-bg-quinary);
 }
 
-.divider {
-  height: 1px;
-  background-color: var(--color-border-emphasis-low);
+.source-card {
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border-emphasis-low);
+  border-radius: var(--border-radius-md);
 }
 
 .source-row {


### PR DESCRIPTION
## 変更内容

`AdvancedAudio` ウィンドウのレイアウト・スタイルを調整しました。

### 具体的な変更

- `modal-layout` に `bare-content` プロパティを追加し、余分なパディングを除去
- 各オーディオソースをカード形式（枠線・角丸）で表示するよう変更
- 区切り線（`.divider`）をカードスタイルに置き換え
- `.content` にパディング・ギャップを追加し、背景色を調整

before
<img width="1017" height="778" alt="Monosnap work 2026-06-01 15-17-45" src="https://github.com/user-attachments/assets/1dcdfa19-ab38-4967-a67b-3859a928360a" />

after
<img width="1024" height="781" alt="Monosnap work 2026-06-01 15-24-19" src="https://github.com/user-attachments/assets/01b23cb2-b3c6-48fc-85ea-cda2611b0fee" />

