### PR TITLE
修正: ソース追加時に「音声出力キャプチャ」の説明が表示されない問題を修正

### DIFF
--- a/app/components/sources/SourcesShowcase.vue
+++ b/app/components/sources/SourcesShowcase.vue
@@ -72,6 +72,14 @@
           <template #media><WasapiInputCaptureIcon /></template>
         </add-source-info>
 
+        <add-source-info
+          v-if="inspectedSource === 'wasapi_output_capture'"
+          sourceType="wasapi_output_capture"
+          key="25"
+        >
+          <template #media><WasapiOutputIcon /></template>
+        </add-source-info>
+
         <add-source-info v-if="inspectedSource === 'ndi_source'" sourceType="ndi_source" key="13">
           <template #media><NdiSourceIcon /></template>
         </add-source-info>


### PR DESCRIPTION
## このpull requestが解決する内容
ソース追加ダイアログで「音声出力キャプチャ」(`wasapi_output_capture`) を選択したとき、ウィンドウ上部に説明文（名前・説明）が表示されない問題を修正します。

## 原因
`wasapi_output_capture` 用の `add-source-info` ブロックが `app/components/sources/SourcesShowcase.vue` から欠落していました。

- **脱落コミット**: `0960e6184`「各コンポーネントのスロットをテンプレート構文に変更しました。」(asaday, 2026-05-28)
  Vue の slot 構文 (`slot="media"`) を template 構文 (`<template #media>`) に一括変換する作業で、他のソースは正しく変換されましたが、`wasapi_output_capture`（当時 `key="6"`）のブロックだけ変換されず、ブロックごと削除されてしまいました。
- **含まれるPR**: #1296 (`feature/to_vue3_all` → `n-air_development`、Vue3移行)
- **最初にリリースされた stable バージョン**: `v1.1.20260617-1` (2026-06-17)

i18n の説明テキスト (`app/i18n/*/source-props.json` の `wasapi_output_capture.description`) やアイコン (`WasapiOutputIcon`) の import・登録は既に存在しており問題なかったため、テンプレートにブロックを復元するだけで解決しました。

## 変更内容
- `app/components/sources/SourcesShowcase.vue`: `wasapi_output_capture` 用の `add-source-info` ブロックを復元

## テスト
- [x] `pnpm start` でアプリを起動し、ソース追加ダイアログで「音声出力キャプチャ」を選択して説明文（名前・説明）が表示されることを確認
- [x] 「音声入力キャプチャ」など他のソースが従来通り表示されることを確認（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
