### PR TITLE
修正: アクティブシーン未確定時の貼り付けクラッシュを修正

### DIFF
--- a/app/services/clipboard/clipboard.ts
+++ b/app/services/clipboard/clipboard.ts
@@ -112,6 +112,9 @@ export class ClipboardService
 
   @shortcut('Ctrl+V')
   paste(duplicateSources = false) {
+    // アクティブシーンが未確定なタイミング(起動直後やシーンコレクション切替中)では貼り付けできない
+    if (!this.scenesService.activeScene) return;
+
     const systemClipboard = this.fetchSystemClipboard();
     if (JSON.stringify(this.state.systemClipboard) !== JSON.stringify(systemClipboard)) {
       this.clear();


### PR DESCRIPTION
## このpull requestが解決する内容
起動直後やシーンコレクション切替中など、アクティブシーンが未確定なタイミングで貼り付け操作（Ctrl+V / 右クリック貼り付け）を行うとクラッシュする問題を修正します。

## 背景
Sentry で以下のクラッシュを確認しました。

- Issue: N-AIR-APP-G78
- エラー: `TypeError: Cannot read properties of null (reading 'createAndAddSource')`
- 発生箇所: `ClipboardService.pasteFromSystemClipboard`
- 発生バージョン: 1.1.20260513-1（現行コードでも再現する）

breadcrumbs から、アプリ起動直後（`navigate Studio` → `navigate PatchNotes` の直後）に貼り付け操作が走り、アクティブシーンがまだ確定していない状態でクラッシュしたとみられます。

## 原因
`paste()` から分岐する貼り付け経路はいずれも `this.scenesService.activeScene` を必要とします。`activeScene` getter は型上 `Scene` を返しますが、`activeSceneId` に対応するシーンが `state.scenes` に存在しない場合は実際には `null` を返すため（`scenes.ts` の `getScene`）、`scene.createAndAddSource(...)` などで null 参照クラッシュが発生していました。null チェックがどの経路にも存在しませんでした。

## 変更内容
- `app/services/clipboard/clipboard.ts`: `paste()` の入口で `activeScene` の null ガードを追加し、未確定時は何もせず return する

`paste()` から分岐する3経路（`copyTo(activeSceneId)` / `pasteFromSystemClipboard` / `pasteItemsFromUnloadedClipboard`）はすべて `activeScene` を必要とするため、入口でまとめてガードするのが最も網羅的です。

## テスト
- [ ] アプリを起動し、シーンが正常に表示された状態で Ctrl+V / 右クリック貼り付けが従来どおり動作することを確認

## 補足
Sentry-Resolves: N-AIR-APP-G78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
