### PR TITLE
開発: main.jsのデッドIPCハンドラを撤去

### DIFF
--- a/main.js
+++ b/main.js
@@ -1245,18 +1245,6 @@ function initialize(crashHandler) {
     }
   });
 
-  ipcMain.on('restartApp', () => {
-    // prevent unexpected cache clear
-    const args = process.argv
-      .slice(1)
-      .filter((x) => !['--clearCacheDir', '--clearCookies', '--includeSceneCollections'].includes(x));
-
-    app.relaunch({ args });
-    // Closing the main window starts the shut down sequence
-    mainWindow.close();
-    closeSplashWindow();
-  });
-
   ipcMain.on('showErrorAlert', () => {
     safeSend(mainWindow, 'showErrorAlert');
   });

--- a/main.js
+++ b/main.js
@@ -1159,22 +1159,6 @@ function initialize(crashHandler) {
     mainWindow.focus();
   });
 
-  function preventClose(e) {
-    if (!shutdownStarted) {
-      e.preventDefault();
-    }
-  }
-
-  ipcMain.on('window-preventClose', (event, id) => {
-    const window = BrowserWindow.fromId(id);
-    window.addListener('close', preventClose);
-  });
-
-  ipcMain.on('window-allowClose', (event, id) => {
-    const window = BrowserWindow.fromId(id);
-    window.removeListener('close', preventClose);
-  });
-
   /**
    * 番組作成・編集画面からログアウトを封じる処理
    * rendererプロセスからは遷移前に止められないのでここに実装がある
@@ -1271,15 +1255,6 @@ function initialize(crashHandler) {
     // Closing the main window starts the shut down sequence
     mainWindow.close();
     closeSplashWindow();
-  });
-
-  ipcMain.on('getMainWindowWebContentsId', (e) => {
-    e.returnValue = mainWindow.webContents.id;
-  });
-
-  ipcMain.on('requestPerformanceStats', (e) => {
-    const stats = app.getAppMetrics();
-    safeSend(e.sender, 'performanceStatsResponse', stats);
   });
 
   ipcMain.on('showErrorAlert', () => {


### PR DESCRIPTION
## このpull requestが解決する内容

`main.js` の `ipcMain` に登録されているが renderer プロセスから一切呼ばれていない、デッドコードになった IPC ハンドラ 4 件を撤去します。

## 調査方法

- リポジトリ全体の grep（全ファイル種別・テスト含む）でチャンネル名の参照をゼロ確認
- 上流 `streamlabs/desktop` の GitHub Code Search でも同様に確認

## 撤去内容

| チャンネル | 理由 |
|-----------|------|
| `window-preventClose` / `window-allowClose` + `preventClose` ヘルパ | N Air 独自追加だが未使用。上流 `streamlabs/desktop` にも存在しない（Code Search 0件） |
| `getMainWindowWebContentsId` | 上流にも定義はあるが呼び出し元なし（上流もデッド） |
| `requestPerformanceStats` / `performanceStatsResponse` | N Air の performance サービスが `remote.app.getAppMetrics()` 直呼びへ移行済みのため IPC 往復ハンドラが不要になった（`app/services/performance/performance.ts:170`） |
| `restartApp` | renderer 側が `remote.app.relaunch()` 直呼びへ移行済みのため不要 |

## 変更ファイル

- `main.js`: 37行削除（デッドハンドラ4件 + ヘルパ関数1件）

## テスト

- [x] `pnpm run test:unit:app` 全パス（62スイート / 938テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
