### PR TITLE
開発: 帯域0kbps警告の閾値を調整しSentryノイズを削減

### DIFF
--- a/app/services/performance/performance.test.ts
+++ b/app/services/performance/performance.test.ts
@@ -277,7 +277,8 @@ describe('Zero Bandwidth Alert', () => {
     const instance = PerformanceService.instance();
     // PerformanceService.init() は StatefulService.init() をオーバーライドしており、
     // mock 環境では state が自動初期化されないため明示的に設定する
-    instance.state = PerformanceService.initialState;
+    // (SET_PERFORMANCE_STATS が破壊的更新するため initialState 自体ではなくコピーを渡す)
+    instance.state = { ...PerformanceService.initialState };
     const obs = require('../../../obs-api');
     obs.NodeObs.OBS_API_getPerformanceStatistics = jest.fn(() => ({
       CPU: 0,

--- a/app/services/performance/performance.test.ts
+++ b/app/services/performance/performance.test.ts
@@ -247,3 +247,84 @@ describe('Init and Streaming State', () => {
     expect(instance.historicalSkippedFrames).toEqual([]);
   });
 });
+
+describe('Zero Bandwidth Alert', () => {
+  function setupLiveStreaming() {
+    const setupLocal = createSetupFunction({
+      injectee: {
+        CustomizationService: {
+          pollingPerformanceStatistics: true,
+        },
+        VideoSettingsService: {
+          contexts: {
+            horizontal: {
+              skippedFrames: 0,
+              encodedFrames: 0,
+            },
+          },
+        },
+        StreamingService: {
+          streamingStatusChange: {
+            subscribe: jest.fn(),
+          },
+          state: { streamingStatus: 'live', streamingStatusTime: null },
+        },
+      },
+    });
+    setupLocal();
+
+    const { PerformanceService } = require('./performance');
+    const instance = PerformanceService.instance();
+    // PerformanceService.init() は StatefulService.init() をオーバーライドしており、
+    // mock 環境では state が自動初期化されないため明示的に設定する
+    instance.state = PerformanceService.initialState;
+    const obs = require('../../../obs-api');
+    obs.NodeObs.OBS_API_getPerformanceStatistics = jest.fn(() => ({
+      CPU: 0,
+      numberDroppedFrames: 0,
+      percentageDroppedFrames: 0,
+      streamingBandwidth: 0,
+      frameRate: 0,
+    }));
+    return instance;
+  }
+
+  test('ZERO_BANDWIDTH_THRESHOLD は 30 秒相当 (15 サンプル) に設定されている', () => {
+    setup();
+    const { PerformanceService } = require('./performance');
+    const instance = PerformanceService.instance();
+    expect(instance.ZERO_BANDWIDTH_THRESHOLD).toBe(15);
+  });
+
+  test('閾値未達では streaming bandwidth stuck アラートを送信しない', () => {
+    const instance = setupLiveStreaming();
+    const { SentryReport } = require('util/sentry-report');
+    const messageSpy = jest.spyOn(SentryReport, 'message');
+
+    for (let i = 0; i < instance.ZERO_BANDWIDTH_THRESHOLD - 1; i++) {
+      instance.update();
+    }
+
+    expect(messageSpy).not.toHaveBeenCalledWith(
+      'PerformanceService',
+      'update',
+      'streaming bandwidth stuck at 0kbps',
+      expect.anything(),
+    );
+  });
+
+  test('閾値到達で streaming bandwidth stuck アラートを1回だけ送信する', () => {
+    const instance = setupLiveStreaming();
+    const { SentryReport } = require('util/sentry-report');
+    const messageSpy = jest.spyOn(SentryReport, 'message');
+
+    for (let i = 0; i < instance.ZERO_BANDWIDTH_THRESHOLD + 5; i++) {
+      instance.update();
+    }
+
+    const bandwidthCalls = messageSpy.mock.calls.filter(
+      ([, , message]) => message === 'streaming bandwidth stuck at 0kbps',
+    );
+    expect(bandwidthCalls.length).toBe(1);
+  });
+});

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -63,7 +63,7 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
   private zeroBandwidthSamples = 0;
   private zeroBandwidthAlertSent = false;
   private zeroBandwidthStartedAt: number | null = null;
-  private readonly ZERO_BANDWIDTH_THRESHOLD = 8; // 8 × 2s = 16s
+  private readonly ZERO_BANDWIDTH_THRESHOLD = 15; // 15 × 2s = 30s
 
   // 移動平均用の履歴配列
   private historicalDroppedFrames: number[] = [];


### PR DESCRIPTION
## このpull requestが解決する内容
「streaming bandwidth stuck at 0kbps」警告（N-AIR-APP-G62）の閾値を16秒から30秒に引き上げ、Sentryのノイズを削減します。

## 背景
`app/services/performance/performance.ts` の `update()` は、配信中に `streamingBandwidth === 0` が連続8サンプル（16秒）継続すると `SentryReport.message('streaming bandwidth stuck at 0kbps', ...)` を送信します。0kbpsから回復すると `zeroBandwidthAlertSent` フラグがリセットされるため、送信は「配信につき1回」ではなく **連続0kbps区間ごとに1回**（同一配信中に 0kbps→回復→再度0kbps が起きれば複数回送信されうる）です。

release 1.1.20260722-1 のトリアージ時点で 5538件/291ユーザーと非常に多く、瞬間的な帯域スタックまで拾ってしまい「配信断絶の兆候」を見るという目的に対してシグナル対ノイズ比が低い状態でした。

## 変更内容
- `app/services/performance/performance.ts`
  - `ZERO_BANDWIDTH_THRESHOLD` を `8`（16秒）→ `15`（30秒）に変更
  - level（warning）・送信条件（連続0kbps区間ごとに1回）・送信内容（`zeroDurationSec` 等のcontext）は変更なし

ユーザー可視の挙動変更はないため `開発:` プレフィックスとしています。

## テスト
- `app/services/performance/performance.test.ts` に `Zero Bandwidth Alert` テストを追加
  - `ZERO_BANDWIDTH_THRESHOLD` が 15 になっていることの確認
  - 閾値未達（14回更新）ではアラートを送信しないこと
  - 閾値到達後（20回更新）もアラートは1回のみ送信されること
- `pnpm run test:unit:app` / `pnpm run typecheck` で確認済み
- 実配信での30秒間0kbps再現による実機確認はしていません（閾値変更のみでロジックは既存のまま）
