### PR TITLE
追加: 配信解像度の選択肢にフルHD(1920x1080)を追加

### DIFF
--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -64,6 +64,8 @@ export interface IObsButtonInputValue extends IObsInput<boolean> {
 
 export interface IObsListInput<TValue> extends IObsInput<TValue> {
   options: IObsListOption<TValue>[];
+  /** raw OBS list values, present only when passed through from the native OBS response */
+  values?: Dictionary<TValue>[];
 }
 
 export interface IObsListOption<TValue> {

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -64,7 +64,7 @@ export interface IObsButtonInputValue extends IObsInput<boolean> {
 
 export interface IObsListInput<TValue> extends IObsInput<TValue> {
   options: IObsListOption<TValue>[];
-  /** raw OBS list values, present only when passed through from the native OBS response */
+  /** raw OBS list values; optional because not every list is backed by native OBS data */
   values?: Dictionary<TValue>[];
 }
 

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -274,16 +274,26 @@ export class SettingsService
 
     // We inject niconico specific resolutions
     if (categoryName === 'Video') {
-      const outputSettings = this.findSetting(settings, 'Untitled', 'Output');
+      const outputSettings = this.findSetting(settings, 'Untitled', 'Output') as
+        | IObsListInput<TObsValue>
+        | undefined;
 
       if (outputSettings) {
         // filter resolutions if duplicated in the meaning of value
-        const output = outputSettings as unknown as { values: { [key: string]: string }[] };
-        output.values = output.values.filter((x) => {
+        outputSettings.values = (outputSettings.values ?? []).filter((x) => {
           // one item has only one key-value pair
-          return !Object.keys(x).some((y) => niconicoResolutions.includes(x[y]));
+          return !Object.keys(x).some((y) => niconicoResolutions.includes(x[y] as string));
         });
-        output.values.unshift(...niconicoResolutionValues);
+        outputSettings.values.unshift(...niconicoResolutionValues);
+        outputSettings.options = outputSettings.options.filter(
+          (x) => !niconicoResolutions.includes(x.value as string),
+        );
+        outputSettings.options.unshift(
+          ...niconicoResolutions.map((res) => ({
+            value: res,
+            description: $t(`settings.Video['Untitled']['Output']['${res}']`, { fallback: res }),
+          })),
+        );
       }
     }
 
@@ -335,17 +345,17 @@ export class SettingsService
         parameterApplyServiceSettings.visible = false;
       }
 
-      const aBitrate = parameters.find((parameter: any) => {
-        return parameter.name === 'ABitrate';
-      }) as any;
+      const aBitrate = parameters.find((parameter) => parameter.name === 'ABitrate') as
+        | IObsListInput<TObsValue>
+        | undefined;
       if (aBitrate) {
-        aBitrate.values = aBitrate.values.filter((x: { [key: string]: string }) => {
-          return !Object.keys(x).some((y) => niconicoAudioBitrates.includes(x[y]));
+        aBitrate.values = (aBitrate.values ?? []).filter((x) => {
+          return !Object.keys(x).some((y) => niconicoAudioBitrates.includes(x[y] as string));
         });
         aBitrate.values.unshift(...niconicoAudioBitrateValues);
-        aBitrate.options = aBitrate.options.filter((x: { value: string; description: string }) => {
-          return !niconicoAudioBitrates.includes(x.value);
-        });
+        aBitrate.options = aBitrate.options.filter(
+          (x) => !niconicoAudioBitrates.includes(x.value as string),
+        );
         aBitrate.options.unshift(...niconicoAudioBitrateOptions);
       }
     }


### PR DESCRIPTION
## このpull requestが解決する内容
設定画面(映像タブ)の配信解像度ドロップダウンの選択肢に、フルHD(1920x1080)を追加します。

<img width="1201" height="1200" alt="image" src="https://github.com/user-attachments/assets/f1ad5adf-87c4-45f0-ae75-c7d2af5b4cf8" />

## 背景
「ニコニコ最適化」機能は1080p配信時に配信解像度をフルHD(1920x1080)へ自動設定しますが、設定画面で配信解像度を手動選択するドロップダウンにはフルHDの選択肢がありませんでした。ニコニコ用解像度の候補注入処理が、UIの描画に実際に使われる`options`プロパティではなく`values`プロパティのみを更新していたためです。

## 変更内容
- `app/services/settings/settings.ts`
  - 配信解像度(Output)のニコニコ用解像度注入で、`options`も`values`と同様にフィルタ・追加するよう修正し、フルHD(1920x1080)を選択肢に追加
  - 追加した選択肢の表示名は、既存の翻訳キー(`settings.Video['Untitled']['Output']['解像度']`)経由で取得するようにし、「HD配信用 (1280x720)」「フルHD配信用(1920x1080)」等のラベルが正しく表示されるようにした
  - 併せて、同箇所のオーディオビットレート注入・配信解像度注入にあった`as any`を除去し、`IObsListInput<TObsValue>`型で扱うように修正
- `app/components/obs/inputs/ObsInput.ts`
  - `IObsListInput`に、OBSネイティブ由来のデータにのみ存在する`values`プロパティ(optional)を追加し、上記の型付けを可能にした

## テスト
- `pnpm run typecheck` / 既存の `app/services/settings/*.test.ts` は全てパス
- 手動確認: 設定 > 映像タブで、キャンバス解像度1280x720のまま配信解像度ドロップダウンにフルHD等のニコニコ用解像度が翻訳済みラベル付きで表示されることを確認
