### PR TITLE
開発: streaming reconnect の captureMessage を削除してBreadcrumbのみにする

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -26,7 +26,6 @@ import * as obs from '../../../obs-api';
 import { RtvcStateService } from '../../services/rtvcStateService';
 import { CustomcastUsageService } from '../custom-cast-usage';
 import { NVoiceCharacterUsageService } from '../nvoice-character-usage';
-import { PerformanceService } from '../performance';
 import { IStreamingSetting } from '../platforms';
 import { SoundDetectorService } from '../sound-detector/sound-detector';
 import { SubStreamService } from '../substream/SubStreamService';
@@ -717,8 +716,6 @@ export class StreamingService
 
   private reconnectStartedAt: number | null = null;
   private reconnectCount = 0;
-  private lastReconnectSentAt = 0;
-  private readonly RECONNECT_RATE_LIMIT_MS = 30_000;
 
   private handleOBSOutputSignal(info: IOBSOutputSignalInfo) {
     console.debug('OBS Output signal: ', info);
@@ -788,28 +785,6 @@ export class StreamingService
           level: 'warning',
           data: { code: info.code, error: info.error, reconnectCount: this.reconnectCount },
         });
-        if (Date.now() - this.lastReconnectSentAt >= this.RECONNECT_RATE_LIMIT_MS) {
-          this.lastReconnectSentAt = Date.now();
-          const streamElapsedSec = this.state.streamingStatusTime
-            ? Math.round(
-              (Date.now() - new Date(this.state.streamingStatusTime).getTime()) / 1000,
-            )
-            : -1;
-          const perfState = PerformanceService.instance.state;
-          SentryReport.message('StreamingService', 'handleOBSOutputSignal', 'streaming reconnect started', {
-            level: 'warning',
-            fingerprint: ['StreamingService', 'reconnect', String(info.code ?? 0)],
-            tags: { signal: 'Reconnect' },
-            extra: {
-              info,
-              streamElapsedSec,
-              reconnectCount: this.reconnectCount,
-              CPU: perfState.CPU,
-              streamingBandwidth: perfState.streamingBandwidth,
-              percentageDroppedFrames: perfState.percentageDroppedFrames,
-            },
-          });
-        }
       } else if (info.signal === EOBSOutputSignal.ReconnectSuccess) {
         const durationMs =
           this.reconnectStartedAt != null ? Date.now() - this.reconnectStartedAt : -1;
@@ -821,12 +796,6 @@ export class StreamingService
           message: 'reconnect_success',
           level: 'info',
           data: { durationMs, reconnectCount: this.reconnectCount },
-        });
-        SentryReport.message('StreamingService', 'handleOBSOutputSignal', 'streaming reconnect succeeded', {
-          level: 'info',
-          fingerprint: ['StreamingService', 'reconnectSuccess'],
-          tags: { signal: 'ReconnectSuccess' },
-          extra: { durationMs, reconnectCount: this.reconnectCount },
         });
       }
     } else if (info.type === EOBSOutputType.Recording) {


### PR DESCRIPTION
## このpull requestが解決する内容

1.1.20260603-1 リリース後、Sentry のイベント数が急増した原因の一部を削減する。

## 背景

PR #1264 で追加した `streaming reconnect started` / `streaming reconnect succeeded` の `captureMessage` が、reconnect を経験するユーザーごとに大量のイベントを生成していた（1.1.20260603-1 で G63: 170件/22ユーザー、G64: 161件/16ユーザー）。

reconnect の発生・成功はすでに `addBreadcrumb` で記録されており、何か別のエラーが発生した際のブレッドクラムとして参照できる。reconnect 単体を独立したイベントとして Sentry に送る価値はなく、ノイズになっていた。

## 変更内容

- `streaming reconnect started` の `SentryReport.message` 呼び出しを削除
  - あわせて専用フィールド `lastReconnectSentAt` / 定数 `RECONNECT_RATE_LIMIT_MS` も削除
- `streaming reconnect succeeded` の `SentryReport.message` 呼び出しを削除
- `addBreadcrumb` による記録は継続（変更なし）

## テスト

- [ ] コードレビューで `captureMessage` の削除と `addBreadcrumb` の継続を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
