### PR TITLE
修正: ニコニコ最適化時に配信解像度をキャンバス解像度で頭打ちにし引き伸ばしを防止

### DIFF
--- a/app/components/settings/OptimizeForNiconico.vue
+++ b/app/components/settings/OptimizeForNiconico.vue
@@ -6,6 +6,14 @@
         <i class="icon-warning-circle"></i>
         {{ $t('streaming.optimizationForNiconico.recordingWarning') }}
       </p>
+      <p v-if="canvasResolutionWarning" class="alert" data-variant="light" data-type="caution">
+        <i class="icon-warning-circle"></i>
+        {{ $t('streaming.optimizationForNiconico.canvasResolutionWarning', {
+          canvas: canvasResolutionWarning.canvas,
+          applied: canvasResolutionWarning.appliedResolution,
+          recommended: canvasResolutionWarning.recommendedResolution,
+        }) }}
+      </p>
       <ul class="optimize-category-list">
         <li
           class="optimize-category-list-item"

--- a/app/components/settings/OptimizeForNiconico.vue.ts
+++ b/app/components/settings/OptimizeForNiconico.vue.ts
@@ -42,6 +42,9 @@ export default defineComponent({
     isRecording(): boolean {
       return StreamingService.instance().isRecording;
     },
+    canvasResolutionWarning(): OptimizedSettings['canvasResolutionWarning'] {
+      return this.settings.canvasResolutionWarning;
+    },
   },
   methods: {
     setDoNotShowAgain(model: IObsInput<boolean>) {

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -54,7 +54,8 @@
   "optimizationForNiconico": {
     "title": "Optimize simple settings",
     "description": "Optimize simple settings to deliver Nicolive.",
-    "recordingWarning": "Cannot optimize while recording. Start streaming without optimization, or stop recording and start streaming again."
+    "recordingWarning": "Cannot optimize while recording. Start streaming without optimization, or stop recording and start streaming again.",
+    "canvasResolutionWarning": "Streaming resolution was limited to {applied} to match your canvas resolution ({canvas}). To stream at higher quality ({recommended}), increase the canvas resolution in Settings > Video."
   },
   "nicoliveProgramSelector": {
     "title": "Select a program",

--- a/app/i18n/ja-JP/streaming.json
+++ b/app/i18n/ja-JP/streaming.json
@@ -54,7 +54,8 @@
   "optimizationForNiconico": {
     "title": "設定の最適化",
     "description": "ニコニコ生放送に最適化した設定で配信します。",
-    "recordingWarning": "録画中は最適化を実行できません。最適化せずに配信を開始するか、録画を停止してから再度配信を開始してください。"
+    "recordingWarning": "録画中は最適化を実行できません。最適化せずに配信を開始するか、録画を停止してから再度配信を開始してください。",
+    "canvasResolutionWarning": "キャンバス解像度（{canvas}）に合わせて配信解像度を {applied} に制限しました。より高画質（{recommended}）で配信するには、設定 > 映像でキャンバス解像度を上げてください。"
   },
   "nicoliveProgramSelector": {
     "title": "配信番組の選択",

--- a/app/services/nicolive-program/ResponseTypes.ts
+++ b/app/services/nicolive-program/ResponseTypes.ts
@@ -90,8 +90,11 @@ export interface ProgramInfo {
     }[];
     /** ストリーム設定 */
     streamSetting: {
-      /** 配信最高画質 */
-      maxQuality: '6Mbps720p' | '2Mbps450p' | '1Mbps450p' | '384kbps288p' | '192kbps288p';
+      /**
+       * 配信最高画質。`parseMaxQuality` でパースする文字列で、書式や値は将来変わり得る。
+       * 例: '8Mbps1080p60fps', '6Mbps720p', '2Mbps450p', '1Mbps450p', '384kbps288p', '192kbps288p'
+       */
+      maxQuality: string;
       /** 配信の向き */
       orientation: 'Landscape' | 'Portrait';
     };

--- a/app/services/settings/niconico-optimization.test.ts
+++ b/app/services/settings/niconico-optimization.test.ts
@@ -230,6 +230,6 @@ describe('clampResolutionToCanvas', () => {
   });
 
   test('falls back to the smallest resolution when nothing fits the canvas', () => {
-    expect(clampResolutionToCanvas({ w: 1280, h: 720 }, 640, 360)).toEqual({ w: 512, h: 288 });
+    expect(clampResolutionToCanvas({ w: 1280, h: 720 }, 320, 180)).toEqual({ w: 512, h: 288 });
   });
 });

--- a/app/services/settings/niconico-optimization.test.ts
+++ b/app/services/settings/niconico-optimization.test.ts
@@ -1,6 +1,6 @@
 import { TObsFormData, TObsValue } from 'components/obs/inputs/ObsInput';
 
-import { getBestSettingsForNiconico } from './niconico-optimization';
+import { clampResolutionToCanvas, getBestSettingsForNiconico } from './niconico-optimization';
 import {
   EncoderFamily,
   ISettingsAccessor,
@@ -189,5 +189,47 @@ describe('getBestSettingsForNiconico', () => {
       audioBitrate: '192',
       videoBitrate: 6000 - 192,
     });
+  });
+
+  test('does not clamp quality when baseWidth/baseHeight are not given (backward compatibility)', () => {
+    const settings = getBestSettingsForNiconico(
+      { bitrate: 6000, height: 1080, fps: 30, useHardwareEncoder: false },
+      accessor,
+    );
+    expect(settings.quality).toBe('1920x1080');
+  });
+
+  test('clamps quality to canvas resolution when it is smaller than the recommended resolution', () => {
+    const settings = getBestSettingsForNiconico(
+      {
+        bitrate: 6000, height: 1080, fps: 30, useHardwareEncoder: false, baseWidth: 1280, baseHeight: 720,
+      },
+      accessor,
+    );
+    expect(settings.quality).toBe('1280x720');
+  });
+
+  test('does not clamp quality when canvas resolution is large enough', () => {
+    const settings = getBestSettingsForNiconico(
+      {
+        bitrate: 6000, height: 1080, fps: 30, useHardwareEncoder: false, baseWidth: 1920, baseHeight: 1080,
+      },
+      accessor,
+    );
+    expect(settings.quality).toBe('1920x1080');
+  });
+});
+
+describe('clampResolutionToCanvas', () => {
+  test('clamps to the largest recommended resolution that fits the canvas', () => {
+    expect(clampResolutionToCanvas({ w: 1920, h: 1080 }, 1280, 720)).toEqual({ w: 1280, h: 720 });
+  });
+
+  test('returns the recommended resolution unchanged when it fits the canvas', () => {
+    expect(clampResolutionToCanvas({ w: 1280, h: 720 }, 1920, 1080)).toEqual({ w: 1280, h: 720 });
+  });
+
+  test('falls back to the smallest resolution when nothing fits the canvas', () => {
+    expect(clampResolutionToCanvas({ w: 1280, h: 720 }, 640, 360)).toEqual({ w: 512, h: 288 });
   });
 });

--- a/app/services/settings/niconico-optimization.ts
+++ b/app/services/settings/niconico-optimization.ts
@@ -1,5 +1,44 @@
 import { EncoderFamily, OptimizationKey, OptimizeSettings, SettingsKeyAccessor } from './optimizer';
 
+/** ニコニコ生放送が推奨する解像度段。大きい順。 */
+export const NICONICO_RESOLUTIONS: { w: number; h: number }[] = [
+  { w: 1920, h: 1080 },
+  { w: 1280, h: 720 },
+  { w: 800, h: 450 },
+  { w: 512, h: 288 },
+];
+
+/**
+ * recommended をキャンバス解像度 (baseW x baseH) に収まる最大の推奨段へクランプする。
+ * 収まる段が無い場合は最小段を返す。
+ */
+export function clampResolutionToCanvas(
+  recommended: { w: number; h: number },
+  baseW: number,
+  baseH: number,
+): { w: number; h: number } {
+  if (recommended.w <= baseW && recommended.h <= baseH) {
+    return recommended;
+  }
+  const fitting = NICONICO_RESOLUTIONS.find((r) => r.w <= baseW && r.h <= baseH);
+  return fitting ?? NICONICO_RESOLUTIONS[NICONICO_RESOLUTIONS.length - 1];
+}
+
+/** 番組の height からニコニコ推奨解像度を返す（キャンバスによるクランプ前） */
+export function getRecommendedResolutionForHeight(height: number): { w: number; h: number } {
+  switch (height) {
+    case 1080:
+      return { w: 1920, h: 1080 };
+    case 720:
+      return { w: 1280, h: 720 };
+    case 450:
+      return { w: 800, h: 450 };
+    case 288:
+    default:
+      return { w: 512, h: 288 };
+  }
+}
+
 /**
  * niconicoに最適な設定値を返す。
  */
@@ -9,11 +48,12 @@ export function getBestSettingsForNiconico(
     height: number;
     fps: number;
     useHardwareEncoder?: boolean;
+    baseWidth?: number;
+    baseHeight?: number;
   },
   settings: SettingsKeyAccessor,
 ): OptimizeSettings {
   let audioBitrate: number;
-  let resolution: string;
   if (options.bitrate >= 6000) {
     audioBitrate = 192;
   } else if (options.bitrate >= 2000) {
@@ -26,21 +66,12 @@ export function getBestSettingsForNiconico(
     audioBitrate = 48;
   }
 
-  switch (options.height) {
-    case 1080:
-      resolution = '1920x1080';
-      break;
-    case 720:
-      resolution = '1280x720';
-      break;
-    case 450:
-      resolution = '800x450';
-      break;
-    case 288:
-    default:
-      resolution = '512x288';
-      break;
+  let resolutionValue = getRecommendedResolutionForHeight(options.height);
+
+  if (options.baseWidth && options.baseHeight) {
+    resolutionValue = clampResolutionToCanvas(resolutionValue, options.baseWidth, options.baseHeight);
   }
+  const resolution = `${resolutionValue.w}x${resolutionValue.h}`;
 
   let encoderSettings: OptimizeSettings = {
     encoder: EncoderFamily.x264,

--- a/app/services/settings/optimizer.ts
+++ b/app/services/settings/optimizer.ts
@@ -452,6 +452,12 @@ export interface OptimizedSettings {
       newValue?: string;
     }[],
   ][];
+  /** キャンバス解像度により配信解像度が推奨より下げられた場合の警告情報 */
+  canvasResolutionWarning?: {
+    canvas: string;
+    recommendedResolution: string;
+    appliedResolution: string;
+  };
 }
 
 /**

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -32,7 +32,7 @@ import { Inject } from '../core/injector';
 import { VideoSettingsService } from '../settings-v2';
 import Utils from '../utils';
 
-import { getBestSettingsForNiconico } from './niconico-optimization';
+import { getBestSettingsForNiconico, getRecommendedResolutionForHeight } from './niconico-optimization';
 import {
   ISettingsAccessor,
   OptimizationKey,
@@ -582,7 +582,20 @@ export class SettingsService
     useHardwareEncoder?: boolean;
   }): OptimizedSettings {
     const accessor = new SettingsKeyAccessor(this);
-    const best = getBestSettingsForNiconico(options, accessor);
+    const { baseResolution } = this.getStreamEncoderSettings();
+    const [baseWidthStr, baseHeightStr] = (baseResolution ?? '').split('x');
+    const baseWidth = parseInt(baseWidthStr, 10);
+    const baseHeight = parseInt(baseHeightStr, 10);
+    const hasValidBase = Number.isFinite(baseWidth) && Number.isFinite(baseHeight)
+      && baseWidth > 0 && baseHeight > 0;
+
+    const best = getBestSettingsForNiconico(
+      {
+        ...options,
+        ...(hasValidBase ? { baseWidth, baseHeight } : {}),
+      },
+      accessor,
+    );
     const opt = new Optimizer(accessor, best);
 
     const current = opt.getCurrentSettings();
@@ -590,11 +603,25 @@ export class SettingsService
     // 最適化の必要な値を抽出する
     const delta: OptimizeSettings = Object.assign({}, ...Optimizer.getDifference(current, best));
 
+    let canvasResolutionWarning: OptimizedSettings['canvasResolutionWarning'];
+    if (hasValidBase) {
+      const recommended = getRecommendedResolutionForHeight(options.height);
+      const recommendedResolution = `${recommended.w}x${recommended.h}`;
+      if (best.quality && best.quality !== recommendedResolution) {
+        canvasResolutionWarning = {
+          canvas: baseResolution,
+          recommendedResolution,
+          appliedResolution: best.quality,
+        };
+      }
+    }
+
     return {
       current,
       best,
       delta,
       info: opt.optimizeInfo(current, delta),
+      canvasResolutionWarning,
     };
   }
 

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -833,6 +833,7 @@ const createInjecteeForOptimizeTest = ({
   showOptimizationDialogForNiconico = true,
   optimizeWithHardwareEncoder = false,
   diffDelta = { encoder: EncoderFamily.x264 } as OptimizedSettings['delta'],
+  canvasResolutionWarning = undefined as OptimizedSettings['canvasResolutionWarning'],
 } = {}) => {
   const injectee = createInjectee({
     isNiconicoLoggedIn: true,
@@ -856,6 +857,7 @@ const createInjecteeForOptimizeTest = ({
         current: {},
         delta: diffDelta,
         info: [],
+        canvasResolutionWarning,
       })),
       optimizeForNiconico: jest.fn(),
     },
@@ -968,6 +970,41 @@ test('optimizeForNiconicoAndStartStreaming: 差分なし・録画中でもtoggle
   expect(showWindow).not.toHaveBeenCalled();
   expect(injectee.SettingsService.optimizeForNiconico).not.toHaveBeenCalled();
   expect(instance.toggleStreaming).toHaveBeenCalledTimes(1);
+});
+
+test('optimizeForNiconicoAndStartStreaming: 差分なし・canvasResolutionWarningあり・ダイアログ無効でもshowWindowを呼ぶ', async () => {
+  const injectee = createInjecteeForOptimizeTest({
+    diffDelta: {},
+    showOptimizationDialogForNiconico: false,
+    canvasResolutionWarning: {
+      canvas: '1280x720',
+      recommendedResolution: '1920x1080',
+      appliedResolution: '1280x720',
+    },
+  });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const instance = StreamingService.instance();
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  showWindow.mockClear();
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).toHaveBeenCalledTimes(1);
+  expect(injectee.SettingsService.optimizeForNiconico).not.toHaveBeenCalled();
+  expect(instance.toggleStreaming).not.toHaveBeenCalled();
 });
 
 test('logStreamEndがstreamingTrackIdが設定されている場合にstream_endを送信する', () => {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -487,8 +487,13 @@ export class StreamingService
       fps: streamingSetting.quality.fps,
       useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
     });
-    if (Object.keys(settings.delta).length > 0 || mustShowDialog) {
-      if (this.customizationService.showOptimizationDialogForNiconico || mustShowDialog || this.isRecording) {
+    if (Object.keys(settings.delta).length > 0 || mustShowDialog || settings.canvasResolutionWarning) {
+      if (
+        this.customizationService.showOptimizationDialogForNiconico
+        || mustShowDialog
+        || this.isRecording
+        || settings.canvasResolutionWarning
+      ) {
         this.windowsService.showWindow({
           componentName: 'OptimizeForNiconico',
           title: $t('streaming.optimizationForNiconico.title'),


### PR DESCRIPTION
## このpull requestが解決する内容

ニコニコ最適化時に、配信解像度がキャンバス解像度より大きい状態が発生しないようにします。

## 背景

ニコニコ最適化(`OptimizeForNiconico`ダイアログ)は番組情報のビットレート等から配信(Output)解像度を自動決定します(高さに応じて1920x1080/1280x720/800x450/512x288の4段)。この際キャンバス(Base)解像度が配信解像度より小さいと、低解像度のキャンバスを配信解像度へ引き伸ばして送信することになり、配信解像度が示す品質より劣った映像が送られてしまいます。最適化は配信開始時に自動発動するため、この状態がユーザーの意識に登りにくい問題がありました。

## 変更内容

- キャンバス解像度が推奨解像度より小さい場合、配信解像度をキャンバス解像度に収まる最大の推奨段へクランプするようにしました(`getBestSettingsForNiconico`)
- クランプにより推奨解像度より下げられた場合、最適化ダイアログに警告を表示し、設定 > 映像でキャンバス解像度を上げれば高画質配信が可能になる旨を案内するようにしました
- キャンバス解像度の自動変更は行いません(最適化ウィンドウと設定ウィンドウはChildWindowで排他のため、案内表示のみに留めています)
- 操作は妨げません(警告表示中もボタンは無効化されません)
- 設定に変更が発生しない場合(既に最適な状態)でもキャンバス解像度による警告があれば最適化ダイアログを表示するようにしました。「次回から最適化ダイアログを表示しない」設定時にも、この警告がある場合はダイアログを表示します

キャンバス解像度1280x720、配信推奨1920x1080のケースで実際に表示される警告:

<img width="901" height="892" alt="image" src="https://github.com/user-attachments/assets/a916b049-809b-43b6-9143-4bf071f5591c" />

### ファイル変更

- `app/services/settings/niconico-optimization.ts`: 推奨解像度段の定数化、`clampResolutionToCanvas`によるクランプロジックを追加
- `app/services/settings/optimizer.ts`: `OptimizedSettings`に`canvasResolutionWarning`フィールドを追加
- `app/services/settings/settings.ts`: `diffOptimizedSettings`でキャンバス解像度を取得し、クランプ発生時に警告情報を組み立てるように変更
- `app/services/streaming/streaming.ts`: `canvasResolutionWarning`がある場合は設定差分が空でも最適化ダイアログを表示するように変更
- `app/components/settings/OptimizeForNiconico.vue(.ts)`: 既存の録画中警告と同じスタイルのcautionアラートを追加
- `app/i18n/{ja-JP,en-US}/streaming.json`: 警告文言を追加

## テスト

- [x] `pnpm run test:unit:app` で既存テスト・追加テストがすべてパスすることを確認
- [x] `pnpm run typecheck` で型エラーがないことを確認
- [x] 実機でキャンバス解像度を1280x720に設定し、1080p推奨の番組で最適化ダイアログを開き、配信解像度が1280x720にクランプされ警告が表示されることを確認
- [x] キャンバス解像度=配信解像度(720x720)の場合、設定差分が無くても警告により最適化ダイアログが表示されることを確認
- [x] 警告表示中も「最適化して配信」ボタンが押せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
