### PR TITLE
修正: ニコニコ生放送の配信開始に失敗したときのエラー表示を原因別に分かりやすく改善

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -88,6 +88,12 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !remote.process.env.N
     {
       sampleRate: /* isPreview ? */ 1.0 /* : 0.1 */,
       beforeSend(event) {
+        // 診断目的で構造化して送るイベントは NOISE チェックより前に通す
+        // (tags.diagnostic が設定されているものは意図的に送っているので除外しない)
+        if ((event.tags as Record<string, unknown>)?.diagnostic) {
+          return event;
+        }
+
         // quota 対策: ユーザー側ネット環境起因またはアプリバグに起因しないノイズを除外する
         const NOISE_PATTERNS = [
           /Failed to make IPC call/,

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -40,7 +40,10 @@
   "notBroadcastingCreateProgram": "Create a program",
   "broadcastStatusFetchingError": {
     "default": "Failed to get information on streaming server.  Please check your internet connection.",
-    "httpError": "Failed to get information on streaming server. ({requestURL}: {statusText})"
+    "httpError": "Failed to get information on streaming server. ({requestURL}: {statusText})",
+    "networkError": "Failed to start streaming. Please check your internet connection and try again.",
+    "serverError": "An error occurred on the niconico side while preparing to stream (code: {statusCode}). Please wait a moment and try again.",
+    "settingsError": "Failed to save streaming settings. Please restart N Air and try again."
   },
   "bitrateFetchingError": {
     "title": "Failed to get bitrate",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -40,7 +40,10 @@
   "notBroadcastingCreateProgram": "番組を作成する",
   "broadcastStatusFetchingError": {
     "default": "配信に必要な情報を取得できませんでした。インターネットの接続状態を確認してください。",
-    "httpError": "配信に必要な情報を取得できませんでした。（{requestURL}: {statusText}）"
+    "httpError": "配信に必要な情報を取得できませんでした。（{requestURL}: {statusText}）",
+    "networkError": "配信を開始できませんでした。インターネット接続を確認して、もう一度お試しください。",
+    "serverError": "配信の準備中にニコニコ側でエラーが発生しました（コード: {statusCode}）。しばらく待ってから再度お試しください。",
+    "settingsError": "配信設定の保存に失敗しました。N Air を再起動してお試しください。"
   },
   "bitrateFetchingError": {
     "title": "ビットレート取得失敗",

--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -95,9 +95,11 @@ test('wrapResultは結果が200でないときレスポンス全体を返す', a
   fetchMock.get(dummyURL, { body: JSON.stringify(dummyErrorBody), status: 404 });
   const res = await fetch(dummyURL);
 
-  await expect(NicoliveClient.wrapResult(res)).resolves.toEqual({
+  // diag フィールドが追加されるため toMatchObject で検証
+  await expect(NicoliveClient.wrapResult(res)).resolves.toMatchObject({
     ok: false,
     value: dummyErrorBody,
+    diag: { route: 'renderer', httpStatus: 404, failureKind: 'http_error' },
   });
   expect(fetchMock.callHistory.done()).toBe(true);
 });
@@ -106,12 +108,11 @@ test('wrapResultはbodyがJSONでなければSyntaxErrorをwrapして返す', as
   fetchMock.get(dummyURL, 'invalid json');
   const res = await fetch(dummyURL);
 
-  await expect(NicoliveClient.wrapResult(res)).resolves.toMatchInlineSnapshot(`
-    {
-      "ok": false,
-      "value": [SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-    }
-  `);
+  // diag フィールドが追加されるため toMatchObject で検証
+  const result = await NicoliveClient.wrapResult(res);
+  expect(result.ok).toBe(false);
+  expect((result as any).value).toBeInstanceOf(SyntaxError);
+  expect((result as any).diag).toMatchObject({ route: 'renderer', failureKind: 'json_parse' });
   expect(fetchMock.callHistory.done()).toBe(true);
 });
 
@@ -448,7 +449,8 @@ describe('NicoliveClient.wrapResult', () => {
   )('%p ok:%p expect:%p', async (_label, ok, value, response) => {
     const res = await NicoliveClient.wrapResult<string>(response);
     console.log(res);
-    expect(res).toEqual({
+    // diag フィールドが失敗時に追加されるため toMatchObject で検証
+    expect(res).toMatchObject({
       ok,
       ...(ok ? { serverDateMs } : {}),
       value,
@@ -483,7 +485,8 @@ describe('NicoliveClient.deleteComment', () => {
     const client = new NicoliveClient({ niconicoSession: 'dummy' });
     {
       const res = client.deleteComment('lv1', '1');
-      await expect(res).resolves.toEqual({ ok, serverDateMs: undefined, value });
+      // diag フィールドが失敗時に追加されるため toMatchObject で検証
+      await expect(res).resolves.toMatchObject({ ok, value });
       expect(fetchViaMainProcess).toHaveBeenCalledWith(expect.anything(), expect.anything());
     }
   });

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -54,9 +54,21 @@ type SucceededResult<T> = {
   serverDateMs?: number;
 };
 
+/** main process 経由か renderer 直送かを示す経路種別 */
+export type RequestRoute = 'main' | 'renderer';
+
+/** API 呼び出し失敗の種別 */
+export type FailureKind = 'network_error' | 'http_error' | 'json_parse' | 'not_logged_in';
+
 export type FailedResult = {
   ok: false;
   value: CommonErrorResponse | Error;
+  /** 診断メタ — 失敗した経路・種別・ステータスを構造化して保持する */
+  diag?: {
+    route: RequestRoute;
+    httpStatus?: number;
+    failureKind: FailureKind;
+  };
 };
 
 /**
@@ -213,6 +225,7 @@ export class NicoliveClient {
 
   static async wrapResult<ResultType>(
     res: Response | MainProcessFetchResponse,
+    route: RequestRoute = 'renderer',
   ): Promise<WrappedResult<ResultType>> {
     const dateHeader = new Headers(res.headers).get('Date');
     const serverDateMs = parseServerDateMs(dateHeader);
@@ -236,6 +249,7 @@ export class NicoliveClient {
       return {
         ok: false,
         value: e as Error,
+        diag: { route, httpStatus: res.status, failureKind: 'json_parse' },
       };
     }
 
@@ -252,13 +266,25 @@ export class NicoliveClient {
     return {
       ok: false,
       value: obj as CommonErrorResponse,
+      diag: { route, httpStatus: res.status, failureKind: 'http_error' },
     };
   }
 
-  static async wrapFetchError(err: Error): Promise<FailedResult> {
+  /** main.js の fetch handler が投げる [MAIN_FETCH_FAIL code=ECODE] 接頭辞のパターン */
+  private static readonly MAIN_FETCH_FAIL_RE = /^\[MAIN_FETCH_FAIL code=([^\]]*)\]/;
+
+  static async wrapFetchError(err: Error, route: RequestRoute = 'renderer'): Promise<FailedResult> {
+    // main 経由 fetch の失敗は [MAIN_FETCH_FAIL code=...] 接頭辞で判別できる
+    const isMainFail = NicoliveClient.MAIN_FETCH_FAIL_RE.test(err.message);
+    const effectiveRoute: RequestRoute = isMainFail ? 'main' : route;
+
+    const failureKind: FailureKind =
+      err instanceof NotLoggedInError ? 'not_logged_in' : 'network_error';
+
     return {
       ok: false,
       value: err,
+      diag: { route: effectiveRoute, failureKind },
     };
   }
 
@@ -287,6 +313,7 @@ export class NicoliveClient {
   ): Promise<WrappedResult<T>> {
     // Origin リクエストヘッダーを付けるには main process で fetch を使う必要がある
     const viaMainProcess = options.headers && 'Origin' in options.headers;
+    const route: RequestRoute = viaMainProcess ? 'main' : 'renderer';
 
     const headers: HeadersInit = {};
     // renderer process だと cookieが取れないので、main process で取ってきて付ける
@@ -299,9 +326,9 @@ export class NicoliveClient {
     });
     try {
       const resp = await (viaMainProcess ? fetchViaMainProcess : fetch)(url, requestInit);
-      return NicoliveClient.wrapResult<T>(resp);
+      return NicoliveClient.wrapResult<T>(resp, route);
     } catch (err) {
-      return NicoliveClient.wrapFetchError(err as Error);
+      return NicoliveClient.wrapFetchError(err as Error, route);
     }
   }
 

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -2,7 +2,7 @@ import * as remote from '@electron/remote';
 import { $t } from 'services/i18n';
 import { SentryReport } from 'util/sentry-report';
 
-import { FailedResult, NotLoggedInError } from './NicoliveClient';
+import { FailedResult, FailureKind, NotLoggedInError, RequestRoute } from './NicoliveClient';
 
 export class NicoliveFailure {
   constructor(
@@ -11,16 +11,25 @@ export class NicoliveFailure {
     public reason: string,
     public additionalMessage: string = '',
     public errorCode: string = '',
+    /** API 呼び出し経路（診断用） */
+    public route?: RequestRoute,
+    /** API 呼び出し失敗の種別（診断用） */
+    public failureKind?: FailureKind,
   ) {}
 
   static fromClientError(method: string, res: FailedResult) {
+    const route = res.diag?.route;
+    const failureKind = res.diag?.failureKind;
+
     if (res.value instanceof NotLoggedInError) {
       console.error(res.value);
-      return new this('logic', method, 'not_logged_in');
+      return new this('logic', method, 'not_logged_in', '', '', route, 'not_logged_in');
     }
     if (res.value instanceof Error) {
       console.error(res.value);
-      return new this('network_error', method, 'network_error');
+      // json_parse は Error だが network_error と区別して reason に残す
+      const kind = failureKind ?? 'network_error';
+      return new this('network_error', method, kind, '', '', route, kind);
     }
     const { errorCode, errorMessage } = res.value.meta;
     const additionalMessage = `${errorCode ?? ''}${errorMessage ? `: ${errorMessage}` : ''}`;
@@ -30,6 +39,8 @@ export class NicoliveFailure {
       res.value.meta.status.toString(10),
       additionalMessage,
       errorCode,
+      route,
+      failureKind,
     );
   }
 

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -71,14 +71,16 @@ test('fetchFilters/失敗', async () => {
   (instance as any).UPDATE_FILTERS = UPDATE_FILTERS;
 
   await expect(instance.fetchFilters()).rejects.toMatchInlineSnapshot(`
-          NicoliveFailure {
-            "additionalMessage": "ERROR_CODE: simple description",
-            "errorCode": "ERROR_CODE",
-            "method": "fetchFilters",
-            "reason": "400",
-            "type": "http_error",
-          }
-        `);
+NicoliveFailure {
+  "additionalMessage": "ERROR_CODE: simple description",
+  "errorCode": "ERROR_CODE",
+  "failureKind": undefined,
+  "method": "fetchFilters",
+  "reason": "400",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
 
   expect(UPDATE_FILTERS).toHaveBeenCalledTimes(0);
 });
@@ -139,14 +141,16 @@ test('addFilters/失敗', async () => {
   (instance as any).UPDATE_FILTERS = UPDATE_FILTERS;
 
   await expect(instance.addFilter({ type: 'word', body: '810' })).rejects.toMatchInlineSnapshot(`
-                    NicoliveFailure {
-                      "additionalMessage": "ERROR_CODE: simple description",
-                      "errorCode": "ERROR_CODE",
-                      "method": "addFilters",
-                      "reason": "400",
-                      "type": "http_error",
-                    }
-                `);
+NicoliveFailure {
+  "additionalMessage": "ERROR_CODE: simple description",
+  "errorCode": "ERROR_CODE",
+  "failureKind": undefined,
+  "method": "addFilters",
+  "reason": "400",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
 
   expect(UPDATE_FILTERS).toHaveBeenCalledTimes(0);
 });
@@ -191,14 +195,16 @@ test('deleteFilters/失敗', async () => {
   (instance as any).UPDATE_FILTERS = UPDATE_FILTERS;
 
   await expect(instance.deleteFilters([114514])).rejects.toMatchInlineSnapshot(`
-                    NicoliveFailure {
-                      "additionalMessage": "ERROR_CODE: simple description",
-                      "errorCode": "ERROR_CODE",
-                      "method": "deleteFilters",
-                      "reason": "400",
-                      "type": "http_error",
-                    }
-                `);
+NicoliveFailure {
+  "additionalMessage": "ERROR_CODE: simple description",
+  "errorCode": "ERROR_CODE",
+  "failureKind": undefined,
+  "method": "deleteFilters",
+  "reason": "400",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
 
   expect(UPDATE_FILTERS).toHaveBeenCalledTimes(0);
 });

--- a/app/services/nicolive-program/nicolive-program.test.ts
+++ b/app/services/nicolive-program/nicolive-program.test.ts
@@ -257,14 +257,16 @@ test('fetchProgramで結果が空ならエラー', async () => {
     .mockResolvedValue({ ok: true, value: [] });
 
   await expect(instance.fetchProgram()).rejects.toMatchInlineSnapshot(`
-                              NicoliveFailure {
-                                "additionalMessage": "",
-                                "errorCode": "",
-                                "method": "fetchProgram",
-                                "reason": "no_suitable_program",
-                                "type": "logic",
-                              }
-                        `);
+NicoliveFailure {
+  "additionalMessage": "",
+  "errorCode": "",
+  "failureKind": undefined,
+  "method": "fetchProgram",
+  "reason": "no_suitable_program",
+  "route": undefined,
+  "type": "logic",
+}
+`);
   expect(instance.client.fetchProgramSchedules).toHaveBeenCalledTimes(1);
   expect(setState).toHaveBeenCalledTimes(3);
   expect(setState.mock.calls).toMatchInlineSnapshot(`
@@ -414,14 +416,16 @@ test('fetchProgramで番組があったが取りに行ったらエラー', async
   });
 
   await expect(instance.fetchProgram()).rejects.toMatchInlineSnapshot(`
-                              NicoliveFailure {
-                                "additionalMessage": "",
-                                "errorCode": "",
-                                "method": "fetchProgram",
-                                "reason": "404",
-                                "type": "http_error",
-                              }
-                        `);
+NicoliveFailure {
+  "additionalMessage": "",
+  "errorCode": "",
+  "failureKind": undefined,
+  "method": "fetchProgram",
+  "reason": "404",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
   expect(instance.client.fetchProgramSchedules).toHaveBeenCalledTimes(1);
   expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
   expect(setState).toHaveBeenCalledTimes(2);
@@ -542,14 +546,16 @@ test('refreshProgram:失敗', async () => {
     .mockResolvedValue({ ok: false, value });
 
   await expect(instance.refreshProgram()).rejects.toMatchInlineSnapshot(`
-                              NicoliveFailure {
-                                "additionalMessage": "",
-                                "errorCode": "",
-                                "method": "fetchProgram",
-                                "reason": "500",
-                                "type": "http_error",
-                              }
-                        `);
+NicoliveFailure {
+  "additionalMessage": "",
+  "errorCode": "",
+  "failureKind": undefined,
+  "method": "fetchProgram",
+  "reason": "500",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
   expect(instance.client.fetchProgram).toHaveBeenCalledTimes(1);
   expect(instance.client.fetchProgram).toHaveBeenCalledWith('lv1');
   expect(setState).not.toHaveBeenCalled();
@@ -601,14 +607,16 @@ test('endProgram:失敗', async () => {
     .mockResolvedValue({ ok: false, value });
 
   await expect(instance.endProgram()).rejects.toMatchInlineSnapshot(`
-                              NicoliveFailure {
-                                "additionalMessage": "",
-                                "errorCode": "",
-                                "method": "endProgram",
-                                "reason": "500",
-                                "type": "http_error",
-                              }
-                        `);
+NicoliveFailure {
+  "additionalMessage": "",
+  "errorCode": "",
+  "failureKind": undefined,
+  "method": "endProgram",
+  "reason": "500",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
   expect(instance.client.endProgram).toHaveBeenCalledTimes(1);
   expect(instance.client.endProgram).toHaveBeenCalledWith('lv1');
   expect(setState).toHaveBeenCalledTimes(2);
@@ -668,14 +676,16 @@ test('extendProgram:失敗', async () => {
     .mockResolvedValue({ ok: false, value });
 
   await expect(instance.extendProgram()).rejects.toMatchInlineSnapshot(`
-                              NicoliveFailure {
-                                "additionalMessage": "",
-                                "errorCode": "",
-                                "method": "extendProgram",
-                                "reason": "500",
-                                "type": "http_error",
-                              }
-                        `);
+NicoliveFailure {
+  "additionalMessage": "",
+  "errorCode": "",
+  "failureKind": undefined,
+  "method": "extendProgram",
+  "reason": "500",
+  "route": undefined,
+  "type": "http_error",
+}
+`);
   expect(instance.client.extendProgram).toHaveBeenCalledTimes(1);
   expect(instance.client.extendProgram).toHaveBeenCalledWith('lv1');
   expect(setState).toHaveBeenCalledTimes(2);

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -343,18 +343,23 @@ describe('setupStreamSettings 失敗時の診断報告', () => {
     // NiconicoService.setupReportState をリセット（静的フィールド）
     (NiconicoService as any).setupReportState.clear();
 
-    // 7 回失敗させる
-    for (let i = 0; i < 7; i++) {
-      await instance.setupStreamSettings('lv12345');
+    // fake-timers で Date.now() を制御し、60秒窓ガードを回避して5件上限を確認する
+    const FakeTimers = require('@sinonjs/fake-timers');
+    const clock = FakeTimers.install({ now: 0, toFake: ['Date'] });
+    try {
+      for (let i = 0; i < 7; i++) {
+        // 各回で60秒以上進めて窓ガードをリセットし、件数上限(5件)だけを検証する
+        clock.tick(61_000);
+        await instance.setupStreamSettings('lv12345');
+      }
+    } finally {
+      clock.uninstall();
     }
 
-    // quota ガードにより最大 5 回しか送信されない
-    expect((SentryReport.message as jest.Mock).mock.calls.length).toBeLessThanOrEqual(5);
+    // quota ガードにより 5 回だけ送信される
+    expect((SentryReport.message as jest.Mock).mock.calls.length).toBe(5);
     // 5 回目の呼び出しに reportCapReached が付く
-    const lastCall = (SentryReport.message as jest.Mock).mock.calls[4];
-    if (lastCall) {
-      const opts = lastCall[3];
-      expect(opts.extra?.reportCapReached).toBe(true);
-    }
+    const fifthCall = (SentryReport.message as jest.Mock).mock.calls[4];
+    expect(fifthCall[3].extra?.reportCapReached).toBe(true);
   });
 });

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -37,9 +37,22 @@ jest.mock('services/i18n', () => ({
 jest.mock('@electron/remote', () => ({
   BrowserWindow: jest.fn(),
 }));
+jest.mock('@sentry/vue', () => ({
+  addBreadcrumb: jest.fn(),
+  withScope: jest.fn((_cb: (scope: any) => void) => _cb({ setLevel: jest.fn(), setTag: jest.fn(), setFingerprint: jest.fn(), setExtra: jest.fn(), setContext: jest.fn() })),
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+jest.mock('util/sentry-report', () => ({
+  SentryReport: {
+    message: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 beforeEach(() => {
   jest.resetModules();
+  jest.clearAllMocks();
 });
 
 function setupInstance() {
@@ -167,4 +180,181 @@ test('setupStreamSettingsで番組取得にリトライで成功する場合', a
   });
   expect(setSettings).toHaveBeenCalledTimes(1);
   expect(setSettings.mock.calls[0]).toMatchSnapshot();
+});
+
+describe('setupStreamSettings 失敗時の診断報告', () => {
+  function makeInjectee(overrides: { setSettings?: () => void } = {}) {
+    const getSettingsFormData = jest.fn().mockReturnValue([
+      {
+        nameSubCategory: 'Untitled',
+        parameters: [
+          { name: 'service', value: '' },
+          { name: 'server', value: '' },
+          { name: 'key', value: '' },
+        ],
+      },
+    ]);
+    const setSettings = overrides.setSettings ?? jest.fn();
+    return {
+      UserService: {},
+      SettingsService: { getSettingsFormData, setSettings },
+    };
+  }
+
+  test('fetchIngestInfo が network_error で失敗した場合、SentryReport.message が step=fetchIngestInfo で呼ばれる', async () => {
+    setup({ injectee: makeInjectee() });
+    const { NiconicoService } = require('./niconico');
+    const { SentryReport } = require('util/sentry-report');
+    const instance = NiconicoService.instance() as NiconicoServiceType;
+
+    // fetchIngestInfo を network_error で失敗させる
+    instance.client.fetchIngestInfo = jest.fn().mockResolvedValue({
+      ok: false,
+      value: new Error('fetch failed'),
+      diag: { route: 'main', failureKind: 'network_error' },
+    });
+    instance.client.fetchMaxQuality = jest.fn().mockResolvedValue({ bitrate: 192, height: 288, fps: 30 });
+
+    const result = await instance.setupStreamSettings('lv12345');
+
+    // emptyStreamingSetting (key='') が返る
+    expect(result.key).toBe('');
+    // lastSetupFailure に失敗が保持される
+    expect(instance.lastSetupFailure).not.toBeNull();
+    expect(instance.lastSetupFailure?.method).toBe('fetchIngestInfo');
+    expect(instance.lastSetupFailure?.failureKind).toBe('network_error');
+    expect(instance.lastSetupFailure?.route).toBe('main');
+
+    // SentryReport.message が呼ばれ、step と failureKind が tags に含まれる
+    expect(SentryReport.message).toHaveBeenCalled();
+    const [, , message, opts] = (SentryReport.message as jest.Mock).mock.calls[0];
+    expect(message).toContain('fetchIngestInfo');
+    expect(message).toContain('network_error');
+    expect(opts.tags['stream.setup.step']).toBe('fetchIngestInfo');
+    expect(opts.tags['stream.setup.failureKind']).toBe('network_error');
+    expect(opts.tags['stream.setup.route']).toBe('main');
+    expect(opts.tags['diagnostic']).toBe('stream-setup');
+    expect(opts.fingerprint).toContain('fetchIngestInfo');
+    expect(opts.fingerprint).toContain('network_error');
+  });
+
+  test('fetchIngestInfo が http_error(503) で失敗した場合、fingerprint に httpStatus が含まれる', async () => {
+    setup({ injectee: makeInjectee() });
+    const { NiconicoService } = require('./niconico');
+    const { SentryReport } = require('util/sentry-report');
+    const instance = NiconicoService.instance() as NiconicoServiceType;
+
+    instance.client.fetchIngestInfo = jest.fn().mockResolvedValue({
+      ok: false,
+      value: { meta: { status: 503, errorCode: 'SERVER_ERROR', errorMessage: 'server error' } },
+      diag: { route: 'main', httpStatus: 503, failureKind: 'http_error' },
+    });
+    instance.client.fetchMaxQuality = jest.fn().mockResolvedValue({ bitrate: 192, height: 288, fps: 30 });
+
+    await instance.setupStreamSettings('lv12345');
+
+    expect(SentryReport.message).toHaveBeenCalled();
+    const [, , , opts] = (SentryReport.message as jest.Mock).mock.calls[0];
+    expect(opts.tags['stream.setup.step']).toBe('fetchIngestInfo');
+    expect(opts.tags['stream.setup.failureKind']).toBe('http_error');
+    expect(opts.tags['stream.setup.httpStatus']).toBe('503');
+    // fingerprint が httpStatus で分割されている
+    expect(opts.fingerprint).toContain('503');
+  });
+
+  test('setSettings が失敗した場合、step=setSettings の fingerprint で報告される', async () => {
+    setup({
+      injectee: makeInjectee({
+        setSettings: jest.fn().mockImplementation(() => { throw new Error('Failed to save settings'); }),
+      }),
+    });
+    const { NiconicoService } = require('./niconico');
+    const { SentryReport } = require('util/sentry-report');
+    const instance = NiconicoService.instance() as NiconicoServiceType;
+
+    instance.client.fetchIngestInfo = jest.fn().mockResolvedValue({
+      ok: true,
+      value: {
+        rtmp: { tcUrl: 'url1', streamName: 'key1', appName: 'app1' },
+        rtmps: { tcUrl: 'url2', streamName: 'key2', appName: 'app2' },
+      },
+    });
+    instance.client.fetchMaxQuality = jest.fn().mockResolvedValue({ bitrate: 192, height: 288, fps: 30 });
+
+    const result = await instance.setupStreamSettings('lv12345');
+
+    expect(result.key).toBe('');
+    expect(instance.lastSetupFailure?.method).toBe('setSettings');
+
+    expect(SentryReport.message).toHaveBeenCalled();
+    const [, , message, opts] = (SentryReport.message as jest.Mock).mock.calls[0];
+    expect(message).toContain('setSettings');
+    expect(opts.tags['stream.setup.step']).toBe('setSettings');
+    expect(opts.fingerprint).toContain('setSettings');
+  });
+
+  test('2回目失敗でのみSentryReport.messageが呼ばれ、1回目(リトライ前)は呼ばれない', async () => {
+    const getSettingsFormData = jest.fn().mockReturnValue([
+      {
+        nameSubCategory: 'Untitled',
+        parameters: [
+          { name: 'service', value: '' },
+          { name: 'server', value: '' },
+          { name: 'key', value: '' },
+        ],
+      },
+    ]);
+    setup({ injectee: { UserService: {}, SettingsService: { getSettingsFormData, setSettings: jest.fn() } } });
+
+    const { NiconicoService } = require('./niconico');
+    const { SentryReport } = require('util/sentry-report');
+    const instance = NiconicoService.instance() as NiconicoServiceType;
+
+    let callCount = 0;
+    instance.client.fetchIngestInfo = jest.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve({ ok: false, value: new Error('fail'), diag: { route: 'main', failureKind: 'network_error' } });
+    });
+    instance.client.fetchMaxQuality = jest.fn().mockResolvedValue({ bitrate: 192, height: 288, fps: 30 });
+
+    await instance.setupStreamSettings('lv12345');
+
+    // fetchIngestInfo が 2 回呼ばれている（リトライあり）
+    expect(callCount).toBe(2);
+    // SentryReport.message は 1 回だけ（2回目失敗時のみ）
+    expect((SentryReport.message as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  test('同一ステップで SETUP_REPORT_MAX_PER_KEY(5) 回を超えたときはSentryReport.messageが抑制される', async () => {
+    const getSettingsFormData = jest.fn().mockReturnValue([
+      { nameSubCategory: 'Untitled', parameters: [{ name: 'service', value: '' }, { name: 'server', value: '' }, { name: 'key', value: '' }] },
+    ]);
+    setup({ injectee: { UserService: {}, SettingsService: { getSettingsFormData, setSettings: jest.fn() } } });
+
+    const { NiconicoService } = require('./niconico');
+    const { SentryReport } = require('util/sentry-report');
+    const instance = NiconicoService.instance() as NiconicoServiceType;
+
+    instance.client.fetchIngestInfo = jest.fn().mockResolvedValue({
+      ok: false, value: new Error('fail'), diag: { route: 'renderer', failureKind: 'network_error' },
+    });
+    instance.client.fetchMaxQuality = jest.fn().mockResolvedValue({ bitrate: 192, height: 288, fps: 30 });
+
+    // NiconicoService.setupReportState をリセット（静的フィールド）
+    (NiconicoService as any).setupReportState.clear();
+
+    // 7 回失敗させる
+    for (let i = 0; i < 7; i++) {
+      await instance.setupStreamSettings('lv12345');
+    }
+
+    // quota ガードにより最大 5 回しか送信されない
+    expect((SentryReport.message as jest.Mock).mock.calls.length).toBeLessThanOrEqual(5);
+    // 5 回目の呼び出しに reportCapReached が付く
+    const lastCall = (SentryReport.message as jest.Mock).mock.calls[4];
+    if (lastCall) {
+      const opts = lastCall[3];
+      expect(opts.extra?.reportCapReached).toBe(true);
+    }
+  });
 });

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -5,6 +5,7 @@ import { Service } from 'services/core/service';
 import { getCookieDomain, transformUrl } from 'services/dev-hosts';
 import { HostsService } from 'services/hosts';
 import { isOk, NicoliveClient } from 'services/nicolive-program/NicoliveClient';
+import { NicoliveFailure } from 'services/nicolive-program/NicoliveFailure';
 import { SettingsService } from 'services/settings';
 import { EStreamingState, StreamingService } from 'services/streaming';
 import { UserService } from 'services/user';
@@ -13,6 +14,7 @@ import { FakeUserAuth, isFakeMode } from 'util/fakeMode';
 import { fetchViaMainProcess } from 'util/fetchViaMainProcess';
 import { RequestError } from 'util/RequestError';
 import { authorizedHeaders, handleErrors } from 'util/requests';
+import { SentryReport } from 'util/sentry-report';
 import { sleep } from 'util/sleep';
 
 import { IPlatformService, IStreamingSetting } from '.';
@@ -189,19 +191,37 @@ export class NiconicoService extends Service implements IPlatformService {
     });
   }
 
+  /** setupStreamSettings の Sentry 報告を抑制するための 2 段 quota ガード状態 */
+  private static readonly SETUP_REPORT_WINDOW_MS = 60_000;
+  private static readonly SETUP_REPORT_MAX_PER_KEY = 5;
+  private static readonly setupReportState = new Map<string, { count: number; last: number | null }>();
+
   /**
    * 有効な番組が選択されていれば、stream URL/key を設定し、その値を返す。
    * そうでなければ、ダイアログを出して選択を促すか、配信していない旨返す。
    * @param programId ユーザーが選択した番組ID(省略は未選択)
+   * @returns 成功時は IStreamingSetting。失敗時は空 setting を返し、failure を lastSetupFailure に保持する。
    */
+  lastSetupFailure: NicoliveFailure | null = null;
+
   async setupStreamSettings(programId: string): Promise<IStreamingSetting> {
+    this.lastSetupFailure = null;
     try {
       // 直接returnしてしまうとcatchできないので一度awaitで受ける
       const result = await this._setupStreamSettings(programId);
       return result;
     } catch (e) {
-      console.error('NiconicoService.setupStreamSettings(1)', e.toString());
       // APIのレスポンスに番組状態が反映されるのが遅れる場合があるので、少し待ってリトライ
+      // 1回目失敗はbreadcrumbのみ(issue化しない)
+      Sentry.addBreadcrumb({
+        category: 'streaming',
+        message: 'setupStreamSettings(1) failed',
+        data: {
+          programId,
+          step: e instanceof NicoliveFailure ? e.method : 'unknown',
+          error: e instanceof Error ? e.message : String(e),
+        },
+      });
       await sleep(3000);
     }
 
@@ -209,29 +229,108 @@ export class NiconicoService extends Service implements IPlatformService {
       const result = await this._setupStreamSettings(programId);
       return result;
     } catch (e) {
-      // リトライは1回だけ
-      console.error('NiconicoService.setupStreamSettings(2)', e.toString());
+      // リトライは1回だけ — 失敗種別を構造化してSentryに報告する
+      const failure = e instanceof NicoliveFailure
+        ? e
+        : new NicoliveFailure('network_error', 'unknown', 'unknown');
+      this.lastSetupFailure = failure;
+
+      const step = failure.method;
+      const failureKind = failure.failureKind ?? failure.reason;
+      const httpStatus = failure.type === 'http_error' ? failure.reason : '';
+      const errorCode = failure.errorCode ?? '';
+      const route = failure.route ?? 'renderer';
+
       Sentry.addBreadcrumb({
         category: 'streaming',
-        message: 'setupStreamSettings failed',
+        message: 'setupStreamSettings(2) failed',
         data: {
           programId,
-          error: e instanceof Error ? e.message : String(e),
-          isNetworkError: e instanceof TypeError,
+          step,
+          failureKind,
+          route,
+          httpStatus,
+          errorCode,
         },
       });
+
+      // 2段quotaガード: セッション内最大5件、60秒に1件
+      const quotaKey = `setupStreamSettings:${step}:${failureKind}`;
+      const state = NiconicoService.setupReportState.get(quotaKey) ?? { count: 0, last: null };
+      const now = Date.now();
+      if (
+        state.count < NiconicoService.SETUP_REPORT_MAX_PER_KEY
+        && (state.last === null || now - state.last >= NiconicoService.SETUP_REPORT_WINDOW_MS)
+      ) {
+        state.count += 1;
+        state.last = now;
+        NiconicoService.setupReportState.set(quotaKey, state);
+        const capReached = state.count >= NiconicoService.SETUP_REPORT_MAX_PER_KEY;
+
+        SentryReport.message(
+          'NiconicoService',
+          'setupStreamSettings',
+          // NOISE文字列を含まない固定書式(beforeSendに捕捉されないよう network_error にアンダースコアを使用)
+          `setupStreamSettings failed at ${step} (${failureKind})`,
+          {
+            level: 'error',
+            fingerprint: ['NiconicoService', 'setupStreamSettings', step, failureKind, httpStatus],
+            tags: {
+              diagnostic: 'stream-setup',
+              'stream.setup.step': step,
+              'stream.setup.failureKind': failureKind,
+              'stream.setup.route': route,
+              ...(httpStatus ? { 'stream.setup.httpStatus': httpStatus } : {}),
+              ...(errorCode ? { 'stream.setup.errorCode': errorCode } : {}),
+            },
+            extra: {
+              programId,
+              errorMessage: e instanceof Error ? e.message : String(e),
+              additionalMessage: failure.additionalMessage,
+              reportCount: state.count,
+              ...(capReached ? { reportCapReached: true } : {}),
+            },
+          },
+        );
+      }
+
       return NiconicoService.emptyStreamingSetting();
     }
   }
 
+  /**
+   * ストリーム設定を試みる。失敗した場合は NicoliveFailure を throw する。
+   * ステップを特定するために fetchIngestInfo, fetchMaxQuality, setSettings を個別に扱う。
+   */
   private async _setupStreamSettings(programId: string): Promise<IStreamingSetting> {
-    const [stream, quality] = await Promise.all([
+    // Promise.allSettled で並列取得し、失敗したステップを特定する
+    const [streamResult, qualityResult] = await Promise.allSettled([
       this.client.fetchIngestInfo(programId),
       this.client.fetchMaxQuality(programId),
     ]);
-    if (!isOk(stream)) {
-      return Promise.reject(stream.value);
+
+    // ingest 情報の取得失敗はリトライ対象かつ致命的
+    if (streamResult.status === 'rejected') {
+      const err = streamResult.reason;
+      throw err instanceof NicoliveFailure
+        ? err
+        : new NicoliveFailure('network_error', 'fetchIngestInfo', 'network_error');
     }
+    const stream = streamResult.value;
+    if (!isOk(stream)) {
+      throw NicoliveFailure.fromClientError('fetchIngestInfo', stream);
+    }
+
+    // quality の取得失敗は致命的でない(fetchMaxQuality は内部でfallback値を返す)
+    // rejected になることは基本ないが、念のため breadcrumb に残す
+    if (qualityResult.status === 'rejected') {
+      Sentry.addBreadcrumb({
+        category: 'streaming',
+        message: 'fetchMaxQuality rejected (non-fatal)',
+        data: { programId, error: String(qualityResult.reason) },
+      });
+    }
+    const quality = qualityResult.status === 'fulfilled' ? qualityResult.value : undefined;
 
     const url = stream.value.rtmp.tcUrl;
     const key = stream.value.rtmp.streamName;
@@ -253,7 +352,18 @@ export class NiconicoService extends Service implements IPlatformService {
         }
       });
     });
-    this.settingsService.setSettings('Stream', settings);
+
+    try {
+      this.settingsService.setSettings('Stream', settings);
+    } catch (e) {
+      // setSettings 失敗は NicoliveFailure でラップしてステップを明示する
+      throw new NicoliveFailure(
+        'network_error',
+        'setSettings',
+        'set_settings_failed',
+        e instanceof Error ? e.message : String(e),
+      );
+    }
 
     // 有効な番組が選択されているので stream keyを返す
     return NiconicoService.createStreamingSetting(url, key, quality);

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -265,7 +265,7 @@ export class StreamingService
             data: {
               programId,
               failureStep: failure?.method ?? 'unknown',
-              failureKind: failure?.failureKind ?? 'unknown',
+              failureKind: failure?.failureKind ?? failure?.reason ?? 'unknown',
               failureRoute: failure?.route ?? 'unknown',
             },
           });

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -27,6 +27,7 @@ import { RtvcStateService } from '../../services/rtvcStateService';
 import { CustomcastUsageService } from '../custom-cast-usage';
 import { NVoiceCharacterUsageService } from '../nvoice-character-usage';
 import { IStreamingSetting } from '../platforms';
+import { NiconicoService } from '../platforms/niconico';
 import { SoundDetectorService } from '../sound-detector/sound-detector';
 import { SubStreamService } from '../substream/SubStreamService';
 
@@ -254,15 +255,40 @@ export class StreamingService
         const setting = await this.userService.updateStreamSettings(programId);
         const streamKey = setting.key;
         if (streamKey === '') {
+          const failure = this.userService.platform.type === 'niconico'
+            ? NiconicoService.instance().lastSetupFailure
+            : null;
+
           Sentry.addBreadcrumb({
             category: 'streaming',
             message: 'streamKey is empty',
-            data: { programId },
+            data: {
+              programId,
+              failureStep: failure?.method ?? 'unknown',
+              failureKind: failure?.failureKind ?? 'unknown',
+              failureRoute: failure?.route ?? 'unknown',
+            },
           });
+
+          // 失敗種別に応じてメッセージを出し分ける
+          let message: string;
+          if (!failure || (failure.type === 'network_error' && failure.reason === 'network_error')) {
+            message = $t('streaming.broadcastStatusFetchingError.networkError');
+          } else if (failure.type === 'network_error' && failure.reason === 'set_settings_failed') {
+            message = $t('streaming.broadcastStatusFetchingError.settingsError');
+          } else if (failure.type === 'http_error') {
+            const statusCode = failure.reason;
+            message = $t('streaming.broadcastStatusFetchingError.serverError', { statusCode });
+          } else if (failure.type === 'logic' && failure.reason === 'not_logged_in') {
+            message = $t('streaming.invalidSessionError');
+          } else {
+            message = $t('streaming.broadcastStatusFetchingError.default');
+          }
+
           await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
             title: $t('streaming.streamingError'),
             type: 'warning',
-            message: $t('streaming.broadcastStatusFetchingError.default'),
+            message,
             buttons: ['Close'],
           });
           return;

--- a/main.js
+++ b/main.js
@@ -1319,10 +1319,12 @@ function initialize(crashHandler) {
       } catch (e) {
         // cause チェーンとURLを文字列化してrendererに伝搬する
         // (Electron の IPC シリアライズでは cause が失われるため)
+        // [MAIN_FETCH_FAIL code=...] 接頭辞は renderer 側 wrapFetchError が機械可読に経路を判別するために使用する
+        const causeCode = e.cause?.code ?? '';
         const cause = e.cause
           ? `${e.cause.name}: ${e.cause.message} (code: ${e.cause.code})`
           : undefined;
-        throw new Error(`${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`);
+        throw new Error(`[MAIN_FETCH_FAIL code=${causeCode}] ${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`);
       }
     },
   );


### PR DESCRIPTION
## このpull requestが解決する内容

ニコニコ生放送の配信開始ボタンを押すと必ずエラーが出るというユーザー報告を受け、原因調査と診断強化を行った。

### 調査で判明した問題

1. **通信経路の差が原因の最有力候補**: `fetchIngestInfo`（v4 API）は `Origin` ヘッダー必須のため main process 経由 fetch を使う。`deleteFilters` 等 v2 API は renderer の通常 fetch を使う。「ingest だけ失敗・他は成功」という報告はこの経路差と整合する。

2. **Sentry で原因を区別できていなかった**: `setupStreamSettings(2)` という固定文字列が issue タイトルになり、ingest 失敗・maxQuality 失敗・setSettings 失敗が全部 1 つの issue `N-AIR-APP-AGY`（5795 events / 138 users）に集約。実際のサンプルイベントを確認すると `Error: Failed to save settings`（ingest は成功しており後続の設定保存が失敗）が多数混在しており、根本原因が異なるものが区別できていなかった。

3. **main 経由 fetch の失敗が Sentry に不可視**: `fetchViaMainProcess` の失敗は renderer の `@sentry` fetch instrumentation を通らず breadcrumb にも出なかった。

4. **ユーザーが対処できないエラー表示**: 失敗の原因に関わらず常に同じ汎用メッセージが表示されていた。

## 変更内容

### Sentry 診断強化
- `NicoliveClient.FailedResult` に `diag?` フィールド（route/failureKind/httpStatus）を追加（後方互換）
- `requestAPI` が経路（main/renderer）を `wrapResult`/`wrapFetchError` に伝達するよう変更
- `main.js` の fetch handler が `[MAIN_FETCH_FAIL code=ECODE]` 接頭辞を付けて throw し、renderer 側で機械可読に経路を判別できるように
- `NicoliveFailure.fromClientError` が `diag` を取り込み `json_parse` を `network_error` から分離
- `setupStreamSettings` の失敗報告を `SentryReport.message` + 2段 quota ガードに置換し、fingerprint を `[step, failureKind, httpStatus]` で分割して issue を種別ごとに分散
- `app.ts` の `beforeSend` NOISE フィルタに `diagnostic` タグ allowlist を追加（診断イベントが誤って捨てられないよう）

### ユーザー向けエラーメッセージの細分化
- `setupStreamSettings` が失敗種別を `lastSetupFailure` に保持
- `streaming.ts` のニコニコ生放送用 `streamKey === ''` 分岐で種別に応じてメッセージを出し分ける
  - ネットワーク障害 → 「インターネット接続を確認して、もう一度お試しください。」
  - サーバーエラー(4xx/5xx) → 「ニコニコ側で一時的な問題が発生しています（コード: {statusCode}）。時間をおいてお試しください。」
  - 設定保存失敗 → 「N Air を再起動してお試しください。」
- ja-JP / en-US の i18n キーを追加

## テスト

- `niconico.test.ts` に新規テストを5件追加
  - ingest 失敗時の SentryReport.message 呼び出しとタグ・fingerprint 検証
  - http_error+503 のステータス別 fingerprint 分割検証
  - setSettings 失敗が別ステップとして報告されることの検証
  - 1回目失敗では issue 化しないこと（breadcrumb のみ）の検証
  - quota ガード（5件上限）の検証
- `NicoliveClient.test.ts` の既存テストを `toMatchObject` に変更し `diag` フィールドの検証を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
