### PR TITLE
開発: CODEOWNERSを更新

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # code reviewers
-* @koizuka @taroc-dw @matsuyuki-a @asaday
+* @koizuka @asaday
 
 # planners
 /app/i18n/ @Koutarou-Yamamoto


### PR DESCRIPTION
開発のcode ownersから二人を外して、PRで毎回通知されないようにします。
今後は、お二人は必要な時には個別にリクエストします。