### PR TITLE
開発: セキュリティアラート270/269のbin/js-yaml脆弱性をlockfile更新で解消（開発環境のみ、アプリ影響なし）

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -19,7 +19,7 @@
     "@inquirer/prompts": "^7.3.2",
     "colors": "^1.4.0",
     "iconv-lite": "^0.7.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "progress": "^2.0.0",
     "semver": "^7.6.3",
     "shelljs": "^0.8.5",

--- a/bin/pnpm-lock.yaml
+++ b/bin/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.3.0
+        version: 4.3.0
       progress:
         specifier: ^2.0.0
         version: 2.0.3
@@ -987,12 +987,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-parse-better-errors@1.0.2:
@@ -2562,7 +2562,7 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       parse-json: 4.0.0
 
   cubic2quad@1.2.1: {}
@@ -2710,12 +2710,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## 影響範囲: 開発環境のみ、アプリ影響なし

`bin/` はビルド・リリーススクリプト専用の独立 pnpm project で、アプリ本体の配布物には含まれません。**直近リリースへの取り込み判断は不要で、先にマージできます。**

## このpull requestが解決する内容

bin/ の js-yaml に関するセキュリティアラートを lockfile 更新で解消します。

| Alert | パッケージ | CVE | 重大度 | 内容 |
|-------|-----------|-----|--------|------|
| [Alert 270](https://github.com/n-air-app/n-air-app/security/dependabot/270) | js-yaml (dev, bin/) | CVE-2026-53550 | Medium | 繰り返しエイリアスによるマージキー処理の二次関数的DoS（3.x系） |
| [Alert 269](https://github.com/n-air-app/n-air-app/security/dependabot/269) | js-yaml (dev, bin/) | CVE-2026-53550 | Medium | 同上（4.x系） |

## 変更内容

| package | before | after |
|---------|--------|-------|
| js-yaml (bin/) | 3.14.2 / 4.1.1 | 3.15.0 / 4.3.0 |

### ファイル変更
- `bin/package.json`: devDependencies の js-yaml specifier を `^4.1.1` → `^4.3.0` に更新
- `bin/pnpm-lock.yaml`: `cosmiconfig@5.2.1` 経由の transitive dependency を含め両系統を更新

関連: #1073

