### PR TITLE
開発: ソース一覧ドラッグ&ドロップ時のTypeErrorを修正し、drag操作をSentry breadcrumbに記録

### DIFF
--- a/app/components/shared/sl-vue-tree/sl-vue-tree.vue.ts
+++ b/app/components/shared/sl-vue-tree/sl-vue-tree.vue.ts
@@ -369,6 +369,10 @@ export default defineComponent({
         return;
       }
 
+      if (isDragStarted) {
+        console.info('[sl-vue-tree] drag started:', draggableNodes.map((n: ISlTreeNode) => n.title));
+      }
+
       this.isDragging = isDragging;
 
       this.setCursorPosition({ node: destNode, placement });
@@ -633,6 +637,7 @@ export default defineComponent({
 
       this.lastSelectedNode = null;
       this.emitInput(newNodes);
+      console.info('[sl-vue-tree] drop:', draggingNodes.map((n: ISlTreeNode) => n.title), '->', this.cursorPosition.placement, this.cursorPosition.node.title);
       this.emitDrop(draggingNodes, this.cursorPosition, event);
       this.stopDrag();
     },
@@ -646,6 +651,9 @@ export default defineComponent({
     },
 
     stopDrag(): void {
+      if (this.isDragging) {
+        console.info('[sl-vue-tree] drag cancelled (no drop)');
+      }
       this.isDragging = false;
       this.mouseIsDown = false;
       this.setCursorPosition(null);

--- a/app/components/shared/sl-vue-tree/sl-vue-tree.vue.ts
+++ b/app/components/shared/sl-vue-tree/sl-vue-tree.vue.ts
@@ -80,6 +80,8 @@ export default defineComponent({
     },
   },
 
+  emits: ['input', 'select', 'beforedrop', 'drop', 'toggle', 'nodeclick', 'nodedblclick', 'nodecontextmenu', 'externaldragover', 'externaldrop'],
+
   data() {
     return {
       rootCursorPosition: null as ICursorPosition | null,

--- a/app/components/sources/SourceFilters.vue.ts
+++ b/app/components/sources/SourceFilters.vue.ts
@@ -122,6 +122,7 @@ export default defineComponent({
       nodes: ISlTreeNodeModel<IFilterNodeData>[],
       position: ICursorPosition<IFilterNodeData>,
     ): void {
+      if (!Array.isArray(nodes)) return;
       const sourceNode = nodes[0];
       const sourceInd = this.filters.findIndex((filter: ISourceFilter) => filter.name === sourceNode.title);
       let targetInd = this.filters.findIndex((filter: ISourceFilter) => filter.name === position.node.title);

--- a/app/components/studio/SourceSelector.vue.ts
+++ b/app/components/studio/SourceSelector.vue.ts
@@ -173,6 +173,10 @@ export default defineComponent({
       treeNodesToMove: ISlTreeNode<ISceneItemNode>[],
       position: ICursorPosition<TSceneNode>,
     ) {
+      if (!Array.isArray(treeNodesToMove)) {
+        Sentry.captureMessage('handleSort: treeNodesToMove is not an array', { level: 'warning', extra: { treeNodesToMove } });
+        return;
+      }
       const nodesToMove = this.scene.getSelection(treeNodesToMove.map((node) => node.data.id));
 
       const destNode = this.scene.getNode(position.node.data.id);


### PR DESCRIPTION
## このpull requestが解決する内容

ソース一覧のドラッグ&ドロップ操作時に Sentry へ記録されていた `TypeError: treeNodesToMove.map is not a function`（N-AIR-APP-G85）を修正し、drag 操作を Sentry breadcrumb に記録するようにします。

なお、ユーザーに見えていた「ソースが元の位置に戻ってしまうことがある」という症状の根本原因はこの PR では解消されません（下記「残る問題」参照）。

## 背景

ユーザーがソース一覧でドラッグ&ドロップ並び替えを行うと、稀にソースが元の位置に戻ってしまうという報告があった。Sentry には `TypeError: treeNodesToMove.map is not a function` が記録されていたが、再現条件は特定できていなかった。

## 原因

`sl-vue-tree` はソース並び替えのドラッグを mouse イベント（mousedown/mousemove/mouseup）で処理していますが、ブラウザがこれと並行してネイティブ HTML5 drag イベントも発火させることがあります。

各ノードアイテムには `@dragover="onExternalDragoverHandler"` があり、内部で `event.preventDefault()` を呼ぶため、ネイティブ `drop` イベントが受理されます。ネイティブ `drop` が発火すると `onExternalDropHandler` が実行され、カーソル位置（`cursorPosition`）が `null` にクリアされます。その後に `mouseup` が来ても `cursorPosition` がないため並び替え処理がスキップされ、ソースが元の位置に戻ります。

さらに `emits` 宣言がなかった `sl-vue-tree` では、親の `@drop="handleSort"` がコンポーネントのルート要素へのネイティブ DOM イベントリスナーとしてもフォールスルーしていたため、バブルアップしたネイティブ `drop` イベントが `handleSort(DragEvent)` を呼び出して `TypeError: treeNodesToMove.map is not a function` が発生していました（Vue がキャッチするためクラッシュはなし）。

## 変更内容

### `app/components/shared/sl-vue-tree/sl-vue-tree.vue.ts`

- `emits` 宣言を追加（`input`, `select`, `beforedrop`, `drop`, `toggle`, `nodeclick`, `nodedblclick`, `nodecontextmenu`, `externaldragover`, `externaldrop`）
  - Vue 3 では `emits` に列挙されたイベントは親へのフォールスルー属性として扱われなくなるため、ネイティブ `drop` イベントがルート要素の `handleSort` を呼び出さなくなる
  - これにより **Sentry に記録されていた `TypeError` は解消される**
- drag 開始・完了・キャンセルを `console.info` で記録
  - Sentry が自動収集する breadcrumb（`console` カテゴリ）として残るため、今後の調査に活用できる

### `app/components/studio/SourceSelector.vue.ts`

- `handleSort` の冒頭に `Array.isArray(treeNodesToMove)` ガードを追加
- 非配列が渡された場合は Sentry に warning を記録してから早期リターン（防御的チェック）

### `app/components/sources/SourceFilters.vue.ts`

- フィルター一覧の `handleSort` にも同様の `Array.isArray(nodes)` ガードを追加（防御的チェック）

## 残る問題・sl-vue-tree の抱える課題

**今回修正しきれていない点：**
各ノードの `@drop="onExternalDropHandler"` は引き続き発火するため、ネイティブ drag 混入時に `cursorPosition` がクリアされてソースが元の位置に戻る現象自体は残る可能性がある。完全に直すには `isDragging` 中はネイティブ `drop` を無視する処理が別途必要。

**sl-vue-tree 自体の構造的な問題：**
- **Vue 3 非対応のまま移植されたライブラリ**: ファイル冒頭に `// @ts-nocheck` があり、型安全性がない。Vue 3 移行以降も `emits` 宣言欠如・ライフサイクルフック変更・スロット構文変更など都度パッチを当て続けている。
- **内部ドラッグとネイティブ drag の競合**: 並び替えを mouse イベントで実装しているにもかかわらず、各ノードに `@dragover.prevent` を持つため、ネイティブ drag イベントも受理してしまう設計上の矛盾がある。
- **メンテナンス停止**: オリジナルの [sl-vue-tree](https://github.com/holiber/sl-vue-tree) は Vue 2 向けに開発されたライブラリで、既にメンテナンスされていない。

これらを踏まえ、sl-vue-tree を廃止して内製の drag & drop ソートコンポーネントへ置き換えることを検討中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
