### PR TITLE
修正: ソースのプロパティでパスを手入力しても反映されない問題を修正

### DIFF
--- a/app/components/obs/inputs/ObsButtonInput.vue.ts
+++ b/app/components/obs/inputs/ObsButtonInput.vue.ts
@@ -5,6 +5,7 @@ import { IObsButtonInputValue, TObsType } from './ObsInput';
 
 const ObsButtonInput = defineComponent({
   name: 'ObsButtonInput',
+  emits: ['input'],
   props: {
     value: { type: Object as PropType<IObsButtonInputValue>, required: true as const },
     category: { type: String },

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -41,6 +41,7 @@ interface IColor {
 
 const ObsColorInput = defineComponent({
   name: 'ObsColorInput',
+  emits: ['input'],
   components: { ColorPicker },
   props: {
     value: { type: Object as PropType<IObsInput<number>>, required: true as const },

--- a/app/components/obs/inputs/ObsEditableListInput.vue.ts
+++ b/app/components/obs/inputs/ObsEditableListInput.vue.ts
@@ -14,6 +14,7 @@ interface ISelectorSortEventData {
 
 const ObsEditableListProperty = defineComponent({
   name: 'ObsEditableListProperty',
+  emits: ['input'],
   components: { Selector },
   props: {
     value: { type: Object as PropType<IObsEditableListInputValue>, required: true as const },

--- a/app/components/obs/inputs/ObsFontInput.vue.ts
+++ b/app/components/obs/inputs/ObsFontInput.vue.ts
@@ -6,6 +6,7 @@ import ObsSystemFontSelector from './ObsSystemFontSelector.vue';
 
 const ObsFontInput = defineComponent({
   name: 'ObsFontInput',
+  emits: ['input'],
   components: { GoogleFontSelector, SystemFontSelector: ObsSystemFontSelector },
   props: {
     value: { type: Object as PropType<IObsInput<IObsFont>>, required: true as const },

--- a/app/components/obs/inputs/ObsFontSizeSelector.vue.ts
+++ b/app/components/obs/inputs/ObsFontSizeSelector.vue.ts
@@ -3,6 +3,7 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'ObsFontSizeSelector',
+  emits: ['input'],
   components: { Dropdown },
   props: {
     value: { type: Number },

--- a/app/components/obs/inputs/ObsGoogleFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsGoogleFontSelector.vue.ts
@@ -9,6 +9,7 @@ import { IGoogleFont } from './ObsInput';
 
 export default defineComponent({
   name: 'GoogleFontSelector',
+  emits: ['input'],
   components: { Dropdown, FontSizeSelector: ObsFontSizeSelector },
   props: {
     value: { type: Object as PropType<IGoogleFont>, required: true as const },

--- a/app/components/obs/inputs/ObsPathInput.vue.ts
+++ b/app/components/obs/inputs/ObsPathInput.vue.ts
@@ -7,6 +7,7 @@ import OpenDialogOptions = Electron.OpenDialogOptions;
 
 const ObsPathInput = defineComponent({
   name: 'ObsPathInput',
+  emits: ['input'],
   props: {
     value: { type: Object as PropType<IObsPathInputValue>, required: true as const },
     category: { type: String },

--- a/app/components/obs/inputs/ObsResolutionInput.vue.ts
+++ b/app/components/obs/inputs/ObsResolutionInput.vue.ts
@@ -5,6 +5,7 @@ import { IObsListInput, IObsListOption, TObsType, TObsValue } from './ObsInput';
 
 const ObsResolutionInput = defineComponent({
   name: 'ObsResolutionInput',
+  emits: ['input'],
   components: { Dropdown },
   props: {
     value: { type: Object as PropType<IObsListInput<TObsValue>>, required: true as const },

--- a/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
@@ -26,6 +26,7 @@ interface IFontSelect extends HTMLElement {
 
 export default defineComponent({
   name: 'ObsSystemFontSelector',
+  emits: ['input'],
   components: { Dropdown, FontSizeSelector: ObsFontSizeSelector },
   props: {
     value: { type: Object as PropType<IObsInput<IObsFont>>, required: true as const },


### PR DESCRIPTION
## このpull requestが解決する内容

ソースのプロパティ画面でパスを手入力しても反映されない問題、およびその他の入力コンポーネントで設定値が正しく送られない潜在的な問題を修正します。

## 原因

Vue 3 では `defineComponent` で `emits` を宣言していないイベント名はネイティブ DOM イベントのフォールスルーとして扱われます。`obs/inputs` 配下の複数コンポーネントで `emits: ['input']` が漏れており、内部の標準 HTML 要素（`input[type=text]` / `input[type=checkbox]` 等）が発火するネイティブ `input` イベントがバブリングして親の `@input` ハンドラを誤起動し、`$event` に DOM Event オブジェクトが渡って設定値が壊れるバグが発生していました。

PR #1340 で `ObsBitMaskInput` の同種バグを修正した際に、他コンポーネントにも同様の漏れがあることが判明しました（起因は #1296 の Vue 3 移行）。

### ObsPathInput の症状（実害確認済み）

1. パス入力欄に文字を打つと、毎キー native `input` イベントが発火
2. `GenericFormItem` の `@input` を誤起動し `InputEvent` が `setPropertiesFormData` に渡る
3. `sourceUpdated` → `refresh()` で入力欄が OBS の値に書き戻される → **「手入力しても変化しない」**

## バグ導入バージョン

#1296 (Vue 3 移行) が原因で、それを取り込んだ **`v1.1.20260617-1`** が最初のバグ発生バージョンです。`v1.1.20260603-1` は Vue 2 版のため正常動作していました。

## 変更内容

`obs/inputs` 配下の `emits: ['input']` 漏れコンポーネントを一括修正（各ファイル1行追加）:

| ファイル | 実害 |
|---|---|
| `ObsPathInput.vue.ts` | あり（パス手入力が反映されない） |
| `ObsFontInput.vue.ts` | 低（`setFontType` は emit しないため顕在化しにくい） |
| `ObsColorInput.vue.ts` | 低（input が readonly のため） |
| `ObsButtonInput.vue.ts` | 予防 |
| `ObsEditableListInput.vue.ts` | 予防 |
| `ObsResolutionInput.vue.ts` | 予防 |
| `ObsFontSizeSelector.vue.ts` | 予防 |
| `ObsSystemFontSelector.vue.ts` | 予防 |
| `ObsGoogleFontSelector.vue.ts` | 予防 |

## テスト

- [x] 画像ソース等のプロパティ画面でパス欄を手入力し、値が正しく反映されることを確認
- [x] フォント設定（「Googleフォントを使う」チェックボックス、フォント選択）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
