### PR TITLE
修正: 詳細音声設定でオーディオトラックを複数選択できない問題を修正

### DIFF
--- a/app/components/obs/inputs/ObsBitMaskInput.vue.ts
+++ b/app/components/obs/inputs/ObsBitMaskInput.vue.ts
@@ -1,5 +1,5 @@
 import { default as Utils, EBit } from 'services/utils';
-import { defineComponent, PropType } from 'vue';
+import { computed, defineComponent, PropType } from 'vue';
 
 import { IObsBitmaskInput, TObsType } from './ObsInput';
 
@@ -10,26 +10,20 @@ const ObsBitMaskInput = defineComponent({
     category: { type: String },
     subCategory: { type: String },
   },
+  setup(props) {
+    const flags = computed(() =>
+      Utils.numberToBinnaryArray(props.value.value, props.value.size).reverse(),
+    );
+    return { flags };
+  },
   data() {
     return {
       testingAnchor: `Form/BitMask/${this.value.name}`,
-      flags: [] as EBit[],
     };
-  },
-  watch: {
-    value() {
-      this.updateFlags();
-    },
-  },
-  mounted() {
-    this.updateFlags();
   },
   methods: {
     emitInput(eventData: IObsBitmaskInput) {
       this.$emit('input', eventData);
-    },
-    updateFlags() {
-      this.flags = Utils.numberToBinnaryArray(this.value.value, this.value.size).reverse();
     },
     onCheckboxChange(event: Event) {
       const el = event.target as HTMLInputElement;
@@ -37,8 +31,9 @@ const ObsBitMaskInput = defineComponent({
       this.onChangeHandler(index, el.checked);
     },
     onChangeHandler(index: number, state: boolean) {
-      this.flags[index] = Number(state);
-      const value = Utils.binnaryArrayToNumber(this.flags.reverse());
+      const newFlags = this.flags.slice() as EBit[];
+      newFlags[index] = Number(state) as EBit;
+      const value = Utils.binnaryArrayToNumber(newFlags.slice().reverse());
       this.emitInput({ ...this.value, value });
     },
   },

--- a/app/components/settings/AdvancedAudio.vue.ts
+++ b/app/components/settings/AdvancedAudio.vue.ts
@@ -2,20 +2,20 @@ import { propertyComponentForType } from 'components/obs/inputs/Components';
 import { TObsValue } from 'components/obs/inputs/ObsInput';
 import ModalLayout from 'components/shared/ModalLayout.vue';
 import { AudioService, IAudioSourceApi } from 'services/audio';
-import { defineComponent } from 'vue';
+import { defineComponent, onUnmounted, ref } from 'vue';
 
 export default defineComponent({
   name: 'AdvancedAudio',
   components: { ModalLayout },
-  data() {
-    return {
-      propertyComponentForType,
-    };
-  },
-  computed: {
-    audioSources() {
-      return AudioService.instance().getSourcesForCurrentScene();
-    },
+  setup() {
+    const audioSources = ref(AudioService.instance().getSourcesForCurrentScene());
+
+    const subscription = AudioService.instance().audioSourceUpdated.subscribe(() => {
+      audioSources.value = AudioService.instance().getSourcesForCurrentScene();
+    });
+    onUnmounted(() => subscription.unsubscribe());
+
+    return { audioSources, propertyComponentForType };
   },
   methods: {
     sourceName(audioSource: IAudioSourceApi): string {

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -341,7 +341,11 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
       }
     });
 
-    this.UPDATE_AUDIO_SOURCE(sourceId, newPatch);
+    // undefined 値を除去してから state を更新（undefined で上書きしないため）
+    const cleanPatch = Object.fromEntries(
+      Object.entries(newPatch).filter(([, v]) => v !== undefined),
+    ) as Partial<IAudioSource>;
+    this.UPDATE_AUDIO_SOURCE(sourceId, cleanPatch);
     this.audioSourceUpdated.next(this.state.audioSources[sourceId]);
   }
 


### PR DESCRIPTION
## 概要

詳細音声設定（AdvancedAudio）でオーディオトラックのチェックボックスを操作すると、チェックした1つ以外が全て外れてしまうバグを修正。

## 原因

3つのバグが重なっていた。

### 1. `ObsBitMaskInput`: `flags.reverse()` の破壊的変更

```typescript
// 修正前: this.flags を直接 reverse() → 元の配列が破壊される
const value = Utils.binnaryArrayToNumber(this.flags.reverse());

// 修正後: コピーしてから reverse()
const value = Utils.binnaryArrayToNumber(newFlags.slice().reverse());
```

### 2. `ObsBitMaskInput`: `flags` が props 変更に追従しない

`flags` を `data` で持ち `watch` でリセットしていたため、親が再レンダリングするたびに内部状態がリセットされていた。`computed` に変更することで props から常に正しい値を参照するようにした。

### 3. `AudioService.setSettings`: `undefined` で state を上書き

`UPDATE_AUDIO_SOURCE` に `undefined` 値を含む patch を渡すと `Object.assign` で state の値が `undefined` に上書きされていた。`undefined` を除去してから渡すよう修正。

```typescript
// 修正前
this.UPDATE_AUDIO_SOURCE(sourceId, newPatch);

// 修正後
const cleanPatch = Object.fromEntries(
  Object.entries(newPatch).filter(([, v]) => v !== undefined),
) as Partial<IAudioSource>;
this.UPDATE_AUDIO_SOURCE(sourceId, cleanPatch);
```

また `AdvancedAudio` の `audioSources` computed が RxJS の `audioSourceUpdated` に反応しない問題も修正。`setup()` 内で subscribe して `ref` を直接更新するよう変更した。

## 変更ファイル

- `app/components/obs/inputs/ObsBitMaskInput.vue.ts` — `flags` を computed 化、`reverse()` 副作用修正
- `app/components/settings/AdvancedAudio.vue.ts` — `setup()` で `audioSourceUpdated` を subscribe
- `app/services/audio/audio.ts` — `undefined` 値を除去してから state 更新
