### PR TITLE
修正: シーンやシーンコレクションの切り替えタイミングで操作が失敗する問題を修正

### DIFF
--- a/app/components/studio/SceneSelector.vue
+++ b/app/components/studio/SceneSelector.vue
@@ -29,7 +29,7 @@
 
           <template #reference>
             <button class="scene-collections__toggle">
-              <span class="scene-name">{{ activeCollection.name }}</span
+              <span class="scene-name">{{ activeCollection?.name }}</span
               ><i class="icon-drop-down-arrow" />
             </button>
           </template>

--- a/app/services/clipboard/clipboard.ts
+++ b/app/services/clipboard/clipboard.ts
@@ -331,26 +331,34 @@ export class ClipboardService
   private beforeCollectionSwitchHandler() {
     // save nodes to unloaded clipboard
     if (!this.hasItemsInUnloadedClipboard() && this.hasItems()) {
-      let sourcesInfo: Dictionary<ISourceInfo> = {};
-      const scenes = this.scenesService.activeScene.getNestedScenes();
-      const scenesNodes: IScenesNodes = { current: [] };
+      // シーンコレクション切替のタイミング次第でactiveSceneや
+      // itemsSceneIdに対応するシーンが既に見つからない(null)ことがある。
+      // その場合はクリップボードの退避を諦めてスキップする。
+      const activeScene = this.scenesService.activeScene;
+      const itemsScene = this.scenesService.getScene(this.state.itemsSceneId);
 
-      scenes.forEach((scene) => {
-        const sceneInfo = this.getSceneInfo(scene, sourcesInfo);
-        scenesNodes[scene.id] = sceneInfo.sceneNodes;
+      if (activeScene && itemsScene) {
+        let sourcesInfo: Dictionary<ISourceInfo> = {};
+        const scenes = activeScene.getNestedScenes();
+        const scenesNodes: IScenesNodes = { current: [] };
+
+        scenes.forEach((scene) => {
+          const sceneInfo = this.getSceneInfo(scene, sourcesInfo);
+          scenesNodes[scene.id] = sceneInfo.sceneNodes;
+          sourcesInfo = sceneInfo.sources;
+        });
+
+        const sceneInfo = this.getSceneInfo(
+          itemsScene,
+          sourcesInfo,
+          this.state.sceneNodesIds,
+        );
+
+        scenesNodes.current = sceneInfo.sceneNodes;
         sourcesInfo = sceneInfo.sources;
-      });
 
-      const sceneInfo = this.getSceneInfo(
-        this.scenesService.getScene(this.state.itemsSceneId),
-        sourcesInfo,
-        this.state.sceneNodesIds,
-      );
-
-      scenesNodes.current = sceneInfo.sceneNodes;
-      sourcesInfo = sceneInfo.sources;
-
-      this.SET_UNLOADED_CLIPBOARD_NODES(sourcesInfo, scenesNodes);
+        this.SET_UNLOADED_CLIPBOARD_NODES(sourcesInfo, scenesNodes);
+      }
     }
 
     if (!this.hasFiltersInUnloadedClipboard() && this.hasFilters()) {

--- a/app/services/custom-cast-usage.test.ts
+++ b/app/services/custom-cast-usage.test.ts
@@ -1,0 +1,107 @@
+import { Subject } from 'rxjs';
+import { jest_fn } from 'util/jest_fn';
+import { createSetupFunction } from 'util/test-setup';
+
+import type { CustomcastUsageService as CustomcastUsageServiceType } from './custom-cast-usage';
+
+const setup = createSetupFunction({
+  state: {},
+});
+
+beforeEach(() => {
+  jest.doMock('services/core/stateful-service');
+  jest.doMock('services/core/injector');
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+});
+
+function prepare(activeScene: unknown = null) {
+  const sceneSwitched = new Subject<void>();
+  const itemAdded = new Subject<{ sourceId: string }>();
+
+  setup({
+    injectee: {
+      ScenesService: {
+        activeScene,
+        sceneSwitched,
+        itemAdded,
+      },
+      SourcesService: {
+        getSource: jest_fn().mockName('getSource'),
+      },
+      NicoliveProgramService: {
+        state: { programID: '' },
+      },
+    },
+  });
+
+  const { CustomcastUsageService } = require('./custom-cast-usage') as {
+    CustomcastUsageService: typeof CustomcastUsageServiceType;
+  };
+  const instance = CustomcastUsageService.instance();
+
+  return { instance, sceneSwitched, itemAdded };
+}
+
+describe('CustomcastUsageService', () => {
+  describe('containsCustomcastInActiveScene', () => {
+    it('activeScene が null のとき false を返す（クラッシュしない）', () => {
+      const { instance } = prepare(null);
+      expect(() => instance.containsCustomcastInActiveScene()).not.toThrow();
+      expect(instance.containsCustomcastInActiveScene()).toBe(false);
+    });
+
+    it('activeScene が存在するがカスタムキャストがないとき false を返す', () => {
+      const mockScene = {
+        getItems: jest_fn().mockName('getItems').mockReturnValue([]),
+      };
+      const { instance } = prepare(mockScene);
+      expect(instance.containsCustomcastInActiveScene()).toBe(false);
+    });
+
+    it('activeScene にカスタムキャストのアイテムがあるとき true を返す', () => {
+      const mockScene = {
+        getItems: jest_fn().mockName('getItems').mockReturnValue([{ sourceId: 'source-1' }]),
+      };
+      const sceneSwitched = new Subject<void>();
+      const itemAdded = new Subject<{ sourceId: string }>();
+
+      setup({
+        injectee: {
+          ScenesService: {
+            activeScene: mockScene,
+            sceneSwitched,
+            itemAdded,
+          },
+          SourcesService: {
+            getSource: jest_fn().mockName('getSource').mockReturnValue({
+              getComparisonDetails: () => ({ propertiesManager: 'custom-cast-ndi' }),
+            }),
+          },
+          NicoliveProgramService: {
+            state: { programID: '' },
+          },
+        },
+      });
+
+      const { CustomcastUsageService } = require('./custom-cast-usage') as {
+        CustomcastUsageService: typeof CustomcastUsageServiceType;
+      };
+      const instance = CustomcastUsageService.instance();
+
+      expect(instance.containsCustomcastInActiveScene()).toBe(true);
+    });
+  });
+
+  describe('startStreaming', () => {
+    it('activeScene が null でもクラッシュせず isCustomcastUsed は false のままになる', () => {
+      const { instance } = prepare(null);
+      expect(() => instance.startStreaming()).not.toThrow();
+      expect(instance.state.isCustomcastUsed).toBe(false);
+    });
+  });
+});

--- a/app/services/custom-cast-usage.ts
+++ b/app/services/custom-cast-usage.ts
@@ -22,6 +22,7 @@ export class CustomcastUsageService extends StatefulService<ICustomcastUsageStat
   @Inject() private nicoliveProgramService: NicoliveProgramService;
 
   init() {
+    super.init();
     this.reset();
 
     this.scenesService.sceneSwitched.subscribe(() => {
@@ -43,7 +44,12 @@ export class CustomcastUsageService extends StatefulService<ICustomcastUsageStat
   }
 
   containsCustomcastInActiveScene(): boolean {
-    for (const item of this.scenesService.activeScene.getItems()) {
+    // 配信開始直後やシーンコレクション切替中などはactiveSceneが一時的にnullになりうる。
+    // その場合は使用なしとして扱う(実害が軽微なためSentry報告はしない)。
+    const activeScene = this.scenesService.activeScene;
+    if (!activeScene) return false;
+
+    for (const item of activeScene.getItems()) {
       if (this.isCustomcastSourceId(item.sourceId)) {
         return true;
       }

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -122,11 +122,21 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   enableStudioMode() {
     if (this.state.studioMode) return;
 
+    // シーンコレクション切替中などは activeScene が一時的に null になりうる。
+    // その場合はstudioModeを開始せずに終了する。
+    const activeScene = this.scenesService.activeScene;
+    if (!activeScene) {
+      SentryReport.message('TransitionsService', 'enableStudioMode', 'activeScene is null, skip entering studio mode', {
+        level: 'warning',
+      });
+      return;
+    }
+
     this.SET_STUDIO_MODE(true);
     this.studioModeChanged.next(true);
 
     if (!this.studioModeTransition) this.createStudioModeTransition();
-    const currentScene = this.scenesService.activeScene.getObsScene();
+    const currentScene = activeScene.getObsScene();
     this.sceneDuplicate = currentScene.duplicate(uuidv4(), obs.ESceneDupType.Copy);
 
     // Immediately switch to the duplicated scene
@@ -141,7 +151,16 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     this.SET_STUDIO_MODE(false);
     this.studioModeChanged.next(false);
 
-    this.getCurrentTransition().set(this.scenesService.activeScene.getObsScene());
+    // シーンコレクション切替中などは activeScene が一時的に null になりうる。
+    // その場合はtransitionへの反映をスキップし、studioMode解除自体は完了させる。
+    const activeScene = this.scenesService.activeScene;
+    if (activeScene) {
+      this.getCurrentTransition().set(activeScene.getObsScene());
+    } else {
+      SentryReport.message('TransitionsService', 'disableStudioMode', 'activeScene is null, skip transition update', {
+        level: 'warning',
+      });
+    }
     this.releaseStudioModeObjects();
   }
 
@@ -210,7 +229,16 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
 
   transition(sceneAId: string, sceneBId: string) {
     if (this.state.studioMode) {
+      // studioModeTransitionが未生成/解放済み、またはsceneBIdに対応するシーンが
+      // 見つからない（シーンコレクション切替中など）場合は反映をスキップする。
       const scene = this.scenesService.getScene(sceneBId);
+      if (!this.studioModeTransition || !scene) {
+        SentryReport.message('TransitionsService', 'transition', 'studioModeTransition or scene is null, skip transition', {
+          level: 'warning',
+          extra: { hasStudioModeTransition: !!this.studioModeTransition, hasScene: !!scene },
+        });
+        return;
+      }
       this.studioModeTransition.set(scene.getObsScene());
       return;
     }


### PR DESCRIPTION
## このpull requestが解決する内容

スタジオモードの切り替え、シーン選択、配信開始、シーンコレクション切り替えのタイミングで `activeScene` などが一時的に `null` になる瞬間に例外が発生し、操作が正しく反映されないことがあった問題を修正します。

## 背景

Sentryで報告されていた複数のJSエラーを調査した結果、いずれも「シーンコレクション切替中や配信開始直後などでシーンがまだ確定していないタイミングで、null チェックなしにメソッドを呼んでいる」という共通の原因パターンでした。想定内の一時的な null 状態なので、throw せず防御的にスキップすることで解決します。

## 変更内容

- `app/services/transitions.ts`
  - `enableStudioMode`: `activeScene` が null のときはスタジオモードを開始せず終了
  - `disableStudioMode`: `activeScene` が null のときは transition への反映のみスキップし、スタジオモード解除自体は完了させる
  - `transition`: `studioModeTransition` または対象シーンが null のときは反映をスキップ
- `app/services/custom-cast-usage.ts`
  - `containsCustomcastInActiveScene`: `activeScene` が null のときは false を返す（配信開始直後の未確定タイミングは想定内のため報告なしで静かに処理）
  - テスト実行のため `init()` に `super.init()` を追加（本番の `StatefulService` には `init()` 自体が存在せず無害。テストの state 初期化に必要）
- `app/components/studio/SceneSelector.vue`
  - `activeCollection.name` を optional chaining に変更（`activeCollection` は元々 null を返せる設計）
- `app/services/clipboard/clipboard.ts`
  - `beforeCollectionSwitchHandler`: `activeScene` / 対象シーンが null の場合はクリップボード退避処理をスキップ

## テスト

- [x] `app/services/custom-cast-usage.test.ts` を新規追加し、`activeScene` が null の場合の分岐を検証
- [x] `pnpm run test:unit:app`（69 スイート / 1034 テスト、全パス）
- [x] `pnpm typecheck`（vue-tsc、エラーなし）
- [x] `pnpm lint`（エラーなし）

## Sentry

Sentry-Resolves: N-AIR-APP-GAW N-AIR-APP-GAJ N-AIR-APP-G0Q N-AIR-APP-G88 N-AIR-APP-GB3
