### PR TITLE
修正: 録画中にニコ生最適化ダイアログでエンコーダー変更が実行されないようにする

### DIFF
--- a/app/components/settings/OptimizeForNiconico.vue
+++ b/app/components/settings/OptimizeForNiconico.vue
@@ -27,7 +27,7 @@
         </li>
       </ul>
       <BoolInput v-if="!isRecording" :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
-      <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
+      <BoolInput v-if="!isRecording" :value="doNotShowAgain" @input="setDoNotShowAgain" />
     </div>
     <div slot="controls">
       <button class="button button--secondary" :disabled="isStarting" @click="skip">

--- a/app/components/settings/OptimizeForNiconico.vue
+++ b/app/components/settings/OptimizeForNiconico.vue
@@ -2,6 +2,10 @@
   <modal-layout :show-controls="false" :customControls="true">
     <div slot="content">
       <p class="optimize-title">{{ $t('streaming.optimizationForNiconico.description') }}</p>
+      <p v-if="isRecording" class="alert" data-variant="light" data-type="caution">
+        <i class="icon-warning-circle"></i>
+        {{ $t('streaming.optimizationForNiconico.recordingWarning') }}
+      </p>
       <ul class="optimize-category-list">
         <li
           class="optimize-category-list-item"
@@ -22,14 +26,14 @@
           </ul>
         </li>
       </ul>
-      <BoolInput :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
+      <BoolInput v-if="!isRecording" :value="useHardwareEncoder" @input="setUseHardwareEncoder" />
       <BoolInput :value="doNotShowAgain" @input="setDoNotShowAgain" />
     </div>
     <div slot="controls">
       <button class="button button--secondary" :disabled="isStarting" @click="skip">
         {{ $t('streaming.skipOptimization') }}
       </button>
-      <button class="button button--primary" :disabled="isStarting" @click="optimizeAndGoLive">
+      <button class="button button--primary" :disabled="isStarting || isRecording" @click="optimizeAndGoLive">
         {{ $t('streaming.optimizeAndGoLive') }}
       </button>
     </div>
@@ -47,6 +51,31 @@
 
 .optimize-title {
   color: var(--color-text-light);
+}
+
+.alert {
+  display: flex;
+  gap: var(--spacing-lg);
+  align-items: center;
+  padding: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-lg);
+  color: var(--text-color, var(--color-object-emphasis-high));
+  background-color: var(--bg-color, var(--color-highlight-medium));
+  border-color: var(--border-color, var(--color-border-emphasis-low));
+  border-style: solid;
+  border-width: var(--border-width, 1px);
+  border-radius: var(--radius-sm);
+
+  &[data-variant='light'] {
+    --border-width: 0;
+  }
+
+  &[data-type='caution'] {
+    --text-color: var(--color-caution-primary);
+    --bg-color: var(--color-caution-light);
+  }
 }
 
 .optimize-category-list {

--- a/app/components/settings/OptimizeForNiconico.vue.ts
+++ b/app/components/settings/OptimizeForNiconico.vue.ts
@@ -59,7 +59,12 @@ export default class OptimizeNiconico extends Vue {
 
   isStarting = false;
 
+  get isRecording() {
+    return this.streamingService.isRecording;
+  }
+
   optimizeAndGoLive() {
+    if (this.isRecording) return;
     this.isStarting = true;
     this.settingsService.optimizeForNiconico(this.settings.best);
     this.streamingService.toggleStreaming();

--- a/app/components/settings/OptimizeForNiconico.vue.ts
+++ b/app/components/settings/OptimizeForNiconico.vue.ts
@@ -73,7 +73,7 @@ export default class OptimizeNiconico extends Vue {
 
   skip() {
     this.isStarting = true;
-    if (this.doNotShowAgain.value) {
+    if (!this.isRecording && this.doNotShowAgain.value) {
       this.customizationService.setOptimizeForNiconico(false);
     }
     this.streamingService.toggleStreaming();

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -47,7 +47,8 @@
   },
   "optimizationForNiconico": {
     "title": "Optimize simple settings",
-    "description": "Optimize simple settings to deliver Nicolive."
+    "description": "Optimize simple settings to deliver Nicolive.",
+    "recordingWarning": "Cannot optimize while recording. Start streaming without optimization, or stop recording and start streaming again."
   },
   "nicoliveProgramSelector": {
     "title": "Select a program",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -47,7 +47,8 @@
   },
   "optimizationForNiconico": {
     "title": "設定の最適化",
-    "description": "ニコニコ生放送に最適化した設定で配信します。"
+    "description": "ニコニコ生放送に最適化した設定で配信します。",
+    "recordingWarning": "録画中は最適化を実行できません。最適化せずに配信を開始するか、録画を停止してから再度配信を開始してください。"
   },
   "nicoliveProgramSelector": {
     "title": "配信番組の選択",

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -1,4 +1,5 @@
 import * as remote from '@electron/remote';
+import { EncoderFamily, OptimizedSettings } from 'services/settings/optimizer';
 import { RequestError } from 'util/RequestError';
 import { createSetupFunction } from 'util/test-setup';
 
@@ -826,6 +827,147 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
 
   expect(instance.optimizeForNiconicoAndStartStreaming).not.toHaveBeenCalled();
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
+});
+
+const createInjecteeForOptimizeTest = ({
+  showOptimizationDialogForNiconico = true,
+  optimizeWithHardwareEncoder = false,
+  diffDelta = { encoder: EncoderFamily.x264 } as OptimizedSettings['delta'],
+} = {}) => {
+  const injectee = createInjectee({
+    isNiconicoLoggedIn: true,
+    optimizeForNiconico: true,
+    updateStreamSettings: () => ({
+      key: 'hoge',
+      quality: { bitrate: 6000, height: 720, fps: 30 },
+    }),
+  });
+  return {
+    ...injectee,
+    CustomizationService: {
+      ...injectee.CustomizationService,
+      showOptimizationDialogForNiconico,
+      optimizeWithHardwareEncoder,
+    },
+    SettingsService: {
+      ...injectee.SettingsService,
+      diffOptimizedSettings: jest.fn((): OptimizedSettings => ({
+        best: {},
+        current: {},
+        delta: diffDelta,
+        info: [],
+      })),
+      optimizeForNiconico: jest.fn(),
+    },
+  };
+};
+
+test('optimizeForNiconicoAndStartStreaming: 差分あり・ダイアログ有効・非録画中はshowWindowを呼ぶ', async () => {
+  const injectee = createInjecteeForOptimizeTest({ showOptimizationDialogForNiconico: true });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const { instance } = StreamingService;
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  showWindow.mockClear();
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).toHaveBeenCalledTimes(1);
+  expect(injectee.SettingsService.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.toggleStreaming).not.toHaveBeenCalled();
+});
+
+test('optimizeForNiconicoAndStartStreaming: 差分あり・ダイアログ無効・非録画中はoptimizeForNiconicoを即適用してtoggleStreamingを呼ぶ', async () => {
+  const injectee = createInjecteeForOptimizeTest({ showOptimizationDialogForNiconico: false });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const { instance } = StreamingService;
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  showWindow.mockClear();
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).not.toHaveBeenCalled();
+  expect(injectee.SettingsService.optimizeForNiconico).toHaveBeenCalledTimes(1);
+  expect(instance.toggleStreaming).toHaveBeenCalledTimes(1);
+});
+
+test('optimizeForNiconicoAndStartStreaming: 差分あり・ダイアログ無効・録画中はshowWindowを呼び即適用しない', async () => {
+  const injectee = createInjecteeForOptimizeTest({ showOptimizationDialogForNiconico: false });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Recording,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const { instance } = StreamingService;
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  showWindow.mockClear();
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).toHaveBeenCalledTimes(1);
+  expect(injectee.SettingsService.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.toggleStreaming).not.toHaveBeenCalled();
+});
+
+test('optimizeForNiconicoAndStartStreaming: 差分なし・録画中でもtoggleStreamingを呼ぶ', async () => {
+  const injectee = createInjecteeForOptimizeTest({ diffDelta: {}, showOptimizationDialogForNiconico: false });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Recording,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const { instance } = StreamingService;
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  showWindow.mockClear();
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).not.toHaveBeenCalled();
+  expect(injectee.SettingsService.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.toggleStreaming).toHaveBeenCalledTimes(1);
 });
 
 test('logStreamEndがstreamingTrackIdが設定されている場合にstream_endを送信する', () => {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -450,7 +450,7 @@ export class StreamingService
       useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
     });
     if (Object.keys(settings.delta).length > 0 || mustShowDialog) {
-      if (this.customizationService.showOptimizationDialogForNiconico || mustShowDialog) {
+      if (this.customizationService.showOptimizationDialogForNiconico || mustShowDialog || this.isRecording) {
         this.windowsService.showWindow({
           componentName: 'OptimizeForNiconico',
           title: $t('streaming.optimizationForNiconico.title'),


### PR DESCRIPTION
## このpull requestが解決する内容

録画中に配信開始してニコ生最適化が走ると、エンコーダーの組み合わせによってはOBSがクラッシュし、録画停止を含むOBS操作が一切効かなくなることがあります。録画中はエンコーダーなどの設定変更を伴う最適化を実行しないことで、このクラッシュを防ぎます。

Closes #1308

## 画面イメージ

<img width="901" height="892" alt="image" src="https://github.com/user-attachments/assets/4ef9e2ec-858c-4545-999a-d5ee9eac69c3" />

## 変更内容

### `streaming.ts`
- `optimizeForNiconicoAndStartStreaming()` で録画中は最適化の即適用を抑止し、「次回から表示しない」設定でも必ずダイアログを表示するよう条件を追加

### `OptimizeForNiconico.vue` / `OptimizeForNiconico.vue.ts`
- 録画中であることを示す警告バナー（赤背景・警告アイコン付き）をダイアログ内に表示
- 録画中は「最適化を実行する」ボタンを無効化（グレーアウト）
- 録画中はハードウェアエンコーダー切替トグルを非表示
- `optimizeAndGoLive()` にガードを追加（二重防衛）

### i18n
- `ja-JP` / `en-US` の `streaming.optimizationForNiconico.recordingWarning` キーを追加

### テスト
- `streaming.test.ts` に `optimizeForNiconicoAndStartStreaming` 内部の4ケースを追加
  - 差分あり・ダイアログ有効・非録画中 → `showWindow` を呼ぶ
  - 差分あり・ダイアログ無効・非録画中 → 即適用して `toggleStreaming`
  - 差分あり・ダイアログ無効・**録画中** → `showWindow` を呼び即適用しない ✅
  - 差分なし・録画中 → `toggleStreaming` のみ（最適化不要なので録画中でも配信開始可）

## 挙動の設計

録画中のダイアログでは選択肢が2つに絞られます:
- **「最適化しないで配信を開始する」**（skip）→ エンコーダー変更なしで配信開始（安全）
- **ダイアログを閉じる** → 配信をやめて録画を継続

「最適化を実行する」は録画中のエンコーダー変更によるOBSクラッシュを防ぐため無効化しています。

## テスト

- [x] 手動: 録画中に配信開始 → 警告バナーが表示され「最適化を実行する」がグレーアウト
- [x] 手動: 「最適化しないで配信を開始する」でクラッシュせず配信開始できる
- [x] 手動: 非録画時は従来通り最適化が動作する

## Sentry

録画中のエンコーダー操作クラッシュとして関連する可能性がある issue（マージ後に再発が減少するか確認してからresolveを判断）:
- N-AIR-APP-FXJ: `obs_encoder_start` / RTMPストリーム開始時のエンコーダー開始クラッシュ (49ev, 1u)
- N-AIR-APP-FXG: `obs_encoder_stop` / エンコーダー停止時クラッシュ (29ev, 1u)
- N-AIR-APP-FYC: `obs_encoder_start` / オーディオ接続クラッシュ (4ev, 1u)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
