### PR TITLE
修正: ニコニコ生放送配信最適化でQSVエンコーダーが選ばれない問題を修正

### DIFF
--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -116,7 +116,8 @@
         "x264": "@:settings.Output.Streaming.Encoder.obs_x264",
         "qsv": "@:settings.Output.Streaming.Encoder.obs_qsv11",
         "nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc",
-        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc"
+        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc",
+        "obs_qsv11_v2": "@:settings.Output.Streaming.Encoder.obs_qsv11_v2"
       },
       "ABitrate": {
         "name": null
@@ -170,7 +171,8 @@
         "obs_x264": "Software (x264)",
         "obs_qsv11": "Hardware (QSV)",
         "ffmpeg_nvenc": "Hardware (NVENC)",
-        "jim_nvenc": "Hardware (NVENC NEW)"
+        "jim_nvenc": "Hardware (NVENC NEW)",
+        "obs_qsv11_v2": "Hardware (QSV)"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"
@@ -299,7 +301,8 @@
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
         "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11",
         "ffmpeg_nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc",
-        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc"
+        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc",
+        "obs_qsv11_v2": "@:settings.Output.Streaming.Encoder.obs_qsv11_v2"
       },
       "RecAEncoder": { "name": null },
       "RecRescale": {

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -116,7 +116,8 @@
         "x264": "@:settings.Output.Streaming.Encoder.obs_x264",
         "qsv": "@:settings.Output.Streaming.Encoder.obs_qsv11",
         "nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc",
-        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc"
+        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc",
+        "obs_qsv11_v2": "@:settings.Output.Streaming.Encoder.obs_qsv11_v2"
       },
       "ABitrate": {
         "name": "音声ビットレート（kbps）"
@@ -170,7 +171,8 @@
         "obs_x264": "ソフトウェア（x264）",
         "obs_qsv11": "ハードウェア（QSV）",
         "ffmpeg_nvenc": "ハードウェア (NVENC)",
-        "jim_nvenc": "ハードウェア (NVENC(新))"
+        "jim_nvenc": "ハードウェア (NVENC(新))",
+        "obs_qsv11_v2": "ハードウェア（QSV）"
       },
       "ApplyServiceSettings": {
         "name": "@:settings.Output.Streaming.EnforceBitrate.name"
@@ -299,7 +301,8 @@
         "obs_x264": "@:settings.Output.Streaming.Encoder.obs_x264",
         "obs_qsv11": "@:settings.Output.Streaming.Encoder.obs_qsv11",
         "ffmpeg_nvenc": "@:settings.Output.Streaming.Encoder.ffmpeg_nvenc",
-        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc"
+        "jim_nvenc": "@:settings.Output.Streaming.Encoder.jim_nvenc",
+        "obs_qsv11_v2": "@:settings.Output.Streaming.Encoder.obs_qsv11_v2"
       },
       "RecAEncoder": { "name": "音声エンコーダー" },
       "RecRescale": {

--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -70,6 +70,7 @@ export function getBestSettingsForNiconico(
       };
     } else if (
       settings.hasSpecificValue(OptimizationKey.encoder, EncoderFamily.qsv)
+      || settings.hasSpecificValue(OptimizationKey.encoder, EncoderFamily.qsvNew)
       || settings.hasSpecificValue(OptimizationKey.encoder, EncoderFamily.advancedQsv)
     ) {
       encoderSettings = {

--- a/app/services/settings/optimizer.test.ts
+++ b/app/services/settings/optimizer.test.ts
@@ -213,3 +213,140 @@ test('SettingsKeyAccessor#optimizeInfo', () => {
 });
 
 test.todo('Optimizer#getCurrentSettings');
+
+// Simple/Advanced 両方 x264 の状態から最適化して Simple の StreamEncoder が QSV になることを検証
+// setValues が Advanced 枝に降りて誤った設定先に書く二重降下バグの回帰防止
+test('Optimizer#optimize: Simple mode x264->qsv, Advanced side must not be touched', () => {
+  // Simple 側と Advanced 側を両方持つ Output フォーム
+  let outputForm: ISettingsSubCategory[] = [
+    {
+      nameSubCategory: 'Untitled',
+      parameters: [{ name: 'Mode', description: 'Mode', value: 'Simple' }],
+    },
+    {
+      nameSubCategory: 'Streaming',
+      parameters: [
+        {
+          name: 'StreamEncoder',
+          description: 'StreamEncoder',
+          value: 'obs_x264',
+          options: [
+            { value: 'obs_x264', description: 'x264' },
+            { value: 'qsv', description: 'QSV' },
+          ],
+        } as any,
+        {
+          name: 'UseAdvanced',
+          description: 'UseAdvanced',
+          value: false,
+          options: [
+            { value: true, description: 'true' },
+            { value: false, description: 'false' },
+          ],
+        } as any,
+        {
+          name: 'QSVPreset',
+          description: 'QSVPreset',
+          value: 'speed',
+          options: [
+            { value: 'quality', description: 'quality' },
+            { value: 'balanced', description: 'balanced' },
+            { value: 'speed', description: 'speed' },
+          ],
+        } as any,
+        // Advanced 側エンコーダー（同一カテゴリ内に共存）
+        {
+          name: 'Encoder',
+          description: 'Encoder',
+          value: 'obs_x264',
+          options: [
+            { value: 'obs_x264', description: 'x264' },
+            { value: 'obs_qsv11_v2', description: 'QSV' },
+          ],
+        } as any,
+        {
+          name: 'VBitrate',
+          description: 'VBitrate',
+          value: 5808,
+        } as any,
+        {
+          name: 'ABitrate',
+          description: 'ABitrate',
+          value: '192',
+        } as any,
+      ],
+    },
+  ];
+  const videoForm: ISettingsSubCategory[] = [
+    {
+      nameSubCategory: 'Untitled',
+      parameters: [
+        { name: 'Output', description: 'Output', value: '1280x720' } as any,
+        { name: 'FPSType', description: 'FPSType', value: 'Common FPS Values' } as any,
+        { name: 'FPSCommon', description: 'FPSCommon', value: '30' } as any,
+      ],
+    },
+  ];
+  const audioForm: ISettingsSubCategory[] = [
+    {
+      nameSubCategory: 'Untitled',
+      parameters: [{ name: 'SampleRate', description: 'SampleRate', value: 48000 } as any],
+    },
+  ];
+
+  const findParam = (form: ISettingsSubCategory[], subCat: string, name: string) => {
+    for (const sub of form) {
+      if (sub.nameSubCategory !== subCat) continue;
+      for (const p of sub.parameters) {
+        if ((p as any).name === name) return p;
+      }
+    }
+    return undefined;
+  };
+
+  const accessor = {
+    getSettingsFormData: jest.fn().mockImplementation((cat: string) => {
+      if (cat === 'Output') return outputForm;
+      if (cat === 'Video') return videoForm;
+      if (cat === 'Audio') return audioForm;
+      return [];
+    }),
+    findSetting: jest
+      .fn()
+      .mockImplementation((form: ISettingsSubCategory[], subCat: string, name: string) => {
+        return findParam(form, subCat, name);
+      }),
+    findSettingValue: jest
+      .fn()
+      .mockImplementation((form: ISettingsSubCategory[], subCat: string, name: string) => {
+        return (findParam(form, subCat, name) as any)?.value;
+      }),
+    setSettings: jest.fn().mockImplementation((cat: string, data: ISettingsSubCategory[]) => {
+      if (cat === 'Output') outputForm = data;
+    }),
+  };
+
+  const best: OptimizeSettings = {
+    outputMode: 'Simple',
+    encoder: EncoderFamily.qsv,
+    simpleUseAdvanced: true,
+    targetUsage: 'speed',
+    videoBitrate: 5808,
+    audioBitrate: '192',
+    quality: '1280x720',
+    fpsType: 'Common FPS Values',
+    fpsCommon: '30',
+    audioSampleRate: 48000,
+  };
+
+  const a = new SettingsKeyAccessor(accessor);
+  const opt = new Optimizer(a, best);
+  opt.optimize(best);
+
+  // Simple 側の StreamEncoder が qsv に変わっていること
+  expect(findParam(outputForm, 'Streaming', 'StreamEncoder')).toMatchObject({ value: 'qsv' });
+  // 出力モードが Simple であること
+  expect(findParam(outputForm, 'Untitled', 'Mode')).toMatchObject({ value: 'Simple' });
+  // Advanced 側の Encoder は触られていないこと（x264 のまま）
+  expect(findParam(outputForm, 'Streaming', 'Encoder')).toMatchObject({ value: 'obs_x264' });
+});

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -149,7 +149,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 ],
               },
               {
-                values: ['qsv', 'obs_qsv11_v2'],
+                values: ['qsv', 'obs_qsv11', 'obs_qsv11_v2'],
                 params: [
                   {
                     key: OptimizationKey.targetUsage,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -11,6 +11,7 @@ export enum EncoderFamily {
   amd = 'amd',
   qsv = 'qsv',
   advancedQsv = 'obs_qsv11',
+  qsvNew = 'obs_qsv11_v2',
   advancedNvenc = 'ffmpeg_nvenc',
 }
 
@@ -148,7 +149,7 @@ export const AllKeyDescriptions: KeyDescription[] = [
                 ],
               },
               {
-                values: ['qsv'],
+                values: ['qsv', 'obs_qsv11_v2'],
                 params: [
                   {
                     key: OptimizationKey.targetUsage,
@@ -847,17 +848,17 @@ export class SettingsKeyAccessor {
     for (const item of keyDescriptions) {
       const key = item.key;
       if (item.dependents) {
-        let currentValue = this.findValue(item);
+        // ターゲット値を先に決め、その値に一致する枝だけを辿る。
+        // 複数の兄弟枝に同一 key が現れる場合（outputMode の Advanced/Simple など）、
+        // 一致しない枝まで降りて誤った設定先に書いてしまうのを防ぐ。
+        const targetValue = values.hasOwnProperty(key) ? values[key] : this.findValue(item);
         for (const dependent of item.dependents) {
-          if (isDependOnItems(values, dependent.params)) {
-            this.setValue(item, dependent.values[0]);
+          if (dependent.values.includes(targetValue) && isDependOnItems(values, dependent.params)) {
+            this.setValue(item, targetValue);
             this.setValues(values, dependent.params);
           }
         }
-        if (values.hasOwnProperty(key)) {
-          currentValue = values[key];
-        }
-        this.setValue(item, currentValue);
+        this.setValue(item, targetValue);
       } else {
         if (values.hasOwnProperty(key)) {
           this.setValue(item, values[key]);


### PR DESCRIPTION
## このpull requestが解決する内容

OBS (osn-0.25.56) 更新により QuickSync H.264 のエンコーダー識別子が変わったことで、ニコニコ配信最適化でハードウェアエンコーダー (QSV) が選ばれなくなっていた問題を修正します。

## 背景

OBS更新前後でエンコーダー識別子が以下のように変わった：
- Advanced モード: `obs_qsv11` → `obs_qsv11_v2`
- Simple モード: `qsv`（変わらず）

また、`setValues` 関数に構造的なバグがあり、Simple モードへの最適化時に Advanced モードのエンコーダー設定にも誤って書き込んでいた（`outputMode` の Advanced/Simple 枝の両方に降りてしまう二重降下バグ）。

## 変更内容

### 識別子対応 (`optimizer.ts`, `niconico-optimization.ts`)
- `EncoderFamily` enum に `qsvNew = 'obs_qsv11_v2'` を追加
- `AllKeyDescriptions` の Advanced QSV 枝の `values` に `'obs_qsv11_v2'` を追加
- `getBestSettingsForNiconico` で `qsvNew` / `advancedQsv` もチェックしてQSVを検出（出力モードを問わず検出できるよう修正）

### setValues 二重降下バグ修正 (`optimizer.ts`)
- `setValues` が `isDependOnItems` のみで枝を選んでいたため、`encoder` キーを持つ `best` に対して `outputMode` の Advanced/Simple 枝**両方**に降りていた
- ターゲット値に一致する枝のみ辿るよう修正（`traverseKeyDescriptions` と同じ選別則に統一）

### 表示名対応 (`app/i18n/`)
- `obs_qsv11_v2` の i18n 表示名「ハードウェア（QSV）」を ja-JP / en-US に追加

### テスト (`optimizer.test.ts`)
- Simple/Advanced 両方 x264 の初期状態から最適化して、Simple の `StreamEncoder` が QSV になり、Advanced 側が変更されないことを検証する回帰テストを追加

## テスト

- [x] 実機: Simple モードで `[niconico-opt] encoder options` を確認し、`qsv` が Simple 用識別子であることを確認
- [x] 実機: Advanced モードで `obs_qsv11_v2` が Advanced 用識別子であることを確認
- [x] 最適化実行後、設定-出力-基本のエンコーダーが「ハードウェア（QSV）」になることを確認
- [x] ユニットテスト追加・通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)