### PR TITLE
修正: コンパクトモードでOBSプレビュー表示中に吹き出しが裏に隠れる問題を修正

### DIFF
--- a/app/components/studio/SideNav.vue
+++ b/app/components/studio/SideNav.vue
@@ -6,7 +6,7 @@
           <i v-if="isCompactMode" class="icon-full-mode" :title="$t('common.fullMode')" />
           <i v-if="!isCompactMode" class="icon-compact-mode" :title="$t('common.compactMode')" />
           <help-tip
-            v-if="isCompactMode"
+            v-if="isCompactMode && compactModeTab !== 'studio'"
             :dismissable-key="CompactModeToggleHelpTipDismissable"
             mode="compact-mode-toggle"
           >


### PR DESCRIPTION
## このpull requestが解決する内容
コンパクトモードで配信関連タブ(studioタブ)を表示中、コンパクトモード切り替えアイコンの吹き出し(ヘルプチップ)がOBSプレビュー画面の裏側に隠れてしまう問題を修正します。

## 背景
コンパクトモード切り替えアイコンには初回案内用の吹き出し(`HelpTip` コンポーネント、`mode="compact-mode-toggle"`)が表示されます。この吹き出しはCSSの `position: absolute` でサイドナビの右横に配置されるDOM要素です。

一方、コンパクトモードの `studio` タブを選択しているとき、サイドナビの右横にはOBSプレビュー(ネイティブウィンドウハンドルへ直接描画)が表示されます。OBSプレビューはネイティブ描画のためCSSの `z-index` が効かず、常にDOM要素より手前に表示されます。そのため `studio` タブでは吹き出しが必ずOBSプレビューの裏に隠れてしまい、ユーザーに見えない状態でした(`niconico` タブでは通常のDOMのみのため問題なく表示されていました)。

## 変更内容
`app/components/studio/SideNav.vue` で、吹き出しの表示条件に「OBSプレビューが表示されるstudioタブでないこと」を追加しました。

```diff
  <help-tip
-   v-if="isCompactMode"
+   v-if="isCompactMode && compactModeTab !== 'studio'"
```

- `compactModeTab` は既存のcomputedプロパティのため追加のimportやstate変更は不要です。
- 吹き出しのdismiss(閉じるボタンで一度閉じたら再表示しない)挙動はそのまま維持されます(このロジック自体は今回変更していません)。

## テスト
- [x] ログイン状態でコンパクトモードに切り替え、`niconico` タブで吹き出しが手前に正しく表示されることを確認
- [x] `studio` タブ(OBSプレビュー表示)に切り替えたとき、吹き出しが表示されない(裏に隠れて見えなくなる状態にならない)ことを確認
- [x] `niconico` タブに戻すと吹き出しが再表示されることを確認(未dismissの場合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
