### PR TITLE
修正: 自動文字起こしのデフォルト音声ソースがデスクトップ音声になる問題を修正

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -10,7 +10,7 @@ import { debounceTime, filter } from 'rxjs/operators';
 import { InitAfter, Inject, mutation, ServiceHelper, StatefulService } from 'services/core';
 import { $t } from 'services/i18n';
 import { ScenesService } from 'services/scenes';
-import { isNoAudioPropertiesManagerType, ISource, Source, SourcesService } from 'services/sources';
+import { isNoAudioPropertiesManagerType, ISource, Source, SourcesService, TSourceType } from 'services/sources';
 import Utils, { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
@@ -175,9 +175,10 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
    * Get AudioSource by WASAPI device ID
    * @param deviceId WASAPI device ID (from getDevices()[].id)
    * @param isDefault If true, also matches when device_id is 'default' (user selected system default)
+   * @param sourceType If specified, only matches sources of this type (e.g. 'wasapi_input_capture')
    * @returns AudioSource if found, undefined otherwise
    */
-  getSourceByDeviceId(deviceId: string, isDefault = false): AudioSource | undefined {
+  getSourceByDeviceId(deviceId: string, isDefault = false, sourceType?: TSourceType): AudioSource | undefined {
     if (!deviceId) {
       return undefined;
     }
@@ -186,6 +187,9 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     const audioSources = this.getSources();
     for (const audioSource of audioSources) {
       try {
+        if (sourceType && audioSource.source.type !== sourceType) {
+          continue;
+        }
         const obsInput = audioSource.source.getObsInput();
         const obsDeviceId = obsInput?.settings?.device_id;
         if (obsDeviceId === deviceId) {

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -77,6 +77,9 @@ const setup = createSetupFunction({
   injectee: {
     AudioService: {
       getSourceByDeviceId: jest_fn().mockName('getSourceByDeviceId').mockReturnValue(undefined),
+      getDevices: jest_fn()
+        .mockName('getDevices')
+        .mockReturnValue([{ id: 'test-device', description: 'Test Device', type: 'input' }]),
       audioSourceUpdated: new Subject(),
     },
     TranscriptionSourceService: {
@@ -108,6 +111,8 @@ interface PrepareOptions {
     };
     voskModelStatus?: { state: string };
     audioDevices?: Array<{ id: string; name: string }>;
+    // AudioService.getDevices() が返すデバイスリスト (type='input'|'output' を含む)
+    obsAudioDevices?: Array<{ id: string; description: string; type: 'input' | 'output' }>;
   };
 }
 
@@ -185,7 +190,12 @@ function prepare(options: PrepareOptions = {}): {
   transcriptionMessages$: Subject<TranscriptionMessage>;
   stopTranscription: jest.Mock;
 } {
-  setup();
+  const obsAudioDevicesOverride = options.mockOverrides?.obsAudioDevices;
+  setup(
+    obsAudioDevicesOverride
+      ? { injectee: { AudioService: { getDevices: jest_fn().mockReturnValue(obsAudioDevicesOverride) } } }
+      : {},
+  );
 
   const getVoskModelStatus = jest_fn()
     .mockName('getVoskModelStatus')
@@ -867,6 +877,54 @@ describe('TranscriptionService', () => {
     it('should initialize with default audio device', () => {
       const { instance } = setupTranscription();
       expect(instance.getAudioDeviceList().length).toBeGreaterThan(0);
+      expect(instance.state.audioDeviceId).toBe('test-device');
+    });
+
+    it('should prefer microphone (input) over desktop audio (output) as default', () => {
+      // vosk-cli リストの先頭が output、2番目が input のケース
+      const { instance } = prepare({
+        mockOverrides: {
+          listAudioDevices: {
+            version: '1',
+            devices: [
+              { id: 'desktop-device', name: 'Desktop Audio', index: 0 },
+              { id: 'mic-device', name: 'Microphone', index: 1 },
+            ],
+          },
+          obsAudioDevices: [
+            { id: 'desktop-device', description: 'Desktop Audio', type: 'output' },
+            { id: 'mic-device', description: 'Microphone', type: 'input' },
+          ],
+        },
+      });
+      expect(instance.state.audioDeviceId).toBe('mic-device');
+    });
+
+    it('should fall back to first device when no input device found', () => {
+      // vosk-cli リストに input が1つも無いケース
+      const { instance } = prepare({
+        mockOverrides: {
+          listAudioDevices: {
+            version: '1',
+            devices: [
+              { id: 'desktop-device', name: 'Desktop Audio', index: 0 },
+            ],
+          },
+          obsAudioDevices: [
+            { id: 'desktop-device', description: 'Desktop Audio', type: 'output' },
+          ],
+        },
+      });
+      expect(instance.state.audioDeviceId).toBe('desktop-device');
+    });
+
+    it('should fall back to first device when getDevices returns empty', () => {
+      // AudioService.getDevices() が空のケース
+      const { instance } = prepare({
+        mockOverrides: {
+          obsAudioDevices: [],
+        },
+      });
       expect(instance.state.audioDeviceId).toBe('test-device');
     });
   });

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -113,6 +113,11 @@ interface PrepareOptions {
     audioDevices?: Array<{ id: string; name: string }>;
     // AudioService.getDevices() が返すデバイスリスト (type='input'|'output' を含む)
     obsAudioDevices?: Array<{ id: string; description: string; type: 'input' | 'output' }>;
+    // AudioService の任意メソッドを上書き
+    audioServiceOverride?: Partial<{
+      getDevices: jest.Mock;
+      getSourceByDeviceId: jest.Mock;
+    }>;
   };
 }
 
@@ -189,13 +194,19 @@ function prepare(options: PrepareOptions = {}): {
   client: VoskClientType;
   transcriptionMessages$: Subject<TranscriptionMessage>;
   stopTranscription: jest.Mock;
+  audioSourceUpdated: Subject<unknown>;
 } {
   const obsAudioDevicesOverride = options.mockOverrides?.obsAudioDevices;
-  setup(
-    obsAudioDevicesOverride
-      ? { injectee: { AudioService: { getDevices: jest_fn().mockReturnValue(obsAudioDevicesOverride) } } }
-      : {},
-  );
+  const audioServiceOverride = options.mockOverrides?.audioServiceOverride;
+  const audioSourceUpdated = new Subject<unknown>();
+  const audioServiceInjectee: Record<string, unknown> = { audioSourceUpdated };
+  if (obsAudioDevicesOverride) {
+    audioServiceInjectee.getDevices = jest_fn().mockReturnValue(obsAudioDevicesOverride);
+  }
+  if (audioServiceOverride) {
+    Object.assign(audioServiceInjectee, audioServiceOverride);
+  }
+  setup({ injectee: { AudioService: audioServiceInjectee } });
 
   const getVoskModelStatus = jest_fn()
     .mockName('getVoskModelStatus')
@@ -259,6 +270,7 @@ function prepare(options: PrepareOptions = {}): {
     stopTranscription: stopTranscription!,
     transcriptionMessages$: transcriptionMessages$!,
     setVoskModelStatus: setVoskModelStatus!,
+    audioSourceUpdated,
   };
 }
 
@@ -926,6 +938,136 @@ describe('TranscriptionService', () => {
         },
       });
       expect(instance.state.audioDeviceId).toBe('test-device');
+    });
+
+    it('should fall back to first device when getDevices throws', () => {
+      // AudioService.getDevices() が例外を投げるケース（OBS 未初期化など）
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { instance } = prepare({
+        mockOverrides: {
+          listAudioDevices: {
+            version: '1',
+            devices: [
+              { id: 'desktop-device', name: 'Desktop Audio', index: 0 },
+              { id: 'mic-device', name: 'Microphone', index: 1 },
+            ],
+          },
+          audioServiceOverride: {
+            getDevices: jest_fn<() => never>()
+              .mockName('getDevices')
+              .mockImplementation(() => { throw new Error('OBS not initialized'); }),
+          },
+        },
+      });
+      // 先頭デバイスにフォールバックし、例外が外に漏れないこと
+      expect(instance.state.audioDeviceId).toBe('desktop-device');
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to get OBS audio devices'),
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('audio device muted stream', () => {
+    it('should call getSourceByDeviceId with wasapi_input_capture only', () => {
+      // getSourceByDeviceId は常に wasapi_input_capture のみで呼ばれること
+      const mockedGetSourceByDeviceId = jest_fn()
+        .mockName('getSourceByDeviceId')
+        .mockReturnValue(undefined);
+      const { audioSourceUpdated } = prepare({
+        mockOverrides: {
+          audioServiceOverride: { getSourceByDeviceId: mockedGetSourceByDeviceId },
+        },
+      });
+      mockedGetSourceByDeviceId.mockClear();
+      audioSourceUpdated.next(undefined);
+
+      const callSourceTypes = mockedGetSourceByDeviceId.mock.calls.map(([, , type]) => type);
+      expect(callSourceTypes.every((t) => t === 'wasapi_input_capture')).toBe(true);
+    });
+
+    it('should return muted=true when exact device_id match is muted', () => {
+      // OBS device_id が完全一致するソースがミュートされていればミュート検出
+      const mockedGetSourceByDeviceId = jest_fn()
+        .mockName('getSourceByDeviceId')
+        .mockImplementation((deviceId: string, isDefault: boolean) => {
+          if (!isDefault && deviceId === 'test-device') return { muted: true };
+          return undefined;
+        });
+      const { instance, audioSourceUpdated } = prepare({
+        mockOverrides: {
+          audioServiceOverride: { getSourceByDeviceId: mockedGetSourceByDeviceId },
+        },
+      });
+      instance.setAudioDeviceId('test-device');
+
+      let muted: boolean | undefined;
+      instance['audioDeviceMuted$'].subscribe((v) => { muted = v; });
+      audioSourceUpdated.next(undefined);
+      expect(muted).toBe(true);
+    });
+
+    it('should detect mute via device_id=default fallback when exact match fails', () => {
+      // 完全一致なし → isDefault=true フォールバックで device_id='default' ソースを検出
+      const mockedGetSourceByDeviceId = jest_fn()
+        .mockName('getSourceByDeviceId')
+        .mockImplementation((deviceId: string, isDefault: boolean, sourceType: string) => {
+          if (!isDefault) return undefined;
+          if (isDefault && sourceType === 'wasapi_input_capture') return { muted: true };
+          return undefined;
+        });
+      const { instance, audioSourceUpdated } = prepare({
+        mockOverrides: {
+          audioServiceOverride: { getSourceByDeviceId: mockedGetSourceByDeviceId },
+        },
+      });
+      instance.setAudioDeviceId('test-device');
+
+      let muted: boolean | undefined;
+      instance['audioDeviceMuted$'].subscribe((v) => { muted = v; });
+      audioSourceUpdated.next(undefined);
+      expect(muted).toBe(true);
+    });
+
+    it('should not pick up desktop audio mute when mic is selected (regression)', () => {
+      // リグレッション: デスクトップ音声がミュートされても文字起こしがミュートにならないこと
+      const mockedGetSourceByDeviceId = jest_fn()
+        .mockName('getSourceByDeviceId')
+        .mockImplementation((_deviceId: string, _isDefault: boolean, sourceType: string) => {
+          // wasapi_input_capture 以外(=output)がヒットしたらミュート扱いにしてテスト失敗させる
+          if (sourceType !== 'wasapi_input_capture') return { muted: true };
+          return undefined; // マイクはアンミュート
+        });
+      const { instance, audioSourceUpdated } = prepare({
+        mockOverrides: {
+          listAudioDevices: {
+            version: '1',
+            devices: [
+              { id: 'desktop-device', name: 'Desktop Audio', index: 0 },
+              { id: 'mic-device', name: 'Microphone', index: 1 },
+            ],
+          },
+          obsAudioDevices: [
+            { id: 'desktop-device', description: 'Desktop Audio', type: 'output' },
+            { id: 'mic-device', description: 'Microphone', type: 'input' },
+          ],
+          audioServiceOverride: { getSourceByDeviceId: mockedGetSourceByDeviceId },
+        },
+      });
+
+      expect(instance.state.audioDeviceId).toBe('mic-device');
+
+      let muted: boolean | undefined;
+      instance['audioDeviceMuted$'].subscribe((v) => { muted = v; });
+      audioSourceUpdated.next(undefined);
+
+      // sourceType フィルタによりデスクトップ音声ソースは除外され、ミュートは false のまま
+      expect(muted).toBe(false);
+      const callsWithWrong = mockedGetSourceByDeviceId.mock.calls.filter(
+        ([, , type]) => type !== 'wasapi_input_capture',
+      );
+      expect(callsWithWrong).toHaveLength(0);
     });
   });
 

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -324,8 +324,10 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
             return false;
           }
 
-          const isDefault = this.isDefaultAudioDevice(audioDeviceId);
-          const audioSource = this.audioService.getSourceByDeviceId(audioDeviceId, isDefault, 'wasapi_input_capture');
+          // まず完全一致で探し、見つからなければ device_id='default' のソースにフォールバック
+          const audioSource =
+            this.audioService.getSourceByDeviceId(audioDeviceId, false, 'wasapi_input_capture')
+            ?? this.audioService.getSourceByDeviceId(audioDeviceId, true, 'wasapi_input_capture');
           return audioSource ? audioSource.muted : false;
         }),
         distinctUntilChanged(),
@@ -632,13 +634,18 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     if (voskDevices.length === 0) {
       return null;
     }
-    const obsInputDeviceIds = new Set(
-      this.audioService.getDevices()
-        .filter((d) => d.type === 'input')
-        .map((d) => d.id),
-    );
-    const inputDevice = voskDevices.find((d) => obsInputDeviceIds.has(d.id));
-    return (inputDevice ?? voskDevices[0]).id;
+    try {
+      const obsInputDeviceIds = new Set(
+        this.audioService.getDevices()
+          .filter((d) => d.type === 'input')
+          .map((d) => d.id),
+      );
+      const inputDevice = voskDevices.find((d) => obsInputDeviceIds.has(d.id));
+      return (inputDevice ?? voskDevices[0]).id;
+    } catch (err) {
+      console.error('Failed to get OBS audio devices for default selection, using first device:', err);
+      return voskDevices[0].id;
+    }
   }
 
   getAudioDeviceIndex<T>(id: string, notFoundValue: T): number | T {
@@ -654,10 +661,6 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
 
   getAudioDeviceList(): { id: string; name: string }[] {
     return this.audioDevices$.value;
-  }
-
-  private isDefaultAudioDevice(audioDeviceId: string): boolean {
-    return this.audioDevices$.value[0]?.id === audioDeviceId;
   }
 
   setAudioDeviceId(audioDeviceId: string | null) {

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -325,7 +325,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
           }
 
           const isDefault = this.isDefaultAudioDevice(audioDeviceId);
-          const audioSource = this.audioService.getSourceByDeviceId(audioDeviceId, isDefault);
+          const audioSource = this.audioService.getSourceByDeviceId(audioDeviceId, isDefault, 'wasapi_input_capture');
           return audioSource ? audioSource.muted : false;
         }),
         distinctUntilChanged(),
@@ -621,8 +621,24 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     }
     // audioDeviceId が未設定なら存在する値で更新する
     if (!this.state.audioDeviceId && this.audioDevices$.value.length > 0) {
-      this.setAudioDeviceId(this.audioDevices$.value[0]?.id || null);
+      this.setAudioDeviceId(this.selectDefaultAudioDeviceId());
     }
+  }
+
+  // マイク(input)を優先してデフォルト音声デバイスIDを選択する。
+  // input が見つからない場合は先頭デバイスにフォールバック。
+  private selectDefaultAudioDeviceId(): string | null {
+    const voskDevices = this.audioDevices$.value;
+    if (voskDevices.length === 0) {
+      return null;
+    }
+    const obsInputDeviceIds = new Set(
+      this.audioService.getDevices()
+        .filter((d) => d.type === 'input')
+        .map((d) => d.id),
+    );
+    const inputDevice = voskDevices.find((d) => obsInputDeviceIds.has(d.id));
+    return (inputDevice ?? voskDevices[0]).id;
   }
 
   getAudioDeviceIndex<T>(id: string, notFoundValue: T): number | T {


### PR DESCRIPTION
## このpull requestが解決する内容

初期状態（キャッシュ全削除→再起動→ログイン）で自動文字起こしを有効にすると、マイクではなくデスクトップ音声が音声ソースとして認識される問題を修正します。

## 再現手順

1. 設定→【一般】から「シーンコレクションを含むすべてのキャッシュを削除して再起動」を実行
2. 再起動後、任意のアカウントでログイン
3. 設定→【自動文字起こし】で自動文字起こしを有効にして音声認識モデルをダウンロード
4. ミキサー内の「デスクトップ音声」をミュートすると、プレビューに「音声ソースがミュートされています」と表示される（本来はマイクをミュートしたときに表示されるべき）

## 原因

### バグ1: デフォルト音声ソースの誤選択

`updateAudioDevices()` で `audioDeviceId` が未設定のとき、vosk-cli が返すデバイスリストの先頭を無条件で選択していた。vosk-cli の列挙順では先頭がデスクトップ音声になる場合があるため、マイクより先にデスクトップ音声が選ばれてしまっていた。

### バグ2: ミュート検出の誤検出

`getSourceByDeviceId(audioDeviceId, isDefault=true)` で OBS の全 audioSources を順に探すため、`device_id='default'` を持つデスクトップ音声が先にヒットしてしまっていた。その結果、マイクのミュート状態ではなくデスクトップ音声のミュート状態が返っていた。

### バグ3（コードレビューで発見）: `isDefaultAudioDevice()` の意味ズレ

バグ2の修正で `getSourceByDeviceId()` に `sourceType='wasapi_input_capture'` を追加したが、`isDefaultAudioDevice()` はvosk デバイスリストの先頭かどうかでフラグを立てていた。マイクが先頭でない場合（= バグ1修正後の通常ケース）に `isDefault=false` となり、OBS で `device_id='default'` として登録されているマイクのミュート検出が失敗していた。

### バグ4（コードレビューで発見）: `selectDefaultAudioDeviceId()` の例外未処理

`selectDefaultAudioDeviceId()` 内の `audioService.getDevices()` 呼び出しが `updateAudioDevices()` の try-catch 外にあり、OBS 未初期化時などに例外が uncaught のまま伝播していた。

## 変更内容

### `app/services/transcription/transcription.ts`

- `selectDefaultAudioDeviceId()` を追加。`audioService.getDevices()` の `type === 'input'` のデバイスIDと vosk-cli のデバイスIDを突合し、マイク（input）を優先選択する。input が見つからない場合は先頭デバイスにフォールバック。内部は try-catch で保護し、例外時も先頭デバイスにフォールバックする。
- `isDefaultAudioDevice()` を廃止。`createAudioDeviceMutedStream()` のミュート検出を「完全一致で検索 → 見つからなければ `device_id='default'` フォールバック」の2段階に変更。これにより、マイクが vosk リストの先頭でなくても正しくミュート状態を追跡できる。

### `app/services/audio/audio.ts`

- `getSourceByDeviceId()` に省略可能な `sourceType?: TSourceType` パラメータを追加。指定時はソースタイプが一致するもののみを対象にする。文字起こし側では `'wasapi_input_capture'` を指定することでデスクトップ音声ソースへの誤マッチを防ぐ。

## テスト

- [x] ユニットテスト追加（全47件パス）
  - マイク優先選択・input なし時フォールバック・`getDevices` 空時フォールバック
  - `getDevices()` 例外時のフォールバック（バグ4対応）
  - ミュート検出: 完全一致・`device_id='default'` フォールバック
  - デスクトップ音声ミュートがマイク選択時に影響しないリグレッションテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)
