### PR TITLE
修正: 数値入力欄が無効状態でも上下ボタンで変更できてしまっていた

### DIFF
--- a/app/components/obs/inputs/ObsIntInput.vue
+++ b/app/components/obs/inputs/ObsIntInput.vue
@@ -1,14 +1,14 @@
 <template>
   <div
     :data-test="testingAnchor"
-    class="input-container IntInput"
+    class="input-container number-input-container"
     :class="{ disabled: value.enabled == false }"
   >
     <div class="input-label">
       <label v-if="value.showDescription !== false">{{ value.description }}</label>
     </div>
     <div class="input-wrapper">
-      <div class="int-input">
+      <div class="number-input">
         <input
           ref="input"
           type="text"
@@ -31,49 +31,3 @@
 </template>
 
 <script lang="ts" src="./ObsIntInput.vue.ts"></script>
-
-<style lang="less">
-@import url('../../../styles/index');
-
-.int-input {
-  position: relative;
-
-  input {
-    padding-right: 32px;
-  }
-
-  .arrows {
-    .absolute(0, 8px, 0, auto);
-
-    width: 30px;
-    color: var(--color-text);
-    cursor: pointer;
-    .transition();
-
-    .arrow {
-      display: flex !important;
-
-      i {
-        position: relative;
-        font-size: @font-size1;
-      }
-
-      &:hover {
-        color: var(--color-text-light);
-      }
-
-      &:active {
-        color: var(--color-text-active);
-      }
-
-      &.arrow-up {
-        .absolute(6px, 4px, auto, auto);
-      }
-
-      &.arrow-down {
-        .absolute(auto, 4px, 6px, auto);
-      }
-    }
-  }
-}
-</style>

--- a/app/components/obs/inputs/ObsIntInput.vue
+++ b/app/components/obs/inputs/ObsIntInput.vue
@@ -13,11 +13,11 @@
           ref="input"
           type="text"
           :value="value.value"
-          @mousewheel="onMouseWheelHandler"
+          @wheel="onMouseWheelHandler"
           :disabled="value.enabled == false"
           @change="updateValue($event)"
         />
-        <div class="arrows" @mousewheel="onMouseWheelHandler">
+        <div class="arrows" @wheel="onMouseWheelHandler">
           <div class="arrow arrow-up" @click="increment">
             <i class="icon-drop-up-arrow"></i>
           </div>

--- a/app/components/obs/inputs/ObsIntInput.vue.ts
+++ b/app/components/obs/inputs/ObsIntInput.vue.ts
@@ -28,10 +28,10 @@ const ObsIntInput = defineComponent({
       if (this.value.type === 'OBS_PROPERTY_UINT' && Number(formattedValue) < 0) {
         formattedValue = '0';
       }
-      if (this.value.minVal !== undefined && Number(value) < this.value.minVal) {
+      if (this.value.minVal !== undefined && Number(formattedValue) < this.value.minVal) {
         formattedValue = String(this.value.minVal);
       }
-      if (this.value.maxVal !== undefined && Number(value) > this.value.maxVal) {
+      if (this.value.maxVal !== undefined && Number(formattedValue) > this.value.maxVal) {
         formattedValue = String(this.value.maxVal);
       }
       const input = (this.$refs.input as HTMLInputElement);

--- a/app/components/obs/inputs/ObsIntInput.vue.ts
+++ b/app/components/obs/inputs/ObsIntInput.vue.ts
@@ -20,6 +20,7 @@ const ObsIntInput = defineComponent({
       this.$emit('input', eventData);
     },
     updateValue(eventOrValue: Event | string) {
+      if (this.value.enabled === false) return;
       const value = eventOrValue instanceof Event
         ? (eventOrValue.target as HTMLInputElement).value
         : eventOrValue;
@@ -40,12 +41,15 @@ const ObsIntInput = defineComponent({
       this.emitInput({ ...this.value, value: Number(formattedValue) });
     },
     increment() {
-      this.updateValue(String(Number((this.$refs.input as HTMLInputElement).value) + 1));
+      if (this.value.enabled === false) return;
+      this.updateValue(String(Number((this.$refs.input as HTMLInputElement).value) + this.value.stepVal));
     },
     decrement() {
-      this.updateValue(String(Number((this.$refs.input as HTMLInputElement).value) - 1));
+      if (this.value.enabled === false) return;
+      this.updateValue(String(Number((this.$refs.input as HTMLInputElement).value) - this.value.stepVal));
     },
     onMouseWheelHandler(event: WheelEvent) {
+      if (this.value.enabled === false) return;
       const input = this.$refs.input as HTMLInputElement;
       const canChange = event.target !== input || input === document.activeElement;
       if (!canChange) return;

--- a/app/components/obs/inputs/ObsNumberInput.vue
+++ b/app/components/obs/inputs/ObsNumberInput.vue
@@ -1,16 +1,31 @@
 <template>
-  <div :data-test="testingAnchor" class="input-container">
+  <div
+    :data-test="testingAnchor"
+    class="input-container number-input-container"
+    :class="{ disabled: value.enabled == false }"
+  >
     <div class="input-label">
-      <label>{{ value.description }}</label>
+      <label v-if="value.showDescription !== false">{{ value.description }}</label>
     </div>
     <div class="input-wrapper">
-      <input
-        ref="input"
-        type="text"
-        :value="value.value"
-        :disabled="value.enabled == false"
-        @input="updateValue($event)"
-      />
+      <div class="number-input">
+        <input
+          ref="input"
+          type="text"
+          :value="value.value"
+          @mousewheel="onMouseWheelHandler"
+          :disabled="value.enabled == false"
+          @change="updateValue($event)"
+        />
+        <div class="arrows" @mousewheel="onMouseWheelHandler">
+          <div class="arrow arrow-up" @click="increment">
+            <i class="icon-drop-up-arrow"></i>
+          </div>
+          <div class="arrow arrow-down" @click="decrement">
+            <i class="icon-drop-down-arrow"></i>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/app/components/obs/inputs/ObsNumberInput.vue
+++ b/app/components/obs/inputs/ObsNumberInput.vue
@@ -13,11 +13,11 @@
           ref="input"
           type="text"
           :value="value.value"
-          @mousewheel="onMouseWheelHandler"
+          @wheel="onMouseWheelHandler"
           :disabled="value.enabled == false"
           @change="updateValue($event)"
         />
-        <div class="arrows" @mousewheel="onMouseWheelHandler">
+        <div class="arrows" @wheel="onMouseWheelHandler">
           <div class="arrow arrow-up" @click="increment">
             <i class="icon-drop-up-arrow"></i>
           </div>

--- a/app/components/obs/inputs/ObsNumberInput.vue.ts
+++ b/app/components/obs/inputs/ObsNumberInput.vue.ts
@@ -1,12 +1,12 @@
 import { defineComponent, PropType } from 'vue';
 
-import { IObsInput, TObsType } from './ObsInput';
+import { IObsNumberInputValue, TObsType } from './ObsInput';
 
 const ObsNumberInput = defineComponent({
   name: 'ObsNumberInput',
   emits: ['input'],
   props: {
-    value: { type: Object as PropType<IObsInput<number>>, required: true as const },
+    value: { type: Object as PropType<IObsNumberInputValue>, required: true as const },
     category: { type: String },
     subCategory: { type: String },
   },
@@ -16,20 +16,40 @@ const ObsNumberInput = defineComponent({
     };
   },
   methods: {
-    emitInput(eventData: IObsInput<number>) {
+    emitInput(eventData: IObsNumberInputValue) {
       this.$emit('input', eventData);
     },
     updateValue(eventOrValue: Event | string) {
+      if (this.value.enabled === false) return;
       const value = eventOrValue instanceof Event
         ? (eventOrValue.target as HTMLInputElement).value
         : eventOrValue;
       let formattedValue = value;
       if (isNaN(Number(formattedValue))) formattedValue = '0';
+      if (Number(formattedValue) < this.value.minVal) formattedValue = String(this.value.minVal);
+      if (Number(formattedValue) > this.value.maxVal) formattedValue = String(this.value.maxVal);
       const input = this.$refs.input as HTMLInputElement;
       if (formattedValue !== value) {
         input.value = formattedValue;
       }
       this.emitInput({ ...this.value, value: Number(formattedValue) });
+    },
+    increment() {
+      if (this.value.enabled === false) return;
+      this.updateValue(String(Number((this.$refs.input as HTMLInputElement).value) + this.value.stepVal));
+    },
+    decrement() {
+      if (this.value.enabled === false) return;
+      this.updateValue(String(Number((this.$refs.input as HTMLInputElement).value) - this.value.stepVal));
+    },
+    onMouseWheelHandler(event: WheelEvent) {
+      if (this.value.enabled === false) return;
+      const input = this.$refs.input as HTMLInputElement;
+      const canChange = event.target !== input || input === document.activeElement;
+      if (!canChange) return;
+      if (event.deltaY > 0) this.decrement();
+      else this.increment();
+      event.preventDefault();
     },
   },
 });

--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -50,6 +50,62 @@ textarea {
   }
 }
 
+.number-input-container {
+  &.disabled {
+    .input-label,
+    .number-input {
+      opacity: @opacity-disabled;
+    }
+
+    .arrows {
+      pointer-events: none;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.number-input {
+  position: relative;
+
+  input {
+    padding-right: 32px;
+  }
+
+  .arrows {
+    .absolute(0, 8px, 0, auto);
+
+    width: 30px;
+    color: var(--color-text);
+    cursor: pointer;
+    .transition();
+
+    .arrow {
+      display: flex !important;
+
+      i {
+        position: relative;
+        font-size: @font-size1;
+      }
+
+      &:hover {
+        color: var(--color-text-light);
+      }
+
+      &:active {
+        color: var(--color-text-active);
+      }
+
+      &.arrow-up {
+        .absolute(6px, 4px, auto, auto);
+      }
+
+      &.arrow-down {
+        .absolute(auto, 4px, 6px, auto);
+      }
+    }
+  }
+}
+
 .input-container {
   position: relative;
   display: flex;

--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -57,9 +57,13 @@ textarea {
       opacity: @opacity-disabled;
     }
 
+    .number-input,
+    input:disabled {
+      cursor: not-allowed;
+    }
+
     .arrows {
       pointer-events: none;
-      cursor: not-allowed;
     }
   }
 }


### PR DESCRIPTION
## 概要

OBS設定の数値入力について、無効時の表示とスピナー操作を修正します。

## 変更内容

- 整数入力と小数入力のスピナー表示を統一
- 小数入力に上下スピナーとマウスホイール操作を追加
- スピナーの増減幅にOBSプロパティの `stepVal` を使用
- 小数入力でも最小値・最大値の範囲に収まるよう補正
- 無効な数値入力のラベル、入力欄、スピナーを無効状態として表示
- 無効時のスピナークリック、マウスホイール、値更新を抑止
- 数値入力の共通スタイルを共有化

## 確認方法

- 有効な整数・小数入力を上下スピナーで変更できること
- フォーカス中の入力をマウスホイールで変更できること
- `stepVal` に従って値が増減すること
- 最小値・最大値を超えないこと
- 無効な数値入力が薄く表示され、入力・スピナー・ホイールで変更できないこと
