### PR TITLE
開発: OBSラッパーメソッドにassertIsDefinedを追加してnull安全性を強化

### DIFF
--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -123,7 +123,9 @@ export class SceneItem extends SceneItemNode {
   }
 
   getObsSceneItem(): obs.ISceneItem {
-    return this.getScene().getObsScene().findItem(this.obsSceneItemId);
+    const item = this.getScene().getObsScene().findItem(this.obsSceneItemId);
+    assertIsDefined(item);
+    return item;
   }
 
   getSettings(): ISceneItemSettings {

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -5,6 +5,7 @@ import { ISource, SourcesService, TSourceType } from 'services/sources';
 import { VideoService } from 'services/video';
 import { assertIsDefined } from 'util/properties-type-guards';
 import { CenteringAxis, ScalableRectangle } from 'util/ScalableRectangle';
+import { assertObsObjectDefined } from 'util/sentry-obs-breadcrumb';
 import { toRaw } from 'vue';
 
 import * as obs from '../../../obs-api';
@@ -124,7 +125,10 @@ export class SceneItem extends SceneItemNode {
 
   getObsSceneItem(): obs.ISceneItem {
     const item = this.getScene().getObsScene().findItem(this.obsSceneItemId);
-    assertIsDefined(item);
+    assertObsObjectDefined(item, 'ScenesService', 'getObsSceneItem', {
+      sceneId: this.sceneId,
+      obsSceneItemId: this.obsSceneItemId,
+    });
     return item;
   }
 

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -10,6 +10,7 @@ import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
 import { Source, SourcesService, TSourceType } from 'services/sources';
 import Utils, { uuidv4 } from 'services/utils';
 import { assertIsDefined } from 'util/properties-type-guards';
+import { assertObsObjectDefined } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../../obs-api';
@@ -69,7 +70,7 @@ export class Scene {
 
   getObsScene(): obs.IScene {
     const scene = obs.SceneFactory.fromName(this.id);
-    assertIsDefined(scene);
+    assertObsObjectDefined(scene, 'ScenesService', 'getObsScene', { sceneId: this.id });
     return scene;
   }
 

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -68,7 +68,9 @@ export class Scene {
   }
 
   getObsScene(): obs.IScene {
-    return obs.SceneFactory.fromName(this.id);
+    const scene = obs.SceneFactory.fromName(this.id);
+    assertIsDefined(scene);
+    return scene;
   }
 
   getNode(sceneNodeId: string): TSceneNode {

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -8,7 +8,7 @@ import {
 } from 'components/obs/inputs/ObsInput';
 import { EOrderMovement } from 'obs-studio-node';
 import { $t } from 'services/i18n';
-import { assertIsDefined } from 'util/properties-type-guards';
+import { assertObsObjectDefined } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../obs-api';
@@ -287,7 +287,7 @@ export class SourceFiltersService extends Service {
   /** フィルターを取得する。見つからない場合は例外を投げる（操作用） */
   private getObsFilter(sourceId: string, filterName: string): obs.IFilter {
     const filter = this.findObsFilter(sourceId, filterName);
-    assertIsDefined(filter);
+    assertObsObjectDefined(filter, 'SourceFiltersService', 'getObsFilter', { sourceId, filterName });
     return filter;
   }
 }

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -165,7 +165,7 @@ export class SourceFiltersService extends Service {
 
   suggestName(sourceId: string, filterName: string): string {
     return namingHelpers.suggestName(filterName, (name: string) =>
-      this.sourcesService.getSource(sourceId).getObsInput().findFilter(name),
+      this.findObsFilter(sourceId, name),
     );
   }
 
@@ -279,8 +279,14 @@ export class SourceFiltersService extends Service {
     });
   }
 
+  /** フィルターを検索する。見つからない場合は undefined を返す（存在チェック用） */
+  private findObsFilter(sourceId: string, filterName: string): obs.IFilter | undefined {
+    return this.sourcesService.getSource(sourceId).getObsInput().findFilter(filterName);
+  }
+
+  /** フィルターを取得する。見つからない場合は例外を投げる（操作用） */
   private getObsFilter(sourceId: string, filterName: string): obs.IFilter {
-    const filter = this.sourcesService.getSource(sourceId).getObsInput().findFilter(filterName);
+    const filter = this.findObsFilter(sourceId, filterName);
     assertIsDefined(filter);
     return filter;
   }

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -220,7 +220,7 @@ export class SourceFiltersService extends Service {
 
   getPropertiesFormData(sourceId: string, filterName: string): TObsFormData {
     if (!filterName) return [];
-    const filter = this.getObsFilter(sourceId, filterName);
+    const filter = this.findObsFilter(sourceId, filterName);
     if (!filter) {
       SentryReport.error('SourceFiltersService', 'getPropertiesFormData', new Error('Filter not found'), {
         extra: { sourceId, filterName },

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -8,6 +8,7 @@ import {
 } from 'components/obs/inputs/ObsInput';
 import { EOrderMovement } from 'obs-studio-node';
 import { $t } from 'services/i18n';
+import { assertIsDefined } from 'util/properties-type-guards';
 import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../obs-api';
@@ -279,6 +280,8 @@ export class SourceFiltersService extends Service {
   }
 
   private getObsFilter(sourceId: string, filterName: string): obs.IFilter {
-    return this.sourcesService.getSource(sourceId).getObsInput().findFilter(filterName);
+    const filter = this.sourcesService.getSource(sourceId).getObsInput().findFilter(filterName);
+    assertIsDefined(filter);
+    return filter;
   }
 }

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -165,7 +165,7 @@ export class SourceFiltersService extends Service {
 
   suggestName(sourceId: string, filterName: string): string {
     return namingHelpers.suggestName(filterName, (name: string) =>
-      this.getObsFilter(sourceId, name),
+      this.sourcesService.getSource(sourceId).getObsInput().findFilter(name),
     );
   }
 

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -4,6 +4,7 @@ import isEqual from 'lodash/isEqual';
 import { ScenesService } from 'services/scenes';
 import Utils from 'services/utils';
 import { assertIsDefined } from 'util/properties-type-guards';
+import { assertObsObjectDefined } from 'util/sentry-obs-breadcrumb';
 
 import * as obs from '../../../obs-api';
 import { Inject, mutation, ServiceHelper } from '../core';
@@ -43,7 +44,7 @@ export class Source implements ISourceApi {
 
   getObsInput(): obs.IInput {
     const input = obs.InputFactory.fromName(this.sourceId);
-    assertIsDefined(input);
+    assertObsObjectDefined(input, 'SourcesService', 'getObsInput', { sourceId: this.sourceId });
     return input;
   }
 

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -42,7 +42,9 @@ export class Source implements ISourceApi {
     scenesService: ScenesService;
 
   getObsInput(): obs.IInput {
-    return obs.InputFactory.fromName(this.sourceId);
+    const input = obs.InputFactory.fromName(this.sourceId);
+    assertIsDefined(input);
+    return input;
   }
 
   getModel() {

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -9,7 +9,7 @@ import { DefaultManager } from 'services/sources/properties-managers/default-man
 import { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
-import { assertIsDefined } from 'util/properties-type-guards';
+import { assertObsObjectDefined } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../obs-api';
@@ -177,7 +177,7 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
    */
   private getCurrentTransition() {
     const source = obs.Global.getOutputSource(0);
-    assertIsDefined(source);
+    assertObsObjectDefined(source, 'TransitionsService', 'getCurrentTransition', { channel: 0 });
     return source as obs.ITransition;
   }
 

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -9,6 +9,7 @@ import { DefaultManager } from 'services/sources/properties-managers/default-man
 import { uuidv4 } from 'services/utils';
 import { WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
+import { assertIsDefined } from 'util/properties-type-guards';
 import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../obs-api';
@@ -175,7 +176,9 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
    * Fetches the transition currently attached to output channel 0
    */
   private getCurrentTransition() {
-    return obs.Global.getOutputSource(0) as obs.ITransition;
+    const source = obs.Global.getOutputSource(0);
+    assertIsDefined(source);
+    return source as obs.ITransition;
   }
 
   /**

--- a/app/util/sentry-obs-breadcrumb.test.ts
+++ b/app/util/sentry-obs-breadcrumb.test.ts
@@ -1,6 +1,14 @@
 import * as Sentry from '@sentry/vue';
+import FakeTimers from '@sinonjs/fake-timers';
 
-import { getLastObsOp, markObsOp, runObsOp, setObsOpObserver } from './sentry-obs-breadcrumb';
+import {
+  assertObsObjectDefined,
+  getLastObsOp,
+  markObsOp,
+  resetNullReportState,
+  runObsOp,
+  setObsOpObserver,
+} from './sentry-obs-breadcrumb';
 import { SentryReport } from './sentry-report';
 
 jest.mock('@sentry/vue', () => ({
@@ -148,5 +156,136 @@ describe('runObsOp', () => {
   test('fn が成功しても SentryReport.error は呼ばれない', () => {
     runObsOp('FooService', 'barMethod', () => {});
     expect(SentryReport.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertObsObjectDefined', () => {
+  let clock: FakeTimers.Clock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetNullReportState();
+    clock = FakeTimers.install();
+  });
+
+  afterEach(() => {
+    clock.uninstall();
+  });
+
+  test('defined な値は throw せず SentryReport.message を呼ばない', () => {
+    const val = { obs: 'object' };
+    expect(() => assertObsObjectDefined(val, 'ScenesService', 'getObsScene')).not.toThrow();
+    expect(SentryReport.message).not.toHaveBeenCalled();
+  });
+
+  test('undefined のとき throw し SentryReport.message が呼ばれる', () => {
+    expect(() =>
+      assertObsObjectDefined(undefined, 'ScenesService', 'getObsScene', { sceneId: 'scene1' }),
+    ).toThrow('Expected OBS object to be defined in ScenesService.getObsScene');
+    expect(SentryReport.message).toHaveBeenCalledWith(
+      'ScenesService',
+      'getObsScene',
+      'OBS object was null/undefined in ScenesService.getObsScene',
+      {
+        level: 'error',
+        fingerprint: ['ScenesService', 'getObsScene', 'obs', 'null'],
+        extra: { sceneId: 'scene1', reportCount: 1 },
+      },
+    );
+  });
+
+  test('null のとき throw し SentryReport.message が呼ばれる', () => {
+    expect(() =>
+      assertObsObjectDefined(null, 'SourcesService', 'getObsInput', { sourceId: 'src1' }),
+    ).toThrow('Expected OBS object to be defined in SourcesService.getObsInput');
+    expect(SentryReport.message).toHaveBeenCalledTimes(1);
+  });
+
+  test('extra を指定しない場合は extra に reportCount のみ付与される', () => {
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    expect(SentryReport.message).toHaveBeenCalledWith(
+      'FooService',
+      'barMethod',
+      expect.any(String),
+      expect.objectContaining({ extra: { reportCount: 1 } }),
+    );
+  });
+
+  test('60 秒窓内の連続呼び出しでは throw は毎回・message は 1 回だけ', () => {
+    // 1 回目（60秒経過なしの時刻 0）
+    clock.tick(0);
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    // 2 回目（窓内）
+    clock.tick(1000);
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+
+    expect(SentryReport.message).toHaveBeenCalledTimes(1);
+  });
+
+  test('60 秒窓を超えると再度 message が送信される', () => {
+    // 1 回目
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    expect(SentryReport.message).toHaveBeenCalledTimes(1);
+
+    // 60 秒経過
+    clock.tick(60_000);
+    // 2 回目
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    expect(SentryReport.message).toHaveBeenCalledTimes(2);
+  });
+
+  test('セッション内上限 (5 件) に達すると以降は message を送信しない', () => {
+    for (let i = 0; i < 5; i++) {
+      clock.tick(60_000); // 60 秒ずつ進めて throttle をリセット
+      expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    }
+    expect(SentryReport.message).toHaveBeenCalledTimes(5);
+
+    // 6 回目: 上限到達済みなので message は呼ばれない
+    clock.tick(60_000);
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    expect(SentryReport.message).toHaveBeenCalledTimes(5); // 変わらない
+  });
+
+  test('上限到達の最後の message には reportCapReached: true が付与される', () => {
+    for (let i = 0; i < 4; i++) {
+      clock.tick(60_000);
+      expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    }
+    // 5 回目（上限ぴったり）
+    clock.tick(60_000);
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+
+    const calls = (SentryReport.message as jest.Mock).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[3].extra).toMatchObject({ reportCount: 5, reportCapReached: true });
+  });
+
+  test('異なる service/method キーは独立してカウントされる', () => {
+    // key1 を 1 回
+    expect(() =>
+      assertObsObjectDefined(undefined, 'FooService', 'method1'),
+    ).toThrow();
+    // key2 を 1 回（窓内でも別キーなので送信される）
+    expect(() =>
+      assertObsObjectDefined(undefined, 'FooService', 'method2'),
+    ).toThrow();
+
+    expect(SentryReport.message).toHaveBeenCalledTimes(2);
+  });
+
+  test('resetNullReportState 後は新規セッションとして報告される', () => {
+    // 上限まで消費
+    for (let i = 0; i < 5; i++) {
+      clock.tick(60_000);
+      expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    }
+    expect(SentryReport.message).toHaveBeenCalledTimes(5);
+
+    // リセット後は再び送信される
+    resetNullReportState();
+    clock.tick(60_000);
+    expect(() => assertObsObjectDefined(undefined, 'FooService', 'barMethod')).toThrow();
+    expect(SentryReport.message).toHaveBeenCalledTimes(6);
   });
 });

--- a/app/util/sentry-obs-breadcrumb.ts
+++ b/app/util/sentry-obs-breadcrumb.ts
@@ -56,3 +56,52 @@ export function runObsOp<T>(
     return undefined;
   }
 }
+
+const NULL_REPORT_WINDOW_MS = 60_000; // バースト連打抑制
+const NULL_REPORT_MAX_PER_KEY = 5; // 継続発生時の総量上限（セッション内）
+
+interface NullReportState {
+  count: number; // これまでに送信した件数
+  last: number | null; // 最後に送信した時刻。null = 一度も送信していない
+}
+const nullReportState = new Map<string, NullReportState>();
+
+/**
+ * OBS オブジェクトが null/undefined でないことを表明する。
+ * null/undefined の場合は Sentry へ fingerprint・コンテキスト付きで報告したうえで throw する。
+ *
+ * 報告は 2 段の quota ガードで抑制する:
+ *   1. 同一 service.method キーでセッション内 最大 NULL_REPORT_MAX_PER_KEY 件まで
+ *   2. 同一キーで NULL_REPORT_WINDOW_MS (60s) に 1 件まで（バースト連打抑制）
+ * throw は常時実行するため、報告抑制中でも制御フローに影響しない。
+ */
+export function assertObsObjectDefined<T>(
+  val: T,
+  serviceName: string,
+  methodName: string,
+  extra?: Record<string, unknown>,
+): asserts val is NonNullable<T> {
+  if (val !== undefined && val !== null) return; // 正常時ゼロコスト
+
+  const key = `${serviceName}.${methodName}`;
+  const state = nullReportState.get(key) ?? { count: 0, last: null };
+  const now = Date.now();
+  // 2 段ガード: 上限未達 かつ (初回 または 60 秒窓経過) のときだけ送信
+  if (state.count < NULL_REPORT_MAX_PER_KEY && (state.last === null || now - state.last >= NULL_REPORT_WINDOW_MS)) {
+    state.count += 1;
+    state.last = now;
+    nullReportState.set(key, state);
+    const capReached = state.count >= NULL_REPORT_MAX_PER_KEY;
+    SentryReport.message(serviceName, methodName, `OBS object was null/undefined in ${key}`, {
+      level: 'error',
+      fingerprint: [serviceName, methodName, 'obs', 'null'],
+      extra: { ...extra, reportCount: state.count, ...(capReached ? { reportCapReached: true } : {}) },
+    });
+  }
+  throw new Error(`Expected OBS object to be defined in ${key}, but received ${val}`);
+}
+
+/** テスト用: assertObsObjectDefined の報告状態をリセットする */
+export function resetNullReportState(): void {
+  nullReportState.clear();
+}


### PR DESCRIPTION
## 概要

`obs-studio-node` の型定義は各取得メソッドが non-nullable な値を返すと宣言しているが、
C++ 実装は IPC 失敗やオブジェクト未発見時に `undefined` を返す。
型定義が non-nullable と宣言しているため `strictNullChecks: true` にしても TypeScript では検出できず、
実行時クラッシュの潜在的原因となっていた。

各 OBS ラッパーメソッドに `assertIsDefined` を追加し、外部パッケージ由来の null を境界で明示的に検出する。

## 変更内容

| ファイル | メソッド | 対象 OBS API |
|---|---|---|
| `app/services/sources/source.ts` | `getObsInput()` | `InputFactory.fromName()` |
| `app/services/scenes/scene.ts` | `getObsScene()` | `SceneFactory.fromName()` |
| `app/services/scenes/scene-item.ts` | `getObsSceneItem()` | `IScene.findItem()` |
| `app/services/source-filters.ts` | `getObsFilter()` | `IInput.findFilter()` |
| `app/services/transitions.ts` | `getCurrentTransition()` | `Global.getOutputSource()` |

## 背景

- `fromName()` / `findItem()` / `findFilter()` / `getOutputSource()` は C++ 側で対象が見つからない場合に `Env().Undefined()` を返す
- `create()` 系メソッドは IPC が生きていれば必ずインスタンスを返すため対応不要
- 他のネイティブバイナリ（`color-picker` / `font-manager` / `node-fontinfo` / `node-libuiohook`）は null を返す API がないため対応不要

## 注意点

`source-filters.ts` では `getObsFilter()`（操作用・存在必須・例外あり）と
`findObsFilter()`（検索用・`undefined` を返す）を明示的に分離している。

`suggestName()` は「この名前が既に使われているか確認する」用途で `findFilter` を呼ぶため、
存在しない名前で呼ぶのが正常動作であり `assertIsDefined` は不適切。
`findObsFilter()` を介することで意図を明確にしている。
