### PR TITLE
修正: カスタムキャストソースを追加できない問題を修正

### DIFF
--- a/app/components/sources/AddSource.vue.ts
+++ b/app/components/sources/AddSource.vue.ts
@@ -23,7 +23,7 @@ export default defineComponent({
   data() {
     const sourceType = WindowsService.instance().getChildWindowQueryParams().sourceType as TSelectableSourceType;
     const sourceAddOptions = WindowsService.instance().getChildWindowQueryParams().sourceAddOptions as ISourceAddOptions;
-    const nVoiceCharacterType: NVoiceCharacterType = sourceAddOptions.propertiesManagerSettings.nVoiceCharacterType || 'near';
+    const nVoiceCharacterType: NVoiceCharacterType = sourceAddOptions.propertiesManagerSettings?.nVoiceCharacterType || 'near';
 
     const sources = SourcesService.instance().getSources().filter((source) => {
       const comparison = {
@@ -54,7 +54,7 @@ export default defineComponent({
 
   computed: {
     nVoiceCharacterType(): NVoiceCharacterType {
-      return this.sourceAddOptions.propertiesManagerSettings.nVoiceCharacterType || 'near';
+      return this.sourceAddOptions.propertiesManagerSettings?.nVoiceCharacterType || 'near';
     },
 
     selectedSource() {
@@ -117,7 +117,7 @@ export default defineComponent({
         this.sourceType === 'near'
         || sourceAddOptions.propertiesManager === 'nvoice-character'
       ) {
-        const type: NVoiceCharacterType = sourceAddOptions.propertiesManagerSettings.nVoiceCharacterType || 'near';
+        const type: NVoiceCharacterType = sourceAddOptions.propertiesManagerSettings?.nVoiceCharacterType || 'near';
         s = NVoiceCharacterService.instance().createNVoiceCharacterSource(type, this.name);
       } else if (this.sourceType === 'text_transcription') {
         s = TranscriptionSourceService.instance().createTextTranscriptionSourceAndOption(

--- a/app/components/sources/SourcesShowcase.vue.ts
+++ b/app/components/sources/SourcesShowcase.vue.ts
@@ -65,7 +65,7 @@ function addSource(
   const { propertiesManager: optionsPropertiesManager, ...optionsWithoutManager } = options;
   if (sourceType === 'custom_cast_ndi_source') {
     SourcesService.instance().showAddSource('ndi_source', {
-      propertiesManagerSettings: { ...optionsWithoutManager },
+      propertiesManagerSettings: optionsWithoutManager,
       propertiesManager: 'custom-cast-ndi',
     });
   } else if (NVoiceCharacterTypes.includes(sourceType as NVoiceCharacterType)) {

--- a/app/components/sources/SourcesShowcase.vue.ts
+++ b/app/components/sources/SourcesShowcase.vue.ts
@@ -64,11 +64,10 @@ function addSource(
 
   const { propertiesManager: optionsPropertiesManager, ...optionsWithoutManager } = options;
   if (sourceType === 'custom_cast_ndi_source') {
-    const propertiesManagerSettings: Dictionary<any> = {
-      ...optionsWithoutManager,
+    SourcesService.instance().showAddSource('ndi_source', {
+      propertiesManagerSettings: { ...optionsWithoutManager },
       propertiesManager: 'custom-cast-ndi',
-    };
-    SourcesService.instance().showAddSource('ndi_source', propertiesManagerSettings);
+    });
   } else if (NVoiceCharacterTypes.includes(sourceType as NVoiceCharacterType)) {
     const propertiesManagerSettings: Dictionary<any> = {
       NVoiceCharacterType: sourceType as NVoiceCharacterType,


### PR DESCRIPTION
## このpull requestが解決する内容

カスタムキャストNDIソースを追加しようとすると、AddSourceウィンドウが背景色だけ表示されて操作不能になり、ソースを追加できない問題を修正します。

カスタムキャストNDIを利用しようとしたユーザー全員が遭遇する不具合です。

**発生バージョン:** v1.1.20260617-1

## 原因

`SourcesShowcase.vue.ts` で `custom_cast_ndi_source` のみ `showAddSource()` への引数の渡し方が他のソース種別と異なっており、`ISourceAddOptions` の構造を取り違えていました。

```typescript
// 修正前（バグ）: propertiesManagerSettings の中身が丸ごと ISourceAddOptions として渡っていた
SourcesService.instance().showAddSource('ndi_source', propertiesManagerSettings);
// → sourceAddOptions.propertiesManagerSettings が undefined になる

// 修正後: 正しい構造で渡す
SourcesService.instance().showAddSource('ndi_source', {
  propertiesManagerSettings: optionsWithoutManager,
  propertiesManager: 'custom-cast-ndi',
});
```

`propertiesManagerSettings` が `undefined` になるため、`AddSource.vue.ts` の `data()` で `propertiesManagerSettings.nVoiceCharacterType` を参照した際に `TypeError: Cannot read properties of undefined` が発生し、Vueコンポーネントが不正状態になっていました。ウィンドウを閉じる際の `TypeError: instance.update is not a function`（Sentry N-AIR-APP-G80）はその二次症状です。

### バグの歴史

`showAddSource()` への渡し方のバグ自体は Vue3 移行前（クラスベース時代）から存在していましたが、当時は表面化していませんでした。

- **移行前（クラスベース）:** `AddSource.vue.ts` では `sourceAddOptions` をクラスプロパティとして初期化し、`nVoiceCharacterType` は getter として定義されていました。`propertiesManagerSettings` が `undefined` でも getter が呼ばれるのはテンプレートレンダリング時であり、クラッシュが起きませんでした。
- **Vue3 移行後（コミット `1ceec5439`、Options API）:** `data()` 内で即座に `propertiesManagerSettings.nVoiceCharacterType` を参照するようになり、`undefined` でクラッシュするようになったため、v1.1.20260617-1 で初めて顕在化しました。

## 変更内容

- `app/components/sources/SourcesShowcase.vue.ts`: `custom_cast_ndi_source` の `showAddSource()` 呼び出しを正しい `ISourceAddOptions` 構造で渡すよう修正（根本原因）
- `app/components/sources/AddSource.vue.ts`: `propertiesManagerSettings` へのアクセス3箇所すべてにオプショナルチェーン (`?.`) を追加（防御的修正）

## テスト

- アプリ起動 → ソース追加 → カスタムキャストNDI を選択 → 追加ボタン → AddSourceウィンドウが正常表示されること
- 通常ソース（画像・ブラウザ等）と N Voice キャラクターソースの追加が従来どおり動作すること

## 関連

Sentry-Resolves: N-AIR-APP-G80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
