### PR TITLE
開発: OBS output error code のSentry issueを整理しlevelをwarningに変更

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -64,6 +64,18 @@ interface IOBSOutputSignalInfo {
   error: string;
 }
 
+const OBS_OUTPUT_CODE_NAMES: Record<number, string> = {
+  [-1]: 'BadPath',
+  [-2]: 'ConnectFailed',
+  [-3]: 'InvalidStream',
+  [-4]: 'Error',
+  [-5]: 'Disconnected',
+  [-6]: 'Unsupported',
+  [-7]: 'NoSpace',
+  [-8]: 'EncoderError',
+  [-65]: 'OutdatedDriver',
+};
+
 export class StreamingService
   extends StatefulService<IStreamingServiceState>
   implements IStreamingServiceApi {
@@ -871,9 +883,11 @@ export class StreamingService
         info.signal !== EOBSOutputSignal.Reconnect &&
         info.signal !== EOBSOutputSignal.ReconnectSuccess
       ) {
-        SentryReport.message('StreamingService', 'handleOBSOutputSignal', `OBS output error code: ${info.code}`, {
-          fingerprint: ['StreamingService', 'outputCode', String(info.code)],
-          tags: { signal: String(info.signal), outputType: String(info.type) },
+        const outputCodeName = OBS_OUTPUT_CODE_NAMES[info.code] ?? String(info.code);
+        SentryReport.message('StreamingService', 'handleOBSOutputSignal', `OBS output error code: ${outputCodeName}`, {
+          level: 'warning',
+          fingerprint: ['StreamingService', 'outputCode'],
+          tags: { signal: String(info.signal), outputType: String(info.type), outputCode: outputCodeName },
           extra: { info, reconnectCount: this.reconnectCount },
         });
       }


### PR DESCRIPTION
## このpull requestが解決する内容

OBS output error code の Sentry イベントを整理する。

## 背景

PR #1264 では `OBS output error code: -2` のように数値コードをメッセージに含め、fingerprint にもコードを入れていた。これにより同じ「OBS出力失敗」なのにエラーコードごとに別の issue が生成され、Sentry の issue 一覧がバラバラになっていた。

## 変更内容

- `OBS_OUTPUT_CODE_NAMES` マップを追加して `EOutputCode` の数値を名前（例: `-2` → `ConnectFailed`）に変換
- fingerprint からエラーコードを除去 → 全コードが1つの issue `OBS output error code` にグループ化
- tags に `outputCode: 'ConnectFailed'` を追加 → Sentry でコード別にフィルタリング可能
- level を `error` → `warning` に変更（OBS 出力エラーはアプリクラッシュではないため）
- メッセージは `OBS output error code: -2` → `OBS output error code: ConnectFailed` に変更（可読性向上）

## テスト

- [ ] コードレビューで fingerprint・tags・level の変更が意図どおりであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
