### PR TITLE
修正: 削除済みソースを参照するシーンアイテムでクラッシュする問題を修正

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -423,7 +423,7 @@ export class AudioSource implements IAudioSourceApi {
 
   constructor(sourceId: string) {
     this.audioSourceState = this.audioService.state.audioSources[sourceId];
-    const sourceState = this.sourcesService.state.sources[sourceId];
+    const sourceState = this.sourcesService.state.sources[sourceId] ?? null;
     Utils.applyProxy(this, this.audioSourceState);
     Utils.applyProxy(this, sourceState);
   }

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -78,9 +78,11 @@ export class Scene {
 
     if (!nodeModel) return null;
 
-    return nodeModel.sceneNodeType === 'item'
-      ? new SceneItem(this.id, nodeModel.id, nodeModel.sourceId)
-      : new SceneItemFolder(this.id, nodeModel.id);
+    if (nodeModel.sceneNodeType === 'item') {
+      if (!this.sourcesService.state.sources[nodeModel.sourceId]) return null;
+      return new SceneItem(this.id, nodeModel.id, nodeModel.sourceId);
+    }
+    return new SceneItemFolder(this.id, nodeModel.id);
   }
 
   getItem(sceneItemId: string): SceneItem {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -105,7 +105,8 @@ export class Scene {
   getItems(): SceneItem[] {
     return this.state.nodes
       .filter((node) => node.sceneNodeType === 'item')
-      .map((item) => this.getItem(item.id));
+      .map((item) => this.getItem(item.id))
+      .filter(Boolean);
   }
 
   getFolders(): SceneItemFolder[] {

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -14,7 +14,8 @@ export const enum EBit {
 }
 
 export default class Utils {
-  static applyProxy(target: Object, source: Object) {
+  static applyProxy(target: Object, source: Object | null | undefined) {
+    if (!source) return;
     Object.keys(source).forEach((propName) => {
       Object.defineProperty(target, propName, {
         configurable: true,


### PR DESCRIPTION
## このpull requestが解決する内容

削除済みまたは未初期化のソースを参照するシーンアイテムにアクセスしたとき、`Object.keys(null)` でクラッシュする問題を修正します。

## 背景

v1.20260618-1 の Sentry トリアージで N-AIR-APP-G70 / G71 / FZY (合計 70 events, 6 users) を確認。
スタックトレース:

```
TypeError: Cannot convert undefined or null to object
  at Function.keys (<anonymous>)
  at Utils.applyProxy
  at new SceneItem (scene-item.ts:97)
  at Scene.getNode → getItems
  at NVoiceCharacterUsageService.collectNVoiceAvatarStylesInActiveScene
```

### 根本原因

**`NVoiceCharacterUsageService` のバグ**。シーン切り替え時に `sceneSwitched` イベントを受けて `collectNVoiceAvatarStylesInActiveScene()` が全シーンアイテムを走査するが、その際に `getItems()` → `getNode()` → `new SceneItem()` の経路で、sourceId に対応するソースが存在しないアイテムに遭遇すると `Utils.applyProxy(this, undefined)` → `Object.keys(undefined)` でクラッシュしていた。

ソースが存在しない状態になる理由は、シーンコレクション読み込み直後（OBS ソースの初期化完了前）や、設定ファイルの不整合など。

### 修正方針

`NVoiceCharacterUsageService` が踏んだ潜在バグを `SceneItem` 生成経路で修正する:
- `getNode()` で source が存在しない場合は null を返す（壊れた SceneItem を生成しない）
- `getItems()` で null をフィルタして後続処理へ伝播しない
- `Utils.applyProxy` にも guard を追加（defense in depth）

## 変更内容

### `app/services/utils.ts`
- `applyProxy(target, source)` の `source` パラメータ型を `Object | null | undefined` に変更
- `if (!source) return` ガードを追加（defense in depth）

### `app/services/scenes/scene.ts`
- `getNode()` で `new SceneItem` を生成する前に `sourcesService.state.sources[nodeModel.sourceId]` の存在チェックを追加し、source が存在しない場合は null を返す
- `getItems()` で null をフィルタし、孤立したアイテムが後続処理でクラッシュしないよう対処

### `app/services/audio/audio.ts`
- `AudioSource` constructor で `sourceState` を `?? null` で明示的に null に変換（同パターンの予防的修正）

## Sentry-Resolves: N-AIR-APP-G70, N-AIR-APP-G71, N-AIR-APP-FZY

🤖 Generated with [Claude Code](https://claude.com/claude-code)
