### PR TITLE
開発: セキュリティアラート268/266/264のwebpack-dev-server関連脆弱性をlockfile更新で解消（開発環境のみ、アプリ影響なし）

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "webdriverio": "7.30.2",
     "webpack": "^5.107.2",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.1.0"
+    "webpack-dev-server": "^5.2.6"
   },
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,10 +336,10 @@ importers:
         version: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.1
-        version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
+        version: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2)
       webpack-dev-server:
-        specifier: ^5.1.0
-        version: 5.2.4(webpack-cli@6.0.1)(webpack@5.107.2)
+        specifier: ^5.2.6
+        version: 5.2.6(webpack-cli@6.0.1)(webpack@5.107.2)
 
 packages:
 
@@ -4203,8 +4203,8 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@2.0.9:
-    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
+  http-proxy-middleware@2.0.10:
+    resolution: {integrity: sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -4866,8 +4866,8 @@ packages:
     resolution: {integrity: sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog==}
     engines: {node: '>=12'}
 
-  launch-editor@2.12.0:
-    resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -6168,6 +6168,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
@@ -7056,8 +7060,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.4:
-    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
+  webpack-dev-server@5.2.6:
+    resolution: {integrity: sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -9892,19 +9896,19 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2)
 
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.107.2)':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.6)(webpack@5.107.2)':
     dependencies:
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.6(webpack-cli@6.0.1)(webpack@5.107.2)
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -12234,7 +12238,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25):
+  http-proxy-middleware@2.0.10(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.17
       http-proxy: 1.18.1
@@ -13050,10 +13054,10 @@ snapshots:
 
   ky@0.30.0: {}
 
-  launch-editor@2.12.0:
+  launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
 
   lazy-val@1.0.5: {}
 
@@ -14364,6 +14368,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.10.0: {}
+
   shell-quote@1.8.4: {}
 
   shelljs@0.9.2:
@@ -15333,12 +15339,12 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2):
+  webpack-cli@6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
       '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)
       '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.107.2)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.6)(webpack@5.107.2)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -15350,7 +15356,7 @@ snapshots:
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.4(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.6(webpack-cli@6.0.1)(webpack@5.107.2)
 
   webpack-dev-middleware@7.4.5(webpack@5.107.2):
     dependencies:
@@ -15363,7 +15369,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
 
-  webpack-dev-server@5.2.4(webpack-cli@6.0.1)(webpack@5.107.2):
+  webpack-dev-server@5.2.6(webpack-cli@6.0.1)(webpack@5.107.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -15381,9 +15387,9 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)
       ipaddr.js: 2.3.0
-      launch-editor: 2.12.0
+      launch-editor: 2.14.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
@@ -15395,7 +15401,7 @@ snapshots:
       ws: 8.20.1
     optionalDependencies:
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -15440,7 +15446,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.107.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'


### PR DESCRIPTION
## 影響範囲: 開発環境のみ、アプリ影響なし

`webpack-dev-server`/`http-proxy-middleware`/`launch-editor` はいずれも `devDependencies` に属し、配布物には含まれません。**直近リリースへの取り込み判断は不要で、先にマージできます。**

## 概要

以下のセキュリティアラートを lockfile 更新で解消します（いずれも `webpack-dev-server` 経由の devDependency）。

| Alert | パッケージ | CVE | 重大度 | 内容 |
|-------|-----------|-----|--------|------|
| [Alert 266](https://github.com/n-air-app/n-air-app/security/dependabot/266) | webpack-dev-server | CVE-2026-9595 | Medium | 許可的なユーザープロキシによる HMR WebSocket 傍受 |
| [Alert 268](https://github.com/n-air-app/n-air-app/security/dependabot/268) | http-proxy-middleware | CVE-2026-55602 | Medium | `router` の host+path 部分文字列マッチングによる Host ヘッダー駆動のバックエンドルーティングバイパス |
| [Alert 264](https://github.com/n-air-app/n-air-app/security/dependabot/264) | launch-editor | CVE-2026-53632 | Medium | Windows での UNC パス処理による NTLMv2 ハッシュ漏洩 |

## 変更内容

- `webpack-dev-server`: 5.2.4 → 5.2.6（direct dependency、`package.json` の specifier も `^5.2.6` に更新）
- `http-proxy-middleware`: 2.0.9 → 2.0.10（`webpack-dev-server` 経由の transitive dependency）
- `launch-editor`: 2.12.0 → 2.14.1（`webpack-dev-server` 経由の transitive dependency）

いずれも開発時のみ使用（devDependency経路）で、本番ビルドには含まれません。

関連: #1073

