### PR TITLE
開発: IPCエラーのSentry fingerprintをminify非依存にして分裂を統合

### DIFF
--- a/app/util/sentry-ipc-request.test.ts
+++ b/app/util/sentry-ipc-request.test.ts
@@ -81,7 +81,7 @@ describe('captureIpcRequestError', () => {
     expect(mockScope.setExtra).toHaveBeenCalledWith('mainError', '(no message)');
   });
 
-  test('fingerprint が err.name + service.method で分割される', () => {
+  test('fingerprint が固定文字列 + service.method で分割される', () => {
     captureIpcRequestError('FooService', 'barMethod', false, undefined, { code: -32603 });
     expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'FooService', 'barMethod']);
   });

--- a/app/util/sentry-ipc-request.ts
+++ b/app/util/sentry-ipc-request.ts
@@ -28,7 +28,8 @@ export function captureIpcRequestError(
   SentryReport.error(serviceName, method, err, {
     tags,
     extra: { mainError: rpcError.message ?? '(no message)' },
-    fingerprint: [err.name, serviceName, method],
+    // err.name は minify でチャンクごとに短縮名になりissueが分裂するため固定文字列を使う
+    fingerprint: ['IpcRequestError', serviceName, method],
   });
 
   return err;


### PR DESCRIPTION
## このpull requestが解決する内容

`getSettingsFormData` IPC エラーが Sentry 上で N-AIR-APP-G60 / N-AIR-APP-G5Z / N-AIR-APP-G61 の 3 issue に分裂していた問題を修正する。

## 背景

`app/util/sentry-ipc-request.ts` の `captureIpcRequestError` は fingerprint 第一要素に `err.name` (= `IpcRequestError` クラスの `new.target.name`) を使用していた。しかし production ビルドの minify により `IpcRequestError` クラス名がチャンクごとに異なる短縮名 (例: `C`) に変換され、同一エラーが複数の fingerprint に分裂して別 issue として記録されていた。culprit が `captureIpcRequestError(bundles/n-air-app/C)` とチャンク依存の短縮名になっているのが傍証。

release 1.1.20260603-1 では以下 3 issue (合計 32 件 / 2 ユーザー) が同一原因で分裂:
- N-AIR-APP-G60: 16 件
- N-AIR-APP-G5Z: 11 件
- N-AIR-APP-G61: 5 件

## 変更内容

- `app/util/sentry-ipc-request.ts`: fingerprint 第一要素を `err.name` から固定文字列 `'IpcRequestError'` に変更
- `app/util/sentry-ipc-request.test.ts`: テスト名を「固定文字列 + service.method」に更新

## テスト

- [x] `pnpm run test:unit:app -- --testPathPattern sentry-ipc-request` 全 10 件パス

Sentry-Resolves: N-AIR-APP-G60 N-AIR-APP-G5Z N-AIR-APP-G61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
