### PR TITLE
開発: サーバーが非JSON応答を返した際に原因不明な例外(SyntaxError)になる問題を修正

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -11,6 +11,13 @@ jest.mock('services/i18n', () => ({
 jest.mock('util/menus/Menu', () => ({}));
 jest.mock('@electron/remote', () => ({
   BrowserWindow: jest.fn(),
+  session: {
+    defaultSession: {
+      webRequest: {
+        onBeforeSendHeaders: jest.fn(),
+      },
+    },
+  },
 }));
 const fetchViaMainProcess = jest
   .fn<Promise<MainProcessFetchResponse>, [string, RequestInit]>()
@@ -114,6 +121,70 @@ test('wrapResultはbodyがJSONでなければSyntaxErrorをwrapして返す', as
   expect((result as any).value).toBeInstanceOf(SyntaxError);
   expect((result as any).diag).toMatchObject({ route: 'renderer', failureKind: 'json_parse' });
   expect(fetchMock.callHistory.done()).toBe(true);
+});
+
+// upstream(プロキシ等)障害時、レスポンスがプレーンテキスト
+// (例: "upstream connect error or disconnect/reset before headers") で返ってくることがある。
+// .json() を直接呼ぶと catch されない SyntaxError が伝播しクラッシュ扱いになるため、
+// 明示的な Error に変換されることを確認する。
+const upstreamErrorBody = 'upstream connect error or disconnect/reset before headers';
+
+describe('非JSONレスポンスの安全な取り扱い', () => {
+  test('fetchOnairUserProgramはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {
+    const client = new NicoliveClient({ niconicoSession: 'dummy' });
+    fetchMock.get(
+      `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/user`,
+      { body: upstreamErrorBody, status: 200 },
+    );
+
+    let error: unknown;
+    await client.fetchOnairUserProgram().catch((e) => { error = e; });
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/fetchOnairUserProgram/);
+  });
+
+  test('fetchKonomiTagsはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {
+    const client = new NicoliveClient({ niconicoSession: 'dummy' });
+    fetchMock.post(
+      `${NicoliveClient.live2ApiBaseURL}/api/v1/konomiTags/GetFollowing`,
+      { body: upstreamErrorBody, status: 200 },
+    );
+
+    let error: unknown;
+    await client.fetchKonomiTags(String(userID)).catch((e) => { error = e; });
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/fetchKonomiTags/);
+  });
+
+  test('fetchUserFollowはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {
+    const client = new NicoliveClient({ niconicoSession: 'dummy' });
+    fetchMock.get(
+      NicoliveClient.userFollowEndpoint(String(userID)),
+      { body: upstreamErrorBody, status: 200 },
+    );
+
+    let error: unknown;
+    await client.fetchUserFollow(String(userID)).catch((e) => { error = e; });
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/fetchUserFollow/);
+  });
+
+  test('unFollowUserは失敗レスポンスがJSONでなくてもSyntaxErrorを投げず本来のエラーメッセージを返す', async () => {
+    const client = new NicoliveClient({ niconicoSession: 'dummy' });
+    fetchMock.delete(
+      NicoliveClient.userFollowEndpoint(String(userID)),
+      { body: upstreamErrorBody, status: 502 },
+    );
+
+    let error: unknown;
+    await client.unFollowUser(String(userID)).catch((e) => { error = e; });
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/unFollowUser failed: 502/);
+  });
 });
 
 interface Suite {

--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -142,6 +142,8 @@ describe('非JSONレスポンスの安全な取り扱い', () => {
     expect(error).not.toBeInstanceOf(SyntaxError);
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(/fetchOnairUserProgram/);
+    // 元のSyntaxErrorがcauseとして保持され、調査時に読めること
+    expect((error as Error).cause).toBeInstanceOf(SyntaxError);
   });
 
   test('fetchKonomiTagsはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -223,6 +223,22 @@ export class NicoliveClient {
     };
   }
 
+  /**
+   * res.json() を直接呼ぶと、サーバーやプロキシがエラー時にプレーンテキスト
+   * (例: "upstream connect error or disconnect/reset before headers") を返した場合、
+   * SyntaxError が catch されずに伝播してクラッシュ扱いになる。
+   * 代わりに本メソッドで text() → JSON.parse を行い、非JSON応答を明示的なエラーに変換する。
+   */
+  private static async parseJsonOrThrow(res: Response, context: string): Promise<any> {
+    const body = await res.text();
+    try {
+      return JSON.parse(body);
+    } catch (e) {
+      console.warn(`${context}: non-json body`, body);
+      throw new Error(`${context}: response is not valid JSON (status=${res.status})`);
+    }
+  }
+
   static async wrapResult<ResultType>(
     res: Response | MainProcessFetchResponse,
     route: RequestRoute = 'renderer',
@@ -467,10 +483,9 @@ export class NicoliveClient {
     const userSession = await this.fetchSession();
     headers.append('X-niconico-session', userSession);
     const request = new Request(url, { headers });
-    return await fetch(request)
-      .then(handleErrors)
-      .then((response) => response.json())
-      .then((json) => json.data);
+    const response = await fetch(request).then(handleErrors);
+    const json = await NicoliveClient.parseJsonOrThrow(response, 'fetchOnairUserProgram');
+    return json.data;
   }
 
   /**
@@ -685,7 +700,7 @@ export class NicoliveClient {
       ),
     );
     if (res.ok) {
-      const json = (await res.json()) as KonomiTags;
+      const json = (await NicoliveClient.parseJsonOrThrow(res, 'fetchKonomiTags')) as KonomiTags;
       return json.konomi_tags;
     }
     throw new Error(`fetchKonomiTags failed: ${res.status} ${res.statusText}`);
@@ -708,7 +723,7 @@ export class NicoliveClient {
       }),
     );
     if (res.ok) {
-      const json = await res.json();
+      const json = await NicoliveClient.parseJsonOrThrow(res, 'fetchUserFollow');
       console.info('fetchUserFollow', json);
       if (isValidUserFollowStatusResponse(json)) {
         return json.data.following;
@@ -766,7 +781,9 @@ export class NicoliveClient {
       }),
     );
     if (!res.ok) {
-      console.info('unFollowUser', userId, res, await res.json());
+      // ログ目的なのでJSONパースは不要 — body がプレーンテキストの場合に
+      // res.json() が SyntaxError を投げて本来のエラーを潰してしまうのを避ける
+      console.info('unFollowUser', userId, res, await res.text());
       throw new Error(`unFollowUser failed: ${res.status} ${res.statusText}`);
     }
   }

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -234,8 +234,9 @@ export class NicoliveClient {
     try {
       return JSON.parse(body);
     } catch (e) {
-      console.warn(`${context}: non-json body`, body);
-      throw new Error(`${context}: response is not valid JSON (status=${res.status})`);
+      // body全文をログに出すとupstream障害時にログ/IPC転送量が増えるため先頭のみ
+      console.warn(`${context}: non-json body`, body.slice(0, 200));
+      throw new Error(`${context}: response is not valid JSON (status=${res.status})`, { cause: e });
     }
   }
 


### PR DESCRIPTION
## このpull requestが解決する内容

配信サーバー（プロキシ等）が障害時にプレーンテキストのエラー応答（例: `upstream connect error or disconnect/reset before headers`）を返した際、それを`response.json()`にかけて原因不明な`SyntaxError`が発生する問題を修正します。ユーザーに表示されるエラーダイアログの文言・挙動自体は変わりませんが、Sentryに送られる例外が文脈付きの`Error`になり、原因調査がしやすくなります。

Sentry: N-AIR-APP-G9C（v1.1.20260630-1で新規発生、1件/1ユーザー）
https://n-air-app2.sentry.io/issues/7584951016/

## 背景

`NicoliveClient.ts`の`wrapResult`経由のAPI呼び出しは、レスポンスボディをtext()で受け取ってから`JSON.parse`をtry/catchで保護しているため、非JSON応答でも想定内のエラーとして扱われます。しかし以下4メソッドは`.json()`を直接呼んでおり、この保護がありませんでした。

- `fetchOnairUserProgram`（配信開始時に呼ばれる。失敗時は既存のcatchで`streaming.broadcastStatusFetchingError.default`ダイアログが出る点は修正前後で変わらない）
- `fetchKonomiTags`
- `fetchUserFollow`
- `unFollowUser`（`!res.ok`分岐でログ用に`res.json()`を呼んでおり、ログ出力目的なのに本来のエラーを`SyntaxError`で潰していた）

（`fetchKonomiTags`/`fetchUserFollow`/`unFollowUser`は呼び出し元に`.catch()`がなく、失敗してもダイアログは出ずログに残るのみ）

## 変更内容

- `res.text()` → try/catchで`JSON.parse`を行う`parseJsonOrThrow`ヘルパーを追加し、上記4メソッドをこのヘルパー経由に変更
- 非JSON応答時は文脈（呼び出し元メソッド名・HTTPステータス）付きの明示的な`Error`（元の`SyntaxError`は`cause`として保持）を投げるようにした
- `unFollowUser`のログ出力は`res.json()`→`res.text()`に変更し、パース不要にした
- ログ出力するレスポンス本文は先頭200文字に制限（upstream障害継続時のログ/IPC転送量への配慮）

## テスト

- [x] `pnpm run test:unit:app`（NicoliveClient.test.ts に非JSON応答時の挙動テストを追加）
- [x] `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sentry-Resolves: N-AIR-APP-G9C
