### PR TITLE
開発: UpdaterWindowの開発確認用にNAIR_FORCE_AUTO_UPDATEを正しく機能させる

### DIFF
--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -29,6 +29,12 @@ class Updater {
 
     autoUpdater.autoDownload = false;
 
+    // 未パッケージ状態では checkForUpdates() が isUpdaterActive() でスキップされるため、
+    // 開発用フラグが立っている場合は強制有効化する。
+    if (process.env.NAIR_FORCE_AUTO_UPDATE) {
+      autoUpdater.forceDevUpdateConfig = true;
+    }
+
     autoUpdater
       .checkForUpdates()
       .then((result) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -308,7 +308,11 @@ module.exports = function (env, argv) {
 
       plugins,
 
-      ignoreWarnings: [{ message: /Can't resolve 'osx-temperature-sensor'/ }],
+      ignoreWarnings: [
+        { message: /Can't resolve 'osx-temperature-sensor'/ },
+        // protobufjs/src/util/inquire.js uses dynamic require() to try optional deps at runtime
+        { module: /protobufjs\/src\/util\/inquire\.js/ },
+      ],
     },
     {
       ...common,


### PR DESCRIPTION
## このpull requestが解決する内容

`NAIR_FORCE_AUTO_UPDATE=1 pnpm start` でUpdateWindowの動作確認をしようとしても、「チェック中」のスピナーのまま一切進まない問題を修正します。

## 原因

`pnpm start` ではアプリが未パッケージ状態（`app.isPackaged === false`）で動作します。electron-updater 6.6.2 の `checkForUpdates()` は内部で以下の判定を行います:

```js
const isEnabled = this.app.isPackaged || this.forceDevUpdateConfig;
```

未パッケージかつ `forceDevUpdateConfig` 未設定だと、`checkForUpdates()` は **イベントを一切発火させずに `Promise.resolve(null)` を即返す**だけになります。その結果 `update-available` / `update-not-available` / `error` のどのリスナーも呼ばれず、UIが初期状態の「チェック中」のまま固まっていました。

`NAIR_FORCE_AUTO_UPDATE` は `main.js` で Updater を起動するだけで、electron-updater 側の強制有効化は行っていなかったことが問題です。

## 変更内容

### `updater/Updater.js`

`run()` 冒頭で `NAIR_FORCE_AUTO_UPDATE` が設定されている場合に `autoUpdater.forceDevUpdateConfig = true` を設定し、electron-updater を強制有効化します。`dev-app-update.yml`（provider: github / owner: n-air-app / repo: n-air-app）は既に存在するため、これで実際の GitHub releases への更新チェックが走るようになります。

### `webpack.config.js`

protobufjs が動的 `require()` でオプション依存を試みる際に発生する既知の webpack 警告 (`Critical dependency: the request of a dependency is an expression`) を `ignoreWarnings` で抑制します。動作には影響しません。

## テスト

- [x] `NAIR_FORCE_AUTO_UPDATE=1 pnpm start` でUpdateWindowが「チェック中」から先へ進むことを確認
  - 公開版が現行版より新しい場合 → asking 画面（更新内容・ダウンロードボタン）が表示される
- [x] `pnpm lint` パス
- [x] `pnpm run test:unit:app` パス（62 suites, 925 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
