### PR TITLE
修正: プリセットのWebカメラ映像が表示されない/枠に合わず縮んでしまう問題を修正

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -18,6 +18,7 @@ import { SourcesService } from 'services/sources';
 import { TransitionsService } from 'services/transitions';
 import { UserService } from 'services/user';
 import { uuidv4 } from 'services/utils';
+import { VideoService } from 'services/video';
 import { WindowsService } from 'services/windows';
 import { SentryReport } from 'util/sentry-report';
 
@@ -53,6 +54,11 @@ export const NODE_TYPES = {
 
 const DEFAULT_COLLECTION_NAME = 'Scenes';
 
+// プリセット背景画像のネオン枠(透過窓)は、プリセットに保存されたWebカメラの
+// transformが示す枠よりわずかに小さいため、フィット時に少し縮小してネオン枠の
+// 内側に収める
+const WEBCAM_FIT_MARGIN_RATIO = 0.98;
+
 interface ISceneCollectionsManifest {
   activeId: string;
   collections: ISceneCollectionsManifestEntry[];
@@ -80,6 +86,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   @Inject() transitionsService: TransitionsService;
   @Inject() dismissablesService: DismissablesService;
   @Inject() settingsService: SettingsService;
+  @Inject() videoService: VideoService;
 
   collectionAdded = new Subject<ISceneCollectionsManifestEntry>();
   collectionRemoved = new Subject<ISceneCollectionsManifestEntry>();
@@ -180,10 +187,68 @@ export class SceneCollectionsService extends Service implements ISceneCollection
 
     await this.save();
 
+    // Webカメラの実解像度が判明した時点で、プリセットが意図した枠にアスペクト比を
+    // 保ったまま中央フィットさせる(カメラ解像度がプリセット作成時と異なると
+    // 保存済みのscaleそのままでは表示サイズが崩れるため)
+    this.scheduleWebcamFitForPreset();
+
     this.finishLoadingOperation();
 
     // dismiss initial scene collections help tip if not yet(since its position is overlapped)
     this.dismissablesService.dismiss(EDismissable.SceneCollectionsHelpTip);
+  }
+
+  /**
+   * プリセットのWebカメラ(dshow_input)シーンアイテムについて、実解像度が判明した
+   * タイミングでプリセットが意図した枠(キャンバス1280x720基準のscaleから復元)に
+   * アスペクト比を保って中央フィットさせる。全アイテムの処理が完了(またはタイムアウト)
+   * した時点で1回だけ保存し、フィット結果を永続化する。
+   */
+  private scheduleWebcamFitForPreset() {
+    // プリセット(basic.json)には複数シーンがあり、Webカメラを含むシーンが必ずしも
+    // アクティブシーンではないため、全シーンを対象にする。
+    // このメソッドは removeAllScenes() 後に root.load() で作られた直後のシーンのみが
+    // 存在する状態で呼ばれる(呼び出し元の installPresetSceneCollection は「シーンが1つ
+    // かつ空」の場合にしか呼ばれないため、ユーザーが既に配置したシーンアイテムに対して
+    // このメソッドが実行されることはない)
+    const webcamItems = this.scenesService.scenes.flatMap((scene) =>
+      scene.getItems().filter((item) => item.type === 'dshow_input'),
+    );
+    if (webcamItems.length === 0) return;
+
+    let remaining = webcamItems.length;
+    const onOneSettled = () => {
+      remaining -= 1;
+      if (remaining === 0) this.save();
+    };
+
+    webcamItems.forEach((item) => {
+      const scene = item.getScene();
+      const sceneItemId = item.sceneItemId;
+      const rawWidth = this.videoService.baseWidth * item.transform.scale.x;
+      const rawHeight = this.videoService.baseHeight * item.transform.scale.y;
+      // プリセットの背景画像(ネオン枠)の透過窓は元のtransformが示す枠よりわずかに
+      // 小さいため、中心を保ったまま少し縮小してネオン枠の内側に収める
+      const width = rawWidth * WEBCAM_FIT_MARGIN_RATIO;
+      const height = rawHeight * WEBCAM_FIT_MARGIN_RATIO;
+      const targetRect = {
+        x: item.transform.position.x + (rawWidth - width) / 2,
+        y: item.transform.position.y + (rawHeight - height) / 2,
+        width,
+        height,
+      };
+
+      scene.fixupSceneItemWhenReadyWithTimeout(
+        item.sourceId,
+        () => {
+          // コールバック実行時点のwidth/heightを確実に反映させるため、
+          // ループ内で作られた古いインスタンスではなく再取得したインスタンスを使う
+          scene.getItem(sceneItemId)?.fitToRect(targetRect);
+          onOneSettled();
+        },
+        onOneSettled,
+      );
+    });
   }
 
   /**

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -339,6 +339,24 @@ export class SceneItem extends SceneItemNode {
     this.setRect(rect);
   }
 
+  /**
+   * 指定した矩形にアスペクト比を保って中央フィットさせる
+   */
+  fitToRect(targetRect: { x: number; y: number; width: number; height: number }) {
+    // ソースの実サイズがまだ確定していない(0x0)場合や、targetRectがゼロサイズの場合、
+    // フィット計算がNaN/Infinityまたはスケール0になり、それがそのままOBSに書き込まれて
+    // 表示が壊れるため中断する
+    if (!this.width || !this.height || !targetRect.width || !targetRect.height) {
+      console.warn(
+        `fitToRect: source ${this.sourceId} size (${this.width}x${this.height}) or targetRect (${targetRect.width}x${targetRect.height}) is not ready, skipping`,
+      );
+      return;
+    }
+    const rect = this.getRectangle();
+    rect.fitTo(new ScalableRectangle(targetRect));
+    this.setRect(rect);
+  }
+
   centerOnScreen() {
     const rect = this.getRectangle();
     rect.centerOn(this.videoService.getScreenRectangle());

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -219,6 +219,57 @@ export class Scene {
       });
   }
 
+  /**
+   * fixupSceneItemWhenReady にタイムアウトと安定待ちを追加したもの。
+   * デバイス起動直後は width/height が連続して変化することがあり、変化した直後の
+   * 値に対して transform を書き込んでもOBS側にすぐ反映されないことがあるため、
+   * 最後の変化から debounceMs 経過して値が安定するまで待ってから callback を呼ぶ。
+   * デバイスが起動せずサイズが確定しないまま購読が残り続けることも防ぐ。
+   */
+  fixupSceneItemWhenReadyWithTimeout(
+    sourceId: string,
+    callback: () => void,
+    onTimeout: () => void,
+    timeoutMs = 15000,
+    debounceMs = 500,
+  ) {
+    if (!sourceId || !callback) return;
+
+    let settled = false;
+    let debounceId: ReturnType<typeof setTimeout> | null = null;
+
+    const timeoutId = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      if (debounceId) clearTimeout(debounceId);
+      subscription.unsubscribe();
+      onTimeout();
+    }, timeoutMs);
+
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      subscription.unsubscribe();
+      callback();
+    };
+
+    const source = this.sourcesService.getSourceById(sourceId);
+    if (source?.width && source?.height) {
+      debounceId = setTimeout(settle, debounceMs);
+    }
+
+    const subscription = this.sourcesService.sourceUpdated
+      .pipe(filter((patch) => patch.sourceId === sourceId))
+      .subscribe((patch) => {
+        if (settled) return;
+        if (debounceId) clearTimeout(debounceId);
+        if (patch.width && patch.height) {
+          debounceId = setTimeout(settle, debounceMs);
+        }
+      });
+  }
+
   addFile(path: string, folderId?: string): TSceneNode {
     let fstat: fs.Stats;
     try {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -232,7 +232,7 @@ export class Scene {
     callback: () => void,
     onTimeout: () => void,
     timeoutMs = 15000,
-    debounceMs = 500,
+    debounceMs = 200,
   ) {
     if (!sourceId || !callback) return;
 

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -1,14 +1,15 @@
 import * as fs from 'fs';
 
 import uniqBy from 'lodash/uniqBy';
-import { filter } from 'rxjs/operators';
+import { filter, startWith } from 'rxjs/operators';
 import { mutation, ServiceHelper } from 'services/core';
 import { Inject } from 'services/core/injector';
 import { TSceneNodeInfo } from 'services/scene-collections/nodes/scene-items';
 import { Selection, SelectionService, TNodesList } from 'services/selection';
 import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
-import { Source, SourcesService, TSourceType } from 'services/sources';
+import { ISource, Source, SourcesService, TSourceType } from 'services/sources';
 import Utils, { uuidv4 } from 'services/utils';
+import { observeUntilStable } from 'util/observeUntilStable';
 import { assertIsDefined } from 'util/properties-type-guards';
 import { assertObsObjectDefined } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
@@ -235,39 +236,17 @@ export class Scene {
   ) {
     if (!sourceId || !callback) return;
 
-    let settled = false;
-    let debounceId: ReturnType<typeof setTimeout> | null = null;
+    const currentSource = this.sourcesService.getSourceById(sourceId);
+    const source$ = this.sourcesService.sourceUpdated.pipe(
+      filter((patch) => patch.sourceId === sourceId),
+      startWith(currentSource ? currentSource.getModel() : undefined),
+    );
 
-    const timeoutId = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      if (debounceId) clearTimeout(debounceId);
-      subscription.unsubscribe();
-      onTimeout();
-    }, timeoutMs);
-
-    const settle = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutId);
-      subscription.unsubscribe();
-      callback();
-    };
-
-    const source = this.sourcesService.getSourceById(sourceId);
-    if (source?.width && source?.height) {
-      debounceId = setTimeout(settle, debounceMs);
-    }
-
-    const subscription = this.sourcesService.sourceUpdated
-      .pipe(filter((patch) => patch.sourceId === sourceId))
-      .subscribe((patch) => {
-        if (settled) return;
-        if (debounceId) clearTimeout(debounceId);
-        if (patch.width && patch.height) {
-          debounceId = setTimeout(settle, debounceMs);
-        }
-      });
+    observeUntilStable<ISource | undefined>(
+      source$,
+      (source) => !!(source?.width && source?.height),
+      { timeoutMs, debounceMs },
+    ).then(callback, onTimeout);
   }
 
   addFile(path: string, folderId?: string): TSceneNode {

--- a/app/services/sources/sources.test.ts
+++ b/app/services/sources/sources.test.ts
@@ -176,3 +176,75 @@ describe('createSource', () => {
     }).toThrow('InputFactory.create returned no input for type=window_capture');
   });
 });
+
+describe('fixSourceSettings', () => {
+  function createFakeWebcam(videoDeviceId: string | undefined) {
+    return {
+      getSettings: jest.fn().mockReturnValue({ video_device_id: videoDeviceId }),
+      updateSettings: jest.fn(),
+      getPropertiesFormData: jest.fn(),
+    };
+  }
+
+  test('video_device_id が空文字の場合、先頭デバイスで補完する', () => {
+    setup();
+    mockGetVideoDevices.mockReturnValue([{ id: 'video_device_0', name: 'Webcam' }]);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+
+    const webcam = createFakeWebcam('');
+    instance.getSourcesByType = jest.fn().mockReturnValue([webcam]);
+
+    instance.fixSourceSettings();
+
+    expect(webcam.updateSettings).toHaveBeenCalledWith({ video_device_id: 'video_device_0' });
+    expect(webcam.getPropertiesFormData).toHaveBeenCalled();
+  });
+
+  test('video_device_id が未設定 (undefined) の場合、先頭デバイスで補完する', () => {
+    setup();
+    mockGetVideoDevices.mockReturnValue([{ id: 'video_device_0', name: 'Webcam' }]);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+
+    const webcam = createFakeWebcam(undefined);
+    instance.getSourcesByType = jest.fn().mockReturnValue([webcam]);
+
+    instance.fixSourceSettings();
+
+    expect(webcam.updateSettings).toHaveBeenCalledWith({ video_device_id: 'video_device_0' });
+  });
+
+  test('video_device_id に有効な値が既にある場合は補完しない', () => {
+    setup();
+    mockGetVideoDevices.mockReturnValue([{ id: 'video_device_0', name: 'Webcam' }]);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+
+    const webcam = createFakeWebcam('existing_device_id');
+    instance.getSourcesByType = jest.fn().mockReturnValue([webcam]);
+
+    instance.fixSourceSettings();
+
+    expect(webcam.updateSettings).not.toHaveBeenCalled();
+    expect(webcam.getPropertiesFormData).toHaveBeenCalled();
+  });
+
+  test('デバイスが1つも無い場合は何もしない', () => {
+    setup();
+    mockGetVideoDevices.mockReturnValue([]);
+
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+
+    const webcam = createFakeWebcam('');
+    instance.getSourcesByType = jest.fn().mockReturnValue([webcam]);
+
+    instance.fixSourceSettings();
+
+    expect(webcam.updateSettings).not.toHaveBeenCalled();
+  });
+});

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -341,8 +341,18 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   fixSourceSettings() {
-    // fix webcam sources's video_device_id
-    this.getSourcesByType('dshow_input').forEach((webcam) => {
+    // fix webcam sources's video_device_id:
+    // シーンプリセットや別環境から読み込まれた dshow_input は video_device_id が
+    // 空/未設定のままのことがあり、その場合デバイスが選択されず映像が表示されない。
+    // 有効な device_id が設定されているソースには一切手を加えない。
+    const webcams = this.getSourcesByType('dshow_input');
+    if (webcams.length === 0) return;
+    const devices = obs.NodeObs.OBS_settings_getVideoDevices();
+    webcams.forEach((webcam) => {
+      const deviceId = webcam.getSettings().video_device_id;
+      if ((deviceId === undefined || deviceId === '') && devices.length > 0) {
+        webcam.updateSettings({ video_device_id: devices[0].id });
+      }
       webcam.getPropertiesFormData();
     });
   }

--- a/app/util/ScalableRectangle.test.ts
+++ b/app/util/ScalableRectangle.test.ts
@@ -1,0 +1,44 @@
+import { ScalableRectangle } from './ScalableRectangle';
+
+describe('ScalableRectangle#fitTo', () => {
+  // target rect: 16:9, x=100,y=50,width=800,height=450 (aspectRatio = 800/450 = 1.7778)
+  const targetRect = { x: 100, y: 50, width: 800, height: 450 };
+
+  test('カメラのアスペクト比が枠と一致する場合、枠にちょうど一致する', () => {
+    // 1600x900 (16:9) の実解像度カメラを想定
+    const item = new ScalableRectangle({ x: 0, y: 0, width: 1600, height: 900 });
+
+    item.fitTo(new ScalableRectangle(targetRect));
+
+    expect(item.scaleX).toBeCloseTo(0.5);
+    expect(item.scaleY).toBeCloseTo(0.5);
+    expect(item.x).toBeCloseTo(100);
+    expect(item.y).toBeCloseTo(50);
+  });
+
+  test('カメラが枠より横長でない(4:3)場合、高さ基準でフィットし左右に均等な余白ができる', () => {
+    // 800x600 (4:3) の実解像度カメラを想定
+    const item = new ScalableRectangle({ x: 0, y: 0, width: 800, height: 600 });
+
+    item.fitTo(new ScalableRectangle(targetRect));
+
+    expect(item.scaleX).toBeCloseTo(0.75);
+    expect(item.scaleY).toBeCloseTo(0.75);
+    // 幅は 600 (枠の800より小さい) になるため、左右に (800-600)/2=100 の余白ができ、中央寄せされる
+    expect(item.x).toBeCloseTo(200);
+    expect(item.y).toBeCloseTo(50);
+  });
+
+  test('カメラが枠より横長の場合、幅基準でフィットし上下に均等な余白ができる', () => {
+    // 1600x400 (アスペクト比4:1) の実解像度カメラを想定
+    const item = new ScalableRectangle({ x: 0, y: 0, width: 1600, height: 400 });
+
+    item.fitTo(new ScalableRectangle(targetRect));
+
+    expect(item.scaleX).toBeCloseTo(0.5);
+    expect(item.scaleY).toBeCloseTo(0.5);
+    expect(item.x).toBeCloseTo(100);
+    // 高さは 200 (枠の450より小さい) になるため、上下に (450-200)/2=125 の余白ができ、中央寄せされる
+    expect(item.y).toBeCloseTo(175);
+  });
+});

--- a/app/util/observeUntilStable.test.ts
+++ b/app/util/observeUntilStable.test.ts
@@ -1,5 +1,5 @@
 import * as FakeTimers from '@sinonjs/fake-timers';
-import { Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import { observeUntilStable } from './observeUntilStable';
 
@@ -94,6 +94,27 @@ describe('observeUntilStable', () => {
     source$.next(1);
     await clock.tickAsync(500);
     expect(onResolve).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('source$がsubscribe中に同期的にエラーを出してもReferenceErrorにならずrejectする', async () => {
+    const onError = jest.fn();
+    await observeUntilStable(throwError(() => new Error('boom')), (v: number) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    }).catch(onError);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toBe('boom');
+  });
+
+  it('isReadyを満たす値を出さずにsource$がcompleteした場合はrejectする', async () => {
+    const onError = jest.fn();
+    await observeUntilStable(of(0), (v: number) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    }).catch(onError);
+
     expect(onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/util/observeUntilStable.test.ts
+++ b/app/util/observeUntilStable.test.ts
@@ -1,0 +1,99 @@
+import * as FakeTimers from '@sinonjs/fake-timers';
+import { Subject } from 'rxjs';
+
+import { observeUntilStable } from './observeUntilStable';
+
+describe('observeUntilStable', () => {
+  let clock: FakeTimers.Clock;
+  let source$: Subject<number>;
+
+  beforeEach(() => {
+    clock = FakeTimers.install();
+    source$ = new Subject<number>();
+  });
+
+  afterEach(() => {
+    clock.uninstall();
+  });
+
+  it('debounceMs経過して値が安定したらresolveする', async () => {
+    const promise = observeUntilStable(source$, (v) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    });
+    let resolved: number | undefined;
+    promise.then((v) => (resolved = v));
+
+    source$.next(1);
+    await clock.tickAsync(499);
+    expect(resolved).toBeUndefined();
+
+    await clock.tickAsync(1);
+    expect(resolved).toBe(1);
+  });
+
+  it('debounceMs以内に新しい値が来ると安定判定がリセットされる', async () => {
+    const promise = observeUntilStable(source$, (v) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    });
+    let resolved: number | undefined;
+    promise.then((v) => (resolved = v));
+
+    source$.next(1);
+    await clock.tickAsync(400);
+    source$.next(2);
+    await clock.tickAsync(400);
+    expect(resolved).toBeUndefined();
+
+    await clock.tickAsync(100);
+    expect(resolved).toBe(2);
+  });
+
+  it('isReadyを満たさない値は無視する', async () => {
+    const promise = observeUntilStable(source$, (v) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    });
+    let resolved: number | undefined;
+    promise.then((v) => (resolved = v));
+
+    source$.next(0);
+    await clock.tickAsync(500);
+    expect(resolved).toBeUndefined();
+
+    source$.next(1);
+    await clock.tickAsync(500);
+    expect(resolved).toBe(1);
+  });
+
+  it('timeoutMs以内に安定しなければrejectする', async () => {
+    const promise = observeUntilStable(source$, (v) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    });
+    const onError = jest.fn();
+    promise.catch(onError);
+
+    await clock.tickAsync(15000);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('timeout後に値が来ても再度resolveしない', async () => {
+    const promise = observeUntilStable(source$, (v) => v > 0, {
+      timeoutMs: 15000,
+      debounceMs: 500,
+    });
+    const onResolve = jest.fn();
+    const onError = jest.fn();
+    promise.then(onResolve, onError);
+
+    await clock.tickAsync(15000);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    source$.next(1);
+    await clock.tickAsync(500);
+    expect(onResolve).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/util/observeUntilStable.ts
+++ b/app/util/observeUntilStable.ts
@@ -1,10 +1,11 @@
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { debounceTime, filter, take, timeout } from 'rxjs/operators';
 
 /**
  * source$ の中から isReady を満たす値を待ち、最後にその値が来てから
  * debounceMs 経過して値が安定するまで待ってから resolve する。
- * timeoutMs 以内に安定しなければ reject する。
+ * timeoutMs 以内に安定しなければ、または isReady を満たす値を出さずに
+ * source$ が complete した場合は reject する。
  */
 export function observeUntilStable<T>(
   source$: Observable<T>,
@@ -12,7 +13,20 @@ export function observeUntilStable<T>(
   options: { timeoutMs: number; debounceMs: number },
 ): Promise<T> {
   return new Promise((resolve, reject) => {
-    const subscription = source$
+    // next/error/complete は subscribe() の呼び出し中に同期的に発火する可能性があり、
+    // その時点では subscription への代入がまだ完了していない。let で事前宣言することで
+    // TDZ(参照前アクセスによるReferenceError)を避け、settled フラグで二重解決
+    // (take(1)のnext直後に同期発火するcomplete等)も防ぐ。
+    let subscription: Subscription | undefined;
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      subscription?.unsubscribe();
+      fn();
+    };
+
+    subscription = source$
       .pipe(
         filter(isReady),
         debounceTime(options.debounceMs),
@@ -20,14 +34,12 @@ export function observeUntilStable<T>(
         take(1),
       )
       .subscribe({
-        next: (value) => {
-          subscription.unsubscribe();
-          resolve(value);
-        },
-        error: (error) => {
-          subscription.unsubscribe();
-          reject(error);
-        },
+        next: (value) => finish(() => resolve(value)),
+        error: (error) => finish(() => reject(error)),
+        complete: () =>
+          finish(() =>
+            reject(new Error('observeUntilStable: source completed without becoming ready')),
+          ),
       });
   });
 }

--- a/app/util/observeUntilStable.ts
+++ b/app/util/observeUntilStable.ts
@@ -1,0 +1,33 @@
+import { Observable } from 'rxjs';
+import { debounceTime, filter, take, timeout } from 'rxjs/operators';
+
+/**
+ * source$ の中から isReady を満たす値を待ち、最後にその値が来てから
+ * debounceMs 経過して値が安定するまで待ってから resolve する。
+ * timeoutMs 以内に安定しなければ reject する。
+ */
+export function observeUntilStable<T>(
+  source$: Observable<T>,
+  isReady: (value: T) => boolean,
+  options: { timeoutMs: number; debounceMs: number },
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const subscription = source$
+      .pipe(
+        filter(isReady),
+        debounceTime(options.debounceMs),
+        timeout(options.timeoutMs),
+        take(1),
+      )
+      .subscribe({
+        next: (value) => {
+          subscription.unsubscribe();
+          resolve(value);
+        },
+        error: (error) => {
+          subscription.unsubscribe();
+          reject(error);
+        },
+      });
+  });
+}

--- a/scene-presets/basic.json
+++ b/scene-presets/basic.json
@@ -124,14 +124,12 @@
         "type": "dshow_input",
         "settings": {
           "active": true,
-          "audio_device_id": "マイク配列 (Realtek Audio):",
           "audio_output_mode": 0,
           "buffering": 0,
           "color_range": "partial",
           "color_space": "default",
           "frame_interval": -1,
           "last_resolution": "1280x720",
-          "last_video_device_id": "Integrated Webcam:\\\\?\\usb#22vid_0bda&pid_568c&mi_00#226&5e1df6&0&0000#22{65e8773d-8f56-11d0-a3b9-00a0c9223196}\\global",
           "res_type": 0,
           "video_format": 0
         },


### PR DESCRIPTION
## このpull requestが解決する内容
シーンプリセットの「プリセット」シーンコレクションに含まれるWebカメラ映像が、初期状態だと表示されない、または表示されても枠より小さく縮んでしまう問題を修正します。

## 背景
プリセット(`scene-presets/basic.json`)のWebカメラソースは以下の2つの問題を抱えていました。

1. `video_device_id` が未設定のままのため、デバイスが選択されずカメラ映像が表示されない
2. カメラの実解像度がプリセット作成時(1280×720)と異なる場合、プリセットに保存された固定の `scale` がそのまま実解像度に適用され、映像が枠に対して小さく縮んで表示される(自由変形だと歪むため、アスペクト比を保ったフィットが必要)

## 変更内容

### video_device_id の自動補完
- `app/services/sources/sources.ts`: `fixSourceSettings()` で `dshow_input` の `video_device_id` が未設定/空の場合、利用可能な先頭デバイスで補完する
- `scene-presets/basic.json`: 開発者個人PC固有の `audio_device_id` / `last_video_device_id` を削除(他環境では機能しない値だったため)

### Webカメラのアスペクト比保持・中央フィット
- `app/services/scenes/scene-item.ts`: 指定した矩形にアスペクト比を保って中央フィットさせる `fitToRect()` を追加
- `app/services/scenes/scene.ts`: デバイス起動直後のwidth/height変化が安定するまでデバウンス待ちし、タイムアウトも備えた `fixupSceneItemWhenReadyWithTimeout()` を追加(既存の `fixupSceneItemWhenReady()` は他箇所で使用中のため変更せず維持)
- `app/services/scene-collections/scene-collections.ts`: プリセットインストール時、Webカメラの実解像度確定を待ってプリセットが意図した枠(キャンバス1280×720基準のscaleから復元)にフィットさせ、完了後に保存する `scheduleWebcamFitForPreset()` を追加

### code-review による追加修正
- `app/services/sources/sources.ts`: `OBS_settings_getVideoDevices()` のネイティブ呼び出しがWebカメラ数分ループ内で繰り返されていたのをループ外に移動
- `app/services/scenes/scene-item.ts`: `fitToRect()` のゼロサイズガードがソース側のみをチェックしており、targetRect側がゼロサイズになるケース(将来のプリセットデータ不備等)を素通りしていたため、両方をチェックするよう修正

### 待ち時間の調整
- `app/services/scenes/scene.ts`: `fixupSceneItemWhenReadyWithTimeout()` の手動タイマー管理(settled/debounceId/timeoutId/subscriptionの4変数)を、`debounceTime`+`timeout`で安定待ちする汎用ユーティリティ `app/util/observeUntilStable.ts` に切り出し、宣言的な実装に整理
- `app/services/scenes/scene.ts`: 上記のデバウンス時間を500msから200msに短縮。シーンコレクションをプリセットに切り替えた直後、フィット確定までの間は元の縮んだサイズのまま表示されるため、その待ち時間が目立つという実機確認でのフィードバックを反映

## 検証
- `app/util/ScalableRectangle.test.ts`(新規): `fitTo()` のアスペクト比保持・中央寄せの3パターンをカバー
- `app/services/sources/sources.test.ts`: `fixSourceSettings()` の補完ロジック4パターンを追加
- `app/util/observeUntilStable.test.ts`(新規): 安定待ち・リセット動作・タイムアウト等5パターンをカバー
- 実機確認: シーンコレクションからプリセットシーンを削除して再起動し、再インストールされる挙動でWebカメラが正しい枠にアスペクト比を保ってフィットして表示されること、再起動後もフィット結果が保持されることを確認済み

## テスト
- [x] 1280×720以外の解像度のWebカメラでプリセットをインストールし、映像が枠にアスペクト比を保って中央フィットして表示されることを確認
- [x] 再起動後もフィット結果が保持されることを確認

なお、既存の(アイテムが入っている)シーンコレクションでは`scheduleWebcamFitForPreset()`自体が実行されないことはコード構造で保証されています(呼び出し元の`installPresetSceneCollection()`は「シーンコレクションが1つかつシーンが1つかつそのシーンが空」の場合のみ呼ばれる)。そのため全機能テストが必要になる手動での回帰確認は不要と判断しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
