### PR TITLE
開発: vue-i18n legacy modeのfallback警告を正しく抑止する

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -270,18 +270,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         // Return nothing - vue-i18n will use the key itself as fallback text
       }) as any, // 型定義と実装が異なっているのでanyに飛ばす
+      // vue-i18n v9 legacy mode: 警告を抑制（OBSの動的キーで大量に出るため）
+      // legacy modeのオプション名は silentTranslationWarn / silentFallbackWarn
       silentTranslationWarn: true,
-      // vue-i18n v9 legacy mode: fallback警告を抑制（OBSの動的キーで大量に出るため）
-      // legacy modeでのオプション名は silentFallbackWarn (Composition APIの fallbackWarn とは別)
       silentFallbackWarn: true,
-      missingWarn: false,
-      fallbackWarn: false,
     });
-
-    // legacy: true モードでは createI18n オプションだけでは fallbackWarn が効かない場合があるため
-    // global インスタンスにも直接設定する
-    (i18n.global as any).fallbackWarn = false;
-    (i18n.global as any).missingWarn = false;
 
     I18nService.setVuei18nInstance(i18n.global);
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -271,7 +271,9 @@ document.addEventListener('DOMContentLoaded', () => {
         // Return nothing - vue-i18n will use the key itself as fallback text
       }) as any, // 型定義と実装が異なっているのでanyに飛ばす
       silentTranslationWarn: true,
-      // vue-i18n v9: fallback警告を抑制（OBSの動的キーで大量に出るため）
+      // vue-i18n v9 legacy mode: fallback警告を抑制（OBSの動的キーで大量に出るため）
+      // legacy modeでのオプション名は silentFallbackWarn (Composition APIの fallbackWarn とは別)
+      silentFallbackWarn: true,
       missingWarn: false,
       fallbackWarn: false,
     });


### PR DESCRIPTION
## このpull requestが解決する内容

設定ウィンドウなどを開いた際に console に大量出力される `[intlify] Fall back to translate '...' key with 'en-US' locale.` 警告を抑止します。

## 原因

vue-i18n の legacy モード（`legacy: true`）では、`createI18n` に渡すオプション名が Composition API 向けとは異なります。

| 目的 | Composition API mode | Legacy mode |
|------|----------------------|-------------|
| fallback警告抑止 | `fallbackWarn: false` | `silentFallbackWarn: true` |
| missing警告抑止 | `missingWarn: false` | `silentTranslationWarn: true` |

内部の `convertComposerOptions()` がオプション名を変換するため、`fallbackWarn: false` / `missingWarn: false` は legacy モードでは無視されており、デフォルトの `true`（警告あり）が使われていました。

## 問題の発生経緯

PR #1296（Vue 3化）の作業中（2026-06-02）に vue-i18n v9 の警告を止めようとして `fallbackWarn: false` / `missingWarn: false` を追加しましたが、legacy mode では無効なオプション名だったため、警告がそのまま残り続けていました。

## 変更内容

- `app/app.ts`: legacy mode で無効な `fallbackWarn`/`missingWarn` および後付けの `(i18n.global as any)` への設定を削除し、`silentFallbackWarn: true` を追加

## Composition API mode への移行について

vue-i18n v9 は legacy mode（`this.$t(...)`）と Composition API mode（`const { t } = useI18n()`）の2つを持ちます。Composition API mode に移行すればオプション名の混乱はなくなりますが、現在 `$t(...)` を使用しているファイルが 82 件あり、移行コストが大きいため今回は見送りました。Vue 3 Composition API（`<script setup>`）への全面移行を検討する際に合わせて対応するのが適切と判断しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
