### PR TITLE
開発: CLAUDE.mdにworktree・テスト・PR運用ルールを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ pnpm install
 pnpm install --dir bin  # Required for pnpm start
 ```
 
+**Worktrees:** Each git worktree is an independent directory and does not share `node_modules` with the main working tree. Always run `pnpm install` (and `pnpm install --dir bin`) immediately after creating a worktree before building or running the app. When using Claude Code, call `EnterWorktree({ path })` to switch the session's cwd into the worktree (avoids needing `Set-Location` on every subsequent command).
+
 **Development:**
 ```bash
 pnpm run compile    # Build development assets
@@ -40,6 +42,8 @@ pnpm run test:unit  # Unit tests (Jest for app + bin)
 pnpm run test:unit:app  # Jest tests for app only
 pnpm screentest     # Visual regression tests
 ```
+
+> **Note:** `pnpm test` runs the full suite (i18n + tsc + AVA) and is slow. For day-to-day development, prefer `pnpm run test:unit:app`. For TypeScript type checking (including `.vue` files), run `pnpm run typecheck` separately.
 
 **Code Quality:**
 ```bash
@@ -151,13 +155,19 @@ test('service behavior', () => {
 - Use `gh pr create --repo ${NAIR_GIT_TARGET_REPO:-n-air-app/n-air-app}` for PRs
 
 **PR Title Rules:** PR titles are collected for patch notes shown to users:
-- **User-visible changes:** Use prefixes that will be grouped in patch notes:
+- **User-visible changes:** Use prefixes that will be grouped in patch notes. The title is shown **as-is to end users** in the patch notes, so write it from the user's perspective — what they can now do, what changed, or what was fixed — not as a technical description:
   - `追加:` - New features users can see/use
   - `変更:` - Changes to existing user-visible functionality  
   - `修正:` - Bug fixes users would notice
-- **Internal/development changes:** Use `開発:` prefix (not shown to users)
+- **Internal/development changes:** Use `開発:` prefix (not shown to users) for technical/internal changes
 - Write titles in Japanese using verb form (not noun form): `○○機能を追加`, `○○問題を修正`
 - Examples: `追加: ニコニコ生放送のコメント読み上げ機能を追加`, `修正: 配信開始時のクラッシュ問題を修正`, `開発: ユニットテストを追加`
+
+**PR Body Rules:**
+- **Issue references:** Use `Closes #NNN` / `Fixes #NNN` / `Resolves #NNN` only when the PR fully resolves the issue — GitHub automatically closes it on merge. For ongoing tracking issues (e.g., security alert trackers), use `関連: #NNN` instead.
+- **Dependabot alert numbers:** Write as `Alert NNN` (not `#NNN`, which becomes a PR/issue link). In tables, use the full URL: `[Alert NNN](https://github.com/n-air-app/n-air-app/security/dependabot/NNN)`. Always add the `dependencies` label (`--label "dependencies"`) on dependency update PRs. For multiple CVEs, write each in full (e.g., `CVE-2026-41672/CVE-2026-41674`), not abbreviated (`CVE-2026-41672/41674`).
+- **Test plan:** List only items requiring manual verification by a human. Do not list CI checks (`pnpm test`, tsc, CI pass) — branch protection enforces these automatically. Omit the Test plan section entirely for lockfile-only PRs.
+- **`gh` body with markdown:** Always pass PR/issue body via `--body-file` (write to a temp file first). Backticks and other shell special characters in `--body "..."` are expanded by the shell.
 
 ## Dependencies Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ test('service behavior', () => {
 
 **Push Remote Configuration:** Developers may use different remotes (personal forks vs main repo):
 - Configure via `.claude/settings.local.json` env variables:
-  - `NAIR_GIT_PUSH_REMOTE`: remote name (e.g., "koizuka", "origin")
-  - `NAIR_GIT_TARGET_REPO`: target repository (e.g., "koizuka/n-air-app", "n-air-app/n-air-app")
+  - `NAIR_GIT_PUSH_REMOTE`: remote name (e.g., "origin", or a personal fork remote)
+  - `NAIR_GIT_TARGET_REPO`: target repository (e.g., "n-air-app/n-air-app", or a personal fork)
 - Use `git push -u ${NAIR_GIT_PUSH_REMOTE:-origin} branch-name` for pushes
 - Use `gh pr create --repo ${NAIR_GIT_TARGET_REPO:-n-air-app/n-air-app}` for PRs
 


### PR DESCRIPTION
## このpull requestが解決する内容

ローカルメモリーに蓄積されていた運用ルールを `CLAUDE.md` に移管し、別セッション・別開発者でも同じガイドラインを参照できるようにします。

## 変更内容

### Development Commands セクション
- **Worktrees**: worktree作成後に `pnpm install` と `pnpm install --dir bin` を実行する必要があること（worktreeは独立ディレクトリでnode_modulesを共有しないため）、およびClaude Code使用時は `EnterWorktree({ path })` でcwdを切り替えることを追記
- **テストコマンド**: `pnpm test` は全スイート（i18n + tsc + AVA）で重いため、日常的なテストは `pnpm run test:unit:app` を使う旨、型チェック（`.vue` ファイル含む）は `pnpm run typecheck` を使う旨を明記

### Git & GitHub Workflow セクション
- **PR Title Rules**: `追加:`/`変更:`/`修正:` prefix のタイトルはそのままエンドユーザーへのパッチノートとして表示されるため、ユーザー目線で書く必要があることを強調
- **PR Body Rules**（新設）:
  - issueリンク: `Closes #NNN` はマージ時に自動クローズするため、トラッキングissueには `関連: #NNN` を使う
  - Dependabotアラート番号: `#NNN` はPRリンクになるため `Alert NNN` 形式で書く。依存更新PRに `dependencies` ラベル必須。CVEは省略しない
  - Test plan: CI確認項目（branch protectionで必須）は書かない。lockfile更新のみのPRはTest planを省略
  - `gh` コマンドの本文: バッククォート等のシェル展開を避けるため常に `--body-file` 経由で渡す

🤖 Generated with [Claude Code](https://claude.com/claude-code)
