### PR TITLE
開発: ソース作成時クラッシュ（N-AIR-APP-G84）の原因特定用にSentryタグを追加

### DIFF
--- a/app/services/sources/sources.test.ts
+++ b/app/services/sources/sources.test.ts
@@ -1,0 +1,178 @@
+/**
+ * SourcesService.createSource のテスト
+ *
+ * ネイティブクラッシュ時にソースタイプを特定できるよう Sentry タグを設定する機能と、
+ * InputFactory.create の null/undefined 戻り値に対する null ガードをテストする。
+ */
+import { createSetupFunction } from 'util/test-setup';
+
+const mockSetTag = jest.fn();
+jest.mock('@sentry/vue', () => ({
+  setTag: mockSetTag,
+  addBreadcrumb: jest.fn(),
+}));
+
+const mockMarkObsOp = jest.fn();
+jest.mock('util/sentry-obs-breadcrumb', () => ({
+  markObsOp: mockMarkObsOp,
+  setObsOpObserver: jest.fn(),
+  getLastObsOp: jest.fn(),
+}));
+
+// OBS ネイティブモジュールのモック（sources.ts は '../../../obs-api' で import している）
+const mockCreate = jest.fn();
+const mockGetVideoDevices = jest.fn().mockReturnValue([]);
+jest.mock('../../../obs-api', () => ({
+  InputFactory: {
+    create: (...args: any[]) => mockCreate(...args),
+    types: jest.fn().mockReturnValue([]),
+  },
+  NodeObs: {
+    RegisterSourceCallback: jest.fn(),
+    OBS_settings_getVideoDevices: (...args: any[]) => mockGetVideoDevices(...args),
+  },
+  Global: {
+    setOutputSource: jest.fn(),
+  },
+  ESourceOutputFlags: {
+    Audio: 1,
+    Video: 2,
+    Async: 4,
+    DoNotDuplicate: 8,
+  },
+}));
+
+jest.mock('services/core/stateful-service');
+jest.mock('services/core/injector');
+jest.mock('services/core/service-initialization-observer', () => ({
+  InitAfter: () => () => {},
+}));
+// source.ts の @ServiceHelper デコレータが inheritMutations を使うため補完
+jest.mock('services/core/service-helper', () => ({
+  ServiceHelper: () => () => {},
+}));
+
+const setup = createSetupFunction({
+  state: {
+    SourcesService: {
+      sources: {},
+      temporarySources: {},
+    },
+  },
+  injectee: {
+    ScenesService: {
+      itemRemoved: { subscribe: jest.fn() },
+      sceneRemoved: { subscribe: jest.fn() },
+    },
+    WindowsService: {
+      createOneOffWindow: jest.fn(),
+    },
+    AudioService: {
+      getSource: jest.fn(),
+    },
+    UserService: {},
+    RtvcStateService: {
+      didAddSource: jest.fn(),
+    },
+  },
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe('createSource', () => {
+  test('ネイティブ呼び出し前に source.createType Sentry タグを設定する', () => {
+    setup();
+
+    const fakeObsInput = {
+      name: 'browser_source_test-id',
+      id: 'browser_source',
+      width: 800,
+      height: 600,
+      muted: false,
+      outputFlags: 2,
+      release: jest.fn(),
+    };
+    mockCreate.mockReturnValue(fakeObsInput);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+
+    instance.propertiesManagers = {};
+    instance.sourceAdded = { next: jest.fn() };
+
+    try {
+      instance.createSource('テストブラウザソース', 'browser_source', {});
+    } catch {
+      // addSource 内部の例外は無視（全モックが揃っていない可能性あり）
+    }
+
+    // Sentry.setTag が source.createType = 'browser_source' で呼ばれたこと
+    expect(mockSetTag).toHaveBeenCalledWith('source.createType', 'browser_source');
+
+    // markObsOp も呼ばれていること（既存の breadcrumb 記録も維持されている）
+    expect(mockMarkObsOp).toHaveBeenCalledWith('SourcesService', 'createSource', { type: 'browser_source' });
+  });
+
+  test('ソースタイプが Sentry タグに反映される（dshow_input の場合）', () => {
+    setup();
+
+    const fakeObsInput = {
+      name: 'dshow_input_test-id',
+      id: 'dshow_input',
+      width: 1280,
+      height: 720,
+      muted: false,
+      outputFlags: 3,
+      release: jest.fn(),
+    };
+    mockCreate.mockReturnValue(fakeObsInput);
+    mockGetVideoDevices.mockReturnValue([{ id: 'video_device_0', name: 'Webcam' }]);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+    instance.propertiesManagers = {};
+    instance.sourceAdded = { next: jest.fn() };
+
+    try {
+      instance.createSource('Webcam', 'dshow_input', {});
+    } catch {
+      // 内部例外は無視
+    }
+
+    expect(mockSetTag).toHaveBeenCalledWith('source.createType', 'dshow_input');
+  });
+
+  test('InputFactory.create が null を返した場合にエラーを投げる', () => {
+    setup();
+    mockCreate.mockReturnValue(null);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+    instance.propertiesManagers = {};
+    instance.sourceAdded = { next: jest.fn() };
+
+    expect(() => {
+      instance.createSource('テストソース', 'monitor_capture', {});
+    }).toThrow('InputFactory.create returned no input for type=monitor_capture');
+
+    // null が返された場合でも、その前に setTag は呼ばれている
+    expect(mockSetTag).toHaveBeenCalledWith('source.createType', 'monitor_capture');
+  });
+
+  test('InputFactory.create が undefined を返した場合にエラーを投げる', () => {
+    setup();
+    mockCreate.mockReturnValue(undefined);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+    instance.propertiesManagers = {};
+    instance.sourceAdded = { next: jest.fn() };
+
+    expect(() => {
+      instance.createSource('テストソース', 'window_capture', {});
+    }).toThrow('InputFactory.create returned no input for type=window_capture');
+  });
+});

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -165,9 +165,15 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     options: ISourceAddOptions = {},
   ): Source {
     markObsOp('SourcesService', 'createSource', { type });
+    // ネイティブクラッシュ時にどのソースタイプで落ちたか特定できるよう、タグとして残す
+    // （minidump クラッシュでもタグは保存される）
+    Sentry.setTag('source.createType', type);
     const id: string = options.sourceId || `${type}_${uuidv4()}`;
     const obsInputSettings = this.getObsSourceCreateSettings(type, settings);
     const obsInput = obs.InputFactory.create(type, id, obsInputSettings);
+    if (!obsInput) {
+      throw new Error(`InputFactory.create returned no input for type=${type}`);
+    }
 
     this.addSource(obsInput, name, options);
 


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue N-AIR-APP-G84 (renderer プロセスが `EXCEPTION_ACCESS_VIOLATION_READ / 0x8` でクラッシュ) の観測性向上と、限定的な防御コードを追加します。

## 背景

N-AIR-APP-G84 では、ユーザーがソース追加ダイアログから新規ソースを追加しようとした際に renderer プロセスがネイティブクラッシュ（minidump）しましたが、ブレッドクラム・タグのいずれからも**どのソースタイプで落ちたか**を特定できませんでした。

- `markObsOp('SourcesService', 'createSource', { type })` は `type` をブレッドクラムの `data` に渡すが、minidump クラッシュでは data は信頼できない
- Sentry の `obs.lastOp` タグには `SourcesService.createSource` という文字列しか残らない

## 変更内容

### `app/services/sources/sources.ts`

1. **Sentry タグ追加 (`source.createType`)**: `createSource` 冒頭、`obs.InputFactory.create()` 呼び出し前に `Sentry.setTag('source.createType', type)` を追加。タグは minidump クラッシュでも保存されるため、次回同種クラッシュでソースタイプを確実に特定できる。
2. **null ガード**: `obs.InputFactory.create()` が `null` / `undefined` を返した場合、明示的にエラーを投げる。ネイティブクラッシュ自体は JS 側では防げないが、ネイティブが null を返すケースでの二次クラッシュを防ぐ。

### `app/services/sources/sources.test.ts` （新規）

上記2点を検証するユニットテストを追加。

## テスト

- [x] 新規ユニットテスト 4件パス (`pnpm run test:unit:app`)
- [x] TypeScript 型チェック通過

## 補足

- ネイティブ C++ 側の null pointer dereference 自体を JS 側で完全に防ぐことはできないため、今回は観測性向上と限定的防御に留める
- `source.createType` タグ付きのクラッシュレポートが蓄積されたら、特定のソースタイプに対する追加防御を検討する

関連: N-AIR-APP-G84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
