### PR TITLE
開発: webpackキャッシュのbuildDependenciesにpackage.jsonとpnpm-lock.yamlを追加

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,8 +110,10 @@ module.exports = function (env, argv) {
       type: 'filesystem',
       buildDependencies: {
         config: [__filename],
+        packageJson: [path.resolve(__dirname, 'package.json')],
+        lockfile: [path.resolve(__dirname, 'pnpm-lock.yaml')],
       },
-    }, // if problem, clean node_modules/.cache
+    },
   };
 
   return [


### PR DESCRIPTION
## 変更内容

webpackのFilesystemキャッシュの `buildDependencies` に `package.json` と `pnpm-lock.yaml` を追加。

これにより、依存パッケージが変更された際にwebpackキャッシュが自動的に無効化されるようになる。

## 変更理由

従来は `webpack.config.js` 自体の変更のみがキャッシュ無効化のトリガーだったため、`pnpm install` 後もキャッシュが残り、古いモジュールが使われる可能性があった。

## 影響範囲

- ビルドキャッシュの無効化タイミングが変わるのみで、ビルド成果物への影響なし
