### PR TITLE
開発: 配信設定失敗時の診断ログにエラー内容が記録されない問題を修正

### DIFF
--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -291,6 +291,10 @@ describe('setupStreamSettings 失敗時の診断報告', () => {
     expect(message).toContain('setSettings');
     expect(opts.tags['stream.setup.step']).toBe('setSettings');
     expect(opts.fingerprint).toContain('setSettings');
+    // catchされる e は Error を継承しない NicoliveFailure なので、
+    // String(e) の "[object Object]" ではなく元のnative例外メッセージが入ること
+    expect(opts.extra.errorMessage).toContain('Failed to save settings');
+    expect(opts.extra.errorMessage).not.toBe('[object Object]');
   });
 
   test('2回目失敗でのみSentryReport.messageが呼ばれ、1回目(リトライ前)は呼ばれない', async () => {

--- a/app/services/platforms/niconico.test.ts
+++ b/app/services/platforms/niconico.test.ts
@@ -236,6 +236,10 @@ describe('setupStreamSettings 失敗時の診断報告', () => {
     expect(opts.tags['diagnostic']).toBe('stream-setup');
     expect(opts.fingerprint).toContain('fetchIngestInfo');
     expect(opts.fingerprint).toContain('network_error');
+    // NicoliveFailure.fromClientError の network_error 分岐は additionalMessage を
+    // 常に空文字にするため、errorMessage が空文字にならず type:reason で
+    // 最低限の診断情報が残ることを確認する
+    expect(opts.extra.errorMessage).toBe('network_error:network_error');
   });
 
   test('fetchIngestInfo が http_error(503) で失敗した場合、fingerprint に httpStatus が含まれる', async () => {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -230,7 +230,8 @@ export class NiconicoService extends Service implements IPlatformService {
       return result;
     } catch (e) {
       // リトライは1回だけ — 失敗種別を構造化してSentryに報告する
-      const failure = e instanceof NicoliveFailure
+      const isNicoliveFailure = e instanceof NicoliveFailure;
+      const failure = isNicoliveFailure
         ? e
         : new NicoliveFailure('network_error', 'unknown', 'unknown');
       this.lastSetupFailure = failure;
@@ -243,11 +244,13 @@ export class NiconicoService extends Service implements IPlatformService {
 
       // NicoliveFailure は Error を継承していないため、String(e) では
       // "[object Object]" になってしまう。e が NicoliveFailure の場合は
-      // 既に additionalMessage に元の native例外メッセージが入っているので
-      // そちらを使う
+      // additionalMessage に元の native例外メッセージが入っていることが多いが、
+      // NicoliveFailure.fromClientError の network_error/json_parse/not_logged_in
+      // 分岐では additionalMessage が常に空文字になる(元のメッセージを保持しない)ため、
+      // その場合は type/reason で最低限の診断情報を残す
       let errorMessage: string;
-      if (e instanceof NicoliveFailure) {
-        errorMessage = failure.additionalMessage;
+      if (isNicoliveFailure) {
+        errorMessage = failure.additionalMessage || `${failure.type}:${failure.reason}`;
       } else if (e instanceof Error) {
         errorMessage = e.message;
       } else {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -241,6 +241,19 @@ export class NiconicoService extends Service implements IPlatformService {
       const errorCode = failure.errorCode ?? '';
       const route = failure.route ?? 'renderer';
 
+      // NicoliveFailure は Error を継承していないため、String(e) では
+      // "[object Object]" になってしまう。e が NicoliveFailure の場合は
+      // 既に additionalMessage に元の native例外メッセージが入っているので
+      // そちらを使う
+      let errorMessage: string;
+      if (e instanceof NicoliveFailure) {
+        errorMessage = failure.additionalMessage;
+      } else if (e instanceof Error) {
+        errorMessage = e.message;
+      } else {
+        errorMessage = String(e);
+      }
+
       Sentry.addBreadcrumb({
         category: 'streaming',
         message: 'setupStreamSettings(2) failed',
@@ -285,7 +298,7 @@ export class NiconicoService extends Service implements IPlatformService {
             },
             extra: {
               programId,
-              errorMessage: e instanceof Error ? e.message : String(e),
+              errorMessage,
               additionalMessage: failure.additionalMessage,
               reportCount: state.count,
               ...(capReached ? { reportCapReached: true } : {}),


### PR DESCRIPTION
## このpull requestが解決する内容

配信設定失敗時（`setupStreamSettings failed at setSettings`）の診断レポートで、肝心の`errorMessage`が`"[object Object]"`になり、native例外の内容が記録されていなかった問題を修正します。

Sentry: N-AIR-APP-G9A（v1.1.20260630-1で新規発生、1件/1ユーザー）
https://n-air-app2.sentry.io/issues/7584559874/

## 背景

`setupStreamSettings`の2回目失敗catchブロックで、`errorMessage: e instanceof Error ? e.message : String(e)`としていましたが、`e`は`Error`を継承しない`NicoliveFailure`であることが多く、`String(e)`は`"[object Object]"`になってしまい実質無意味な文字列しか記録されませんでした。

## 変更内容

- `e`が`NicoliveFailure`の場合は`additionalMessage`（native例外メッセージが格納されていることが多い）を優先して使うよう修正
- ただし`NicoliveFailure.fromClientError`の`network_error`/`json_parse`/`not_logged_in`分岐では`additionalMessage`が常に空文字になるため、その場合は`failure.type:failure.reason`で最低限の診断情報を残すようにフォールバック
  - `additionalMessage`はユーザー向けエラーダイアログ（`openErrorDialogFromFailure`）でも使われているため、`NicoliveFailure`側は変更せず`niconico.ts`側のみで対応
- 併せて`e instanceof NicoliveFailure`の重複判定を1回に整理

## テスト

- [x] `pnpm run test:unit:app`（`niconico.test.ts`にerrorMessageが実内容を保持することの検証を追加）
- [x] `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sentry-Resolves: N-AIR-APP-G9A
