### PR TITLE
開発: json_parse失敗をSentryに報告する(quotaガード付き)

### DIFF
--- a/app/services/nicolive-program/NicoliveFailure.test.ts
+++ b/app/services/nicolive-program/NicoliveFailure.test.ts
@@ -169,7 +169,7 @@ test('http_error タイプの場合は Sentry に送信する', async () => {
   );
 });
 
-test('json_parse は type=network_error でも Sentry に送信される(fingerprint集約・diagnosticタグ付き)', async () => {
+test('json_parse は type=network_error でも Sentry に送信される(サンプリングに当選した場合。fingerprint集約・diagnosticタグ付き)', async () => {
   jest.doMock('./NicoliveClient', () => ({
     NotLoggedInError: class {},
     isCertificateErrorCode: () => false,
@@ -186,7 +186,12 @@ test('json_parse は type=network_error でも Sentry に送信される(fingerp
   expect(failure.type).toBe('network_error');
   expect(failure.failureKind).toBe('json_parse');
 
-  await openErrorDialogFromFailure(failure);
+  const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0); // 必ずサンプリングに当選させる
+  try {
+    await openErrorDialogFromFailure(failure);
+  } finally {
+    randomSpy.mockRestore();
+  }
   expect(sentryMessage).toHaveBeenCalledWith(
     'NicoliveProgram',
     'openErrorDialogFromFailure',
@@ -203,7 +208,31 @@ test('json_parse は type=network_error でも Sentry に送信される(fingerp
   );
 });
 
-test('json_parse の連打は2段quotaガードで抑制される(セッション内1件・60秒窓)', async () => {
+test('json_parse はサンプリングで外れると送信されない', async () => {
+  jest.doMock('./NicoliveClient', () => ({
+    NotLoggedInError: class {},
+    isCertificateErrorCode: () => false,
+  }));
+  const { sentryMessage, NicoliveFailure, openErrorDialogFromFailure } = prepare('network_error');
+  const { resetJsonParseReportState } = require('./NicoliveFailure');
+  resetJsonParseReportState();
+
+  const failure = NicoliveFailure.fromClientError('fetchProgramSchedules', {
+    ok: false,
+    value: new SyntaxError('Unexpected token'),
+    diag: { route: 'renderer', failureKind: 'json_parse' },
+  });
+
+  const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.99); // 必ずサンプリングから外す
+  try {
+    await openErrorDialogFromFailure(failure);
+  } finally {
+    randomSpy.mockRestore();
+  }
+  expect(sentryMessage).not.toHaveBeenCalled();
+});
+
+test('json_parse の連打はサンプリングに当選してもセッション内1件で抑制される', async () => {
   jest.doMock('./NicoliveClient', () => ({
     NotLoggedInError: class {},
     isCertificateErrorCode: () => false,
@@ -219,11 +248,16 @@ test('json_parse の連打は2段quotaガードで抑制される(セッショ�
       diag: { route: 'renderer', failureKind: 'json_parse' },
     });
 
-  await openErrorDialogFromFailure(makeFailure());
-  await openErrorDialogFromFailure(makeFailure());
-  await openErrorDialogFromFailure(makeFailure());
+  const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0); // 毎回サンプリングに当選させる
+  try {
+    await openErrorDialogFromFailure(makeFailure());
+    await openErrorDialogFromFailure(makeFailure());
+    await openErrorDialogFromFailure(makeFailure());
+  } finally {
+    randomSpy.mockRestore();
+  }
 
-  // MAX_PER_KEY=1 のため、同一 method の2回目以降は60秒窓内は送信されない
+  // MAX_PER_KEY=1 のため、サンプリングに当選し続けても2回目以降は送信されない
   expect(sentryMessage).toHaveBeenCalledTimes(1);
 });
 

--- a/app/services/nicolive-program/NicoliveFailure.test.ts
+++ b/app/services/nicolive-program/NicoliveFailure.test.ts
@@ -168,3 +168,80 @@ test('http_error タイプの場合は Sentry に送信する', async () => {
     expect.objectContaining({ level: 'warning' }),
   );
 });
+
+test('json_parse は type=network_error でも Sentry に送信される(fingerprint集約・diagnosticタグ付き)', async () => {
+  jest.doMock('./NicoliveClient', () => ({
+    NotLoggedInError: class {},
+    isCertificateErrorCode: () => false,
+  }));
+  const { sentryMessage, NicoliveFailure, openErrorDialogFromFailure } = prepare('network_error');
+  const { resetJsonParseReportState } = require('./NicoliveFailure');
+  resetJsonParseReportState();
+
+  const failure = NicoliveFailure.fromClientError('fetchProgramSchedules', {
+    ok: false,
+    value: new SyntaxError('Unexpected token'),
+    diag: { route: 'renderer', failureKind: 'json_parse' },
+  });
+  expect(failure.type).toBe('network_error');
+  expect(failure.failureKind).toBe('json_parse');
+
+  await openErrorDialogFromFailure(failure);
+  expect(sentryMessage).toHaveBeenCalledWith(
+    'NicoliveProgram',
+    'openErrorDialogFromFailure',
+    expect.stringContaining('fetchProgramSchedules'),
+    expect.objectContaining({
+      level: 'warning',
+      fingerprint: ['NicoliveProgram', 'json_parse', 'fetchProgramSchedules'],
+      tags: expect.objectContaining({
+        diagnostic: 'json-parse',
+        'failure.method': 'fetchProgramSchedules',
+        'failure.failureKind': 'json_parse',
+      }),
+    }),
+  );
+});
+
+test('json_parse の連打は2段quotaガードで抑制される(セッション内1件・60秒窓)', async () => {
+  jest.doMock('./NicoliveClient', () => ({
+    NotLoggedInError: class {},
+    isCertificateErrorCode: () => false,
+  }));
+  const { sentryMessage, NicoliveFailure, openErrorDialogFromFailure } = prepare('network_error');
+  const { resetJsonParseReportState } = require('./NicoliveFailure');
+  resetJsonParseReportState();
+
+  const makeFailure = () =>
+    NicoliveFailure.fromClientError('fetchProgramSchedules', {
+      ok: false,
+      value: new SyntaxError('Unexpected token'),
+      diag: { route: 'renderer', failureKind: 'json_parse' },
+    });
+
+  await openErrorDialogFromFailure(makeFailure());
+  await openErrorDialogFromFailure(makeFailure());
+  await openErrorDialogFromFailure(makeFailure());
+
+  // MAX_PER_KEY=1 のため、同一 method の2回目以降は60秒窓内は送信されない
+  expect(sentryMessage).toHaveBeenCalledTimes(1);
+});
+
+test('json_parse でない network_error(certificate_error 等)は従来どおり送信されない', async () => {
+  jest.doMock('./NicoliveClient', () => ({
+    NotLoggedInError: class {},
+    isCertificateErrorCode: (code: string) => code === 'SELF_SIGNED_CERT_IN_CHAIN',
+  }));
+  const { sentryMessage, NicoliveFailure, openErrorDialogFromFailure } = prepare('network_error');
+  const { resetJsonParseReportState } = require('./NicoliveFailure');
+  resetJsonParseReportState();
+
+  const failure = NicoliveFailure.fromClientError('fetchIngestInfo', {
+    ok: false,
+    value: new Error('[MAIN_FETCH_FAIL code=SELF_SIGNED_CERT_IN_CHAIN] fetch failed'),
+    diag: { route: 'main', failureKind: 'network_error', errorCode: 'SELF_SIGNED_CERT_IN_CHAIN' },
+  });
+
+  await openErrorDialogFromFailure(failure);
+  expect(sentryMessage).not.toHaveBeenCalled();
+});

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -91,36 +91,30 @@ function fallbackToX00(reason: string): string {
 
 /**
  * json_parse (サーバー障害等でupstreamが非JSON応答を返す異常) の Sentry 報告を
- * 抑制するための 2 段 quota ガード状態。
+ * 抑制するための quota ガード状態。
  * AWS障害等で全ユーザーが同時多発するケースを想定し、既存の他ガード(5件/60秒)より
- * 強く絞る: セッション内 1 件・60 秒に 1 件。
+ * 強く絞る: セッション内 1 件まで、かつ確率サンプリング(10%)を通ったものだけ報告する。
+ * サンプリングで外れた場合はカウントを消費せず、次回発生時に再度抽選の機会を残す。
  */
-const JSON_PARSE_REPORT_WINDOW_MS = 60_000;
 const JSON_PARSE_REPORT_MAX_PER_KEY = 1;
-const jsonParseReportState = new Map<string, { count: number; last: number | null }>();
+const JSON_PARSE_REPORT_SAMPLE_RATE = 0.1;
+const jsonParseReportCount = new Map<string, number>();
 
 /** テスト用: json_parse の報告状態をリセットする */
 export function resetJsonParseReportState(): void {
-  jsonParseReportState.clear();
+  jsonParseReportCount.clear();
 }
 
 export async function openErrorDialogFromFailure(failure: NicoliveFailure): Promise<void> {
   // json_parse は type: 'network_error' に分類されるため、以下の通常の
   // network_error 除外(ユーザー側ネット切断は送信しない)から漏れて未報告になっていた。
   // サーバー側異常(upstream が非JSON応答を返す)であり切り分けたいため、
-  // 2段quotaガード(セッション内1件・60秒に1件) + fingerprint集約を通してのみ報告する。
+  // quotaガード(セッション内1件・確率サンプリング) + fingerprint集約を通してのみ報告する。
   if (failure.failureKind === 'json_parse') {
     const quotaKey = failure.method;
-    const state = jsonParseReportState.get(quotaKey) ?? { count: 0, last: null };
-    const now = Date.now();
-    if (
-      state.count < JSON_PARSE_REPORT_MAX_PER_KEY
-      && (state.last === null || now - state.last >= JSON_PARSE_REPORT_WINDOW_MS)
-    ) {
-      state.count += 1;
-      state.last = now;
-      jsonParseReportState.set(quotaKey, state);
-      const capReached = state.count >= JSON_PARSE_REPORT_MAX_PER_KEY;
+    const count = jsonParseReportCount.get(quotaKey) ?? 0;
+    if (count < JSON_PARSE_REPORT_MAX_PER_KEY && Math.random() < JSON_PARSE_REPORT_SAMPLE_RATE) {
+      jsonParseReportCount.set(quotaKey, count + 1);
 
       SentryReport.message(
         'NicoliveProgram',
@@ -135,7 +129,7 @@ export async function openErrorDialogFromFailure(failure: NicoliveFailure): Prom
             'failure.failureKind': 'json_parse',
             ...(failure.route ? { 'failure.route': failure.route } : {}),
           },
-          extra: { failure, reportCount: state.count, ...(capReached ? { reportCapReached: true } : {}) },
+          extra: { failure, sampleRate: JSON_PARSE_REPORT_SAMPLE_RATE },
         },
       );
     }

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -93,7 +93,8 @@ function fallbackToX00(reason: string): string {
  * json_parse (サーバー障害等でupstreamが非JSON応答を返す異常) の Sentry 報告を
  * 抑制するための quota ガード状態。
  * AWS障害等で全ユーザーが同時多発するケースを想定し、既存の他ガード(5件/60秒)より
- * 強く絞る: セッション内 1 件まで、かつ確率サンプリング(10%)を通ったものだけ報告する。
+ * 強く絞る: method ごとにセッション内 1 件まで、かつ確率サンプリング(10%)を
+ * 通ったものだけ報告する。
  * サンプリングで外れた場合はカウントを消費せず、次回発生時に再度抽選の機会を残す。
  */
 const JSON_PARSE_REPORT_MAX_PER_KEY = 1;
@@ -109,7 +110,8 @@ export async function openErrorDialogFromFailure(failure: NicoliveFailure): Prom
   // json_parse は type: 'network_error' に分類されるため、以下の通常の
   // network_error 除外(ユーザー側ネット切断は送信しない)から漏れて未報告になっていた。
   // サーバー側異常(upstream が非JSON応答を返す)であり切り分けたいため、
-  // quotaガード(セッション内1件・確率サンプリング) + fingerprint集約を通してのみ報告する。
+  // quotaガード(method ごとにセッション内1件・確率サンプリング) + fingerprint集約を
+  // 通してのみ報告する。
   if (failure.failureKind === 'json_parse') {
     const quotaKey = failure.method;
     const count = jsonParseReportCount.get(quotaKey) ?? 0;

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -89,8 +89,57 @@ function fallbackToX00(reason: string): string {
   return reason;
 }
 
+/**
+ * json_parse (サーバー障害等でupstreamが非JSON応答を返す異常) の Sentry 報告を
+ * 抑制するための 2 段 quota ガード状態。
+ * AWS障害等で全ユーザーが同時多発するケースを想定し、既存の他ガード(5件/60秒)より
+ * 強く絞る: セッション内 1 件・60 秒に 1 件。
+ */
+const JSON_PARSE_REPORT_WINDOW_MS = 60_000;
+const JSON_PARSE_REPORT_MAX_PER_KEY = 1;
+const jsonParseReportState = new Map<string, { count: number; last: number | null }>();
+
+/** テスト用: json_parse の報告状態をリセットする */
+export function resetJsonParseReportState(): void {
+  jsonParseReportState.clear();
+}
+
 export async function openErrorDialogFromFailure(failure: NicoliveFailure): Promise<void> {
-  if (failure.type !== 'network_error') {
+  // json_parse は type: 'network_error' に分類されるため、以下の通常の
+  // network_error 除外(ユーザー側ネット切断は送信しない)から漏れて未報告になっていた。
+  // サーバー側異常(upstream が非JSON応答を返す)であり切り分けたいため、
+  // 2段quotaガード(セッション内1件・60秒に1件) + fingerprint集約を通してのみ報告する。
+  if (failure.failureKind === 'json_parse') {
+    const quotaKey = failure.method;
+    const state = jsonParseReportState.get(quotaKey) ?? { count: 0, last: null };
+    const now = Date.now();
+    if (
+      state.count < JSON_PARSE_REPORT_MAX_PER_KEY
+      && (state.last === null || now - state.last >= JSON_PARSE_REPORT_WINDOW_MS)
+    ) {
+      state.count += 1;
+      state.last = now;
+      jsonParseReportState.set(quotaKey, state);
+      const capReached = state.count >= JSON_PARSE_REPORT_MAX_PER_KEY;
+
+      SentryReport.message(
+        'NicoliveProgram',
+        'openErrorDialogFromFailure',
+        `openErrorDialogFromFailure: non-json response (${failure.method})`,
+        {
+          level: 'warning',
+          fingerprint: ['NicoliveProgram', 'json_parse', failure.method],
+          tags: {
+            diagnostic: 'json-parse',
+            'failure.method': failure.method,
+            'failure.failureKind': 'json_parse',
+            ...(failure.route ? { 'failure.route': failure.route } : {}),
+          },
+          extra: { failure, reportCount: state.count, ...(capReached ? { reportCapReached: true } : {}) },
+        },
+      );
+    }
+  } else if (failure.type !== 'network_error') {
     SentryReport.message('NicoliveProgram', 'openErrorDialogFromFailure', 'openErrorDialogFromFailure', {
       level: 'warning',
       extra: { failure },


### PR DESCRIPTION
## このpull requestが解決する内容
サーバー障害等でAPI応答が非JSON（プレーンテキスト等）になった `json_parse` 失敗を、スロットルした上でSentryに報告できるようにします。

## 背景
`openErrorDialogFromFailure` は `network_error`（ユーザー側のネットワーク切断等）を意図的にSentryへ送信していません。ユーザー環境依存でノイズになりやすく、対応不能な報告が積み重なるのを避けるための既存の設計です。

`json_parse`（番組スケジュール取得等でupstream障害時にサーバーが非JSON応答を返す異常）もこの `network_error` に分類されるため、同じ理由で報告対象外になっていました。ただし json_parse はユーザー環境要因ではなくサーバー側の異常であり、AWS障害のような大規模障害を検知する手がかりとして拾えると有用です。一方で、そうした障害時は全ユーザーで同時多発するため、素朴に送信条件を外すとSentryのquotaを圧迫します。

そこで、json_parse だけを対象に、量を強く絞った上でSentryに報告できるようにします。

## 変更内容
- `NicoliveFailure.ts`
  - `openErrorDialogFromFailure` に、`failureKind === 'json_parse'` 専用の Sentry 報告分岐を追加（`network_error` を送信しない既存方針自体は変更しない）
  - quotaガードとして **セッション内1件まで + 10%の確率サンプリング** を実装。全ユーザー同時多発時でも送信量を直接削減する。サンプリング落選時はカウントを消費せず、次回発生時に再抽選される
  - `fingerprint: ['NicoliveProgram', 'json_parse', method]` で method 毎に1 issue へ集約
  - `tags: { diagnostic: 'json-parse', ... }` を付与し、`app.ts` の `beforeSend` にあるネットワーク系ノイズパターンによる誤dropを回避
  - json_parse 以外の `network_error`（証明書エラー等）は変更なし、従来どおり送信されない

## テスト
- `NicoliveFailure.test.ts` にユニットテストを追加
  - json_parse がサンプリングに当選した場合にSentryへ送信されること（fingerprint/diagnosticタグ確認）
  - サンプリングで外れた場合は送信されないこと
  - 同一 method の連打がサンプリングに当選し続けてもセッション内1件で抑制されること
  - json_parse でない network_error は従来どおり送信されないこと（回帰確認）
