### PR TITLE
修正: ウィンドウの最大化ボタンがなくなっていたのを修正

### DIFF
--- a/app/components/nicolive-area/AreaSwitcher.vue.ts
+++ b/app/components/nicolive-area/AreaSwitcher.vue.ts
@@ -15,7 +15,7 @@ export default defineComponent({
   components: { Popper },
 
   props: {
-    contents: { type: Array as () => IArea[] },
+    contents: { type: Array as () => IArea[], required: true as const },
   },
 
   data() {

--- a/app/components/obs/inputs/GenericForm.vue.ts
+++ b/app/components/obs/inputs/GenericForm.vue.ts
@@ -10,7 +10,7 @@ export default defineComponent({
     input: (_value: IObsInput<TObsValue>[], _index: number) => true,
   },
   props: {
-    value: { type: Array as PropType<IObsInput<TObsValue>[]> },
+    value: { type: Array as PropType<IObsInput<TObsValue>[]>, default: (): IObsInput<TObsValue>[] => [] },
     category: { type: String },
     subCategory: { type: String },
   },

--- a/app/components/obs/inputs/GenericFormGroups.vue.ts
+++ b/app/components/obs/inputs/GenericFormGroups.vue.ts
@@ -11,7 +11,7 @@ export default defineComponent({
     input: (_value: ISettingsSubCategory[]) => true,
   },
   props: {
-    value: { type: Array as PropType<ISettingsSubCategory[]> },
+    value: { type: Array as PropType<ISettingsSubCategory[]>, default: (): ISettingsSubCategory[] => [] },
     category: { type: String },
     isLoggedIn: { type: Boolean },
   },

--- a/app/components/shared/Display.vue.ts
+++ b/app/components/shared/Display.vue.ts
@@ -10,7 +10,6 @@ export default defineComponent({
     paddingSize: { type: Number, default: 0 },
     drawUI: { type: Boolean, default: false },
     renderingMode: { type: Number },
-    clickHandler: { type: Boolean },
   },
 
   data() {

--- a/app/components/shared/HelpTip.vue.ts
+++ b/app/components/shared/HelpTip.vue.ts
@@ -6,7 +6,7 @@ export default defineComponent({
   name: 'HelpTip',
 
   props: {
-    dismissableKey: { type: String as () => EDismissable },
+    dismissableKey: { type: String as () => EDismissable, required: true as const },
     mode: { type: String, default: 'scene-selector' },
   },
 

--- a/app/components/shared/Hotkey.vue.ts
+++ b/app/components/shared/Hotkey.vue.ts
@@ -13,7 +13,7 @@ export default defineComponent({
   name: 'HotkeyComponent',
 
   props: {
-    hotkey: { type: Object as () => Hotkey },
+    hotkey: { type: Object as () => Hotkey, required: true as const },
   },
 
   data() {

--- a/app/components/studio/EditableSceneCollection.vue.ts
+++ b/app/components/studio/EditableSceneCollection.vue.ts
@@ -8,8 +8,8 @@ export default defineComponent({
   name: 'EditableSceneCollection',
 
   props: {
-    collectionId: { type: String },
-    selected: { type: Boolean },
+    collectionId: { type: String, required: true as const },
+
   },
 
   data() {

--- a/app/components/studio/MixerItem.vue.ts
+++ b/app/components/studio/MixerItem.vue.ts
@@ -12,7 +12,7 @@ export default defineComponent({
   components: { Slider, MixerVolmeter },
 
   props: {
-    audioSource: { type: Object as PropType<AudioSource> },
+    audioSource: { type: Object as PropType<AudioSource>, required: true as const },
   },
 
   computed: {

--- a/app/components/studio/SideNav.vue.ts
+++ b/app/components/studio/SideNav.vue.ts
@@ -23,10 +23,6 @@ export default defineComponent({
     StreamingStatus,
   },
 
-  props: {
-
-  },
-
   data() {
     return {
       slideOpen: false,

--- a/app/components/studio/SideNav.vue.ts
+++ b/app/components/studio/SideNav.vue.ts
@@ -24,7 +24,7 @@ export default defineComponent({
   },
 
   props: {
-    locked: { type: Boolean },
+
   },
 
   data() {

--- a/app/components/studio/TitleBar.vue.ts
+++ b/app/components/studio/TitleBar.vue.ts
@@ -11,7 +11,7 @@ export default defineComponent({
 
   props: {
     title: { type: String },
-    resizable: { type: Boolean },
+    resizable: { type: Boolean, default: true },
   },
 
   computed: {

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -7,7 +7,7 @@
   >
     <title-bar class="main-title" :title="title" />
     <div class="main-contents">
-      <side-nav v-if="page !== 'Onboarding'" :locked="applicationLoading"></side-nav>
+      <side-nav v-if="page !== 'Onboarding'"></side-nav>
       <div class="main-middle" v-if="showMainMiddle">
         <div v-if="shouldLockContent" class="main-loading">
           <custom-loader></custom-loader>


### PR DESCRIPTION
## 概要

Vue 3 移行に伴う `type: Boolean` props の挙動変化により、メインウィンドウのタイトルバーに最大化ボタンが表示されなかった問題を修正します。

Vue 3 では `type: Boolean` の prop は親から渡されなかった場合に `undefined` ではなく `false` になります。`TitleBar` の `resizable` prop に `default: true` が設定されていなかったため、メインウィンドウ（`:resizable` 未指定）では `resizable === false` となり、最大化ボタンの `v-if` 条件が常に `false` になっていました。

あわせて、同様の問題が起きうる他の props の整理も行いました。

## 変更内容

### バグ修正
- `TitleBar.vue.ts`: `resizable` prop に `default: true` を追加

### 未使用 prop の削除
- `Display.vue.ts`: `clickHandler` prop 削除
- `SideNav.vue.ts`: `locked` prop 削除（`Main.vue` の渡し側も削除）
- `EditableSceneCollection.vue.ts`: `selected` prop 削除

### 型安全性向上（`required: true` / `default` 追加）
- `AreaSwitcher.vue.ts`: `contents` に `required: true`
- `Hotkey.vue.ts`: `hotkey` に `required: true`
- `MixerItem.vue.ts`: `audioSource` に `required: true`
- `EditableSceneCollection.vue.ts`: `collectionId` に `required: true`
- `HelpTip.vue.ts`: `dismissableKey` に `required: true`
- `GenericForm.vue.ts`: `value` に `default: (): IObsInput<TObsValue>[] => []`
- `GenericFormGroups.vue.ts`: `value` に `default: (): ISettingsSubCategory[] => []`
