### PR TITLE
修正: 高度な音声設定で音声トラックを複数選択できない問題を修正

### DIFF
--- a/app/components/obs/inputs/ObsBitMaskInput.vue.ts
+++ b/app/components/obs/inputs/ObsBitMaskInput.vue.ts
@@ -5,6 +5,7 @@ import { IObsBitmaskInput, TObsType } from './ObsInput';
 
 const ObsBitMaskInput = defineComponent({
   name: 'ObsBitMaskInput',
+  emits: ['input'],
   props: {
     value: { type: Object as PropType<IObsBitmaskInput>, required: true as const },
     category: { type: String },
@@ -38,7 +39,7 @@ const ObsBitMaskInput = defineComponent({
     },
     onChangeHandler(index: number, state: boolean) {
       this.flags[index] = Number(state);
-      const value = Utils.binnaryArrayToNumber(this.flags.reverse());
+      const value = Utils.binnaryArrayToNumber([...this.flags].reverse());
       this.emitInput({ ...this.value, value });
     },
   },


### PR DESCRIPTION
## このpull requestが解決する内容

高度な音声設定画面で、各音声デバイスの音声トラックを複数選択できない問題を修正します。

チェックボックスを操作すると、クリックしたトラックだけがonになり、他が全てoffになっていました（チェックを入れる・外すどちらの操作でも発生）。

## 原因

Vue 3 では `emits` を宣言していないイベント名はネイティブ DOM イベントのフォールスルーとして扱われます。`ObsBitMaskInput` に `emits: ['input']` がなかったため、内部チェックボックスのネイティブ `input` イベント（`change` より先に発火）が root `<div>` までバブリングし、`AdvancedAudio` の `@input` ハンドラが `$event.value = undefined`（`InputEvent` に `.value` プロパティなし）で呼ばれていました。

これにより `setSettings({ audioMixers: undefined })` が実行され、Vuex state の `audioMixers` が壊れて `updateFlags()` が全0のフラグ配列を生成し、次のクリックで「クリックしたビットだけ」が立つ排他的な挙動になっていました。

Vue 2 では `@input` はコンポーネントの Vue イベントのみ購読し、ネイティブ DOM イベントには `.native` 修飾子が必要だったため発生していませんでした。

## バグ導入バージョン

#1296 (Vue 3 移行) が原因で、それを取り込んだ **`v1.1.20260617-1`** が最初のバグ発生バージョンです。`v1.1.20260603-1` は Vue 2 版のため正常動作していました。

## 変更内容

`app/components/obs/inputs/ObsBitMaskInput.vue.ts`
- `emits: ['input']` を追加（根本修正）
- `onChangeHandler` 内の `this.flags.reverse()` → `[...this.flags].reverse()` に変更（副次修正: 非破壊化）

## テスト

- [x] 高度な音声設定を開き、任意のデバイスで音声トラックを複数選択できることを確認
- [x] 既存のチェックを操作しても他のトラックのチェックが外れないことを確認
- [x] 設定を閉じて再度開き、選択状態が正しく保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
