### PR TITLE
開発: セキュリティアラート272/271/278/255のjs-yaml/tar脆弱性をlockfile更新で解消（js-yamlはアプリ影響あり、tarは開発環境のみ）

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4791,16 +4791,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -6544,8 +6540,8 @@ packages:
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
     engines: {node: '>=18'}
 
   tasklist@5.0.0:
@@ -8299,7 +8295,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8384,7 +8380,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -8671,7 +8667,7 @@ snapshots:
       node-fetch: 2.6.13(encoding@0.1.13)
       nopt: 8.1.0
       semver: 7.8.4
-      tar: 7.5.16
+      tar: 7.5.20
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10063,7 +10059,7 @@ snapshots:
       hosted-git-info: 4.1.0
       is-ci: 3.0.1
       isbinaryfile: 5.0.7
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -10482,7 +10478,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-ci: 3.0.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -10829,7 +10825,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -10838,7 +10834,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -11074,7 +11070,7 @@ snapshots:
       builder-util-runtime: 9.3.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -11202,7 +11198,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.3.1
       fs-extra: 10.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -12984,16 +12980,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -14775,7 +14767,7 @@ snapshots:
   supertap@3.0.1:
     dependencies:
       indent-string: 5.0.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       serialize-error: 7.0.1
       strip-ansi: 7.1.2
 
@@ -14842,7 +14834,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.16:
+  tar@7.5.20:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## 影響範囲: js-yamlはアプリ影響あり、tarは開発環境のみ

- **js-yaml（Alert 272/271）**: `electron-updater`（`dependencies`、`bundles/updater.js` として配布物に含まれる）と `electron-builder`（devDependency）の両方から依存されており、**アプリ影響あり**。直近リリースへの取り込みを判断してください。
- **tar（Alert 278/255）**: `@electron/rebuild`/`app-builder-lib` 等ビルド時ツール経由のみで、配布物には含まれません。**開発環境のみ、アプリ影響なし**。

## このpull requestが解決する内容

root の js-yaml / tar に関するセキュリティアラートを lockfile 更新で解消します。

| Alert | パッケージ | CVE | 重大度 | 内容 |
|-------|-----------|-----|--------|------|
| [Alert 272](https://github.com/n-air-app/n-air-app/security/dependabot/272) | js-yaml (dev) | CVE-2026-53550 | Medium | 繰り返しエイリアスによるマージキー処理の二次関数的DoS（3.x系） |
| [Alert 271](https://github.com/n-air-app/n-air-app/security/dependabot/271) | js-yaml (runtime) | CVE-2026-53550 | Medium | 同上（4.x系） |
| [Alert 278](https://github.com/n-air-app/n-air-app/security/dependabot/278) | tar (dev) | CVE-2026-59871 | Medium | PAX numeric path type confusion によるプロセスクラッシュ |
| [Alert 255](https://github.com/n-air-app/n-air-app/security/dependabot/255) | tar (dev) | CVE-2026-53655 | Medium | PAX size override による GNU long-name/long-link ヘッダの解釈差異（file smuggling） |

## 変更内容

| package | before | after |
|---------|--------|-------|
| js-yaml | 3.14.2 / 4.1.1 | 3.15.0 / 4.3.0 |
| tar | 7.5.16 | 7.5.20 |

### ファイル変更
- `pnpm-lock.yaml`: js-yaml（3.x/4.x 両系統）と tar（7.x系）を更新

## 対応不可（記録のみ）

- tar の 6.x 系（`@electron/node-gyp` 経由のピン固定）は上流待ちのため残存。既知の Alert 150/148 と同じ経路。

関連: #1073

