### PR TITLE
開発: Vosk CLI の WARNING ログを Sentry に error として送信しないよう修正

### DIFF
--- a/app/services/transcription/VoskClient.ts
+++ b/app/services/transcription/VoskClient.ts
@@ -206,7 +206,11 @@ export class VoskClient implements ITranscriber {
       stderrBuffer = lines.pop() || ''; // Keep the last incomplete line
       for (const line of lines) {
         if (line.trim()) {
-          console.error(`Vosk CLI process error: ${line}`);
+          if (line.startsWith('WARNING')) {
+            console.warn(`Vosk CLI process warning: ${line}`);
+          } else {
+            console.error(`Vosk CLI process error: ${line}`);
+          }
           this.transcribe$?.next({ info: `Error: ${line}` });
         }
       }


### PR DESCRIPTION
## このpull requestが解決する内容

Vosk CLI プロセスの stderr に出力される `WARNING` レベルのログが `console.error` で記録されていたため、Sentry に error として大量送信されていた問題を修正します。

## 背景

Sentry issue N-AIR-APP-F04 で確認された通り、Vosk の音声認識エンジンが以下のような WARNING を stderr に出力することがあります:

```
WARNING (VoskAPI:CheckMemoryUsage():determinize-lattice-pruned.cc:316) Did not reach requested beam ...
```

これは Vosk 内部の lattice サイズが設定上限を超えた際の通常の WARNING であり、エラーではありません。しかし `console.error` で記録されていたため、Sentry の Electron SDK が error イベントとして capture し、ノイズになっていました（1251件 / 33ユーザー）。

## 変更内容

`VoskClient.ts` の stderr ハンドラーで、`WARNING` で始まる行を `console.warn` に降格します。

- `WARNING` で始まる行 → `console.warn`（Sentry に送信されない）
- それ以外 → 従来通り `console.error`

## テスト計画

- Vosk 音声文字起こし機能を使用して、配信中に WARNING が発生しても Sentry に error が送信されないことを確認

Sentry-Resolves: N-AIR-APP-F04

🤖 Generated with [Claude Code](https://claude.com/claude-code)
