### PR TITLE
開発: e2eテストのafterEachクリーンアップでEBUSYが発生する問題を修正

### DIFF
--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -13,8 +13,8 @@ import {
   initializeTasks,
   killElectronInstances,
   testFn,
-  waitForCrashHandlerExit,
   waitForElectronInstancesExist,
+  waitForLogFileHandlesReleased,
 } from './runner-utils';
 
 export const test = testFn; // the overridden "test" function
@@ -281,9 +281,10 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     }
     await killElectronInstances();
 
-    // Wait for crash-handler-process.exe to exit before attempting cleanup
-    // This ensures crash-handler.log is closed before fs.rmSync attempts deletion
-    await waitForCrashHandlerExit();
+    // Wait for crash-handler-process.exe and obs64.exe to exit before attempting
+    // cleanup. This ensures crash-handler.log and node-obs/logs/*.txt are closed
+    // before fs.rmSync attempts deletion.
+    await waitForLogFileHandlesReleased();
 
     appIsRunning = false;
 

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -169,6 +169,10 @@ export async function killElectronInstances() {
 // for these to fully exit, or fs.rmSync can fail with EBUSY on Windows.
 const LOCK_HOLDING_IMAGE_NAMES = ['crash-handler-process.exe', 'obs64.exe'];
 
+function isLockHoldingTask(task: any) {
+  return LOCK_HOLDING_IMAGE_NAMES.includes(task.imageName) && !ignoreTaskPIDs.includes(task.pid);
+}
+
 export async function waitForLogFileHandlesReleased() {
   const interval = 100;
   const timeout = 5000;
@@ -177,9 +181,7 @@ export async function waitForLogFileHandlesReleased() {
 
   do {
     const tasks = await tasklist();
-    const lockHoldingTasks = tasks.filter((task: any) =>
-      LOCK_HOLDING_IMAGE_NAMES.includes(task.imageName),
-    );
+    const lockHoldingTasks = tasks.filter(isLockHoldingTask);
 
     if (lockHoldingTasks.length === 0) {
       return;

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -141,7 +141,11 @@ async function getRawElectronTasks() {
   const tasks = await tasklist();
   return tasks.filter(
     (task: any) =>
-      task.imageName === 'electron.exe' || task.imageName === 'crash-handler-process.exe',
+      task.imageName === 'electron.exe' ||
+      task.imageName === 'crash-handler-process.exe' ||
+      // obs64.exe holds an open handle on node-obs/logs/*.txt until it exits;
+      // without waiting for it, cleanup can hit EBUSY on Windows.
+      task.imageName === 'obs64.exe',
   );
 }
 
@@ -160,7 +164,12 @@ export async function killElectronInstances() {
   tasks.forEach((task: any) => kill(task.pid));
 }
 
-export async function waitForCrashHandlerExit() {
+// Processes that keep an open handle on files under the cache dir (e.g.
+// node-obs/logs/*.txt, crash-handler.log) until they exit. Cleanup must wait
+// for these to fully exit, or fs.rmSync can fail with EBUSY on Windows.
+const LOCK_HOLDING_IMAGE_NAMES = ['crash-handler-process.exe', 'obs64.exe'];
+
+export async function waitForLogFileHandlesReleased() {
   const interval = 100;
   const timeout = 5000;
 
@@ -168,11 +177,11 @@ export async function waitForCrashHandlerExit() {
 
   do {
     const tasks = await tasklist();
-    const crashHandlerTasks = tasks.filter(
-      (task: any) => task.imageName === 'crash-handler-process.exe',
+    const lockHoldingTasks = tasks.filter((task: any) =>
+      LOCK_HOLDING_IMAGE_NAMES.includes(task.imageName),
     );
 
-    if (crashHandlerTasks.length === 0) {
+    if (lockHoldingTasks.length === 0) {
       return;
     }
 
@@ -180,9 +189,7 @@ export async function waitForCrashHandlerExit() {
     timeLeft -= interval;
   } while (timeLeft > 0);
 
-  console.warn(
-    `Warning: crash-handler-process.exe still running after ${timeout}ms timeout`,
-  );
+  console.warn(`Warning: ${LOCK_HOLDING_IMAGE_NAMES.join('/')} still running after ${timeout}ms timeout`);
 }
 
 export async function waitForElectronInstancesExist() {


### PR DESCRIPTION
## このpull requestが解決する内容

e2eテストの `afterEach` クリーンアップ時に、Windows CIで断続的に `EBUSY: resource busy or locked` エラーが発生し、`--fail-fast` により他のテストまで巻き込んでキャンセルされる問題を修正します。

## 背景

[#1370](https://github.com/n-air-app/n-air-app/pull/1370) と [#1371](https://github.com/n-air-app/n-air-app/pull/1371) のCI初回実行で、いずれもテスト自体（`streaming`/`scenes`）は成功していたにもかかわらず、`afterEach.always` フックの `fs.rmSync` によるキャッシュディレクトリ削除が `node-obs/logs/*.txt` の `EBUSY` で失敗していました。

原因を調査したところ、`test/helpers/webdriver/runner-utils.ts` の `killElectronInstances()`/`waitForCrashHandlerExit()` は `electron.exe` と `crash-handler-process.exe` のみを対象にしており、OBS本体プロセスの `obs64.exe`（`node_modules/obs-studio-node`）が対象外でした。`obs64.exe` は `node-obs/logs/*.txt` のファイルハンドルを保持し続けるため、`electron.exe` のkillに追随して終了する前にクリーンアップが走ると `EBUSY` が発生します。

## 変更内容

- `test/helpers/webdriver/runner-utils.ts`
  - `getRawElectronTasks()` の対象プロセスに `obs64.exe` を追加（kill対象に含める）
  - `waitForCrashHandlerExit()` を `waitForLogFileHandlesReleased()` にリネームし、待機対象を `crash-handler-process.exe` と `obs64.exe` の両方に拡張
- `test/helpers/webdriver/index.ts`: リネームに合わせて呼び出しを更新

## 影響範囲

- e2eテストのヘルパーコードのみで、アプリ本体のランタイムには影響しません

## テスト
- [x] 既存のリトライロジック（`fs.rmSync` を最大30回×100msリトライ）は保険として維持

関連: #1073
