### PR TITLE
開発: OBS配信切断(Disconnected)時のSentryノイズを抑制

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -733,6 +733,7 @@ export class StreamingService
     console.debug('OBS Output signal: ', info);
 
     const time = new Date().toISOString();
+    const outputCodeName = info.code ? (OBS_OUTPUT_CODE_NAMES[info.code] ?? String(info.code)) : undefined;
 
     if (info.type === EOBSOutputType.Streaming) {
       const time = new Date().toISOString();
@@ -773,7 +774,7 @@ export class StreamingService
           category: 'streaming.signal',
           message: 'stop',
           level: 'info',
-          data: { code: info.code, error: info.error },
+          data: { code: info.code, outputCode: outputCodeName, error: info.error },
         });
         this.SET_STREAMING_STATUS(EStreamingState.Offline, time);
         this.streamingStatusChange.next(EStreamingState.Offline);
@@ -795,7 +796,7 @@ export class StreamingService
           category: 'streaming.signal',
           message: 'reconnect',
           level: 'warning',
-          data: { code: info.code, error: info.error, reconnectCount: this.reconnectCount },
+          data: { code: info.code, outputCode: outputCodeName, error: info.error, reconnectCount: this.reconnectCount },
         });
       } else if (info.signal === EOBSOutputSignal.ReconnectSuccess) {
         const durationMs =
@@ -850,9 +851,9 @@ export class StreamingService
     if (info.code) {
       if (
         info.signal !== EOBSOutputSignal.Reconnect &&
-        info.signal !== EOBSOutputSignal.ReconnectSuccess
+        info.signal !== EOBSOutputSignal.ReconnectSuccess &&
+        info.code !== obs.EOutputCode.Disconnected
       ) {
-        const outputCodeName = OBS_OUTPUT_CODE_NAMES[info.code] ?? String(info.code);
         SentryReport.message('StreamingService', 'handleOBSOutputSignal', `OBS output error code: ${outputCodeName}`, {
           level: 'warning',
           fingerprint: ['StreamingService', 'outputCode'],


### PR DESCRIPTION
## このpull requestが解決する内容

OBS配信が `Disconnected` コードで停止したときに発火していた Sentry warning イベントを抑制します。

## 背景

v1.20260618-1 の Sentry トリアージにて、N-AIR-APP-G81 (133 events, 35 users, Escalating) を確認。
ニコニコ生放送では番組終了時にRTMPサーバー側から接続が切断され、OBSが `EOutputCode.Disconnected (-5)` で `stop` シグナルを発火する。これは正常な終了フローであり Sentry イベントを送る必要はない。

- `EOutputCode.Success (0)` は `if (info.code)` の falsy ガードで既に除外済み
- `Disconnected (-5)` は truthy なため従来はレポートされていた
- 実際の「突然の切断」も同じコードだが、breadcrumb に stop/reconnect の履歴が残るため他のイベント発生時に文脈として参照可能

## 変更内容

- `streaming.ts`: `EOutputCode.Disconnected` を Sentry レポートの除外条件に追加
- `stop` / `reconnect` breadcrumb の `data` に `outputCode` 人可読名を追加（`code=0` 時は省略）
- `outputCodeName` の重複 lookup を解消（`if (info.code)` ブロック先頭で1回だけ計算）

## Sentry-Resolves: N-AIR-APP-G81
