### PR TITLE
変更: ドロップできないファイルをシーンに追加しようとした際に理由を説明するメッセージを表示するよう変更

### DIFF
--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -9,6 +9,7 @@ import StudioFooter from 'components/studio/StudioFooter.vue';
 import TitleBar from 'components/studio/TitleBar.vue';
 import { AppService } from 'services/app';
 import { CompactModeService } from 'services/compact-mode';
+import { $t } from 'services/i18n';
 import { NavigationService } from 'services/navigation';
 import { ScenesService } from 'services/scenes';
 import { UserService } from 'services/user';
@@ -93,17 +94,36 @@ export default defineComponent({
   },
 
   methods: {
-    onDropHandler(event: DragEvent) {
+    async onDropHandler(event: DragEvent) {
       const files = event.dataTransfer.files;
       if (!ScenesService.instance().activeScene) {
         SentryReport.message('MainWindow', 'onDropHandler', 'Attempted to add files to a scene when no scene was active', { level: 'warning' });
         return;
       }
 
+      const unavailableFiles: string[] = [];
       let fi = files.length;
       while (fi--) {
         const file = files.item(fi);
-        ScenesService.instance().activeScene.addFile(file.path);
+        if (!file.path) {
+          unavailableFiles.push(file.name);
+          continue;
+        }
+        try {
+          ScenesService.instance().activeScene.addFile(file.path);
+        } catch {
+          unavailableFiles.push(file.name);
+        }
+      }
+
+      if (unavailableFiles.length > 0) {
+        await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
+          type: 'warning',
+          title: $t('scenes.dropFileNotAvailableTitle'),
+          message: $t('scenes.dropFileNotAvailable'),
+          buttons: [$t('common.ok')],
+          noLink: true,
+        });
       }
     },
   },

--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -1,6 +1,6 @@
 {
   "dropFileNotAvailableTitle": "Cannot Add File",
-  "dropFileNotAvailable": "Could not get the path of the dropped file.\nIf you dropped a file directly from cloud storage such as OneDrive, please download it locally first and try again.",
+  "dropFileNotAvailable": "Could not get the path of the dropped file.\nDropping files from browser windows, other app windows, or inside ZIP archives is not supported.",
   "enterTheNameOfTheSceneCollection": "Please enter the name of the Scenes Collection",
   "nameIsRequired": "The scene name is required",
   "enterTheNameOfTheScene": "Please enter the name of the scene",

--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -1,4 +1,6 @@
 {
+  "dropFileNotAvailableTitle": "Cannot Add File",
+  "dropFileNotAvailable": "Could not get the path of the dropped file.\nIf you dropped a file directly from cloud storage such as OneDrive, please download it locally first and try again.",
   "enterTheNameOfTheSceneCollection": "Please enter the name of the Scenes Collection",
   "nameIsRequired": "The scene name is required",
   "enterTheNameOfTheScene": "Please enter the name of the scene",

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -1,4 +1,6 @@
 {
+  "dropFileNotAvailableTitle": "ファイルを追加できません",
+  "dropFileNotAvailable": "ドロップされたファイルのパスを取得できませんでした。\nOneDriveなどのクラウドストレージから直接ドロップした場合は、ローカルにダウンロードしてからお試しください。",
   "enterTheNameOfTheSceneCollection": "シーンコレクションの名前を入力して下さい。",
   "nameIsRequired": "シーンの名前が必要です。",
   "enterTheNameOfTheScene": "シーンの名前を入力して下さい。",

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -1,6 +1,6 @@
 {
   "dropFileNotAvailableTitle": "ファイルを追加できません",
-  "dropFileNotAvailable": "ドロップされたファイルのパスを取得できませんでした。\nOneDriveなどのクラウドストレージから直接ドロップした場合は、ローカルにダウンロードしてからお試しください。",
+  "dropFileNotAvailable": "ドロップされたファイルのパスを取得できませんでした。\nブラウザや他のアプリのウィンドウ、ZIPファイル内のファイルなど、ローカルパスが取得できないソースからのドロップには対応していません。",
   "enterTheNameOfTheSceneCollection": "シーンコレクションの名前を入力して下さい。",
   "nameIsRequired": "シーンの名前が必要です。",
   "enterTheNameOfTheScene": "シーンの名前を入力して下さい。",

--- a/app/services/clipboard/clipboard.ts
+++ b/app/services/clipboard/clipboard.ts
@@ -299,7 +299,13 @@ export class ClipboardService
     const clipboard = this.state.systemClipboard;
     const scene = this.scenesService.activeScene;
     if (clipboard.files.length) {
-      clipboard.files.forEach((filePath) => scene.addFile(filePath));
+      clipboard.files.forEach((filePath) => {
+        try {
+          scene.addFile(filePath);
+        } catch {
+          // ファイルが存在しない場合は無視する
+        }
+      });
       return;
     }
     const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -10,6 +10,7 @@ import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
 import { Source, SourcesService, TSourceType } from 'services/sources';
 import Utils, { uuidv4 } from 'services/utils';
 import { assertIsDefined } from 'util/properties-type-guards';
+import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../../obs-api';
 
@@ -213,8 +214,15 @@ export class Scene {
   }
 
   addFile(path: string, folderId?: string): TSceneNode {
-    const fstat = fs.lstatSync(path);
-    if (!fstat) return null;
+    let fstat: fs.Stats;
+    try {
+      fstat = fs.lstatSync(path);
+    } catch (e: unknown) {
+      SentryReport.message('ScenesService', 'addFile', `Failed to lstat dropped path: ${(e as Error).message}`, {
+        level: 'warning',
+      });
+      return null;
+    }
     const fname = path.split('\\').slice(-1)[0];
 
     if (fstat.isDirectory()) {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -221,7 +221,7 @@ export class Scene {
       SentryReport.message('ScenesService', 'addFile', `Failed to lstat dropped path: ${(e as Error).message}`, {
         level: 'warning',
       });
-      return null;
+      throw e;
     }
     const fname = path.split('\\').slice(-1)[0];
 


### PR DESCRIPTION
## このpull requestが解決する内容

ファイルをドラッグ&ドロップでシーンに追加する際、Electronがファイルパスを取得できない場合にUnhandledエラーが発生する問題を修正します。
パスが取得できなかった場合は「ファイルを追加できません」ダイアログをユーザーに表示します。

## 背景

Sentry N-AIR-APP-FXF（59件 / 41ユーザー）の調査により、`file.path` が空文字列になるケースが原因と特定。

`fs.lstatSync('')` → `ENOENT: no such file or directory, lstat`（パス末尾にパス文字列がない）が発生し、`addFile()` 内の `if (!fstat) return null` というガードが機能していませんでした（`lstatSync` は `null` でなく例外を投げるため）。

### ファイルパスが取得できないケース（2種類）

**① `file.path` が空文字列になる場合** — Electronの `File.path` 拡張は、ファイルがローカルファイルシステムのパスを持たない場合に空文字列になる:
- ブラウザウィンドウからのD&D（Chrome/Edgeのセキュリティサンドボックスによりパス非公開）
- Discord・メールクライアントなどの添付ファイルのD&D
- ZIPファイルを開いて中身をD&D（Windowsの仮想ファイルシステム扱いでパス非取得）

**② `lstatSync` が失敗する場合** — パスはあるが実体にアクセスできない:
- ドロップ直後にファイルが削除された
- ネットワークドライブが切断された

## 変更内容

- `app/services/scenes/scene.ts`: `lstatSync` 失敗時に Sentry warning を送った上で例外を再 throw
- `app/components/windows/Main.vue.ts`: `file.path` が空のファイルと `addFile` 例外を検出し、`remote.dialog.showMessageBox` でユーザーに通知
- `app/services/clipboard/clipboard.ts`: クリップボード貼り付け時の `addFile` 例外を silent catch
- `app/i18n/ja-JP/scenes.json`, `app/i18n/en-US/scenes.json`: ダイアログ用メッセージキーを追加

## テスト

- [x] 型チェック通過 (`vue-tsc --noEmit`)

Closes #1320
Sentry-Resolves: N-AIR-APP-FXF

🤖 Generated with [Claude Code](https://claude.com/claude-code)
