### PR TITLE
開発: 設定カテゴリ切り替え時にSentryブレッドクラムを追加

### DIFF
--- a/app/components/settings/Settings.vue.ts
+++ b/app/components/settings/Settings.vue.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue';
 import GenericFormGroups from 'components/obs/inputs/GenericFormGroups.vue';
 import { CategoryIcons } from 'components/settings/CategoryIcons';
 import CommentSettings from 'components/settings/CommentSettings.vue';
@@ -178,6 +179,7 @@ export default class Settings extends Vue {
 
   @Watch('categoryName')
   onCategoryNameChangedHandler(categoryName: SettingsCategory) {
+    Sentry.addBreadcrumb({ category: 'settings', message: `category: ${categoryName}`, level: 'info' });
     this.settingsData = this.settingsService.getSettingsFormData(categoryName);
     this.$refs.settingsContainer.scrollTop = 0;
     this.isTocOpen = true;


### PR DESCRIPTION
## このpull requestが解決する内容

設定ウィンドウでどのカテゴリをクリックしていたかを Sentry ブレッドクラムに記録する。

## 背景

IPC接続断（Lost IPC Connection）や `getSettingsFormData` 失敗などのエラー調査時、設定サイドメニューの `nav-item` クリックは `ui.click` ブレッドクラムにCSSセレクタとして記録されるが、どのカテゴリ名をクリックしたかは分からなかった。
`onCategoryNameChangedHandler` に1行追加することで、カテゴリ名を明示的に記録できるようにした。

## 変更内容

- `app/components/settings/Settings.vue.ts`
  - `@sentry/vue` をインポート
  - `onCategoryNameChangedHandler` の先頭で `Sentry.addBreadcrumb({ category: 'settings', message: 'category: <名前>' })` を追加

## テスト

- [ ] 設定ウィンドウを開き、各カテゴリをクリックする操作を行ったあとSentryイベントを発生させ、ブレッドクラムに `settings | category: <名前>` が記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
