### PR TITLE
開発: nicolive-comment-protobuf を v2026.616.161033 に更新し USER_FOLLOW・クリエイターサポート目標達成通知に対応

### DIFF
--- a/app/services/nicolive-program/ChatMessage.ts
+++ b/app/services/nicolive-program/ChatMessage.ts
@@ -37,6 +37,8 @@ export const NotificationTypeTable = [
   'visited',
   'supporterRegistered',
   'userLevelUp',
+  'userFollow',
+  'creatorSupportGoalAchievement',
 ] as const;
 
 export type NotificationType = (typeof NotificationTypeTable)[number] | 'unknown';

--- a/app/services/nicolive-program/ChatMessage/classifier.test.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.test.ts
@@ -27,12 +27,18 @@ test('エモーション', () => {
   expect(classify({ notification: { type: 'emotion', message: 'args' } })).toBe('emotion');
 });
 
-test.each<NotificationType>(['programExtended', 'rankingIn', 'rankingUpdated', 'visited'])(
-  'info: %s',
-  (type) => {
-    expect(classify({ notification: { type, message: '' } })).toBe('info');
-  },
-);
+test.each<NotificationType>([
+  'programExtended',
+  'rankingIn',
+  'rankingUpdated',
+  'visited',
+  'supporterRegistered',
+  'userLevelUp',
+  'userFollow',
+  'creatorSupportGoalAchievement',
+])('info: %s', (type) => {
+  expect(classify({ notification: { type, message: '' } })).toBe('info');
+});
 
 test.each<NotificationType>(['ichiba', 'quote', 'cruise'])('system: %s', (type) => {
   expect(classify({ notification: { type, message: '' } })).toBe('system');

--- a/app/services/nicolive-program/ChatMessage/classifier.ts
+++ b/app/services/nicolive-program/ChatMessage/classifier.ts
@@ -25,27 +25,21 @@ export function classify(chat: MessageResponse) {
   if (isNotificationMessage(chat)) {
     switch (chat.notification.type) {
       case 'ichiba':
-        return 'system' as const;
       case 'quote':
+      case 'cruise':
+      case 'unknown':
         return 'system' as const;
       case 'emotion':
         return 'emotion' as const;
-      case 'cruise':
-        return 'system' as const;
       case 'programExtended':
-        return 'info' as const;
       case 'rankingIn':
-        return 'info' as const;
       case 'rankingUpdated':
-        return 'info' as const;
       case 'visited':
-        return 'info' as const;
       case 'supporterRegistered':
-        return 'info' as const;
       case 'userLevelUp':
+      case 'userFollow':
+      case 'creatorSupportGoalAchievement':
         return 'info' as const;
-      case 'unknown':
-        return 'system' as const;
     }
   }
   if (isGiftMessage(chat)) return 'gift' as const;

--- a/app/services/nicolive-program/NdgrCommentReceiver.test.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.test.ts
@@ -298,6 +298,40 @@ describe('convertChunkedMessageToMessageResponse', () => {
       expected: { chat: { date, date_usec, content: 'test', mail: 'blue' } },
     },
     {
+      title: 'simpleNotificationV2 userFollow',
+      msg: {
+        message: {
+          simpleNotificationV2: {
+            type: dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.USER_FOLLOW,
+            message: 'userFollowMessage',
+          },
+        },
+      },
+      expected: {
+        notification: { date, date_usec, type: 'userFollow', message: 'userFollowMessage' },
+      },
+    },
+    {
+      title: 'simpleNotificationV2 creatorSupportGoalAchievement',
+      msg: {
+        message: {
+          simpleNotificationV2: {
+            type: dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType
+              .CREATOR_SUPPORT_GOAL_ACHIRVEMENT,
+            message: 'goalAchievedMessage',
+          },
+        },
+      },
+      expected: {
+        notification: {
+          date,
+          date_usec,
+          type: 'creatorSupportGoalAchievement',
+          message: 'goalAchievedMessage',
+        },
+      },
+    },
+    {
       title: 'ichiba',
       msg: { message: { simpleNotification: { ichiba: 'ichiba' } } },
       expected: { notification: { date, date_usec, type: 'ichiba', message: 'ichiba' } },

--- a/app/services/nicolive-program/NdgrCommentReceiver.ts
+++ b/app/services/nicolive-program/NdgrCommentReceiver.ts
@@ -151,24 +151,31 @@ function convertSimpleNotificationToMessageResponse(
   };
 }
 
+// "ACHIRVEMENT" is a typo in the upstream proto definition (missing 'E'); do not correct it here.
+const simpleNotificationV2TypeMap = {
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.UNKNOWN]: 'unknown',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.ICHIBA]: 'ichiba',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.EMOTION]: 'emotion',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.CRUISE]: 'cruise',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.PROGRAM_EXTENDED]:
+    'programExtended',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.RANKING_IN]: 'rankingIn',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.VISITED]: 'visited',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.SUPPORTER_REGISTERED]:
+    'supporterRegistered',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.USER_LEVEL_UP]:
+    'userLevelUp',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.USER_FOLLOW]:
+    'userFollow',
+  [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.CREATOR_SUPPORT_GOAL_ACHIRVEMENT]:
+    'creatorSupportGoalAchievement',
+} as const;
+
 function convertSimpleNotificationV2ToMessageResponse(
   common: CommonComponent,
   notification: dwango.nicolive.chat.data.atoms.ISimpleNotificationV2,
 ): MessageResponse | undefined {
-  const types = {
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.UNKNOWN]: 'unknown',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.ICHIBA]: 'ichiba',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.EMOTION]: 'emotion',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.CRUISE]: 'cruise',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.PROGRAM_EXTENDED]:
-      'programExtended',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.RANKING_IN]: 'rankingIn',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.VISITED]: 'visited',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.SUPPORTER_REGISTERED]:
-      'supporterRegistered',
-    [dwango.nicolive.chat.data.atoms.SimpleNotificationV2.NotificationType.USER_LEVEL_UP]:
-      'userLevelUp',
-  } as const;
+  const types = simpleNotificationV2TypeMap;
   let type: NotificationType = 'unknown';
   if (notification.type in types) {
     type = types[notification.type as keyof typeof types] as NotificationType;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@electron/remote": "2.1.3",
     "@n-air-app/n-voice-package": "^1.0.2",
-    "@n-air-app/nicolive-comment-protobuf": "2026.116.121242",
+    "@n-air-app/nicolive-comment-protobuf": "2026.616.161033",
     "@sentry/electron": "7.13.0",
     "@sentry/vue": "10.50.0",
     "@vue/compiler-sfc": "^3.5.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@babel/core@7.29.7)(@types/babel__core@7.20.5)
       '@n-air-app/nicolive-comment-protobuf':
-        specifier: 2026.116.121242
-        version: 2026.116.121242
+        specifier: 2026.616.161033
+        version: 2026.616.161033
       '@sentry/electron':
         specifier: 7.13.0
         version: 7.13.0
@@ -1369,8 +1369,8 @@ packages:
   '@n-air-app/n-voice-package@1.0.2':
     resolution: {integrity: sha512-E9TsrIhqoX8p6ZGeg9j0s3+fIZMoQONxlPt2nw1ctZGpMnK4O5IO6hug9wWg5oLG4C3gYV763Yem7p8NIb2EqQ==, tarball: https://npm.pkg.github.com/download/@n-air-app/n-voice-package/1.0.2/3ad9bb4da017848de7a399c171bb971a5f987e52}
 
-  '@n-air-app/nicolive-comment-protobuf@2026.116.121242':
-    resolution: {integrity: sha512-KF8t1jNeETZOSpp50UhHkdAcq2LNgOWtqIyW9mKT2HnIKdN/Sw/EHEqI9csGK1/pbtPHjjt2MosunUvteUO5PA==, tarball: https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2026.116.121242/36407e5ae0a52bebe93c8f581aa46c886054721f}
+  '@n-air-app/nicolive-comment-protobuf@2026.616.161033':
+    resolution: {integrity: sha512-HfNaAjWhzW4N835fiCnKNMKandzeQiiq1yVFQKAYZOMAKk6oMW2tTAtWU20dbfUWy9Q41feHbfqlTTZurDJvIw==, tarball: https://npm.pkg.github.com/download/@n-air-app/nicolive-comment-protobuf/2026.616.161033/af36971e3c70fe424835e350f7bd8ed24f9502f0}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -8676,7 +8676,7 @@ snapshots:
       - '@types/babel__core'
       - supports-color
 
-  '@n-air-app/nicolive-comment-protobuf@2026.116.121242':
+  '@n-air-app/nicolive-comment-protobuf@2026.616.161033':
     dependencies:
       protobufjs: 8.6.3
 


### PR DESCRIPTION
## 変更内容

`@n-air-app/nicolive-comment-protobuf` を `2026.116.121242` → `2026.616.161033` に更新し、新しいプロトコルメッセージタイプへの対応を追加します。

### 依存更新

| package | before | after |
|---------|--------|-------|
| @n-air-app/nicolive-comment-protobuf | 2026.116.121242 | 2026.616.161033 |

### 新リリースの追加内容

| 追加要素 | 概要 |
|---------|------|
| `SimpleNotificationV2.NotificationType.USER_FOLLOW = 9` | フォロー通知（既存パッケージに存在したが未対応） |
| `SimpleNotificationV2.NotificationType.CREATOR_SUPPORT_GOAL_ACHIRVEMENT = 10` | クリエイターサポート目標達成通知 |
| `CreatorSupportGoalStatus`（state系） | 目標進捗状態（未対応。受信しても既存の未処理 state として無害に無視される） |

### コード変更

- `NotificationTypeTable` に `userFollow` / `creatorSupportGoalAchievement` を追加
- `simpleNotificationV2TypeMap` をモジュールスコープの定数に移動（関数コールごとの再構築を回避）
- `classifier.ts` の switch を fall-through 形式に整理
- 上流 proto 定義の typo `ACHIRVEMENT`（ACHIEVEMENT の誤り）にコメントを追記
- 両通知タイプを `info` スタイル（system コンポーネント）でチャット欄に表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)
