### PR TITLE
開発: pnpm start をTTYでない環境から実行した際のstdin.unrefエラーを修正

### DIFF
--- a/bin/start-with-auto-env.js
+++ b/bin/start-with-auto-env.js
@@ -13,5 +13,7 @@ childProcess.stderr.pipe(process.stderr);
 
 childProcess.on('close', (code) => {
   process.exitCode = code;
-  process.stdin.unref();
+  if (typeof process.stdin.unref === 'function') {
+    process.stdin.unref();
+  }
 });


### PR DESCRIPTION
## このpull requestが解決する内容

`pnpm start` を TTY でない環境（Claude Code の Bash ツールなど、標準入力がパイプ経由の環境）から実行した際、アプリ終了後に `process.stdin.unref is not a function` の TypeError が発生する問題を修正します。

Closes #1337

## 原因

`bin/start-with-auto-env.js` の子プロセス終了時に `process.stdin.unref()` を呼んでいますが、`process.stdin` が TTY の場合は `net.Socket`（`unref()` を持つ）ですが、パイプ接続時は `Readable` ストリームとなり `unref()` を持たないため例外になっていました。

アプリ本体は正常に終了しており、この TypeError はラッパースクリプト側のみの問題です。

## 変更内容

`process.stdin.unref` が関数として存在する場合のみ呼び出すよう条件チェックを追加しました。

## テスト

- [x] Claude Code の Bash ツールから `pnpm start` を実行し、アプリ終了後にエラーが発生しないことを確認
