### PR TITLE
修正: シーン内のソースをドラッグして並び替える際に操作が失敗する問題を修正

### DIFF
--- a/app/components/studio/SourceSelector.vue.ts
+++ b/app/components/studio/SourceSelector.vue.ts
@@ -182,9 +182,17 @@ export default defineComponent({
         Sentry.captureMessage('handleSort: treeNodesToMove is not an array', { level: 'warning', extra: { treeNodesToMove } });
         return;
       }
+      // シーンコレクション切替中などはactiveSceneが一時的にnullになりうる。
+      if (!this.scene) return;
+
       const nodesToMove = this.scene.getSelection(treeNodesToMove.map((node) => node.data.id));
 
       const destNode = this.scene.getNode(position.node.data.id);
+      // ドラッグ中に対象ノードが削除されるなどでdestNodeが見つからない場合がある。
+      if (!destNode) {
+        Sentry.captureMessage('handleSort: destNode not found', { level: 'warning', extra: { destNodeId: position.node.data.id } });
+        return;
+      }
 
       if (position.placement === 'before') {
         nodesToMove.placeBefore(destNode.id);

--- a/app/services/scenes/scene.test.ts
+++ b/app/services/scenes/scene.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Scene.reconcileNodeOrderWithObs (setNodesOrder経由) のテスト
+ *
+ * ドラッグ操作中の削除・シーン切替との競合などでVuex state上のアイテムと
+ * OBSネイティブ側のアイテム集合が一時的にズレたとき、対応するOBS側アイテムが
+ * 見つからないアイテムはスキップして処理を継続することを検証する (N-AIR-APP-FWY, G8M)。
+ */
+import * as Sentry from '@sentry/vue';
+import { createSetupFunction } from 'util/test-setup';
+
+jest.mock('@sentry/vue', () => ({
+  captureMessage: jest.fn(),
+  withScope: jest.fn((cb) => cb({
+    setLevel: jest.fn(),
+    setTag: jest.fn(),
+    setFingerprint: jest.fn(),
+    setExtra: jest.fn(),
+    setContext: jest.fn(),
+  })),
+}));
+
+jest.mock('util/sentry-obs-breadcrumb', () => ({
+  markObsOp: jest.fn(),
+  setObsOpObserver: jest.fn(),
+  getLastObsOp: jest.fn(),
+  assertObsObjectDefined: jest.fn(),
+}));
+
+jest.mock('services/core/stateful-service');
+jest.mock('services/core/injector');
+jest.mock('services/core/service-helper', () => ({
+  ServiceHelper: () => () => {},
+}));
+
+const setup = createSetupFunction();
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+function makeObsScene(items: { id: number }[]) {
+  return {
+    getItems: jest.fn(() => [...items]),
+    moveItem: jest.fn(),
+  };
+}
+
+function prepare({
+  itemIds,
+  obsItemIds,
+}: {
+  itemIds: { sceneItemId: string; sourceId: string; obsSceneItemId: number }[];
+  obsItemIds: number[];
+}) {
+  const sceneId = 'scene1';
+  const nodes = itemIds.map(({ sceneItemId, sourceId, obsSceneItemId }) => ({
+    id: sceneItemId,
+    sceneNodeType: 'item' as const,
+    sourceId,
+    obsSceneItemId,
+  }));
+
+  const sources: Record<string, unknown> = {};
+  itemIds.forEach(({ sourceId }) => {
+    sources[sourceId] = { sourceId };
+  });
+
+  const obsScene = makeObsScene(obsItemIds.map((id) => ({ id })));
+
+  setup({
+    injectee: {
+      ScenesService: {
+        state: {
+          scenes: {
+            [sceneId]: { id: sceneId, nodes },
+          },
+        },
+        getScene: jest.fn(),
+      },
+      SourcesService: {
+        state: { sources },
+      },
+      SelectionService: {},
+      VideoSettingsService: {},
+      VideoService: {},
+    },
+  });
+
+  const { Scene } = require('./scene') as { Scene: new (id: string) => any };
+  const scene = new Scene(sceneId);
+  jest.spyOn(scene, 'getObsScene').mockReturnValue(obsScene);
+
+  return { scene, obsScene };
+}
+
+describe('Scene.reconcileNodeOrderWithObs (via setNodesOrder)', () => {
+  test('全アイテムに対応するOBS側アイテムがある場合、すべてmoveItemされる', () => {
+    const { scene, obsScene } = prepare({
+      itemIds: [
+        { sceneItemId: 'item1', sourceId: 'source1', obsSceneItemId: 1 },
+        { sceneItemId: 'item2', sourceId: 'source2', obsSceneItemId: 2 },
+      ],
+      obsItemIds: [2, 1],
+    });
+
+    expect(() => scene.setNodesOrder(['item1', 'item2'])).not.toThrow();
+    expect(obsScene.moveItem).toHaveBeenCalledTimes(2);
+  });
+
+  test('対応するOBS側アイテムが見つからないアイテムはスキップし、他のアイテムは処理を継続する', () => {
+    const { scene, obsScene } = prepare({
+      itemIds: [
+        { sceneItemId: 'item1', sourceId: 'source1', obsSceneItemId: 1 },
+        { sceneItemId: 'item2', sourceId: 'source2', obsSceneItemId: 999 }, // OBS側に存在しない
+      ],
+      obsItemIds: [1],
+    });
+
+    expect(() => scene.setNodesOrder(['item1', 'item2'])).not.toThrow();
+    // item1のみmoveItemが呼ばれる (item2はスキップ)
+    expect(obsScene.moveItem).toHaveBeenCalledTimes(1);
+    expect(obsScene.moveItem).toHaveBeenCalledWith(0, 0);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled(); // SentryReportはwithScope経由
+  });
+
+  test('対応するOBS側アイテムが1件も見つからない場合でもクラッシュしない', () => {
+    const { scene, obsScene } = prepare({
+      itemIds: [
+        { sceneItemId: 'item1', sourceId: 'source1', obsSceneItemId: 1 },
+      ],
+      obsItemIds: [],
+    });
+
+    expect(() => scene.setNodesOrder(['item1'])).not.toThrow();
+    expect(obsScene.moveItem).not.toHaveBeenCalled();
+  });
+});

--- a/app/services/scenes/scene.test.ts
+++ b/app/services/scenes/scene.test.ts
@@ -5,7 +5,6 @@
  * OBSネイティブ側のアイテム集合が一時的にズレたとき、対応するOBS側アイテムが
  * 見つからないアイテムはスキップして処理を継続することを検証する (N-AIR-APP-FWY, G8M)。
  */
-import * as Sentry from '@sentry/vue';
 import { createSetupFunction } from 'util/test-setup';
 
 jest.mock('@sentry/vue', () => ({
@@ -91,7 +90,9 @@ function prepare({
   const scene = new Scene(sceneId);
   jest.spyOn(scene, 'getObsScene').mockReturnValue(obsScene);
 
-  return { scene, obsScene };
+  const Sentry = require('@sentry/vue');
+
+  return { scene, obsScene, Sentry };
 }
 
 describe('Scene.reconcileNodeOrderWithObs (via setNodesOrder)', () => {
@@ -109,7 +110,7 @@ describe('Scene.reconcileNodeOrderWithObs (via setNodesOrder)', () => {
   });
 
   test('対応するOBS側アイテムが見つからないアイテムはスキップし、他のアイテムは処理を継続する', () => {
-    const { scene, obsScene } = prepare({
+    const { scene, obsScene, Sentry } = prepare({
       itemIds: [
         { sceneItemId: 'item1', sourceId: 'source1', obsSceneItemId: 1 },
         { sceneItemId: 'item2', sourceId: 'source2', obsSceneItemId: 999 }, // OBS側に存在しない
@@ -121,7 +122,10 @@ describe('Scene.reconcileNodeOrderWithObs (via setNodesOrder)', () => {
     // item1のみmoveItemが呼ばれる (item2はスキップ)
     expect(obsScene.moveItem).toHaveBeenCalledTimes(1);
     expect(obsScene.moveItem).toHaveBeenCalledWith(0, 0);
-    expect(Sentry.captureMessage).not.toHaveBeenCalled(); // SentryReportはwithScope経由
+    // スキップしたことがSentryに報告される
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'OBS scene item not found for obsSceneItemId, skipping moveItem',
+    );
   });
 
   test('対応するOBS側アイテムが1件も見つからない場合でもクラッシュしない', () => {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -402,9 +402,13 @@ export class Scene {
    * Makes sure all scene items are in the correct order in OBS.
    */
   private reconcileNodeOrderWithObs() {
-    const obsItems = this.getObsScene().getItems().reverse();
+    const obsScene = this.getObsScene();
     this.getItems().forEach((item, index) => {
-      const currentIndex = obsItems.findIndex((obsItem) => obsItem.id === item.obsSceneItemId);
+      // moveItem実行後はOBS側の並びが変わるため、都度取り直す必要がある。
+      const currentIndex = obsScene
+        .getItems()
+        .reverse()
+        .findIndex((obsItem) => obsItem.id === item.obsSceneItemId);
       // stateとOBS側のアイテム集合が一時的にズレている(ドラッグ操作中の削除・
       // シーン切替との競合など)と対応するOBS側アイテムが見つからないことがある。
       // その場合はこのアイテムの並び替えのみスキップして処理を継続する。
@@ -415,7 +419,7 @@ export class Scene {
         });
         return;
       }
-      this.getObsScene().moveItem(currentIndex, index);
+      obsScene.moveItem(currentIndex, index);
     });
   }
 

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -326,6 +326,16 @@ export class Scene {
     const sourceNode = this.getNode(sourceNodeId);
     const destNode = this.getNode(destNodeId);
 
+    // ドラッグ操作中の削除やシーン切替との競合で、既に存在しないノードIDが
+    // 渡されることがある。その場合は並び替えをスキップする。
+    if (!sourceNode) {
+      SentryReport.message('Scene', 'placeAfter', 'sourceNode not found, skipping reorder', {
+        level: 'warning',
+        extra: { sceneId: this.id, sourceNodeId, destNodeId },
+      });
+      return;
+    }
+
     if (destNode && destNode.id === sourceNode.id) return;
 
     const destNodeIsParentForSourceNode = destNode && destNode.id === sourceNode.parentId;
@@ -392,23 +402,46 @@ export class Scene {
    * Makes sure all scene items are in the correct order in OBS.
    */
   private reconcileNodeOrderWithObs() {
+    const obsItems = this.getObsScene().getItems().reverse();
     this.getItems().forEach((item, index) => {
-      const currentIndex = this.getObsScene()
-        .getItems()
-        .reverse()
-        .findIndex((obsItem) => obsItem.id === item.obsSceneItemId);
+      const currentIndex = obsItems.findIndex((obsItem) => obsItem.id === item.obsSceneItemId);
+      // stateとOBS側のアイテム集合が一時的にズレている(ドラッグ操作中の削除・
+      // シーン切替との競合など)と対応するOBS側アイテムが見つからないことがある。
+      // その場合はこのアイテムの並び替えのみスキップして処理を継続する。
+      if (currentIndex === -1) {
+        SentryReport.message('Scene', 'reconcileNodeOrderWithObs', 'OBS scene item not found for obsSceneItemId, skipping moveItem', {
+          level: 'warning',
+          extra: { sceneId: this.id, sceneItemId: item.id, obsSceneItemId: item.obsSceneItemId, index },
+        });
+        return;
+      }
       this.getObsScene().moveItem(currentIndex, index);
     });
   }
 
   placeBefore(sourceNodeId: string, destNodeId: string) {
     const destNode = this.getNode(destNodeId);
+    // ドラッグ操作中の削除やシーン切替との競合で、既に存在しないノードIDが
+    // 渡されることがある。その場合は並び替えをスキップする。
+    if (!destNode) {
+      SentryReport.message('Scene', 'placeBefore', 'destNode not found, skipping reorder', {
+        level: 'warning',
+        extra: { sceneId: this.id, sourceNodeId, destNodeId },
+      });
+      return;
+    }
     const newDestNode = destNode.getPrevSiblingNode();
     if (newDestNode) {
       this.placeAfter(sourceNodeId, newDestNode.id);
     } else if (destNode.parentId) {
       const sourceNode = this.getNode(sourceNodeId);
-      assertIsDefined(sourceNode);
+      if (!sourceNode) {
+        SentryReport.message('Scene', 'placeBefore', 'sourceNode not found, skipping reorder', {
+          level: 'warning',
+          extra: { sceneId: this.id, sourceNodeId, destNodeId },
+        });
+        return;
+      }
       sourceNode.setParent(destNode.parentId); // place to the top of folder
     } else {
       this.placeAfter(sourceNodeId); // place to the top of scene


### PR DESCRIPTION
## このpull requestが解決する内容

シーン内のソース（アイテム）をドラッグ&ドロップで並び替える際に、"Index not found in Scene." 例外が発生して操作が失敗することがあった問題を修正します。

## 背景

Sentryで報告されていた頻出エラー（N-AIR-APP-FWY: 58件/34ユーザー、N-AIR-APP-G8M: 4件/3ユーザー）を調査した結果、シーン内アイテムの並び替え時に、Vuex state上のシーンアイテムとOBSネイティブ側のアイテム集合が一時的にズレていると、`Scene.reconcileNodeOrderWithObs` が対応するOBS側アイテムを見つけられずに `moveItem(-1, ...)` を呼んで例外が発生し、並び替え操作全体が失敗していたことが直接の原因でした。

このズレが具体的にどの操作によって生じているかは、Sentryのスタックトレースだけからは特定できていません。ドラッグ操作自体にはロックや排他制御が無く、並び替え中に何らかの理由でstateとOBS側の対応関係が崩れると、それだけで例外に直結する作りになっていました。原因調査を続ける余地はありますが、まずは「対応関係が崩れていても例外を投げずに安全側に処理を続行する」という防御的な対処を優先し、実際にどのくらいの頻度でスキップが発生しているかをSentry側の記録（`sceneId`/`sceneItemId`/`obsSceneItemId`をextraに含めて報告）から継続的に観測できるようにしました。OBS呼び出し自体は同期IPCのため、待機やリトライでの解決は見込めません。

## 変更内容

- `app/services/scenes/scene.ts`
  - `reconcileNodeOrderWithObs`: 対応するOBS側アイテムが見つからないアイテムはそのアイテムの並び替えのみスキップし、他のアイテムの処理は継続する（`moveItem`実行後にOBS側の並びが変わるため、OBS側アイテム取得は毎イテレーションで取り直す）
  - `placeAfter`/`placeBefore`: 既に削除されたノードIDが渡された場合は例外の代わりに早期returnでスキップする
- `app/components/studio/SourceSelector.vue.ts`
  - `handleSort`: `activeScene` / `destNode` が null の場合の早期returnガードを追加（他のメソッドと一貫させる）

## テスト

- [x] `app/services/scenes/scene.test.ts` を新規追加し、`reconcileNodeOrderWithObs` のスキップ挙動（対応不能アイテムはスキップ、対応可能アイテムは処理継続）を検証
- [x] `pnpm run test:unit:app`（70 スイート / 1037 テスト、全パス）
- [x] `pnpm typecheck`（vue-tsc、エラーなし）
- [x] `pnpm lint`（エラーなし）

## Sentry

Sentry-Resolves: N-AIR-APP-FWY N-AIR-APP-G8M

