### PR TITLE
開発: 既知のOBSバックエンドIPC切断エラーをSentryで分類・降格

### DIFF
--- a/app/util/sentry-ipc-request.test.ts
+++ b/app/util/sentry-ipc-request.test.ts
@@ -119,4 +119,16 @@ describe('captureIpcRequestError', () => {
     expect(mockScope.setLevel).toHaveBeenCalledWith('warning');
     expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'ObsBackendIpcLost']);
   });
+
+  test('OBSバックエンドIPC切断エラーは breadcrumb の level も warning になる', () => {
+    captureIpcRequestError('SourcesService', 'getAvailableSourcesTypesList', false, undefined, {
+      code: -32000,
+      message: 'INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.',
+    });
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'ipc.request',
+      message: 'SourcesService.getAvailableSourcesTypesList failed (code: -32000)',
+      level: 'warning',
+    });
+  });
 });

--- a/app/util/sentry-ipc-request.test.ts
+++ b/app/util/sentry-ipc-request.test.ts
@@ -110,13 +110,13 @@ describe('captureIpcRequestError', () => {
     expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'FooService', 'barMethod']);
   });
 
-  test('メインウィンドウ応答不能エラーは warning に降格され専用 fingerprint になる', () => {
+  test('OBSバックエンドIPC切断エラーは warning に降格され専用 fingerprint になる', () => {
     captureIpcRequestError('SourcesService', 'getAvailableSourcesTypesList', false, undefined, {
       code: -32000,
       message: 'INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.',
     });
-    expect(mockScope.setTag).toHaveBeenCalledWith('ipc.mainErrorKind', 'mainWindowUnreachable');
+    expect(mockScope.setTag).toHaveBeenCalledWith('ipc.mainErrorKind', 'obsBackendIpcLost');
     expect(mockScope.setLevel).toHaveBeenCalledWith('warning');
-    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'MainWindowUnreachable']);
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'ObsBackendIpcLost']);
   });
 });

--- a/app/util/sentry-ipc-request.test.ts
+++ b/app/util/sentry-ipc-request.test.ts
@@ -99,4 +99,24 @@ describe('captureIpcRequestError', () => {
     expect(result.methodName).toBe('Symbol(myMethod)');
     expect(mockScope.setTag).toHaveBeenCalledWith('method', 'Symbol(myMethod)');
   });
+
+  test('通常の rpcError では ipc.mainErrorKind が other になり level は error のまま', () => {
+    captureIpcRequestError('FooService', 'barMethod', false, undefined, {
+      code: -32603,
+      message: 'some other error',
+    });
+    expect(mockScope.setTag).toHaveBeenCalledWith('ipc.mainErrorKind', 'other');
+    expect(mockScope.setLevel).toHaveBeenCalledWith('error');
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'FooService', 'barMethod']);
+  });
+
+  test('メインウィンドウ応答不能エラーは warning に降格され専用 fingerprint になる', () => {
+    captureIpcRequestError('SourcesService', 'getAvailableSourcesTypesList', false, undefined, {
+      code: -32000,
+      message: 'INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.',
+    });
+    expect(mockScope.setTag).toHaveBeenCalledWith('ipc.mainErrorKind', 'mainWindowUnreachable');
+    expect(mockScope.setLevel).toHaveBeenCalledWith('warning');
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['IpcRequestError', 'MainWindowUnreachable']);
+  });
 });

--- a/app/util/sentry-ipc-request.ts
+++ b/app/util/sentry-ipc-request.ts
@@ -3,6 +3,10 @@ import * as Sentry from '@sentry/vue';
 import { IpcRequestError } from './ipc-request-error';
 import { SentryReport } from './sentry-report';
 
+// メインウィンドウ自体が IPC 応答不能（クラッシュ/リロード中等）な状態を示す main プロセス側のエラー文言。
+// OBS バックエンドの例外とは原因が異なるため別 issue として分離・降格する。
+const MAIN_WINDOW_UNREACHABLE_RE = /Failed to make IPC call, verify IPC status\./;
+
 export function captureIpcRequestError(
   serviceName: string,
   methodName: string | symbol,
@@ -19,9 +23,12 @@ export function captureIpcRequestError(
     level: 'error',
   });
 
+  const isMainWindowUnreachable = MAIN_WINDOW_UNREACHABLE_RE.test(rpcError.message ?? '');
+
   const tags: Record<string, string> = {
     isHelper: String(isHelper),
     'rpc.code': String(rpcError.code),
+    'ipc.mainErrorKind': isMainWindowUnreachable ? 'mainWindowUnreachable' : 'other',
   };
   if (isHelper && resourceId) tags.resourceId = resourceId;
 
@@ -29,7 +36,10 @@ export function captureIpcRequestError(
     tags,
     extra: { mainError: rpcError.message ?? '(no message)' },
     // err.name は minify でチャンクごとに短縮名になりissueが分裂するため固定文字列を使う
-    fingerprint: ['IpcRequestError', serviceName, method],
+    fingerprint: isMainWindowUnreachable
+      ? ['IpcRequestError', 'MainWindowUnreachable']
+      : ['IpcRequestError', serviceName, method],
+    level: isMainWindowUnreachable ? 'warning' : 'error',
   });
 
   return err;

--- a/app/util/sentry-ipc-request.ts
+++ b/app/util/sentry-ipc-request.ts
@@ -3,9 +3,10 @@ import * as Sentry from '@sentry/vue';
 import { IpcRequestError } from './ipc-request-error';
 import { SentryReport } from './sentry-report';
 
-// メインウィンドウ自体が IPC 応答不能（クラッシュ/リロード中等）な状態を示す main プロセス側のエラー文言。
-// OBS バックエンドの例外とは原因が異なるため別 issue として分離・降格する。
-const MAIN_WINDOW_UNREACHABLE_RE = /Failed to make IPC call, verify IPC status\./;
+// obs-studio-node が OBS バックエンドプロセスと通信する独自ネイティブ IPC が切断された際の
+// main プロセス側エラー文言（Electron の IPC とは無関係。詳細: n-air-app#1380）。
+// アプリ側に再接続機構がなく既知の未解決issueのため、原因不明の他エラーとは分離・降格する。
+const OBS_BACKEND_IPC_LOST_RE = /Failed to make IPC call, verify IPC status\./;
 
 export function captureIpcRequestError(
   serviceName: string,
@@ -23,12 +24,12 @@ export function captureIpcRequestError(
     level: 'error',
   });
 
-  const isMainWindowUnreachable = MAIN_WINDOW_UNREACHABLE_RE.test(rpcError.message ?? '');
+  const isObsBackendIpcLost = OBS_BACKEND_IPC_LOST_RE.test(rpcError.message ?? '');
 
   const tags: Record<string, string> = {
     isHelper: String(isHelper),
     'rpc.code': String(rpcError.code),
-    'ipc.mainErrorKind': isMainWindowUnreachable ? 'mainWindowUnreachable' : 'other',
+    'ipc.mainErrorKind': isObsBackendIpcLost ? 'obsBackendIpcLost' : 'other',
   };
   if (isHelper && resourceId) tags.resourceId = resourceId;
 
@@ -36,10 +37,10 @@ export function captureIpcRequestError(
     tags,
     extra: { mainError: rpcError.message ?? '(no message)' },
     // err.name は minify でチャンクごとに短縮名になりissueが分裂するため固定文字列を使う
-    fingerprint: isMainWindowUnreachable
-      ? ['IpcRequestError', 'MainWindowUnreachable']
+    fingerprint: isObsBackendIpcLost
+      ? ['IpcRequestError', 'ObsBackendIpcLost']
       : ['IpcRequestError', serviceName, method],
-    level: isMainWindowUnreachable ? 'warning' : 'error',
+    level: isObsBackendIpcLost ? 'warning' : 'error',
   });
 
   return err;

--- a/app/util/sentry-ipc-request.ts
+++ b/app/util/sentry-ipc-request.ts
@@ -17,14 +17,13 @@ export function captureIpcRequestError(
 ): IpcRequestError {
   const method = String(methodName);
   const err = new IpcRequestError(serviceName, method, rpcError);
+  const isObsBackendIpcLost = OBS_BACKEND_IPC_LOST_RE.test(rpcError.message ?? '');
 
   Sentry.addBreadcrumb({
     category: 'ipc.request',
     message: `${serviceName}.${method} failed (code: ${rpcError.code})`,
-    level: 'error',
+    level: isObsBackendIpcLost ? 'warning' : 'error',
   });
-
-  const isObsBackendIpcLost = OBS_BACKEND_IPC_LOST_RE.test(rpcError.message ?? '');
 
   const tags: Record<string, string> = {
     isHelper: String(isHelper),


### PR DESCRIPTION
## このpull requestが解決する内容
Sentry で無条件に error レベル送信されている IpcRequestError の一部（既知のOBSバックエンドIPC切断によるもの）を warning に降格し、原因不明の IPC 例外と区別できるようにします。

## 背景
Sentry issue N-AIR-APP-GCA / N-AIR-APP-G6V（`IpcRequestError: IPC request failed: SourcesService.getAvailableSourcesTypesList`, rpc.code=-32000）を調査したところ、event の `extra.mainError` に main プロセス側の実エラーが既に記録されていました。

```
INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.
```

この文字列は `node_modules/obs-studio-node/obs_studio_client.node` のネイティブバイナリに埋め込まれた `ipc::client_win`（OBSバックエンドプロセスとの通信用ソケット/パイプ）由来で、**Electron の IPC ではなく、obs-studio-node が使う独自ネイティブ IPC の切断エラー**です。

このエラーが発生すると、アプリ側には再接続の仕組みがないため、ユーザーが自力でアプリを再起動するまで機能が使えない状態が続きます。根本原因の詳細と対応検討は #1380 に切り出しました。本PRはその根本対応ではなく、**この既知の切断エラーが原因不明のOBSバックエンド例外と混在してSentryのノイズになっている**問題への対処です。

`app/util/sentry-ipc-request.ts` の `captureIpcRequestError` は、この種の既知の切断エラーを含め全ての IPC 失敗を無条件に `error` レベルで送信していました。

## 変更内容
- `app/util/sentry-ipc-request.ts`
  - `rpcError.message` が `"Failed to make IPC call, verify IPC status."` を含む場合、OBSバックエンドIPC切断と判定
  - 該当する場合は Sentry 送信 level を `error` → `warning` に降格
  - fingerprint を `['IpcRequestError', 'ObsBackendIpcLost']` に分離し、原因不明の他の IPC 例外（`['IpcRequestError', serviceName, method]`）と別 issue に集約されるようにする
  - `ipc.mainErrorKind` タグ（`obsBackendIpcLost` / `other`）を追加し、Sentry 上で集計・絞り込みできるようにする

## 設計上の注意
OBSバックエンドIPCが切断される根本原因・再接続機構の実装可否は #1380 で別途検討します。本PRは症状の分類・優先度調整のみを行うもので、Sentry issue の resolve は行いません。

## テスト
- `app/util/sentry-ipc-request.test.ts` に以下を追加
  - 通常の rpcError では `ipc.mainErrorKind: 'other'` かつ level は `error` のまま
  - OBSバックエンドIPC切断パターンの message では `ipc.mainErrorKind: 'obsBackendIpcLost'`、level は `warning`、fingerprint が専用のものになる
- `pnpm run test:unit:app` / `pnpm run typecheck` で確認済み
