### PR TITLE
変更: N Airの起動処理と進行状況表示を改善

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -19,7 +19,7 @@ import tooltipDirective from 'directives/tooltip';
 import electron from 'electron';
 import { Settings } from 'luxon';
 import { setupGlobalContextMenuForEditableElement } from 'util/menus/GlobalMenu';
-import { createApp } from 'vue';
+import { createApp, nextTick } from 'vue';
 import { createI18n, type Locale, type Path } from 'vue-i18n';
 
 import * as obs from '../obs-api';
@@ -30,6 +30,13 @@ import { WindowsService } from './services/windows';
 import { createStore } from './store';
 
 const { ipcRenderer } = electron;
+
+function logStartupMilestone(name: string, startedAt?: number) {
+  const detail = startedAt === undefined ? undefined : `${Math.round(performance.now() - startedAt)}ms`;
+  ipcRenderer.send('startup-milestone', name, detail);
+}
+
+logStartupMilestone('bundle-evaluated');
 
 import * as remote from '@electron/remote';
 
@@ -169,8 +176,12 @@ const showDialog = (message: string): void => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  logStartupMilestone('dom-content-loaded');
+  const storeStartedAt = performance.now();
   createStore().then(async (store) => {
+    logStartupMilestone('store-ready', storeStartedAt);
     const windowsService: WindowsService = WindowsService.instance();
+    let mainAppService: AppService | null = null;
 
     if (Utils.isMainWindow()) {
       // Services
@@ -202,12 +213,16 @@ document.addEventListener('DOMContentLoaded', () => {
         path.join(appService.appDataDirectory, 'basic.ini'),
       );
 
+      ipcRenderer.on('closeWindow', () => windowsService.closeMainWindow());
+      logStartupMilestone('obs-api-initialize-started');
+      const obsStartedAt = performance.now();
       const apiResult = obs.NodeObs.OBS_API_initAPI(
         'en-US',
         appService.appDataDirectory,
         remote.process.env.NAIR_VERSION,
         SENTRY_MINIDUMP_URL,
       );
+      logStartupMilestone('obs-api-initialized', obsStartedAt);
 
       if (apiResult !== obs.EVideoCodes.Success) {
         const message = apiInitErrorResultToMessage(apiResult);
@@ -222,8 +237,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      ipcRenderer.on('closeWindow', () => windowsService.closeMainWindow());
-      AppService.instance().load();
+      mainAppService = appService;
     } else {
       if (Utils.isChildWindow()) {
         ipcRenderer.on('closeWindow', () => windowsService.closeChildWindow());
@@ -232,7 +246,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // setup vue-i18n plugin
     const i18nService: I18nService = I18nService.instance();
+    const i18nStartedAt = performance.now();
     await i18nService.load(); // load translations from a disk
+    logStartupMilestone('i18n-loaded', i18nStartedAt);
     const notFoundKeys = new Set<string>();
 
     // load notFoundKeys from file
@@ -322,6 +338,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     app.mount('#app');
+    await nextTick();
+
+    if (mainAppService) {
+      // メイン画面の外枠とローダーを描画してから、重いシーン復元を開始する。
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+      });
+      logStartupMilestone('main-shell-rendered');
+      await mainAppService.load();
+      await nextTick();
+    }
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => logStartupMilestone('vue-mounted'));
+    });
 
     Sentry.getCurrentScope().setTag('windowId', windowId);
 

--- a/app/components/studio/TitleBar.vue
+++ b/app/components/studio/TitleBar.vue
@@ -10,7 +10,13 @@
         @click="maximize"
         v-if="!isCompactMode && resizable !== false"
       />
-      <i class="link icon-close-square titlebar-action" data-test="titlebar-close" @click="close" />
+      <i
+        class="link icon-close-square titlebar-action"
+        :class="{ 'titlebar-action--disabled': !closable }"
+        :aria-disabled="!closable"
+        data-test="titlebar-close"
+        @click="close"
+      />
     </div>
   </div>
 </template>
@@ -98,6 +104,12 @@
   &:not(:disabled):hover {
     color: var(--color-titlebar-action-hover);
   }
+}
+
+.titlebar-action--disabled {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.4;
 }
 
 .dev-hosts-badge {

--- a/app/components/studio/TitleBar.vue
+++ b/app/components/studio/TitleBar.vue
@@ -10,13 +10,13 @@
         @click="maximize"
         v-if="!isCompactMode && resizable !== false"
       />
-      <i
+      <button
+        type="button"
         class="link icon-close-square titlebar-action"
-        :class="{ 'titlebar-action--disabled': !closable }"
-        :aria-disabled="!closable"
+        :disabled="!closable"
         data-test="titlebar-close"
         @click="close"
-      />
+      ></button>
     </div>
   </div>
 </template>
@@ -97,19 +97,21 @@
   .margin-right();
 
   display: inline-block;
+  padding: 0;
   font-size: @font-size4;
   color: var(--color-titlebar-action);
   cursor: pointer;
+  background: transparent;
+  border: 0;
 
   &:not(:disabled):hover {
     color: var(--color-titlebar-action-hover);
   }
-}
 
-.titlebar-action--disabled {
-  pointer-events: none;
-  cursor: default;
-  opacity: 0.4;
+  &:disabled {
+    cursor: default;
+    opacity: 0.4;
+  }
 }
 
 .dev-hosts-badge {

--- a/app/components/studio/TitleBar.vue.ts
+++ b/app/components/studio/TitleBar.vue.ts
@@ -12,6 +12,7 @@ export default defineComponent({
   props: {
     title: { type: String },
     resizable: { type: Boolean, default: true },
+    closable: { type: Boolean, default: true },
   },
 
   computed: {
@@ -52,6 +53,8 @@ export default defineComponent({
     },
 
     close() {
+      if (!this.closable) return;
+
       if (Utils.isMainWindow() && StreamingService.instance().isStreaming) {
         if (!confirm($t('streaming.endStreamInStreamingConfirm'))) return;
       }

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -5,7 +5,7 @@
     @drop="onDropHandler"
     :class="{ isCompactMode: isCompactMode }"
   >
-    <title-bar class="main-title" :title="title" />
+    <title-bar class="main-title" :title="title" :closable="!applicationLoading" />
     <div class="main-contents">
       <side-nav v-if="page !== 'Onboarding'"></side-nav>
       <div class="main-middle" v-if="showMainMiddle">

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -33,7 +33,6 @@ export default defineComponent({
   },
 
   mounted() {
-    remote.getCurrentWindow().show();
     WindowSizeService.instance(); // manage compact mode
   },
 

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -110,6 +110,9 @@ export class AppService extends StatefulService<IAppState> {
       // the apps to already be in place when their sources are created.
       // await this.platformAppsService.initialize();
 
+      // 初期化中の Studio 操作を防ぐため、シーン復元前にパッチノートを表示判定する。
+      this.patchNotesService.showPatchNotesIfRequired(willOnboard);
+
       const sceneCollectionsStartedAt = performance.now();
       await this.sceneCollectionsService.initialize();
       electron.ipcRenderer.send(
@@ -141,16 +144,15 @@ export class AppService extends StatefulService<IAppState> {
       'app-interactive',
       `${Math.round(performance.now() - loadStartedAt)}ms`,
     );
-    this.initializeDeferredServices(willOnboard);
+    this.initializeDeferredServices();
     return result;
   }
 
   /** 操作開始に必須でないサービスを、初期画面の描画を妨げないタイミングで初期化する。 */
-  private initializeDeferredServices(willOnboard: boolean) {
+  private initializeDeferredServices() {
     window.requestAnimationFrame(() => window.setTimeout(() => {
       const startedAt = performance.now();
       UsageStatisticsService.instance().recordEvent({ event: 'boot' });
-      this.patchNotesService.showPatchNotesIfRequired(willOnboard);
       this.informationsService;
       this.transcriptionService;
       electron.ipcRenderer.send(

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -85,8 +85,10 @@ export class AppService extends StatefulService<IAppState> {
   readonly pid = require('process').pid;
 
   async load() {
-    UsageStatisticsService.instance().recordEvent({ event: 'boot' });
-    return this.runInLoadingMode(async () => {
+    const loadStartedAt = performance.now();
+    electron.ipcRenderer.send('startup-milestone', 'app-load-started');
+    const willOnboard = this.onboardingService.willOnboardOnStartup();
+    const result = await this.runInLoadingMode(async () => {
       if (Utils.isDevMode()) {
         electron.ipcRenderer.on('showErrorAlert', () => {
           this.SET_ERROR_ALERT(true);
@@ -108,11 +110,13 @@ export class AppService extends StatefulService<IAppState> {
       // the apps to already be in place when their sources are created.
       // await this.platformAppsService.initialize();
 
-      // パッチノートはOBS/シーンに依存しないため、シーン初期化前に表示判定する
-      const willOnboard = this.onboardingService.willOnboardOnStartup();
-      this.patchNotesService.showPatchNotesIfRequired(willOnboard);
-
+      const sceneCollectionsStartedAt = performance.now();
       await this.sceneCollectionsService.initialize();
+      electron.ipcRenderer.send(
+        'startup-milestone',
+        'scene-collections-initialized',
+        `${Math.round(performance.now() - sceneCollectionsStartedAt)}ms`,
+      );
 
       this.startMonitoringStudioMode();
       this.onboardingService.startOnboardingIfRequired();
@@ -128,14 +132,33 @@ export class AppService extends StatefulService<IAppState> {
       this.ipcServerService.listen();
       this.tcpServerService.listen();
 
-      this.informationsService;
-
-      this.transcriptionService;
-
       this.crashReporterService.endStartup();
 
       this.protocolLinksService.start(this.state.argv);
     });
+    electron.ipcRenderer.send(
+      'startup-milestone',
+      'app-interactive',
+      `${Math.round(performance.now() - loadStartedAt)}ms`,
+    );
+    this.initializeDeferredServices(willOnboard);
+    return result;
+  }
+
+  /** 操作開始に必須でないサービスを、初期画面の描画を妨げないタイミングで初期化する。 */
+  private initializeDeferredServices(willOnboard: boolean) {
+    window.requestAnimationFrame(() => window.setTimeout(() => {
+      const startedAt = performance.now();
+      UsageStatisticsService.instance().recordEvent({ event: 'boot' });
+      this.patchNotesService.showPatchNotesIfRequired(willOnboard);
+      this.informationsService;
+      this.transcriptionService;
+      electron.ipcRenderer.send(
+        'startup-milestone',
+        'deferred-services-initialized',
+        `${Math.round(performance.now() - startedAt)}ms`,
+      );
+    }, 0));
   }
 
   private shutdownHandler() {

--- a/app/services/file-manager.ts
+++ b/app/services/file-manager.ts
@@ -37,8 +37,8 @@ export class FileManagerService extends Service {
   async exists(filePath: string): Promise<boolean> {
     const truePath = path.resolve(filePath);
 
-    if (this.files[truePath]) return Promise.resolve(true);
-    return this.fileExists(truePath);
+    if (this.files[truePath]) return true;
+    return fs.existsSync(truePath);
   }
 
   write(filePath: string, data: string) {
@@ -169,16 +169,6 @@ export class FileManagerService extends Service {
         });
       }
     }
-  }
-
-  /**
-   * Checks if a file exists
-   * @param string a path to the file
-   */
-  private fileExists(filePath: string): Promise<boolean> {
-    return new Promise((resolve) => {
-      fs.exists(filePath, (exists) => resolve(exists));
-    });
   }
 
   /**

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -36,6 +36,9 @@ interface ISchema {
 export class RootNode extends Node<ISchema, {}> {
   schemaVersion = 3;
 
+  measureLoadStep?: (name: string, operation: () => Promise<void>) => Promise<void>;
+  reportLoadTiming?: (name: string, duration: number) => void;
+
   @Inject() videoService: VideoService;
   @Inject() videoSettingsService: VideoSettingsService;
   @Inject() scenesService: ScenesService;
@@ -88,68 +91,81 @@ export class RootNode extends Node<ISchema, {}> {
 
     const wh = this.videoSettingsService.baseResolutions.horizontal;
     const targetResolution = { width: wh.baseWidth, height: wh.baseHeight };
-    this.videoService.setBaseResolution(targetResolution);
+    await this.runLoadStep('scene-collections-resolution-initialized', async () => {
+      this.videoService.setBaseResolution(targetResolution);
+    });
 
     // Load transitions
-    try {
-      await this.data.transitions.load();
-      // Collect errors from transitions
-      const transitionErrors = this.data.transitions.getLoadErrors();
-      transitionErrors.forEach((err) => this.addLoadError(err));
-    } catch (e) {
-      console.error('Failed to load transitions:', e);
-      this.addLoadError({
-        type: 'transition',
-        name: 'Transitions',
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-
-    // Load sources
-    try {
-      await this.data.sources.load({});
-      // Collect errors from sources
-      const sourceErrors = this.data.sources.getLoadErrors();
-      sourceErrors.forEach((err) => this.addLoadError(err));
-    } catch (e) {
-      console.error('Failed to load sources:', e);
-      this.addLoadError({
-        type: 'source',
-        name: 'Sources',
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-
-    // Load scenes
-    try {
-      await this.data.scenes.load({});
-      // Collect errors from scenes
-      const sceneErrors = this.data.scenes.getLoadErrors();
-      sceneErrors.forEach((err) => this.addLoadError(err));
-    } catch (e) {
-      console.error('Failed to load scenes:', e);
-      this.addLoadError({
-        type: 'scene',
-        name: 'Scenes',
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-
-    // Load hotkeys
-    if (this.data.hotkeys) {
+    await this.runLoadStep('scene-collections-transitions-loaded', async () => {
       try {
-        await this.data.hotkeys.load({});
-        // Collect errors from hotkeys
-        const hotkeyErrors = this.data.hotkeys.getLoadErrors();
-        hotkeyErrors.forEach((err) => this.addLoadError(err));
+        await this.data.transitions.load();
+        // Collect errors from transitions
+        const transitionErrors = this.data.transitions.getLoadErrors();
+        transitionErrors.forEach((err) => this.addLoadError(err));
       } catch (e) {
-        console.error('Failed to load hotkeys:', e);
+        console.error('Failed to load transitions:', e);
         this.addLoadError({
-          type: 'hotkey',
-          name: 'Hotkeys',
+          type: 'transition',
+          name: 'Transitions',
           error: e instanceof Error ? e : new Error(String(e)),
         });
       }
+    });
+
+    // Load sources
+    await this.runLoadStep('scene-collections-sources-loaded', async () => {
+      this.data.sources.reportLoadTiming = this.reportLoadTiming;
+      try {
+        await this.data.sources.load({});
+        // Collect errors from sources
+        const sourceErrors = this.data.sources.getLoadErrors();
+        sourceErrors.forEach((err) => this.addLoadError(err));
+      } catch (e) {
+        console.error('Failed to load sources:', e);
+        this.addLoadError({
+          type: 'source',
+          name: 'Sources',
+          error: e instanceof Error ? e : new Error(String(e)),
+        });
+      } finally {
+        this.data.sources.reportLoadTiming = undefined;
+      }
+    });
+
+    // Load scenes
+    await this.runLoadStep('scene-collections-scenes-loaded', async () => {
+      try {
+        await this.data.scenes.load({});
+        // Collect errors from scenes
+        const sceneErrors = this.data.scenes.getLoadErrors();
+        sceneErrors.forEach((err) => this.addLoadError(err));
+      } catch (e) {
+        console.error('Failed to load scenes:', e);
+        this.addLoadError({
+          type: 'scene',
+          name: 'Scenes',
+          error: e instanceof Error ? e : new Error(String(e)),
+        });
+      }
+    });
+
+    // Load hotkeys
+    if (this.data.hotkeys) {
+      await this.runLoadStep('scene-collections-node-hotkeys-loaded', async () => {
+        try {
+          await this.data.hotkeys!.load({});
+          // Collect errors from hotkeys
+          const hotkeyErrors = this.data.hotkeys!.getLoadErrors();
+          hotkeyErrors.forEach((err) => this.addLoadError(err));
+        } catch (e) {
+          console.error('Failed to load hotkeys:', e);
+          this.addLoadError({
+            type: 'hotkey',
+            name: 'Hotkeys',
+            error: e instanceof Error ? e : new Error(String(e)),
+          });
+        }
+      });
     }
 
     // Rescale scene items to fit the current canvas resolution if the
@@ -165,20 +181,26 @@ export class RootNode extends Node<ISchema, {}> {
       && (savedResolution.width !== targetResolution.width
         || savedResolution.height !== targetResolution.height)
     ) {
-      try {
-        this.scenesService.rescaleAllScenes(
-          targetResolution.width / savedResolution.width,
-          targetResolution.height / savedResolution.height,
-        );
-      } catch (e) {
-        console.error('Failed to rescale scene items:', e);
-        this.addLoadError({
-          type: 'format',
-          name: $t('scenes.rescaleFailed'),
-          error: e instanceof Error ? e : new Error(String(e)),
-        });
-      }
+      await this.runLoadStep('scene-collections-scenes-rescaled', async () => {
+        try {
+          this.scenesService.rescaleAllScenes(
+            targetResolution.width / savedResolution.width,
+            targetResolution.height / savedResolution.height,
+          );
+        } catch (e) {
+          console.error('Failed to rescale scene items:', e);
+          this.addLoadError({
+            type: 'format',
+            name: $t('scenes.rescaleFailed'),
+            error: e instanceof Error ? e : new Error(String(e)),
+          });
+        }
+      });
     }
+  }
+
+  private runLoadStep(name: string, operation: () => Promise<void>): Promise<void> {
+    return this.measureLoadStep ? this.measureLoadStep(name, operation) : operation();
   }
 
   migrate(version: number) {

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -60,6 +60,8 @@ export interface ISourceInfo {
 export class SourcesNode extends Node<ISchema, {}> {
   schemaVersion = 3;
 
+  reportLoadTiming?: (name: string, duration: number) => void;
+
   @Inject() private fontLibraryService: FontLibraryService;
   @Inject() private sourcesService: SourcesService;
   @Inject() private audioService: AudioService;
@@ -223,6 +225,17 @@ export class SourcesNode extends Node<ISchema, {}> {
     this.clearLoadErrors();
     this.sanitizeSources();
 
+    const timings = new Map<string, number>();
+    const sourceCreationTimings = new Map<string, number>();
+    const measure = <T>(name: string, operation: () => T): T => {
+      const startedAt = performance.now();
+      try {
+        return operation();
+      } finally {
+        timings.set(name, (timings.get(name) ?? 0) + performance.now() - startedAt);
+      }
+    };
+
     // This ensures we have bound the source size callback
     // before creating any sources in OBS.
     this.sourcesService;
@@ -237,42 +250,58 @@ export class SourcesNode extends Node<ISchema, {}> {
 
       // Try to create the OBS input source
       try {
-        const settings = applyPathConvertForPreset(sourceInfo.type, sourceInfo.settings);
-        obsInput = obs.InputFactory.create(sourceInfo.type, sourceInfo.id, settings);
+        const startedAt = performance.now();
+        try {
+          const settings = applyPathConvertForPreset(sourceInfo.type, sourceInfo.settings);
+          obsInput = obs.InputFactory.create(sourceInfo.type, sourceInfo.id, settings);
+        } finally {
+          const duration = performance.now() - startedAt;
+          timings.set('inputs-created', (timings.get('inputs-created') ?? 0) + duration);
+          sourceCreationTimings.set(
+            sourceInfo.type,
+            (sourceCreationTimings.get(sourceInfo.type) ?? 0) + duration,
+          );
+        }
 
         // Apply basic source properties (equivalent to createSources lines 1563-1570)
-        if (obsInput.audioMixers) {
-          obsInput.muted = sourceInfo.muted || false;
-          obsInput.volume = sourceInfo.volume != null ? sourceInfo.volume : 1;
-          obsInput.syncOffset = { sec: 0, nsec: 0 };
-        }
+        measure('basic-properties-applied', () => {
+          if (obsInput!.audioMixers) {
+            obsInput!.muted = sourceInfo.muted || false;
+            obsInput!.volume = sourceInfo.volume != null ? sourceInfo.volume : 1;
+            obsInput!.syncOffset = { sec: 0, nsec: 0 };
+          }
 
-        obsInput.deinterlaceMode = sourceInfo.deinterlaceMode || obs.EDeinterlaceMode.Disable;
-        obsInput.deinterlaceFieldOrder = sourceInfo.deinterlaceFieldOrder || obs.EDeinterlaceFieldOrder.Top;
+          obsInput!.deinterlaceMode =
+            sourceInfo.deinterlaceMode ?? obs.EDeinterlaceMode.Disable;
+          obsInput!.deinterlaceFieldOrder =
+            sourceInfo.deinterlaceFieldOrder ?? obs.EDeinterlaceFieldOrder.Top;
+        });
 
         // Create and add filters (equivalent to createSources lines 1573-1589)
-        if (sourceInfo.filters && Array.isArray(sourceInfo.filters.items)) {
-          sourceInfo.filters.items.forEach((filterInfo) => {
-            try {
-              const obsFilter = obs.FilterFactory.create(
-                filterInfo.type,
-                filterInfo.name,
-                filterInfo.settings,
-              );
-              if (obsFilter) {
-                obsFilter.enabled = filterInfo.enabled === undefined ? true : filterInfo.enabled;
-                obsInput!.addFilter(obsFilter);
-                obsFilter.release();
+        measure('filters-created', () => {
+          if (sourceInfo.filters && Array.isArray(sourceInfo.filters.items)) {
+            sourceInfo.filters.items.forEach((filterInfo) => {
+              try {
+                const obsFilter = obs.FilterFactory.create(
+                  filterInfo.type,
+                  filterInfo.name,
+                  filterInfo.settings,
+                );
+                if (obsFilter) {
+                  obsFilter.enabled = filterInfo.enabled === undefined ? true : filterInfo.enabled;
+                  obsInput!.addFilter(obsFilter);
+                  obsFilter.release();
+                }
+              } catch (filterError) {
+                console.warn(
+                  `Failed to create filter "${filterInfo.name}" for source "${sourceInfo.name}":`,
+                  filterError,
+                );
+                // Note: filter errors are not added to loadErrors as they are less critical
               }
-            } catch (filterError) {
-              console.warn(
-                `Failed to create filter "${filterInfo.name}" for source "${sourceInfo.name}":`,
-                filterError,
-              );
-              // Note: filter errors are not added to loadErrors as they are less critical
-            }
-          });
-        }
+            });
+          }
+        });
       } catch (e) {
         console.warn(`Failed to create input for source "${sourceInfo.name}":`, e);
         this.addLoadError({
@@ -289,42 +318,39 @@ export class SourcesNode extends Node<ISchema, {}> {
       // If source creation succeeded, add it to the service and configure it
       if (obsInput) {
         try {
-          this.sourcesService.addSource(obsInput, sourceInfo.name, {
-            channel: sourceInfo.channel,
-            propertiesManager: sourceInfo.propertiesManager,
-            propertiesManagerSettings: sourceInfo.propertiesManagerSettings || {},
+          measure('sources-added', () => {
+            this.sourcesService.addSource(obsInput!, sourceInfo.name, {
+              channel: sourceInfo.channel,
+              deinterlaceMode: sourceInfo.deinterlaceMode,
+              deinterlaceFieldOrder: sourceInfo.deinterlaceFieldOrder,
+              propertiesManager: sourceInfo.propertiesManager,
+              propertiesManagerSettings: sourceInfo.propertiesManagerSettings || {},
+            });
           });
 
-          const newSource = this.sourcesService.getSource(sourceInfo.id);
-          if (newSource.async && newSource.video) {
-            if (sourceInfo.deinterlaceMode !== undefined) {
-              newSource.setDeinterlaceMode(sourceInfo.deinterlaceMode);
-            }
-            if (sourceInfo.deinterlaceFieldOrder !== undefined) {
-              newSource.setDeinterlaceFieldOrder(sourceInfo.deinterlaceFieldOrder);
-            }
-          }
+          const useAudio = !isNoAudioPropertiesManagerType(sourceInfo.propertiesManager ?? 'default');
 
-          const useAudio = !isNoAudioPropertiesManagerType(sourceInfo.propertiesManager);
-
-          if (useAudio && obsInput.audioMixers) {
-            const audioSource = this.audioService.getSource(sourceInfo.id);
-            if (!audioSource) {
-              // maybe the source was removed after the last save
-              if (Utils.isDevMode()) {
-                console.warn(`Audio source ${sourceInfo.id} not found in AudioService. ignore.`);
+          measure('source-audio-settings-applied', () => {
+            if (useAudio && obsInput!.audioMixers) {
+              const audioSource = this.audioService.getSource(sourceInfo.id);
+              if (!audioSource) {
+                // maybe the source was removed after the last save
+                if (Utils.isDevMode()) {
+                  console.warn(`Audio source ${sourceInfo.id} not found in AudioService. ignore.`);
+                }
+                Sentry.captureEvent({
+                  message: 'Audio source not found in AudioService',
+                  level: 'warning',
+                  tags: {
+                    sourceId: sourceInfo.id,
+                  },
+                  extra: {
+                    audioSources: Object.keys(this.audioService.state.audioSources),
+                  },
+                });
+                return;
               }
-              Sentry.captureEvent({
-                message: 'Audio source not found in AudioService',
-                level: 'warning',
-                tags: {
-                  sourceId: sourceInfo.id,
-                },
-                extra: {
-                  audioSources: Object.keys(this.audioService.state.audioSources),
-                },
-              });
-            } else {
+
               audioSource.setMul(sourceInfo.volume != null ? sourceInfo.volume : 1);
 
               // マイグレーション: 音声を持つべきソースでaudioMixers=0の場合、デフォルト値に修正
@@ -372,7 +398,7 @@ export class SourcesNode extends Node<ISchema, {}> {
               });
               audioSource.setHidden(!!sourceInfo.mixerHidden);
             }
-          }
+          });
 
           if (sourceInfo.hotkeys) {
             promises.push(sourceInfo.hotkeys.load({ sourceId: sourceInfo.id }));
@@ -391,8 +417,22 @@ export class SourcesNode extends Node<ISchema, {}> {
       }
     });
 
+    timings.forEach((duration, name) => {
+      this.reportLoadTiming?.(`scene-collections-source-${name}`, duration);
+    });
+    sourceCreationTimings.forEach((duration, sourceType) => {
+      this.reportLoadTiming?.(`scene-collections-source-created-${sourceType}`, duration);
+    });
+
+    const hotkeysStartedAt = performance.now();
     return new Promise((resolve) => {
-      Promise.all(promises).then(() => resolve());
+      Promise.all(promises).then(() => {
+        this.reportLoadTiming?.(
+          'scene-collections-source-hotkeys-loaded',
+          performance.now() - hotkeysStartedAt,
+        );
+        resolve();
+      });
     });
   }
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
+import electron from 'electron';
 import { Subject } from 'rxjs';
 import { TcpServerService } from 'services/api/tcp-server';
 import { AppService } from 'services/app';
@@ -107,45 +108,94 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    */
   private collectionLoaded = false;
 
+  /** 起動時のシーンコレクション初期化について、段階別計測中かどうか。 */
+  private measuringInitialization = false;
+
   /**
    * Does not use the standard init function so we can have asynchronous
    * initialization.
    */
   async initialize() {
-    await this.migrate();
-    await this.stateService.loadManifestFile();
-    if (this.activeCollection) {
-      await this.load(this.activeCollection.id);
-    } else if (this.collections.length > 0) {
-      let latestId = this.collections[0].id;
-      let latestModified = this.collections[0].modified;
+    this.measuringInitialization = true;
+    try {
+      await this.measureInitializationStep('scene-collections-migration', () => this.migrate());
+      this.stateService.reportLoadTiming = (name, duration) =>
+        this.reportInitializationTiming(name, duration);
+      try {
+        await this.measureInitializationStep(
+          'scene-collections-manifest-loaded',
+          () => this.stateService.loadManifestFile(),
+        );
+      } finally {
+        this.stateService.reportLoadTiming = undefined;
+      }
+      await this.measureInitializationStep('scene-collections-active-loaded', async () => {
+        if (this.activeCollection) {
+          await this.load(this.activeCollection.id);
+        } else if (this.collections.length > 0) {
+          let latestId = this.collections[0].id;
+          let latestModified = this.collections[0].modified;
 
-      this.collections.forEach((collection) => {
-        if (collection.modified > latestModified) {
-          latestModified = collection.modified;
-          latestId = collection.id;
+          this.collections.forEach((collection) => {
+            if (collection.modified > latestModified) {
+              latestModified = collection.modified;
+              latestId = collection.id;
+            }
+          });
+
+          await this.load(latestId);
+        } else {
+          await this.create();
         }
       });
 
-      await this.load(latestId);
-    } else {
-      await this.create();
+      await this.measureInitializationStep('scene-collections-preset-checked', async () => {
+        const scenes = this.scenesService.scenes;
+        if (
+          this.collections.length === 1
+          && scenes.length === 1
+          && scenes[0].getItems().length === 0
+        ) {
+          // シーンが一つで空であるため、シーンプリセットをインストールする
+          await this.installPresetSceneCollection();
+        } else if (!this.appService.obsConfigExisted) {
+          // basic.ini がなかった場合(キャッシュクリア後など)、OBS がデフォルト値(1920x1080)で
+          // 初期化するため、N Air のデフォルト解像度(1920x1080)に合わせる
+          this.ensureCanvasResolution('1920x1080');
+        }
+      });
+
+      // 読み込んだソース情報を環境に合わせて更新する
+      await this.measureInitializationStep('scene-collections-source-settings-fixed', async () => {
+        this.sourcesService.fixSourceSettings();
+      });
+
+      this.initialized = true;
+    } finally {
+      this.measuringInitialization = false;
     }
+  }
 
-    const scenes = this.scenesService.scenes;
-    if (this.collections.length === 1 && scenes.length === 1 && scenes[0].getItems().length === 0) {
-      // シーンが一つで空であるため、シーンプリセットをインストールする
-      await this.installPresetSceneCollection();
-    } else if (!this.appService.obsConfigExisted) {
-      // basic.ini がなかった場合(キャッシュクリア後など)、OBS がデフォルト値(1920x1080)で
-      // 初期化するため、N Air のデフォルト解像度(1920x1080)に合わせる
-      this.ensureCanvasResolution('1920x1080');
+  /** 起動時のみ処理時間を計測し、メインプロセスの起動ログへ送る。 */
+  private async measureInitializationStep<T>(name: string, operation: () => Promise<T>): Promise<T> {
+    if (!this.measuringInitialization) return operation();
+
+    const startedAt = performance.now();
+    try {
+      return await operation();
+    } finally {
+      electron.ipcRenderer.send(
+        'startup-milestone',
+        name,
+        `${Math.round(performance.now() - startedAt)}ms`,
+      );
     }
+  }
 
-    // 読み込んだソース情報を環境に合わせて更新する
-    this.sourcesService.fixSourceSettings();
-
-    this.initialized = true;
+  /** すでに計測済みの起動処理時間をメインプロセスの起動ログへ送る。 */
+  private reportInitializationTiming(name: string, duration: number) {
+    if (!this.measuringInitialization) return;
+    electron.ipcRenderer.send('startup-milestone', name, `${Math.round(duration)}ms`);
   }
 
   /** キャンバス解像度を指定の値に設定する */
@@ -323,7 +373,10 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    */
   async load(id: string): Promise<void> {
     this.startLoadingOperation();
-    await this.deloadCurrentApplicationState();
+    await this.measureInitializationStep(
+      'scene-collections-current-state-unloaded',
+      () => this.deloadCurrentApplicationState(),
+    );
 
     const collection = this.getCollection(id);
     const collectionName = collection ? collection.name : id;
@@ -331,8 +384,14 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     let loadErrors: ILoadError[] = [];
 
     try {
-      await this.setActiveCollection(id);
-      loadErrors = await this.readCollectionDataAndLoadIntoApplicationState(id);
+      await this.measureInitializationStep(
+        'scene-collections-active-selected',
+        () => this.setActiveCollection(id),
+      );
+      loadErrors = await this.measureInitializationStep(
+        'scene-collections-data-loaded',
+        () => this.readCollectionDataAndLoadIntoApplicationState(id),
+      );
     } catch (e) {
       SentryReport.error('SceneCollectionsService', 'load', e, {
         tags: { collectionId: id, collectionName },
@@ -677,7 +736,10 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * @returns Array of load errors that occurred during loading
    */
   private async readCollectionDataAndLoadIntoApplicationState(id: string): Promise<ILoadError[]> {
-    const exists = await this.stateService.collectionFileExists(id);
+    const exists = await this.measureInitializationStep(
+      'scene-collections-file-checked',
+      () => this.stateService.collectionFileExists(id),
+    );
     if (!exists) return [];
 
     let data: string;
@@ -687,7 +749,10 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       data = this.stateService.readCollectionFile(id);
       if (data == null) throw new Error('Got blank data from collection file');
 
-      loadErrors = await this.loadDataIntoApplicationState(data);
+      loadErrors = await this.measureInitializationStep(
+        'scene-collections-application-state-loaded',
+        () => this.loadDataIntoApplicationState(data),
+      );
     } catch (e) {
       // Check for a backup and load it
       const exists = await this.stateService.collectionFileExists(id, true);
@@ -704,7 +769,9 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     }
 
     // Everything was successful, write a backup
-    this.stateService.writeDataToCollectionFile(id, data, true);
+    await this.measureInitializationStep('scene-collections-backup-written', async () => {
+      this.stateService.writeDataToCollectionFile(id, data, true);
+    });
     this.collectionLoaded = true;
 
     return loadErrors;
@@ -717,9 +784,25 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    */
   private async loadDataIntoApplicationState(data: string): Promise<ILoadError[]> {
     const parseWarnings: IParseWarning[] = [];
-    const root = parse(data, NODE_TYPES, (warning) => parseWarnings.push(warning));
-    await root.load();
-    this.hotkeysService.bindHotkeys();
+    const root = await this.measureInitializationStep(
+      'scene-collections-data-parsed',
+      async () => parse(data, NODE_TYPES, (warning) => parseWarnings.push(warning)),
+    );
+    if (this.measuringInitialization) {
+      root.measureLoadStep = (name: string, operation: () => Promise<void>) =>
+        this.measureInitializationStep(name, operation);
+      root.reportLoadTiming = (name: string, duration: number) =>
+        this.reportInitializationTiming(name, duration);
+    }
+    try {
+      await this.measureInitializationStep('scene-collections-nodes-loaded', () => root.load());
+    } finally {
+      root.measureLoadStep = undefined;
+      root.reportLoadTiming = undefined;
+    }
+    await this.measureInitializationStep('scene-collections-hotkeys-bound', async () => {
+      this.hotkeysService.bindHotkeys();
+    });
     const loadErrors = root.getLoadErrors();
     parseWarnings.forEach((warning) => loadErrors.push(this.parseWarningToLoadError(warning)));
     return loadErrors;

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -28,6 +28,8 @@ export const ScenePresetId = 'preset/basic';
 export class SceneCollectionsStateService extends StatefulService<ISceneCollectionsManifest> {
   @Inject() fileManagerService: FileManagerService;
 
+  reportLoadTiming?: (name: string, duration: number) => void;
+
   static initialState: ISceneCollectionsManifest = {
     activeId: null,
     collections: [],
@@ -45,11 +47,23 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
    * Loads the manifest file into the state for this service.
    */
   async loadManifestFile() {
-    await this.ensureDirectory();
+    const measure = async <T>(name: string, operation: () => Promise<T> | T): Promise<T> => {
+      const startedAt = performance.now();
+      try {
+        return await operation();
+      } finally {
+        this.reportLoadTiming?.(name, performance.now() - startedAt);
+      }
+    };
+
+    await measure('scene-collections-manifest-directory-ensured', () => this.ensureDirectory());
 
     let sceneCollectionsManifest: ISceneCollectionsManifest | null = null;
     try {
-      sceneCollectionsManifest = await this._loadManifestFile();
+      sceneCollectionsManifest = await measure(
+        'scene-collections-manifest-primary-read',
+        () => this._loadManifestFile(),
+      );
     } catch (e) {
       const scope = new Sentry.Scope();
       scope.setTag('service', 'SceneCollectionsStateService');
@@ -58,7 +72,10 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
 
       try {
         // バックアップから読み込み
-        sceneCollectionsManifest = await this._loadManifestFile(true);
+        sceneCollectionsManifest = await measure(
+          'scene-collections-manifest-backup-read',
+          () => this._loadManifestFile(true),
+        );
 
         // sentryに結果を送信（元のエラーはbreadcrumbで拾う）
         if (sceneCollectionsManifest) {
@@ -75,11 +92,17 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
     }
 
     if (sceneCollectionsManifest) {
-      this.LOAD_STATE(sceneCollectionsManifest);
+      await measure('scene-collections-manifest-state-loaded', () => {
+        this.LOAD_STATE(sceneCollectionsManifest!);
+      });
     }
 
-    await this.flushManifestFile();
-    await this.flushManifestFile(true);
+    await measure('scene-collections-manifest-primary-flush-scheduled', () =>
+      this.flushManifestFile(),
+    );
+    await measure('scene-collections-manifest-backup-flush-scheduled', () =>
+      this.flushManifestFile(true),
+    );
   }
 
   private async _loadManifestFile(backup?: boolean): Promise<ISceneCollectionsManifest | null> {
@@ -181,22 +204,9 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
    * Creates the scene collections directory if it doesn't exist
    */
   async ensureDirectory() {
-    const exists = await new Promise((resolve) => {
-      fs.exists(this.collectionsDirectory, (exists) => resolve(exists));
-    });
+    if (fs.existsSync(this.collectionsDirectory)) return;
 
-    if (!exists) {
-      await new Promise<void>((resolve, reject) => {
-        fs.mkdir(this.collectionsDirectory, (err) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-
-          resolve();
-        });
-      });
-    }
+    await fs.promises.mkdir(this.collectionsDirectory, { recursive: true });
   }
 
   get collectionsDirectory() {

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -84,6 +84,8 @@ export interface ISourcesServiceApi {
 export interface ISourceAddOptions<TPropertiesManagerSettings = Dictionary<any>> {
   channel?: number;
   sourceId?: string; // A new ID will be generated if one is not specified
+  deinterlaceMode?: obs.EDeinterlaceMode;
+  deinterlaceFieldOrder?: obs.EDeinterlaceFieldOrder;
   propertiesManager?: TPropertiesManager;
   propertiesManagerSettings?: Dictionary<any>;
   audioSettings?: Partial<IAudioSource>;

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -108,6 +108,8 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     channel?: number;
     isTemporary?: boolean;
     propertiesManagerType?: TPropertiesManager;
+    deinterlaceMode?: obs.EDeinterlaceMode;
+    deinterlaceFieldOrder?: obs.EDeinterlaceFieldOrder;
   }) {
     const id = addOptions.id;
     const sourceModel: ISource = {
@@ -130,8 +132,9 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       muted: false,
       resourceId: 'Source' + JSON.stringify([id]),
       channel: addOptions.channel,
-      deinterlaceMode: obs.EDeinterlaceMode.Disable,
-      deinterlaceFieldOrder: obs.EDeinterlaceFieldOrder.Top,
+      deinterlaceMode: addOptions.deinterlaceMode ?? obs.EDeinterlaceMode.Disable,
+      deinterlaceFieldOrder:
+        addOptions.deinterlaceFieldOrder ?? obs.EDeinterlaceFieldOrder.Top,
     };
 
     if (addOptions.isTemporary) {
@@ -197,6 +200,8 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       channel: options.channel,
       isTemporary: options.isTemporary,
       propertiesManagerType: managerType,
+      deinterlaceMode: options.deinterlaceMode,
+      deinterlaceFieldOrder: options.deinterlaceFieldOrder,
     });
     const source = this.getSource(id);
     const muted = obsInput.muted;

--- a/main.js
+++ b/main.js
@@ -410,6 +410,24 @@ function initialize(crashHandler) {
 
   logStartupMilestone('main-initialize');
 
+  let mainShellRendered = false;
+  let updateCheckFinished = process.env.NODE_ENV !== 'production' &&
+    !process.env.NAIR_FORCE_AUTO_UPDATE;
+
+  function showMainWindowWhenReady() {
+    if (
+      mainShellRendered &&
+      updateCheckFinished &&
+      mainWindow &&
+      !mainWindow.isDestroyed() &&
+      !mainWindow.isVisible()
+    ) {
+      mainWindow.show();
+      closeSplashWindow();
+      logStartupMilestone('main-window-shown');
+    }
+  }
+
   ipcMain.on('startup-milestone', (event, name, detail) => {
     logStartupMilestone(`renderer:${name}`, detail);
 
@@ -417,12 +435,10 @@ function initialize(crashHandler) {
       name === 'main-shell-rendered' &&
       mainWindow &&
       !mainWindow.isDestroyed() &&
-      event.sender === mainWindow.webContents &&
-      !mainWindow.isVisible()
+      event.sender === mainWindow.webContents
     ) {
-      mainWindow.show();
-      closeSplashWindow();
-      logStartupMilestone('main-window-shown');
+      mainShellRendered = true;
+      showMainWindowWhenReady();
     }
   });
 
@@ -1097,13 +1113,15 @@ function initialize(crashHandler) {
       }
     }, 0);
 
-    // スプラッシュ表示を確実にするため、Updaterを少し遅延起動
+    // アプリの起動を更新確認でブロックしない。
     setTimeout(() => {
       if (process.env.NODE_ENV === 'production' || process.env.NAIR_FORCE_AUTO_UPDATE) {
-        new Updater(startApp, logStartupMilestone).run();
-      } else {
-        startApp();
+        new Updater(logStartupMilestone, () => {
+          updateCheckFinished = true;
+          showMainWindowWhenReady();
+        }).run();
       }
+      startApp();
     }, 0);
   });
 

--- a/main.js
+++ b/main.js
@@ -1080,7 +1080,7 @@ function initialize(crashHandler) {
 
   app.on('ready', () => {
     logStartupMilestone('electron-ready');
-    // Show splash window immediately (skip in test environment)
+    // Show splash window immediately
     createSplashWindow();
     updateSplashStatus(...splashProgressByMilestone['electron-ready']);
 

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Set Up Environment Variables
 ////////////////////////////////////////////////////////////////////////////////
+const startupStartedAt = Date.now();
 const pjson = require('./package.json');
 
 if (pjson.env === 'production') {
@@ -383,6 +384,48 @@ function initialize(crashHandler) {
   const logFile = path.join(app.getPath('userData'), 'app.log');
   const maxLogBytes = 131072;
 
+  const {
+    createSplashWindow,
+    closeSplashWindow,
+    updateSplashStatus,
+  } = require('./splash/splash-window');
+
+  const splashProgressByMilestone = {
+    'electron-ready': ['N Airを起動しています…', 20],
+    'start-app': ['設定を読み込んでいます…', 32],
+    'main-window-created': ['画面を準備しています…', 45],
+    'renderer:bundle-evaluated': ['配信機能を準備しています…', 58],
+    'renderer:obs-api-initialize-started': ['配信機能を起動しています…', 70],
+    'renderer:obs-api-initialized': ['配信画面を読み込んでいます…', 88],
+    'renderer:app-load-started': ['シーンとソースを復元しています…', 90],
+    'renderer:scene-collections-initialized': ['起動の準備を整えています…', 95],
+  };
+
+  function logStartupMilestone(name, detail = '') {
+    const elapsed = Date.now() - startupStartedAt;
+    console.log(`[STARTUP] +${elapsed}ms ${name}${detail ? ` (${detail})` : ''}`);
+    const splashProgress = splashProgressByMilestone[name];
+    if (splashProgress) updateSplashStatus(...splashProgress);
+  }
+
+  logStartupMilestone('main-initialize');
+
+  ipcMain.on('startup-milestone', (event, name, detail) => {
+    logStartupMilestone(`renderer:${name}`, detail);
+
+    if (
+      name === 'main-shell-rendered' &&
+      mainWindow &&
+      !mainWindow.isDestroyed() &&
+      event.sender === mainWindow.webContents &&
+      !mainWindow.isVisible()
+    ) {
+      mainWindow.show();
+      closeSplashWindow();
+      logStartupMilestone('main-window-shown');
+    }
+  });
+
   ipcMain.on('logmsg', (e, msg) => {
     logFromRemote(msg.level, msg.sender, msg.message);
   });
@@ -675,9 +718,6 @@ function initialize(crashHandler) {
     console.log('Sentry disabled, SENTRY_DSN = ', sentryDefs.DSN);
   }
 
-  // Import splash window functions
-  const { createSplashWindow, closeSplashWindow } = require('./splash/splash-window');
-
   // Safely send IPC messages to a BrowserWindow or WebContents.
   // During dev hot reload, the render frame may be disposed while the window is still alive.
   // BrowserWindow.isDestroyed() does not catch this — only the frame is replaced, not the window.
@@ -697,6 +737,7 @@ function initialize(crashHandler) {
   }
 
   async function startApp() {
+    logStartupMilestone('start-app');
     if (process.argv.includes('--clearCookies')) {
       SentryElectron.captureEvent({
         message: 'clearCookies',
@@ -713,6 +754,7 @@ function initialize(crashHandler) {
     } else {
       await recollectUserSessionCookie();
     }
+    logStartupMilestone('cookies-ready');
     const isDevMode = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
     let crashHandlerLogPath = '';
     if (process.env.NODE_ENV !== 'production' || !!process.env.SLOBS_PREVIEW) {
@@ -783,6 +825,7 @@ function initialize(crashHandler) {
         ...(devHostsPartition ? { partition: devHostsPartition } : {}),
       },
     });
+    logStartupMilestone('main-window-created');
 
     remote.enable(mainWindow.webContents);
     mainWindowState.manage(mainWindow); // maximize: false なのでリスナー登録のみ
@@ -798,13 +841,9 @@ function initialize(crashHandler) {
       setTimeout(() => openDevTools(), 100);
     }
 
-    // Close splash when main window content is loaded
+    // Vueの初回描画が完了するまではスプラッシュを維持する。
     mainWindow.webContents.once('did-finish-load', () => {
-      // Give Vue a moment to render before showing
-      setTimeout(() => {
-        mainWindow.show();
-        closeSplashWindow();
-      }, 100);
+      logStartupMilestone('main-window-did-finish-load');
     });
 
     // Ensure splash is closed on error
@@ -1040,8 +1079,10 @@ function initialize(crashHandler) {
   });
 
   app.on('ready', () => {
+    logStartupMilestone('electron-ready');
     // Show splash window immediately (skip in test environment)
     createSplashWindow();
+    updateSplashStatus(...splashProgressByMilestone['electron-ready']);
 
     // バックグラウンドで起動時のクリーンアップ処理を実行（非ブロッキング）
     setTimeout(() => {
@@ -1059,7 +1100,7 @@ function initialize(crashHandler) {
     // スプラッシュ表示を確実にするため、Updaterを少し遅延起動
     setTimeout(() => {
       if (process.env.NODE_ENV === 'production' || process.env.NAIR_FORCE_AUTO_UPDATE) {
-        new Updater(startApp).run();
+        new Updater(startApp, logStartupMilestone).run();
       } else {
         startApp();
       }

--- a/splash/index.html
+++ b/splash/index.html
@@ -24,50 +24,32 @@
       .logo-svg {
         width: 200px;
         height: auto;
-        margin-bottom: 60px;
+        margin-bottom: 48px;
         color: #9eeaf9;
       }
 
-      .text {
+      .status {
         color: #ffffff;
-        font-size: 16px;
-        opacity: 0.7;
-        margin-bottom: 40px;
+        font-size: 14px;
+        opacity: 0.82;
+        margin-bottom: 18px;
+        min-height: 20px;
       }
 
-      .loading-dots {
-        display: flex;
-        gap: 16px;
-        align-items: center;
-        justify-content: center;
+      .progress-track {
+        width: 240px;
+        height: 3px;
+        overflow: hidden;
+        border-radius: 2px;
+        background: rgb(255 255 255 / 14%);
       }
 
-      .loading-dots .dot {
-        width: 10px;
-        height: 10px;
-        border-radius: 50%;
-        background-color: #9eeaf9;
-        animation: pulse 1.4s ease-in-out infinite;
-      }
-
-      .loading-dots .dot:nth-child(1) {
-        animation-delay: 0s;
-      }
-
-      .loading-dots .dot:nth-child(2) {
-        animation-delay: 0.15s;
-      }
-
-      .loading-dots .dot:nth-child(3) {
-        animation-delay: 0.3s;
-      }
-
-      .loading-dots .dot:nth-child(4) {
-        animation-delay: 0.45s;
-      }
-
-      .loading-dots .dot:nth-child(5) {
-        animation-delay: 0.6s;
+      .progress-bar {
+        width: 12%;
+        height: 100%;
+        border-radius: inherit;
+        background: #9eeaf9;
+        transition: width 300ms ease-out;
       }
 
       .version {
@@ -80,18 +62,6 @@
         opacity: 0.5;
       }
 
-      @keyframes pulse {
-        0%,
-        80%,
-        100% {
-          opacity: 0.3;
-          transform: scale(0.8);
-        }
-        40% {
-          opacity: 1;
-          transform: scale(1.2);
-        }
-      }
     </style>
   </head>
   <body>
@@ -126,15 +96,14 @@
         fill="currentColor"
       ></path>
     </svg>
-    <div class="loading-dots">
-      <div class="dot"></div>
-      <div class="dot"></div>
-      <div class="dot"></div>
-      <div class="dot"></div>
-      <div class="dot"></div>
+    <div class="status" id="status">起動準備中…</div>
+    <div class="progress-track">
+      <div class="progress-bar" id="progress"></div>
     </div>
     <div class="version" id="version"></div>
     <script>
+      const { ipcRenderer } = require('electron');
+
       // Display version information from environment variable
       // Note: nodeIntegration is enabled for this window to access process.env
       const version = process.env.NAIR_VERSION || '';
@@ -144,6 +113,13 @@
       } else {
         console.log('Version element or version not found', { version, versionElement });
       }
+
+      ipcRenderer.on('splash-status', (_event, { status, progress }) => {
+        const statusElement = document.getElementById('status');
+        const progressElement = document.getElementById('progress');
+        if (statusElement) statusElement.textContent = status;
+        if (progressElement) progressElement.style.width = `${progress}%`;
+      });
     </script>
   </body>
 </html>

--- a/splash/splash-window.js
+++ b/splash/splash-window.js
@@ -2,6 +2,7 @@ const { BrowserWindow } = require('electron');
 const path = require('node:path');
 
 let splashWindow = null;
+let latestStatus = { status: '起動準備中…', progress: 12 };
 
 function createSplashWindow() {
   // Close existing splash window if it exists (for test app restarts)
@@ -25,6 +26,10 @@ function createSplashWindow() {
     },
   });
 
+  splashWindow.webContents.once('did-finish-load', () => {
+    if (!splashWindow || splashWindow.isDestroyed()) return;
+    splashWindow.webContents.send('splash-status', latestStatus);
+  });
   splashWindow.loadFile(path.join(__dirname, 'index.html'));
   splashWindow.show();
 }
@@ -36,7 +41,19 @@ function closeSplashWindow() {
   }
 }
 
+function updateSplashStatus(status, progress) {
+  latestStatus = { status, progress };
+  if (
+    !splashWindow ||
+    splashWindow.isDestroyed() ||
+    splashWindow.webContents.isLoadingMainFrame()
+  ) return;
+
+  splashWindow.webContents.send('splash-status', latestStatus);
+}
+
 module.exports = {
   createSplashWindow,
   closeSplashWindow,
+  updateSplashStatus,
 };

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -7,6 +7,8 @@ const semver = require('semver');
 const path = require('path');
 const electron = require('electron');
 
+const UPDATE_CHECK_TIMEOUT_MS = 2000;
+
 class Updater {
   // startApp is a callback that will start the app.  Ideally this
   // would have been done with a promise, but electron tries to quit
@@ -15,13 +17,15 @@ class Updater {
   // the auto updater.  Pre-initializing the mainWindow is now a
   // good option either, since then closing the auto updater will
   // orphan the main process in the background.
-  constructor(startApp) {
+  constructor(startApp, logStartupMilestone = () => {}) {
     this.startApp = startApp;
+    this.logStartupMilestone = logStartupMilestone;
   }
 
   run() {
     this.updateState = {};
     this.cancellationToken = undefined;
+    this.continuingToApp = false;
 
     this.bindListeners();
 
@@ -35,12 +39,22 @@ class Updater {
       autoUpdater.forceDevUpdateConfig = true;
     }
 
+    this.logStartupMilestone('update-check-started');
+    this.updateCheckTimeout = setTimeout(() => {
+      this.logStartupMilestone('update-check-timeout', `${UPDATE_CHECK_TIMEOUT_MS}ms`);
+      this.skipUpdateAndContinue();
+    }, UPDATE_CHECK_TIMEOUT_MS);
+
     autoUpdater
       .checkForUpdates()
       .then((result) => {
         // Store cancellationToken from checkForUpdates result
         if (result && result.cancellationToken) {
           this.cancellationToken = result.cancellationToken;
+          if (this.continuingToApp) {
+            this.cancellationToken.cancel();
+            this.cancellationToken = null;
+          }
         }
       })
       .catch(() => {
@@ -51,10 +65,20 @@ class Updater {
   }
 
   async skipUpdateAndContinue() {
+    if (this.continuingToApp) return;
+    this.continuingToApp = true;
+    clearTimeout(this.updateCheckTimeout);
+    this.logStartupMilestone('update-check-finished');
+
+    if (this.cancellationToken) {
+      this.cancellationToken.cancel();
+      this.cancellationToken = null;
+    }
+
     // Closing the only window would normally quit the app, so ensure it doesn't.
     electron.app.once('will-quit', (e) => e.preventDefault());
     this.finished = true;
-    this.browserWindow.close();
+    if (!this.browserWindow.isDestroyed()) this.browserWindow.close();
     await this.startApp();
   }
 
@@ -81,6 +105,9 @@ class Updater {
 
   bindListeners() {
     autoUpdater.on('update-available', (info) => {
+      if (this.continuingToApp) return;
+      clearTimeout(this.updateCheckTimeout);
+      this.logStartupMilestone('update-available');
       this.updateState.asking = true;
       this.updateState.releaseNotes = this.textToLines(info.releaseNotes);
       this.updateState.releaseDate = info.releaseDate;
@@ -105,6 +132,7 @@ isUnskippable: ${this.updateState.isUnskippable}`);
     });
 
     autoUpdater.on('update-not-available', () => {
+      this.logStartupMilestone('update-not-available');
       this.skipUpdateAndContinue();
     });
 
@@ -135,8 +163,9 @@ isUnskippable: ${this.updateState.isUnskippable}`);
     });
 
     autoUpdater.on('error', () => {
-      this.updateState.error = true;
-      this.pushState();
+      if (this.continuingToApp) return;
+      this.logStartupMilestone('update-check-error');
+      this.skipUpdateAndContinue();
     });
 
     ipcMain.on('autoUpdate-getState', () => {

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -2,34 +2,21 @@
 // be required by the main electron process.
 
 const { autoUpdater } = require('electron-updater');
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { BrowserWindow, ipcMain } = require('electron');
 const semver = require('semver');
 const path = require('path');
-const electron = require('electron');
-
-const UPDATE_CHECK_TIMEOUT_MS = 2000;
 
 class Updater {
-  // startApp is a callback that will start the app.  Ideally this
-  // would have been done with a promise, but electron tries to quit
-  // when the last window is closed, so the hand-off has to be
-  // synchronous.  Otherwise, electron will quit as soon as we close
-  // the auto updater.  Pre-initializing the mainWindow is now a
-  // good option either, since then closing the auto updater will
-  // orphan the main process in the background.
-  constructor(startApp, logStartupMilestone = () => {}) {
-    this.startApp = startApp;
+  constructor(logStartupMilestone = () => {}, onUpdaterClosed = () => {}) {
     this.logStartupMilestone = logStartupMilestone;
+    this.onUpdaterClosed = onUpdaterClosed;
   }
 
   run() {
     this.updateState = {};
     this.cancellationToken = undefined;
-    this.continuingToApp = false;
 
     this.bindListeners();
-
-    this.browserWindow = this.initWindow();
 
     autoUpdater.autoDownload = false;
 
@@ -40,10 +27,6 @@ class Updater {
     }
 
     this.logStartupMilestone('update-check-started');
-    this.updateCheckTimeout = setTimeout(() => {
-      this.logStartupMilestone('update-check-timeout', `${UPDATE_CHECK_TIMEOUT_MS}ms`);
-      this.skipUpdateAndContinue();
-    }, UPDATE_CHECK_TIMEOUT_MS);
 
     autoUpdater
       .checkForUpdates()
@@ -51,23 +34,16 @@ class Updater {
         // Store cancellationToken from checkForUpdates result
         if (result && result.cancellationToken) {
           this.cancellationToken = result.cancellationToken;
-          if (this.continuingToApp) {
-            this.cancellationToken.cancel();
-            this.cancellationToken = null;
-          }
         }
       })
       .catch(() => {
-        // This usually means there is no internet connection.
-        // In this case, we shouldn't prevent starting the app.
-        this.skipUpdateAndContinue();
+        // The error event normally handles failures, but also finish here in case it is not emitted.
+        this.closeUpdater();
       });
   }
 
-  async skipUpdateAndContinue() {
-    if (this.continuingToApp) return;
-    this.continuingToApp = true;
-    clearTimeout(this.updateCheckTimeout);
+  closeUpdater() {
+    if (this.finished) return;
     this.logStartupMilestone('update-check-finished');
 
     if (this.cancellationToken) {
@@ -75,11 +51,9 @@ class Updater {
       this.cancellationToken = null;
     }
 
-    // Closing the only window would normally quit the app, so ensure it doesn't.
-    electron.app.once('will-quit', (e) => e.preventDefault());
     this.finished = true;
-    if (!this.browserWindow.isDestroyed()) this.browserWindow.close();
-    await this.startApp();
+    if (this.browserWindow && !this.browserWindow.isDestroyed()) this.browserWindow.close();
+    this.onUpdaterClosed();
   }
 
   // PRIVATE
@@ -105,8 +79,6 @@ class Updater {
 
   bindListeners() {
     autoUpdater.on('update-available', (info) => {
-      if (this.continuingToApp) return;
-      clearTimeout(this.updateCheckTimeout);
       this.logStartupMilestone('update-available');
       this.updateState.asking = true;
       this.updateState.releaseNotes = this.textToLines(info.releaseNotes);
@@ -122,6 +94,7 @@ class Updater {
 newVersion: ${info.version}
 isUnskippable: ${this.updateState.isUnskippable}`);
       // cancellationToken is now obtained from checkForUpdates() result
+      this.browserWindow = this.initWindow();
       this.pushState();
     });
 
@@ -133,7 +106,7 @@ isUnskippable: ${this.updateState.isUnskippable}`);
 
     autoUpdater.on('update-not-available', () => {
       this.logStartupMilestone('update-not-available');
-      this.skipUpdateAndContinue();
+      this.closeUpdater();
     });
 
     autoUpdater.on('download-progress', (progress) => {
@@ -152,8 +125,7 @@ isUnskippable: ${this.updateState.isUnskippable}`);
         this.cancellationToken.cancel();
         this.cancellationToken = null;
       }
-      this.finished = true;
-      this.skipUpdateAndContinue();
+      this.closeUpdater();
     });
 
     autoUpdater.on('update-downloaded', () => {
@@ -163,9 +135,8 @@ isUnskippable: ${this.updateState.isUnskippable}`);
     });
 
     autoUpdater.on('error', () => {
-      if (this.continuingToApp) return;
       this.logStartupMilestone('update-check-error');
-      this.skipUpdateAndContinue();
+      this.closeUpdater();
     });
 
     ipcMain.on('autoUpdate-getState', () => {
@@ -184,7 +155,7 @@ isUnskippable: ${this.updateState.isUnskippable}`);
       useContentSize: true,
       title: `${process.env.NAIR_PRODUCT_NAME} - Ver: ${process.env.NAIR_VERSION}`,
       frame: true,
-      closable: true,
+      closable: !this.updateState.isUnskippable,
       resizable: false,
       show: false,
     });
@@ -198,12 +169,16 @@ isUnskippable: ${this.updateState.isUnskippable}`);
     });
 
     browserWindow.on('closed', () => {
-      // Prevent leaving a zombie process
       if (this.cancellationToken) {
         this.cancellationToken.cancel();
         this.cancellationToken = null;
       }
-      if (!this.finished) app.quit();
+      this.browserWindow = null;
+      if (!this.finished) {
+        this.finished = true;
+        this.logStartupMilestone('update-check-finished');
+        this.onUpdaterClosed();
+      }
     });
 
     if (process.env.NODE_ENV !== 'production') {
@@ -216,7 +191,7 @@ isUnskippable: ${this.updateState.isUnskippable}`);
   }
 
   pushState() {
-    if (!this.browserWindow.isDestroyed()) {
+    if (this.browserWindow && !this.browserWindow.isDestroyed()) {
       this.browserWindow.send('autoUpdate-pushState', this.updateState);
     }
   }


### PR DESCRIPTION
## 概要

N Airの起動処理と、起動中の進行状況表示を見直します。

空のメイン画面を表示することなく、スプラッシュ画面からメイン画面内のローディング表示へ切り替わるようにしました。

再計測の結果、起動時間は変更前後で概ね同等であり、体感できる高速化は確認できませんでした。本変更の主な効果は、起動段階の可視化と初期化中の操作防止です。

## 変更内容

- 更新確認とアプリ初期化を並行して実行
- 更新がない場合は、更新確認とメインシェル描画の両方が完了してからメイン画面を表示
- 更新がある場合はメイン画面を表示せず、従来どおりUpdater画面を表示
- OBS初期化後、シーン・ソース復元より先にVueの外枠とローダーを描画
- メインシェルの描画完了をIPCで通知し、その時点でスプラッシュを終了
- スプラッシュ画面に起動段階ごとのメッセージとプログレスバーを追加
- パッチノートをシーン・ソース復元前に表示し、初期化中のStudio操作を防止
- シーン・ソース復元中はメイン画面の閉じるボタンを無効化
- 操作開始に必須でない以下の処理を初期描画後へ遅延
  - 起動統計
  - お知らせ取得
  - 文字起こしサービス
- シーンコレクション、ルートノード、ソース復元に起動時間の計測を追加
- ソース登録時のデインターレース設定を一度にまとめ、OBSへの重複設定を削除
- ファイル・ディレクトリの存在確認で、イベントループ混雑の影響を受けにくい同期処理を使用

## 計測結果

`origin/n-air_development`（`b1bda7021`）と本PR（`7da37e436`）の開発ビルドを同一環境で比較しました。両方で同じユーザーデータを使用し、1回目をウォームアップとして除外したうえで各5回の平均を算出しています。

計測点は両実装で同じ意味になるよう、メインウィンドウを実際に表示した時点、必須初期化の完了時点、その後の二重 `requestAnimationFrame` 完了時点に揃えました。

| 指標 | 変更前 | 変更後 | 差 | 変更前の範囲 | 変更後の範囲 |
|---|---:|---:|---:|---:|---:|
| メイン画面表示 | 2,551 ms | 2,571 ms | +20 ms（+0.8%） | 2,498–2,589 ms | 2,553–2,617 ms |
| 操作可能 | 3,946 ms | 3,877 ms | -69 ms（-1.7%） | 3,925–3,979 ms | 3,856–3,925 ms |
| 最終描画 | 4,009 ms | 4,006 ms | -3 ms（-0.1%） | 3,982–4,044 ms | 3,989–4,051 ms |

中央値は、メイン画面表示が2,552 msから2,560 ms、操作可能が3,943 msから3,871 ms、最終描画が4,003 msから3,996 msでした。

操作可能までは平均69 ms短縮していますが、メイン画面表示と最終描画はほぼ同等です。測定範囲も重なっており、全体として体感できる起動高速化は確認できませんでした。

計測値はPC性能、OBSソース構成、接続デバイス、キャッシュ状況などによって変動します。

## 影響範囲と回帰リスク

- OBS APIの同期初期化順序は変更していません
- シーン・ソース復元の開始位置をVue初回描画後へ移動しています
- 復元中は既存のメイン画面内ローダーによって操作を制限し、閉じるボタンも無効化します
- パッチノートは従来の意図を維持し、シーン・ソース復元前に表示します
- 更新確認とアプリ初期化は並行しますが、更新確認の結果が確定するまでメイン画面は表示しません
- 更新が見つかった場合はUpdater画面を優先し、任意更新を閉じた場合のみ準備済みのメイン画面を表示します
- シーン復元時のデインターレース設定方法を変更しているため、該当ソースの設定保持を確認する必要があります
- 起動時間の明確な改善は確認できていないため、並行化・遅延実行による複雑性が妥当かレビューが必要です

## 手動確認

- 通常起動時に空のメイン画面が表示されないこと
- スプラッシュからメイン画面内ローダーへ自然に切り替わること
- 起動中はメイン画面の閉じるボタンが無効になり、起動完了後に有効になること
- 未読のパッチノートがシーン・ソース復元前に表示されること
- 起動後に保存済みのシーンとソースが正しく復元されること
- デインターレース設定済みの映像ソースで設定が維持されること
- 更新なしの場合、更新確認と初期描画の完了後にメイン画面が表示されること
- 更新ありの場合、メイン画面ではなくUpdater画面が表示されること
- スキップ可能な更新を「あとで」または×で閉じるとメイン画面が表示されること