### PR TITLE
開発: キャッシュ削除再起動時のcrash-handler.log削除失敗(EBUSY)を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -602,6 +602,21 @@ function initialize(crashHandler) {
 
   const SentryElectron = require('@sentry/electron/main');
 
+  // crash-handler-process.exe を終了させてから app.exit() する。
+  // 直接 app.exit() を呼ぶと crash-handler.log がロックされたまま残り、
+  // 次の --clearCacheDir 再起動で EBUSY になる。
+  function exitWithCrashHandlerCleanup(exitCode = 0) {
+    const enableCrashHandler = !process.env.DEV_SERVER || process.env.NAIR_DEBUG_CRASH_HANDLER;
+    if (enableCrashHandler && crashHandler) {
+      try {
+        crashHandler.terminateCrashHandler(pid);
+      } catch (e) {
+        console.error('[EXIT] Failed to terminate crash handler:', e);
+      }
+    }
+    setTimeout(() => app.exit(exitCode), 500);
+  }
+
   function handleFinishedReport() {
     // 先にsentryへの送信flushを開始する
     const flush = SentryElectron.flush(3000).catch((error) => {
@@ -616,7 +631,7 @@ function initialize(crashHandler) {
 
     // ダイアログが閉じたら終了
     flush.finally(() => {
-      app.exit();
+      exitWithCrashHandlerCleanup();
     });
   }
 
@@ -842,7 +857,7 @@ function initialize(crashHandler) {
     } catch (e) {
       console.error('Exception while loading node-libuiohook', e);
       await showRequiredSystemComponentInstallGuideDialog();
-      app.exit();
+      exitWithCrashHandlerCleanup();
     }
 
     mainWindow.on('closed', () => {
@@ -859,23 +874,15 @@ function initialize(crashHandler) {
       getAppSession().flushStorageData();
       console.log('[EXIT] Storage data flushed');
 
-      // Unregister from crash handler before exiting
-      const enableCrashHandler = !process.env.DEV_SERVER || process.env.NAIR_DEBUG_CRASH_HANDLER;
-      if (enableCrashHandler && crashHandler) {
-        try {
-          crashHandler.unregisterProcess(pid);
-          console.log('[EXIT] Unregistered from crash handler');
-        } catch (e) {
-          console.error('[EXIT] Failed to unregister from crash handler:', e);
-        }
-      }
-
-      console.log('[EXIT] Calling app.exit(0)');
+      console.log('[EXIT] Scheduling app.exit(0) after crash handler termination');
 
       // Flush all pending logs before exiting
       flushLogBufferSync();
 
-      app.exit(0);
+      // crash-handler-process.exe を終了させてから exit する。
+      // terminateCrashHandler は tryConnect (非同期 connect→write) を使うため、
+      // setTimeout でイベントループに逃がし送信完了の猶予を与える。
+      exitWithCrashHandlerCleanup();
     });
 
     // Pre-initialize the child window

--- a/main.js
+++ b/main.js
@@ -239,7 +239,8 @@ async function showRequiredSystemComponentInstallGuideDialog() {
     case 2:
       break;
   }
-  app.exit(0);
+  // 呼び出し元が exit を担う（crash-handler 起動前の呼び出しは app.exit() 直呼び、
+  // 起動後の呼び出しは exitWithCrashHandlerCleanup() 経由）
 }
 
 async function recollectUserSessionCookie() {
@@ -337,8 +338,9 @@ try {
   initialize(crashHandler);
 } catch (e) {
   console.error('require crash-handler failed: ', e);
-  app.on('ready', () => {
-    showRequiredSystemComponentInstallGuideDialog();
+  app.on('ready', async () => {
+    await showRequiredSystemComponentInstallGuideDialog();
+    app.exit(0);
   });
 }
 
@@ -613,8 +615,12 @@ function initialize(crashHandler) {
       } catch (e) {
         console.error('[EXIT] Failed to terminate crash handler:', e);
       }
+      // terminateCrashHandler は tryConnect (非同期 connect→write) を使うため、
+      // setTimeout でイベントループに逃がし送信完了の猶予を与える。
+      setTimeout(() => app.exit(exitCode), 500);
+    } else {
+      app.exit(exitCode);
     }
-    setTimeout(() => app.exit(exitCode), 500);
   }
 
   function handleFinishedReport() {


### PR DESCRIPTION
## このpull requestが解決する内容

`pnpm start` で起動後、設定画面の「キャッシュを削除して再起動」を実行すると、毎回

> ファイルの削除に失敗しました / Failed to delete '...' ... EBUSY

というエラーダイアログが出る問題を修正します。

開発環境 (`pnpm start`) ではほぼ100%再現します。パッケージ化したリリース版では `crash-handler.log` が userData に書き込まれないため（後述）、そもそも発生しません。

## 原因

アプリ終了時に `crashHandler.unregisterProcess(pid)` だけを呼んでいたため、`crash-handler-process.exe` 自体は起動したまま残り `crash-handler.log`（userData 配下）を握ったままでした。新プロセスが `--clearCacheDir` 付きで起動すると ready 前のトップレベル処理で `fs.rmSync(userData)` を実行しますが、旧プロセスの `crash-handler-process.exe` がまだ log ファイルを保持しているため EBUSY で削除失敗します。

`crash-handler.log` は `NODE_ENV !== 'production'` または `SLOBS_PREVIEW` 時のみ userData 配下に書き込まれます。リリース版ではこのログファイル自体が userData に存在しないため、問題が発生しません。

## 変更内容

`exitWithCrashHandlerCleanup(exitCode)` ヘルパーを追加し、すべての終了経路で共通使用するよう変更しました。

- `crashHandler.terminateCrashHandler(pid)` でソケット経由に crash-handler-process に終了シグナルを送信
- `terminateCrashHandler` は非同期 connect→write (`tryConnect`) を使うため、`setTimeout(..., 500)` でイベントループに逃がして送信完了の猶予を確保
- 修正対象の終了経路:
  - `mainWindow.on('closed')` — 通常シャットダウン
  - libuiohook 初期化失敗パス (`app.exit()` 直呼びだったため crash-handler が残っていた)
  - `handleFinishedReport()` / uncaughtException パス (同上)

また `MAX_RETRIES` を `5` から元の `3` に戻しました（根本対策により保険は不要）。

## テスト

- `pnpm run compile` → `pnpm start` で起動し、設定 → 一般 →「キャッシュを削除して再起動」実行
- 「ファイルの削除に失敗しました」ダイアログが出ないことを確認
- 「すべてのキャッシュを削除して再起動」でも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
