### PR TITLE
開発: Electron 22/14で削除済みAPIのdead codeを整理し、new-windowをsetWindowOpenHandlerに置換

### DIFF
--- a/main.js
+++ b/main.js
@@ -1210,7 +1210,7 @@ function initialize(crashHandler) {
     if (!window || window.webContents.isDestroyed()) return;
     window.webContents.setWindowOpenHandler((details) => {
       if (/^https?:/.test(details.url)) {
-        shell.openExternal(details.url);
+        shell.openExternal(details.url).catch((e) => console.error('shell.openExternal failed:', e));
       }
       return { action: 'deny' };
     });

--- a/main.js
+++ b/main.js
@@ -1205,14 +1205,15 @@ function initialize(crashHandler) {
    * @see https://github.com/electron/electron/pull/11679#issuecomment-359180722
    **/
 
-  function preventNewWindow(e, url) {
-    e.preventDefault();
-    shell.openExternal(url);
-  }
-
   ipcMain.on('window-preventNewWindow', (_event, id) => {
     const window = BrowserWindow.fromId(id);
-    window.webContents.on('new-window', preventNewWindow);
+    if (!window || window.webContents.isDestroyed()) return;
+    window.webContents.setWindowOpenHandler((details) => {
+      if (/^https?:/.test(details.url)) {
+        shell.openExternal(details.url);
+      }
+      return { action: 'deny' };
+    });
   });
 
   // The main process acts as a hub for various windows
@@ -1270,22 +1271,6 @@ function initialize(crashHandler) {
     // Closing the main window starts the shut down sequence
     mainWindow.close();
     closeSplashWindow();
-  });
-
-  /* The following 2 methods need to live in the main process
-     because events bound using the remote module are not
-     executed synchronously and therefore default actions
-     cannot be prevented. */
-  ipcMain.on('webContents-preventNavigation', (e, id) => {
-    webContents.fromId(id).on('will-navigate', (e) => {
-      e.preventDefault();
-    });
-  });
-
-  ipcMain.on('webContents-preventPopup', (e, id) => {
-    webContents.fromId(id).on('new-window', (e) => {
-      e.preventDefault();
-    });
   });
 
   ipcMain.on('getMainWindowWebContentsId', (e) => {

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -150,7 +150,6 @@ isUnskippable: ${this.updateState.isUnskippable}`);
       height: 369,
       webPreferences: {
         nodeIntegration: true,
-        enableRemoteModule: true,
         contextIsolation: false,
       },
       useContentSize: true,


### PR DESCRIPTION
## このpull requestが解決する内容

Electron 22〜14 で既に削除済みの API を使っていた dead code を整理し、`new-window` イベントを正しく機能する `setWindowOpenHandler` に置き換えます。

## 背景

- `new-window` イベントは **Electron 22 で削除済み**。N Air は Electron 29 を使用しているため、従来の登録コードは発火せず dead code 状態だった。
- 番組作成/編集ウィンドウ内の `target=_blank` リンクが意図に反して Electron 内の新規ウィンドウとして開いていた（または無反応）。
- `enableRemoteModule: true` は **Electron 14 以降で削除済み**の無効オプション。`@electron/remote` は `remote.enable()` による有効化に移行済み。

## 変更内容

### main.js

| 変更 | 内容 |
|------|------|
| `window-preventNewWindow` IPC ハンドラ | `new-window` イベントリスナー（Electron 22 で削除済み・dead code）を `setWindowOpenHandler` に置換。`http/https` スキームのみ外部ブラウザへ転送（`javascript:` / `file://` 等を安全にブロック） |
| `webContents-preventNavigation` ハンドラ | `new-window` 依存かつ呼び出し元ゼロの dead code を削除 |
| `webContents-preventPopup` ハンドラ | 同上 |

### updater/Updater.js

| 変更 | 内容 |
|------|------|
| `enableRemoteModule: true` 削除 | Electron 14 以降で削除済みの無効オプションを除去。直後の `remote.enable()` 呼び出しが機能を担う |

## 挙動の変化

ユーザー体感が変わるのは **番組作成/編集ウィンドウのポップアップ挙動のみ**:

- **修正前**: `new-window` イベントが Electron 29 で発火しないため、ページ内の外部リンクが意図せず Electron 内で新規ウィンドウとして開いていた
- **修正後**: `setWindowOpenHandler` で正しくキャプチャされ、`http/https` URL は既定ブラウザで開き、Electron 内の新規ウィンドウは開かない

他の変更（dead code 削除・`enableRemoteModule` 削除）は挙動変化なし。

## テスト

- [x] `pnpm exec tsc --noEmit` — 型エラーなし
- [x] `pnpm run test:unit:app` — 62 suites, 938 passed
- [x] 番組作成/編集ウィンドウ内の外部リンクをクリックして既定ブラウザで開くことを確認
- [x] 番組作成フロー（作成完了 → 番組ページ遷移 → 自動クローズ）が正常に動作することを確認
- [x] `NAIR_FORCE_AUTO_UPDATE=1 pnpm start` で Updater ウィンドウが正常表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

