### PR TITLE
開発: vueコンポーネントへのany型流入箇所に型を付ける

### DIFF
--- a/app/components/nicolive-area/CommentViewer.vue.ts
+++ b/app/components/nicolive-area/CommentViewer.vue.ts
@@ -26,7 +26,7 @@ import { SettingsService } from 'services/settings';
 import { SnackbarService } from 'services/snackbar';
 import { SoundDetectorService } from 'services/sound-detector';
 import { Menu } from 'util/menus/Menu';
-import { defineComponent } from 'vue';
+import { Component, defineComponent } from 'vue';
 
 import NAirLogo from '../../../media/images/n-air-logo.svg';
 
@@ -40,7 +40,7 @@ import CommentFilter from './CommentFilter.vue';
 import CommentForm from './CommentForm.vue';
 import SoundDetectorButton from './SoundDetectorButton.vue';
 
-const componentMap: { [type in ChatComponentType]: any } = {
+const componentMap: { [type in ChatComponentType]: Component } = {
   common: CommonComment,
   nicoad: NicoadComment,
   gift: GiftComment,
@@ -331,7 +331,7 @@ export default defineComponent({
               id: 'Undo delete a comment',
               label: 'コメント削除を取り消す',
               click: () => {
-                NicoliveCommentViewerService.instance().undoDeleteComment(item.value.id).catch((e: any) => {
+                NicoliveCommentViewerService.instance().undoDeleteComment(item.value.id).catch((e: unknown) => {
                   if (e instanceof NicoliveFailure) {
                     openErrorDialogFromFailure(e);
                   }
@@ -355,7 +355,7 @@ export default defineComponent({
                         onClick: () => {
                           NicoliveCommentViewerService.instance()
                             .undoDeleteComment(item.value.id)
-                            .catch((e: any) => {
+                            .catch((e: unknown) => {
                               if (e instanceof NicoliveFailure) {
                                 openErrorDialogFromFailure(e);
                               }
@@ -364,7 +364,7 @@ export default defineComponent({
                       },
                     });
                   })
-                  .catch((e: any) => {
+                  .catch((e: unknown) => {
                     if (e instanceof NicoliveFailure) {
                       openErrorDialogFromFailure(e);
                     }
@@ -387,7 +387,7 @@ export default defineComponent({
                     messageId: `${item.value.id}`,
                     memo: item.value.content,
                   })
-                  .catch((e: any) => {
+                  .catch((e: unknown) => {
                     if (e instanceof NicoliveFailure) {
                       openErrorDialogFromFailure(e);
                     }

--- a/app/components/nicolive-area/ModeratorConfirmDialog.vue.ts
+++ b/app/components/nicolive-area/ModeratorConfirmDialog.vue.ts
@@ -5,6 +5,12 @@ import Util from 'services/utils';
 import { WindowsService } from 'services/windows';
 import { defineComponent } from 'vue';
 
+interface ModeratorConfirmDialogParams {
+  userName: string;
+  userId: string;
+  operation: 'add' | 'remove';
+}
+
 export default defineComponent({
   name: 'ModeratorConfirmDialog',
 
@@ -12,11 +18,11 @@ export default defineComponent({
 
   data() {
     const windowId = Util.getCurrentUrlParams().windowId;
-    const queryParams = WindowsService.instance().getWindowOptions(windowId) as any;
+    const queryParams = WindowsService.instance().getWindowOptions(windowId) as ModeratorConfirmDialogParams;
     return {
       user: {
-        userName: queryParams.userName as string,
-        userId: queryParams.userId as string,
+        userName: queryParams.userName,
+        userId: queryParams.userId,
       },
       isClosing: false,
     };
@@ -27,8 +33,8 @@ export default defineComponent({
       return Util.getCurrentUrlParams().windowId;
     },
 
-    queryParams() {
-      return WindowsService.instance().getWindowOptions(this.windowId);
+    queryParams(): ModeratorConfirmDialogParams {
+      return WindowsService.instance().getWindowOptions(this.windowId) as ModeratorConfirmDialogParams;
     },
 
     userName(): string {
@@ -36,7 +42,7 @@ export default defineComponent({
     },
 
     operation(): 'add' | 'remove' {
-      return (this.queryParams as any).operation as 'add' | 'remove';
+      return this.queryParams.operation;
     },
   },
 

--- a/app/components/nicolive-area/UserInfo.vue.ts
+++ b/app/components/nicolive-area/UserInfo.vue.ts
@@ -20,11 +20,12 @@ import {
   NicoliveFailure,
   openErrorDialogFromFailure,
 } from 'services/nicolive-program/NicoliveFailure';
+import { FilterRecord } from 'services/nicolive-program/ResponseTypes';
 import { isWrappedChat, WrappedChatWithComponent } from 'services/nicolive-program/WrappedChat';
 import { WindowsService } from 'services/windows';
-import { defineComponent } from 'vue';
+import { Component, defineComponent } from 'vue';
 
-const componentMap: { [type in ChatComponentType]: any } = {
+const componentMap: { [type in ChatComponentType]: Component } = {
   common: CommonComment,
   nicoad: NicoadComment,
   gift: GiftComment,
@@ -80,12 +81,12 @@ export default defineComponent({
       return WindowsService.instance().getChildWindowQueryParams().userId as string;
     },
 
-    isPremium() {
-      return WindowsService.instance().getChildWindowQueryParams().isPremium;
+    isPremium(): boolean {
+      return WindowsService.instance().getChildWindowQueryParams().isPremium as boolean;
     },
 
-    isSupporter() {
-      return WindowsService.instance().getChildWindowQueryParams().isSupporter;
+    isSupporter(): boolean {
+      return WindowsService.instance().getChildWindowQueryParams().isSupporter as boolean;
     },
 
     comments(): WrappedChatWithComponent[] {
@@ -198,7 +199,7 @@ export default defineComponent({
           type: 'user',
           body: this.userId,
         })
-        .catch((e: any) => {
+        .catch((e: unknown) => {
           if (e instanceof NicoliveFailure) {
             openErrorDialogFromFailure(e);
           }
@@ -207,14 +208,14 @@ export default defineComponent({
 
     async unBlockUser() {
       const filterRecord = NicoliveCommentFilterService.instance().state.filters.find(
-        (filter: any) => filter.type === 'user' && filter.body === this.userId,
+        (filter: FilterRecord) => filter.type === 'user' && filter.body === this.userId,
       );
       if (!filterRecord) {
         console.warn('unBlockUser: block user filter not found', this.userId);
         return;
       }
 
-      await NicoliveCommentFilterService.instance().deleteFilters([filterRecord.id]).catch((e: any) => {
+      await NicoliveCommentFilterService.instance().deleteFilters([filterRecord.id]).catch((e: unknown) => {
         if (e instanceof NicoliveFailure) {
           openErrorDialogFromFailure(e);
         }

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -107,8 +107,8 @@ const ObsColorInput = defineComponent({
       document.removeEventListener('mousedown', this.onDocumentMouseDown);
     },
     onDocumentMouseDown(event: MouseEvent) {
-      const menu = this.$refs.colorPickerMenu as any;
-      if (menu && menu.$el && menu.$el.contains(event.target as Node)) {
+      const menu = this.$refs.colorPickerMenu as InstanceType<typeof ColorPicker> | undefined;
+      if (menu && menu.$el && (menu.$el as HTMLElement).contains(event.target as Node)) {
         return;
       }
       const el = this.$el as HTMLElement;

--- a/app/components/shared/Dropdown.vue.ts
+++ b/app/components/shared/Dropdown.vue.ts
@@ -105,7 +105,7 @@ export default defineComponent({
     // ドロップダウンの選択肢（文字列配列またはオブジェクト配列）
     // オブジェクト配列を使う場合は label と trackBy の指定が必須
     options: {
-      type: Array as PropType<any[]>,
+      type: Array as PropType<unknown[]>,
       required: true,
     },
     // オプションからラベル（表示テキスト）を取得するプロパティ名

--- a/app/components/shared/ModalLayout.vue.ts
+++ b/app/components/shared/ModalLayout.vue.ts
@@ -1,6 +1,6 @@
 import { AppService } from 'services/app';
 import { WindowsService } from 'services/windows';
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
 export default defineComponent({
   name: 'ModalLayout',
@@ -12,10 +12,10 @@ export default defineComponent({
     // If controls are shown, whether or not to show the cancel button.
     showCancel: { type: Boolean, default: true },
     // Will be called when "done" is clicked if controls are enabled
-    doneHandler: { type: Function },
+    doneHandler: { type: Function as PropType<() => void> },
     // Will be called when "cancel" is clicked.
     // By default this will just close the window.
-    cancelHandler: { type: Function },
+    cancelHandler: { type: Function as PropType<() => void> },
     // The height of the fixed section
     fixedSectionHeight: { type: Number },
     /**
@@ -47,7 +47,7 @@ export default defineComponent({
   methods: {
     cancel() {
       if (this.cancelHandler) {
-        (this.cancelHandler as Function)();
+        this.cancelHandler();
       } else {
         WindowsService.instance().closeChildWindow();
       }
@@ -55,7 +55,7 @@ export default defineComponent({
 
     done() {
       if (this.doneHandler) {
-        (this.doneHandler as Function)();
+        this.doneHandler();
       } else {
         WindowsService.instance().closeChildWindow();
       }

--- a/app/components/sources/BrowserSourceInteraction.vue.ts
+++ b/app/components/sources/BrowserSourceInteraction.vue.ts
@@ -19,7 +19,7 @@ export default defineComponent({
   computed: {
     sourceId(): string {
       const windowId = Utils.getCurrentUrlParams().windowId;
-      return WindowsService.instance().getWindowOptions(windowId).sourceId;
+      return WindowsService.instance().getWindowOptions(windowId).sourceId as string;
     },
 
     source() {

--- a/app/components/sources/SourceProperties.vue.ts
+++ b/app/components/sources/SourceProperties.vue.ts
@@ -48,7 +48,7 @@ export default defineComponent({
       return (
         WindowsService.instance().getWindowOptions(this.windowId).sourceId
         || WindowsService.instance().getChildWindowQueryParams().sourceId
-      );
+      ) as string;
     },
 
     source() {

--- a/app/components/windows/Projector.vue.ts
+++ b/app/components/windows/Projector.vue.ts
@@ -29,8 +29,8 @@ export default defineComponent({
       return WindowsService.instance().state[this.windowId].isFullScreen;
     },
 
-    sourceId(): string {
-      return WindowsService.instance().getWindowOptions(this.windowId).sourceId as string;
+    sourceId(): string | undefined {
+      return WindowsService.instance().getWindowOptions(this.windowId).sourceId;
     },
 
     allDisplays() {

--- a/app/components/windows/Projector.vue.ts
+++ b/app/components/windows/Projector.vue.ts
@@ -30,7 +30,7 @@ export default defineComponent({
     },
 
     sourceId(): string {
-      return WindowsService.instance().getWindowOptions(this.windowId).sourceId;
+      return WindowsService.instance().getWindowOptions(this.windowId).sourceId as string;
     },
 
     allDisplays() {


### PR DESCRIPTION
vue-tsc が通るようになったことで把握できた、Vueコンポーネントに `any` 型が
素通りしていた箇所に型を付ける。

## 変更内容

### props の型付け
- `ModalLayout`: `doneHandler`/`cancelHandler` を `Function` → `PropType<() => void>`
- `Dropdown`: `options` を `PropType<any[]>` → `PropType<unknown[]>`

### `$refs` の型付け
- `ObsColorInput`: `$refs.colorPickerMenu` を `as any` → `InstanceType<typeof ColorPicker>`

### `componentMap` の型付け
- `CommentViewer`/`UserInfo`: `{ [type in ChatComponentType]: any }` → `Component`

### `catch (e: any)` の除去
- `CommentViewer`/`UserInfo`: `.catch((e: any)` → `.catch((e: unknown)`
- `UserInfo`: `filter: any` → `FilterRecord`

### `getWindowOptions` 呼び出し側の型付け
- `ModeratorConfirmDialog`: `as any` を除去し `ModeratorConfirmDialogParams` インターフェースを定義
- `BrowserSourceInteraction`/`Projector`/`SourceProperties`: `.sourceId` に `as string` を追加

## テスト
- `pnpm run typecheck` が通ることを確認済み
