### PR TITLE
修正: シーンアイテム一覧で右クリック時に対象アイテムを選択するよう修正

### DIFF
--- a/app/components/studio/SourceSelector.vue.ts
+++ b/app/components/studio/SourceSelector.vue.ts
@@ -120,6 +120,11 @@ export default defineComponent({
     },
 
     showContextMenuForNode(node: ISlTreeNode<ISceneItemNode>, event: MouseEvent) {
+      // 右クリックしたノードが未選択なら単体選択し直す。
+      // 既に選択に含まれていれば（複数選択含む）選択を維持する。
+      if (!SelectionService.instance().isSelected(node.data.id)) {
+        this.makeActive([node], event);
+      }
       this.showContextMenu(node.data.id, event);
     },
 


### PR DESCRIPTION
## このpull requestが解決する内容

シーンアイテム一覧（SourceSelector）で未選択のアイテムを右クリックしたとき、直前に選択されていた別のアイテムに対するコンテキストメニューが表示されてしまう問題を修正します。

## 背景

右クリック時のメニュー生成は `EditMenu` が `SelectionService`（シングルトン）の現在の選択を参照する仕組みになっているため、右クリックしたアイテムと選択中のアイテムがずれていると意図しないアイテムを操作してしまう操作ミスが起きていました。

## 変更内容

`app/components/studio/SourceSelector.vue.ts` の `showContextMenuForNode` を修正しました。

| ケース | 修正前 | 修正後 |
|--------|--------|--------|
| 未選択のアイテムを右クリック | 直前の選択に対するメニューが出る | 右クリックしたアイテムが選択され、そのアイテムのメニューが出る |
| 選択済みのアイテムを右クリック（複数選択含む） | 変わらず | 選択を維持したままメニューが出る（複数選択に対する項目も機能する） |

右クリックしたアイテムが未選択の場合のみ `SelectionService.select()` を呼び出し、既に選択に含まれている場合は選択を維持します。OBS や一般的なファイラーと同じ挙動です。

## テスト

- [x] 未選択のアイテムを右クリック → そのアイテムが選択され、そのアイテムへのメニューが表示されること
- [x] 複数選択した状態で選択中のアイテムを右クリック → 複数選択が維持されたままメニューが出ること
- [x] 複数選択した状態で選択外のアイテムを右クリック → そのアイテム単体が選択され、メニューが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
