### PR TITLE
開発: モニターキャプチャの範囲選択終了時に発生していた例外を修正

### DIFF
--- a/app/services/sources/monitor-capture-cropping.ts
+++ b/app/services/sources/monitor-capture-cropping.ts
@@ -81,7 +81,12 @@ export class MonitorCaptureCroppingService extends StatefulService<IMonitorCaptu
     this.SET_WINDOW_ID(windowId);
 
     const windowObj = this.windowsService.getWindow(windowId);
-    windowObj.on('close', () => this.endCropping());
+    windowObj.on('close', () => {
+      // 自発的に閉じた（レンダラー側window.close()等）ウィンドウなので、
+      // setter経由での再度のclose()呼び出しを避けるため先に参照を外す
+      this._currentWindow = null;
+      this.endCropping();
+    });
 
     this.currentWindow = windowObj;
   }


### PR DESCRIPTION
## このpull requestが解決する内容

モニターキャプチャの範囲選択（クロッピング）操作の終了時に、内部的な例外（`TypeError: Object has been destroyed`）が発生していた問題を修正します。

## 背景

クロッピング用のオーバーレイウィンドウが自発的に閉じる際（Escapeキー・フォーカス外れ・マウスアップ後の `window.close()`）、`close` イベントハンドラが `endCropping()` → `currentWindow` の setter を経由して、**既にclose処理中の同じウィンドウに対して再度 `close()` を呼び出していました**。この2回目の呼び出しが `@electron/remote` のRPC内で対象オブジェクトの破棄後に実行され、例外となっていました。

なお、クロップ操作自体はウィンドウが閉じる前に完了しており、エラーダイアログ表示は開発モード限定のため、ユーザーの操作結果には影響していませんでした。

## 変更内容

- `app/services/sources/monitor-capture-cropping.ts`
  - `startCropping()`: ウィンドウの `close` イベントハンドラで `endCropping()` を呼ぶ前に `_currentWindow` を直接 `null` にし、setter経由での再度の `close()` 呼び出しをスキップするように修正

## テスト

- [x] `pnpm typecheck`（vue-tsc、エラーなし）

## Sentry

Sentry-Resolves: N-AIR-APP-EKB
