### PR TITLE
修正: OBSとの通信が切断された際に即座に通知して再起動を促すよう修正

### DIFF
--- a/app/app-services.ts
+++ b/app/app-services.ts
@@ -41,6 +41,7 @@ export { NicoliveProgramStateService } from 'services/nicolive-program/state';
 export { NVoiceCharacterService } from 'services/nvoice-character';
 export { NVoiceCharacterUsageService } from 'services/nvoice-character-usage';
 export { ObsImporterService } from 'services/obs-importer';
+export { ObsIpcHealthService } from 'services/obs-ipc-health';
 export { OnboardingService } from 'services/onboarding';
 export { PatchNotesService } from 'services/patch-notes';
 export { PerformanceService } from 'services/performance';

--- a/app/services/obs-ipc-health/index.ts
+++ b/app/services/obs-ipc-health/index.ts
@@ -1,0 +1,1 @@
+export * from './obs-ipc-health';

--- a/app/services/obs-ipc-health/obs-ipc-health.test.ts
+++ b/app/services/obs-ipc-health/obs-ipc-health.test.ts
@@ -1,0 +1,188 @@
+import fs from 'fs';
+import path from 'path';
+
+import { createSetupFunction } from 'util/test-setup';
+
+const mockShowMessageBox = jest.fn();
+const mockGetCurrentWindow = jest.fn().mockReturnValue({ id: 'current' });
+jest.mock('@electron/remote', () => ({
+  dialog: { showMessageBox: mockShowMessageBox },
+  getCurrentWindow: mockGetCurrentWindow,
+}));
+jest.mock('services/i18n', () => ({ $t: (key: string) => key }));
+jest.mock('util/sentry-obs-breadcrumb', () => ({
+  getLastObsOp: () => 'SourcesService.removeSource',
+}));
+const mockSentryMessage = jest.fn();
+jest.mock('util/sentry-report', () => ({ SentryReport: { message: mockSentryMessage } }));
+
+jest.mock('services/core/stateful-service');
+jest.mock('services/core/injector');
+jest.mock('services/app', () => ({ AppService: class {} }));
+jest.mock('services/windows', () => ({ WindowsService: class {} }));
+
+describe('ObsIpcHealthService', () => {
+  let mockRelaunch: jest.Mock;
+  let mockGetWindow: jest.Mock;
+  let mockIsChildWindowShown: jest.Mock;
+
+  const setup = createSetupFunction({
+    injectee: {},
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockRelaunch = jest.fn();
+    mockGetWindow = jest.fn().mockReturnValue(undefined);
+    mockIsChildWindowShown = jest.fn().mockReturnValue(false);
+
+    setup({
+      injectee: {
+        AppService: { relaunch: mockRelaunch },
+        WindowsService: {
+          getWindow: mockGetWindow,
+          isChildWindowShown: mockIsChildWindowShown,
+        },
+      },
+    });
+  });
+
+  test('notifyIpcLost() で isLost が true になる', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+
+    expect(instance.isLost).toBe(true);
+  });
+
+  test('3回呼んでもダイアログは1回だけ表示される', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('first');
+    instance.notifyIpcLost('second');
+    instance.notifyIpcLost('third');
+
+    expect(mockShowMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  test('ipcLost Subject が1回だけ発火し、検知元が渡る', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+    const observer = jest.fn();
+    instance.ipcLost.subscribe(observer);
+
+    instance.notifyIpcLost('PerformanceService.getState');
+    instance.notifyIpcLost('SettingsService.getSettingsFormData');
+
+    expect(observer).toHaveBeenCalledTimes(1);
+    expect(observer).toHaveBeenCalledWith('PerformanceService.getState');
+  });
+
+  test('ダイアログで「はい」を選ぶと relaunch が呼ばれる', async () => {
+    mockShowMessageBox.mockResolvedValue({ response: 0 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockRelaunch).toHaveBeenCalledTimes(1);
+  });
+
+  test('ダイアログで「いいえ」を選ぶと relaunch は呼ばれない', async () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockRelaunch).not.toHaveBeenCalled();
+  });
+
+  test('「いいえ」を選んだ後に再度 notifyIpcLost してもダイアログが表示されない', async () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+    await Promise.resolve();
+    await Promise.resolve();
+    instance.notifyIpcLost('test again');
+
+    expect(mockShowMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  test('子ウィンドウが表示されている場合は child をモーダル親にする', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    mockIsChildWindowShown.mockReturnValue(true);
+    const childWindow = { id: 'child' };
+    mockGetWindow.mockImplementation((id: string) => (id === 'child' ? childWindow : undefined));
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+
+    expect(mockShowMessageBox).toHaveBeenCalledWith(childWindow, expect.anything());
+  });
+
+  test('子ウィンドウが非表示の場合は main をモーダル親にする', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    mockIsChildWindowShown.mockReturnValue(false);
+    const mainWindow = { id: 'main' };
+    mockGetWindow.mockImplementation((id: string) => (id === 'main' ? mainWindow : undefined));
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+
+    expect(mockShowMessageBox).toHaveBeenCalledWith(mainWindow, expect.anything());
+  });
+
+  test('main も取得できない場合は getCurrentWindow をモーダル親にする', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    mockIsChildWindowShown.mockReturnValue(false);
+    mockGetWindow.mockReturnValue(undefined);
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('test');
+
+    expect(mockShowMessageBox).toHaveBeenCalledWith({ id: 'current' }, expect.anything());
+  });
+
+  test('Sentry へ diagnostic タグ付き・warning で1回だけ報告する', () => {
+    mockShowMessageBox.mockResolvedValue({ response: 1 });
+    const { ObsIpcHealthService } = require('./obs-ipc-health');
+    const instance = ObsIpcHealthService.instance();
+
+    instance.notifyIpcLost('PerformanceService.getState');
+    instance.notifyIpcLost('SettingsService.getSettingsFormData');
+
+    expect(mockSentryMessage).toHaveBeenCalledTimes(1);
+    expect(mockSentryMessage).toHaveBeenCalledWith(
+      'ObsIpcHealthService',
+      'notifyIpcLost',
+      'obs backend ipc lost',
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ diagnostic: 'obs-ipc-lost' }),
+        fingerprint: ['ObsIpcHealthService', 'obsBackendIpcLost'],
+      }),
+    );
+  });
+
+  test('ObsIpcHealthService が app-services.ts に登録されている', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../../app-services.ts'), 'utf8');
+    expect(src).toMatch(/export \{ ObsIpcHealthService \} from 'services\/obs-ipc-health';/);
+  });
+});

--- a/app/services/obs-ipc-health/obs-ipc-health.ts
+++ b/app/services/obs-ipc-health/obs-ipc-health.ts
@@ -25,8 +25,9 @@ export class ObsIpcHealthService extends Service {
   @Inject() private windowsService: WindowsService;
 
   /** IPC 切断が検知されたときに1度だけ発火する。引数は検知元の識別子 */
-  ipcLost = new Subject<string>();
+  private readonly ipcLostSubject = new Subject<string>();
 
+  readonly ipcLost = this.ipcLostSubject.asObservable();
   private lost = false;
 
   get isLost(): boolean {

--- a/app/services/obs-ipc-health/obs-ipc-health.ts
+++ b/app/services/obs-ipc-health/obs-ipc-health.ts
@@ -1,0 +1,83 @@
+import * as remote from '@electron/remote';
+import { Subject } from 'rxjs';
+import { AppService } from 'services/app';
+import { Inject } from 'services/core/injector';
+import { Service } from 'services/core/service';
+import { $t } from 'services/i18n';
+import { WindowsService } from 'services/windows';
+import { getLastObsOp } from 'util/sentry-obs-breadcrumb';
+import { SentryReport } from 'util/sentry-report';
+
+/**
+ * obs-studio-node の独自ネイティブ IPC（obs64.exe との通信）が切断されたことを
+ * アプリ全体で1度だけ検知・通知するサービス。
+ *
+ * 切断は obs64.exe(libobs) 側のクラッシュに起因し、obs-studio-node に再接続APIが
+ * 存在しないため復旧できない（n-air-app#1380）。したがってできることは
+ * 「早く検知してユーザーに再起動を促す」ことのみ。
+ *
+ * 注意: plain Service なので isLost を子ウィンドウから参照してはいけない
+ * （internal-api-client のプロキシは非関数プロパティを転送しないため、
+ *  子ウィンドウのローカルインスタンスの値=false が返る）。
+ */
+export class ObsIpcHealthService extends Service {
+  @Inject() private appService: AppService;
+  @Inject() private windowsService: WindowsService;
+
+  /** IPC 切断が検知されたときに1度だけ発火する。引数は検知元の識別子 */
+  ipcLost = new Subject<string>();
+
+  private lost = false;
+
+  get isLost(): boolean {
+    return this.lost;
+  }
+
+  /**
+   * IPC 切断を通知する。2回目以降の呼び出しは何もしない（2秒ポーリングからの再入対策）。
+   * @param source 検知元（例: 'PerformanceService.getState'）
+   */
+  notifyIpcLost(source: string): void {
+    if (this.lost) return;
+    this.lost = true; // await より前に同期で立てる
+
+    SentryReport.message('ObsIpcHealthService', 'notifyIpcLost', 'obs backend ipc lost', {
+      level: 'warning',
+      // app.ts の beforeSend が /Failed to make IPC call/ を NOISE として捨てるため、
+      // 意図的に送るこのイベントには diagnostic タグが必須 (app.ts の beforeSend 参照)
+      tags: { diagnostic: 'obs-ipc-lost', 'ipc.detectedBy': source },
+      fingerprint: ['ObsIpcHealthService', 'obsBackendIpcLost'],
+      extra: { source, lastObsOp: getLastObsOp() },
+    });
+
+    this.ipcLost.next(source);
+
+    this.offerRestart().catch(() => {});
+  }
+
+  private getDialogParent(): Electron.BrowserWindow {
+    if (this.windowsService.isChildWindowShown()) {
+      const child = this.windowsService.getWindow('child');
+      if (child) return child;
+    }
+    return this.windowsService.getWindow('main') ?? remote.getCurrentWindow();
+  }
+
+  private async offerRestart(): Promise<void> {
+    const choice = await remote.dialog.showMessageBox(this.getDialogParent(), {
+      type: 'error',
+      buttons: [$t('common.yes'), $t('common.no')],
+      title: $t('common.confirm'),
+      message: $t('settings.noticeIpcError'),
+      detail: $t('settings.noticeIpcErrorDetail'),
+      noLink: true,
+      cancelId: 1,
+      defaultId: 0,
+    });
+    if (choice.response === 0) {
+      this.appService.relaunch();
+    }
+    // 「いいえ」の場合も lost は解除しない: 再接続手段が無いため
+    // ポーリング再開も再通知もしない（n-air-app#1380）
+  }
+}

--- a/app/services/obs-ipc-health/obs-ipc-health.ts
+++ b/app/services/obs-ipc-health/obs-ipc-health.ts
@@ -51,7 +51,7 @@ export class ObsIpcHealthService extends Service {
       extra: { source, lastObsOp: getLastObsOp() },
     });
 
-    this.ipcLost.next(source);
+    this.ipcLostSubject.next(source);
 
     this.offerRestart().catch(() => {});
   }

--- a/app/services/performance/performance.test.ts
+++ b/app/services/performance/performance.test.ts
@@ -238,8 +238,9 @@ describe('Init and Streaming State', () => {
     expect(instance.historicalSkippedFrames).toEqual([]);
   });
 
-  test('init() で ipcLost を subscribe し、通知を受けると clearInterval される', () => {
-    const ipcLostSubscribe = jest.fn();
+  test('init() で ipcLost を subscribe し、通知を受けるとポーリングと購読を停止する', () => {
+    const unsubscribe = jest.fn();
+    const ipcLostSubscribe = jest.fn((_callback: () => void) => ({ unsubscribe }));
     const setupWithMock = createSetupFunction({
       injectee: makeInjectee({
         ObsIpcHealthService: {
@@ -262,6 +263,7 @@ describe('Init and Streaming State', () => {
     ipcLostCallback();
 
     expect(clearIntervalSpy).toHaveBeenCalledWith(intervalIdBefore);
+    expect(unsubscribe).toHaveBeenCalled();
     clearIntervalSpy.mockRestore();
   });
 });

--- a/app/services/performance/performance.test.ts
+++ b/app/services/performance/performance.test.ts
@@ -1,7 +1,7 @@
 import { createSetupFunction } from 'util/test-setup';
 
-const setup = createSetupFunction({
-  injectee: {
+function makeInjectee(over: any = {}) {
+  return {
     CustomizationService: {
       pollingPerformanceStatistics: true,
     },
@@ -17,8 +17,19 @@ const setup = createSetupFunction({
       streamingStatusChange: {
         subscribe: jest.fn(),
       },
+      state: { streamingStatus: 'offline', streamingStatusTime: null },
     },
-  },
+    ObsIpcHealthService: {
+      notifyIpcLost: jest.fn(),
+      isLost: false,
+      ipcLost: { subscribe: jest.fn() },
+    },
+    ...over,
+  };
+}
+
+const setup = createSetupFunction({
+  injectee: makeInjectee(),
 });
 
 jest.mock('services/core/stateful-service');
@@ -35,6 +46,10 @@ jest.mock('services/streaming', () => ({
   },
 }));
 jest.mock('services/settings-v2/video', () => ({}));
+jest.mock('services/obs-ipc-health', () => ({}));
+jest.mock('util/obs-ipc-error', () => ({
+  isObsBackendIpcLost: jest.fn(() => false),
+}));
 jest.mock('../../../obs-api', () => ({
   NodeObs: {},
   Global: {
@@ -55,24 +70,11 @@ test('get instance', () => {
 
 test('getState returns proper state when pollingPerformanceStatistics is false', () => {
   const setupLocal = createSetupFunction({
-    injectee: {
+    injectee: makeInjectee({
       CustomizationService: {
         pollingPerformanceStatistics: false, // false に設定
       },
-      VideoSettingsService: {
-        contexts: {
-          horizontal: {
-            skippedFrames: 0,
-            encodedFrames: 0,
-          },
-        },
-      },
-      StreamingService: {
-        streamingStatusChange: {
-          subscribe: jest.fn(),
-        },
-      },
-    },
+    }),
   });
   setupLocal();
 
@@ -203,24 +205,13 @@ describe('Init and Streaming State', () => {
   test('streamingStatusChange subscription resets historical data', () => {
     const subscribeMock = jest.fn();
     const setupWithMock = createSetupFunction({
-      injectee: {
-        CustomizationService: {
-          pollingPerformanceStatistics: true,
-        },
-        VideoSettingsService: {
-          contexts: {
-            horizontal: {
-              skippedFrames: 0,
-              encodedFrames: 0,
-            },
-          },
-        },
+      injectee: makeInjectee({
         StreamingService: {
           streamingStatusChange: {
             subscribe: subscribeMock,
           },
         },
-      },
+      }),
     });
     setupWithMock();
 
@@ -246,30 +237,46 @@ describe('Init and Streaming State', () => {
     expect(instance.historicalLaggedFrames).toEqual([]);
     expect(instance.historicalSkippedFrames).toEqual([]);
   });
+
+  test('init() で ipcLost を subscribe し、通知を受けると clearInterval される', () => {
+    const ipcLostSubscribe = jest.fn();
+    const setupWithMock = createSetupFunction({
+      injectee: makeInjectee({
+        ObsIpcHealthService: {
+          notifyIpcLost: jest.fn(),
+          isLost: false,
+          ipcLost: { subscribe: ipcLostSubscribe },
+        },
+      }),
+    });
+    setupWithMock();
+
+    const { PerformanceService } = require('./performance');
+    const instance = PerformanceService.instance();
+
+    expect(ipcLostSubscribe).toHaveBeenCalled();
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+    const intervalIdBefore = instance.intervalId;
+
+    const ipcLostCallback = ipcLostSubscribe.mock.calls[0][0];
+    ipcLostCallback();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalIdBefore);
+    clearIntervalSpy.mockRestore();
+  });
 });
 
 describe('Zero Bandwidth Alert', () => {
   function setupLiveStreaming() {
     const setupLocal = createSetupFunction({
-      injectee: {
-        CustomizationService: {
-          pollingPerformanceStatistics: true,
-        },
-        VideoSettingsService: {
-          contexts: {
-            horizontal: {
-              skippedFrames: 0,
-              encodedFrames: 0,
-            },
-          },
-        },
+      injectee: makeInjectee({
         StreamingService: {
           streamingStatusChange: {
             subscribe: jest.fn(),
           },
           state: { streamingStatus: 'live', streamingStatusTime: null },
         },
-      },
+      }),
     });
     setupLocal();
 
@@ -327,5 +334,184 @@ describe('Zero Bandwidth Alert', () => {
       ([, , message]) => message === 'streaming bandwidth stuck at 0kbps',
     );
     expect(bandwidthCalls.length).toBe(1);
+  });
+});
+
+describe('OBS バックエンド IPC 切断の検知', () => {
+  function setupWithGetPerformanceStatistics(impl: () => any) {
+    const obsIpcHealthService = {
+      notifyIpcLost: jest.fn(),
+      isLost: false,
+      ipcLost: { subscribe: jest.fn() },
+    };
+    const setupLocal = createSetupFunction({
+      injectee: makeInjectee({ ObsIpcHealthService: obsIpcHealthService }),
+    });
+    setupLocal();
+
+    const { PerformanceService } = require('./performance');
+    const instance = PerformanceService.instance();
+    instance.state = { ...PerformanceService.initialState };
+    const obs = require('../../../obs-api');
+    obs.NodeObs.OBS_API_getPerformanceStatistics = jest.fn(impl);
+    return { instance, obsIpcHealthService };
+  }
+
+  test('getState() が IPC 切断エラーで失敗すると notifyIpcLost が呼ばれる', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(true);
+    const { instance, obsIpcHealthService } = setupWithGetPerformanceStatistics(() => {
+      throw new Error('Failed to make IPC call, verify IPC status.');
+    });
+
+    const result = instance.getState();
+
+    expect(result).toBeNull();
+    expect(obsIpcHealthService.notifyIpcLost).toHaveBeenCalledWith('PerformanceService.getState');
+  });
+
+  test('getState() が IPC 切断以外のエラーで失敗した場合は notifyIpcLost を呼ばず従来の SentryReport.error を送る', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(false);
+    const { instance, obsIpcHealthService } = setupWithGetPerformanceStatistics(() => {
+      throw new Error('some other error');
+    });
+    const { SentryReport } = require('util/sentry-report');
+    const errorSpy = jest.spyOn(SentryReport, 'error');
+
+    const result = instance.getState();
+
+    expect(result).toBeNull();
+    expect(obsIpcHealthService.notifyIpcLost).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('PerformanceService', 'getState', expect.anything(), expect.anything());
+  });
+
+  test('IPC 切断時は SentryReport.error を送らない（ObsIpcHealthService が1度だけ報告する）', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(true);
+    const { instance } = setupWithGetPerformanceStatistics(() => {
+      throw new Error('Failed to make IPC call, verify IPC status.');
+    });
+    const { SentryReport } = require('util/sentry-report');
+    const errorSpy = jest.spyOn(SentryReport, 'error');
+
+    instance.getState();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('readFrameStats', () => {
+  function setupForFrameStats(over: any = {}) {
+    const obsIpcHealthService = {
+      notifyIpcLost: jest.fn(),
+      isLost: false,
+      ipcLost: { subscribe: jest.fn() },
+    };
+    const setupLocal = createSetupFunction({
+      injectee: makeInjectee({ ObsIpcHealthService: obsIpcHealthService, ...over }),
+    });
+    setupLocal();
+
+    const { PerformanceService } = require('./performance');
+    const instance = PerformanceService.instance();
+    instance.state = { ...PerformanceService.initialState };
+    const obs = require('../../../obs-api');
+    obs.NodeObs.OBS_API_getPerformanceStatistics = jest.fn(() => ({
+      CPU: 0,
+      numberDroppedFrames: 0,
+      percentageDroppedFrames: 0,
+      streamingBandwidth: 0,
+      frameRate: 0,
+    }));
+    return { instance, obsIpcHealthService, obs };
+  }
+
+  test('obs.Global.laggedFrames が throw しても update() は例外を投げない', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(false);
+    const { instance, obs } = setupForFrameStats();
+    Object.defineProperty(obs.Global, 'laggedFrames', {
+      get() {
+        throw new Error('boom');
+      },
+      configurable: true,
+    });
+
+    expect(() => instance.update()).not.toThrow();
+
+    // 後続のテストに影響しないよう元に戻す
+    Object.defineProperty(obs.Global, 'laggedFrames', { value: 0, configurable: true });
+  });
+
+  test('obs.Global.laggedFrames が IPC 切断で throw すると notifyIpcLost が呼ばれる', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(true);
+    const { instance, obsIpcHealthService, obs } = setupForFrameStats();
+    Object.defineProperty(obs.Global, 'laggedFrames', {
+      get() {
+        throw new Error('Failed to make IPC call, verify IPC status.');
+      },
+      configurable: true,
+    });
+
+    instance.update();
+
+    expect(obsIpcHealthService.notifyIpcLost).toHaveBeenCalledWith('PerformanceService.readFrameStats');
+
+    Object.defineProperty(obs.Global, 'laggedFrames', { value: 0, configurable: true });
+  });
+
+  test('フレーム統計取得に失敗しても前回値を引き継いで CPU / 帯域の更新は継続する', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(false);
+    const { instance, obs } = setupForFrameStats();
+    instance.state.numberLaggedFrames = 42;
+    Object.defineProperty(obs.Global, 'laggedFrames', {
+      get() {
+        throw new Error('boom');
+      },
+      configurable: true,
+    });
+
+    instance.update();
+
+    expect(instance.state.numberLaggedFrames).toBe(42);
+
+    Object.defineProperty(obs.Global, 'laggedFrames', { value: 0, configurable: true });
+  });
+
+  test('videoSettingsService.contexts.horizontal が undefined でも 0 として扱う', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(false);
+    const { instance } = setupForFrameStats({
+      VideoSettingsService: { contexts: { horizontal: undefined } },
+    });
+
+    expect(() => instance.update()).not.toThrow();
+    expect(instance.state.numberSkippedFrames).toBe(0);
+  });
+
+  test('フレーム統計の失敗 Sentry 報告は連続失敗しても1回だけ', () => {
+    const { isObsBackendIpcLost } = require('util/obs-ipc-error');
+    (isObsBackendIpcLost as jest.Mock).mockReturnValue(false);
+    const { instance, obs } = setupForFrameStats();
+    const { SentryReport } = require('util/sentry-report');
+    const errorSpy = jest.spyOn(SentryReport, 'error');
+    Object.defineProperty(obs.Global, 'laggedFrames', {
+      get() {
+        throw new Error('boom');
+      },
+      configurable: true,
+    });
+
+    instance.update();
+    instance.update();
+    instance.update();
+
+    const frameStatsCalls = errorSpy.mock.calls.filter(([, method]) => method === 'readFrameStats');
+    expect(frameStatsCalls.length).toBe(1);
+
+    Object.defineProperty(obs.Global, 'laggedFrames', { value: 0, configurable: true });
   });
 });

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -1,11 +1,14 @@
 import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
+import { Subscription } from 'rxjs';
 import { Inject } from 'services/core/injector';
 import { mutation, StatefulService } from 'services/core/stateful-service';
 import { CustomizationService } from 'services/customization';
+import { ObsIpcHealthService } from 'services/obs-ipc-health';
 import { VideoSettingsService } from 'services/settings-v2/video';
 import { EStreamingState, StreamingService } from 'services/streaming';
 import { getKeys } from 'util/getKeys';
+import { isObsBackendIpcLost } from 'util/obs-ipc-error';
 import { getLastObsOp } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
 
@@ -41,6 +44,8 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
   private videoSettingsService: VideoSettingsService;
   @Inject()
   private streamingService: StreamingService;
+  @Inject()
+  private obsIpcHealthService: ObsIpcHealthService;
 
   static initialState: IPerformanceState = {
     CPU: 0,
@@ -59,6 +64,8 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
 
   private intervalId: number;
   private statsFailed: boolean = false;
+  private frameStatsFailed: boolean = false;
+  private ipcLostSubscription: Subscription;
 
   private zeroBandwidthSamples = 0;
   private zeroBandwidthAlertSent = false;
@@ -80,6 +87,10 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
 
   init() {
     this.intervalId = window.setInterval(() => this.update(), STATS_UPDATE_INTERVAL);
+
+    // IPC 切断後はポーリングしても必ず失敗し、2秒ごとに Sentry ノイズを生むだけなので停止する。
+    // SettingsService 側で先に検知された場合もここで止まる
+    this.ipcLostSubscription = this.obsIpcHealthService.ipcLost.subscribe(() => this.stop());
 
     // 配信状態の変化を監視して履歴をリセット
     this.streamingService.streamingStatusChange.subscribe((status) => {
@@ -129,6 +140,12 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
         percentageSkippedFrames: this.state.percentageSkippedFrames || 0,
       };
     } catch (e) {
+      if (isObsBackendIpcLost(e)) {
+        // 復旧不能な切断。ObsIpcHealthService 側で1度だけ Sentry 報告＋ダイアログを出すので、
+        // ここでは個別の SentryReport / breadcrumb を積まない
+        this.obsIpcHealthService.notifyIpcLost('PerformanceService.getState');
+        return null;
+      }
       if (this.statsFailed) {
         // Sentryイベント数削減のため、2回目以降はbreadcrumbsに記録する
         Sentry.addBreadcrumb({
@@ -174,11 +191,18 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
       })
       .reduce((sum, usage) => sum + usage);
 
-    // OBS からフレーム統計を取得
-    const currentLaggedFrames = obs.Global.laggedFrames;
-    const currentRenderedFrames = obs.Global.totalFrames;
-    const currentSkippedFrames = this.videoSettingsService.contexts.horizontal?.skippedFrames || 0;
-    const currentEncodedFrames = this.videoSettingsService.contexts.horizontal?.encodedFrames || 0;
+    // OBS からフレーム統計を取得。取得できない場合は前回値を流用し、
+    // 差分0として残りの統計（CPU / 帯域）の更新を継続する
+    const frames = this.readFrameStats() ?? {
+      lagged: this.state.numberLaggedFrames,
+      rendered: this.state.numberRenderedFrames,
+      skipped: this.state.numberSkippedFrames,
+      encoded: this.state.numberEncodedFrames,
+    };
+    const currentLaggedFrames = frames.lagged;
+    const currentRenderedFrames = frames.rendered;
+    const currentSkippedFrames = frames.skipped;
+    const currentEncodedFrames = frames.encoded;
 
     // 差分ファクターの計算（前回からの変化量）
     const framesLagged = currentLaggedFrames - this.state.numberLaggedFrames;
@@ -273,6 +297,40 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
 
   stop() {
     window.clearInterval(this.intervalId);
+  }
+
+  /**
+   * OBS からフレーム統計（ラグ・レンダリング・スキップ・エンコード数）を取得する。
+   * 取得に失敗した場合は null を返す（呼び出し元で前回値へフォールバックする）。
+   */
+  private readFrameStats(): {
+    lagged: number;
+    rendered: number;
+    skipped: number;
+    encoded: number;
+  } | null {
+    try {
+      const stats = {
+        lagged: obs.Global.laggedFrames,
+        rendered: obs.Global.totalFrames,
+        skipped: this.videoSettingsService.contexts.horizontal?.skippedFrames || 0,
+        encoded: this.videoSettingsService.contexts.horizontal?.encodedFrames || 0,
+      };
+      this.frameStatsFailed = false;
+      return stats;
+    } catch (e) {
+      if (isObsBackendIpcLost(e)) {
+        this.obsIpcHealthService.notifyIpcLost('PerformanceService.readFrameStats');
+        return null;
+      }
+      if (!this.frameStatsFailed) {
+        this.frameStatsFailed = true;
+        SentryReport.error('PerformanceService', 'readFrameStats', e, {
+          extra: { lastObsOp: getLastObsOp() },
+        });
+      }
+      return null;
+    }
   }
 
   /**

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -89,9 +89,10 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
     this.intervalId = window.setInterval(() => this.update(), STATS_UPDATE_INTERVAL);
 
     // IPC 切断後はポーリングしても必ず失敗し、2秒ごとに Sentry ノイズを生むだけなので停止する。
-    // SettingsService 側で先に検知された場合もここで止まる
     this.ipcLostSubscription = this.obsIpcHealthService.ipcLost.subscribe(() => this.stop());
 
+    // init() より前に切断が検知されていた場合にもポーリングを止める
+    if (this.obsIpcHealthService.isLost) this.stop();
     // 配信状態の変化を監視して履歴をリセット
     this.streamingService.streamingStatusChange.subscribe((status) => {
       if (status === EStreamingState.Live) {

--- a/app/services/performance/performance.ts
+++ b/app/services/performance/performance.ts
@@ -298,6 +298,7 @@ export class PerformanceService extends StatefulService<IPerformanceState> {
 
   stop() {
     window.clearInterval(this.intervalId);
+    this.ipcLostSubscription?.unsubscribe();
   }
 
   /**

--- a/app/services/settings/settings.ipc-error.test.ts
+++ b/app/services/settings/settings.ipc-error.test.ts
@@ -1,11 +1,3 @@
-// Mock @electron/remote
-const mockShowMessageBox = jest.fn();
-const mockGetCurrentWindow = jest.fn().mockReturnValue({});
-jest.mock('@electron/remote', () => ({
-  dialog: { showMessageBox: mockShowMessageBox },
-  getCurrentWindow: mockGetCurrentWindow,
-}));
-
 jest.mock('@sentry/vue', () => ({ addBreadcrumb: jest.fn() }));
 jest.mock('services/i18n', () => ({ $t: (key: string) => key }));
 
@@ -26,6 +18,7 @@ jest.mock('services/audio', () => ({ AudioService: class {}, E_AUDIO_CHANNELS: {
 jest.mock('services/dismissables', () => ({ DismissablesService: class {}, EDismissable: {} }));
 jest.mock('services/nicolive-program/nicolive-comment-synthesizer', () => ({ NicoliveCommentSynthesizerService: class {} }));
 jest.mock('services/nicolive-program/state', () => ({ NicoliveProgramStateService: class {} }));
+jest.mock('services/obs-ipc-health', () => ({ ObsIpcHealthService: class {} }));
 jest.mock('services/sound-detector', () => ({ SoundDetectorService: class {} }));
 jest.mock('services/sources', () => ({ SourcesService: class {} }));
 jest.mock('services/user', () => ({ UserService: class {} }));
@@ -48,26 +41,23 @@ describe('SettingsService: getSettingsFormData IPC エラーハンドリング',
   let SettingsService: any;
   let IpcRequestErrorClass: any;
   let instance: any;
-  let mockRelaunch: jest.Mock;
+  let mockNotifyIpcLost: jest.Mock;
 
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
 
-    jest.doMock('@electron/remote', () => ({
-      dialog: { showMessageBox: mockShowMessageBox },
-      getCurrentWindow: mockGetCurrentWindow,
-    }));
     jest.doMock('services/i18n', () => ({ $t: (key: string) => key }));
 
-    mockRelaunch = jest.fn();
+    mockNotifyIpcLost = jest.fn();
 
     ({ SettingsService } = require('./settings'));
     ({ IpcRequestError: IpcRequestErrorClass } = require('util/ipc-request-error'));
 
     instance = Object.create(SettingsService.prototype);
-    instance.appService = { relaunch: mockRelaunch };
+    instance.appService = { relaunch: jest.fn() };
     instance.windowsService = { getWindow: jest.fn().mockReturnValue(null) };
+    instance.obsIpcHealthService = { notifyIpcLost: mockNotifyIpcLost };
     instance.obsIpcError = false;
     instance.settingsFormDataCache = new Map();
   });
@@ -89,7 +79,6 @@ describe('SettingsService: getSettingsFormData IPC エラーハンドリング',
       jest.spyOn(instance, 'getSettingsFormDataImpl').mockImplementation(() => {
         throw new IpcRequestErrorClass('SettingsService', 'getSettingsFormData', { code: -32000 });
       });
-      jest.spyOn(instance, 'offerRestart').mockResolvedValue(undefined);
 
       const result = instance.getSettingsFormData('General');
 
@@ -103,22 +92,21 @@ describe('SettingsService: getSettingsFormData IPC エラーハンドリング',
       jest.spyOn(instance, 'getSettingsFormDataImpl').mockImplementation(() => {
         throw new IpcRequestErrorClass('SettingsService', 'getSettingsFormData', { code: -32000 });
       });
-      jest.spyOn(instance, 'offerRestart').mockResolvedValue(undefined);
 
       const result = instance.getSettingsFormData('General');
 
       expect(result).toBe(cached);
     });
 
-    test('offerRestart が呼ばれる', () => {
+    test('notifyIpcLost が呼ばれる', () => {
       jest.spyOn(instance, 'getSettingsFormDataImpl').mockImplementation(() => {
         throw new IpcRequestErrorClass('SettingsService', 'getSettingsFormData', { code: -32000 });
       });
-      const offerRestartSpy = jest.spyOn(instance, 'offerRestart').mockResolvedValue(undefined);
 
       instance.getSettingsFormData('General');
 
-      expect(offerRestartSpy).toHaveBeenCalledTimes(1);
+      expect(mockNotifyIpcLost).toHaveBeenCalledTimes(1);
+      expect(mockNotifyIpcLost).toHaveBeenCalledWith('SettingsService.getSettingsFormData');
     });
 
     test('obsIpcError が true の場合は getSettingsFormDataImpl を呼ばずキャッシュを返す', () => {
@@ -137,13 +125,36 @@ describe('SettingsService: getSettingsFormData IPC エラーハンドリング',
       jest.spyOn(instance, 'getSettingsFormDataImpl').mockImplementation(() => {
         throw new IpcRequestErrorClass('SettingsService', 'getSettingsFormData', { code: -32000 });
       });
-      jest.spyOn(instance, 'offerRestart').mockResolvedValue(undefined);
 
       instance.getSettingsFormData('General');
       instance.getSettingsFormData('Output');
       instance.getSettingsFormData('Audio');
 
       expect(instance['getSettingsFormDataImpl']).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('生のネイティブ IPC 切断エラー（IpcRequestError でない）', () => {
+    test('Failed to make IPC call を含む生の Error でも notifyIpcLost が呼ばれキャッシュを返す', () => {
+      jest.spyOn(instance, 'getSettingsFormDataImpl').mockImplementation(() => {
+        throw new Error('INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.');
+      });
+
+      const result = instance.getSettingsFormData('General');
+
+      expect(instance.obsIpcError).toBe(true);
+      expect(mockNotifyIpcLost).toHaveBeenCalledWith('SettingsService.getSettingsFormData');
+      expect(result).toEqual([]);
+    });
+
+    test('Lost IPC Connection を含む生の Error でも notifyIpcLost が呼ばれる', () => {
+      jest.spyOn(instance, 'getSettingsFormDataImpl').mockImplementation(() => {
+        throw new Error('Lost IPC Connection');
+      });
+
+      instance.getSettingsFormData('General');
+
+      expect(mockNotifyIpcLost).toHaveBeenCalledWith('SettingsService.getSettingsFormData');
     });
   });
 
@@ -154,24 +165,7 @@ describe('SettingsService: getSettingsFormData IPC エラーハンドリング',
 
       expect(() => instance.getSettingsFormData('General')).toThrow('other error');
       expect(instance.obsIpcError).toBe(false);
-    });
-  });
-
-  describe('offerRestart', () => {
-    test('ダイアログで「はい」を選ぶと relaunch が呼ばれる', async () => {
-      mockShowMessageBox.mockResolvedValue({ response: 0 });
-
-      await instance['offerRestart']();
-
-      expect(mockRelaunch).toHaveBeenCalledTimes(1);
-    });
-
-    test('ダイアログで「いいえ」を選ぶと relaunch は呼ばれない', async () => {
-      mockShowMessageBox.mockResolvedValue({ response: 1 });
-
-      await instance['offerRestart']();
-
-      expect(mockRelaunch).not.toHaveBeenCalled();
+      expect(mockNotifyIpcLost).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 
-import * as remote from '@electron/remote';
 import * as Sentry from '@sentry/vue';
 import {
   inputValuesToObsValues,
@@ -18,11 +17,13 @@ import { DismissablesService, EDismissable } from 'services/dismissables';
 import { $t } from 'services/i18n';
 import { NicoliveCommentSynthesizerService } from 'services/nicolive-program/nicolive-comment-synthesizer';
 import { NicoliveProgramStateService } from 'services/nicolive-program/state';
+import { ObsIpcHealthService } from 'services/obs-ipc-health';
 import { SoundDetectorService } from 'services/sound-detector';
 import { SourcesService } from 'services/sources';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
 import { IpcRequestError } from 'util/ipc-request-error';
+import { isObsBackendIpcLost } from 'util/obs-ipc-error';
 import { markObsOp } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
 import { toRaw } from 'vue';
@@ -132,6 +133,7 @@ export class SettingsService
   @Inject() private windowsService: WindowsService;
   @Inject() private appService: AppService;
   @Inject() private userService: UserService;
+  @Inject() private obsIpcHealthService: ObsIpcHealthService;
 
   @Inject() videoSettingsService: VideoSettingsService;
   @Inject() private dismissablesService: DismissablesService;
@@ -213,29 +215,15 @@ export class SettingsService
       this.settingsFormDataCache.set(categoryName, result);
       return result;
     } catch (e) {
-      if (e instanceof IpcRequestError) {
+      // 生のネイティブ例外（メインウィンドウでの直接呼び出し）と IpcRequestError（RPC 越し）の
+      // 両方を拾う。instanceof IpcRequestError は rpcError.message が空でも RPC 失敗なら
+      // 従来通り縮退させるために残す
+      if (isObsBackendIpcLost(e) || e instanceof IpcRequestError) {
         this.obsIpcError = true;
-        this.offerRestart().catch(() => {});
+        this.obsIpcHealthService.notifyIpcLost('SettingsService.getSettingsFormData');
         return this.settingsFormDataCache.get(categoryName) ?? [];
       }
       throw e;
-    }
-  }
-
-  private async offerRestart(): Promise<void> {
-    const parentWindow = this.windowsService.getWindow('child') ?? remote.getCurrentWindow();
-    const choice = await remote.dialog.showMessageBox(parentWindow, {
-      type: 'error',
-      buttons: [$t('common.yes'), $t('common.no')],
-      title: $t('common.confirm'),
-      message: $t('settings.noticeIpcError'),
-      detail: $t('settings.noticeIpcErrorDetail'),
-      noLink: true,
-      cancelId: 1,
-      defaultId: 0,
-    });
-    if (choice.response === 0) {
-      this.appService.relaunch();
     }
   }
 

--- a/app/util/obs-ipc-error.test.ts
+++ b/app/util/obs-ipc-error.test.ts
@@ -1,0 +1,77 @@
+import { IpcRequestError } from './ipc-request-error';
+import { isObsBackendIpcLost, isObsBackendIpcLostMessage } from './obs-ipc-error';
+
+describe('isObsBackendIpcLostMessage', () => {
+  test('Failed to make IPC call, verify IPC status. を含む文字列を true と判定する', () => {
+    expect(isObsBackendIpcLostMessage('INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.')).toBe(true);
+  });
+
+  test('Lost IPC Connection を含む文字列を true と判定する', () => {
+    expect(isObsBackendIpcLostMessage('Uncaught Error: Lost IPC Connection')).toBe(true);
+  });
+
+  test('無関係な文字列は false', () => {
+    expect(isObsBackendIpcLostMessage('some other error')).toBe(false);
+  });
+
+  test('undefined は false', () => {
+    expect(isObsBackendIpcLostMessage(undefined)).toBe(false);
+  });
+
+  test('null は false', () => {
+    expect(isObsBackendIpcLostMessage(null)).toBe(false);
+  });
+
+  test('空文字は false', () => {
+    expect(isObsBackendIpcLostMessage('')).toBe(false);
+  });
+});
+
+describe('isObsBackendIpcLost', () => {
+  test('生の Error（メインウィンドウでのネイティブ例外）を true と判定する', () => {
+    expect(isObsBackendIpcLost(new Error('Failed to make IPC call, verify IPC status.'))).toBe(true);
+  });
+
+  test('Lost IPC Connection の生の Error も true と判定する', () => {
+    expect(isObsBackendIpcLost(new Error('Lost IPC Connection'))).toBe(true);
+  });
+
+  test('IpcRequestError の rpcError.message で判定する', () => {
+    const err = new IpcRequestError('SourcesService', 'getAvailableSourcesTypesList', {
+      code: -32000,
+      message: 'INTERNAL_SERVER_ERROR Failed to make IPC call, verify IPC status.',
+    });
+    expect(isObsBackendIpcLost(err)).toBe(true);
+  });
+
+  test('IpcRequestError で rpcError.message が undefined なら false', () => {
+    const err = new IpcRequestError('SourcesService', 'getAvailableSourcesTypesList', {
+      code: -32000,
+    });
+    expect(isObsBackendIpcLost(err)).toBe(false);
+  });
+
+  test('string を直接渡しても判定できる', () => {
+    expect(isObsBackendIpcLost('Failed to make IPC call, verify IPC status.')).toBe(true);
+  });
+
+  test('message プロパティを持つ非 Error オブジェクトも判定する', () => {
+    expect(isObsBackendIpcLost({ message: 'Lost IPC Connection' })).toBe(true);
+  });
+
+  test('null を渡しても throw せず false を返す', () => {
+    expect(isObsBackendIpcLost(null)).toBe(false);
+  });
+
+  test('undefined を渡しても throw せず false を返す', () => {
+    expect(isObsBackendIpcLost(undefined)).toBe(false);
+  });
+
+  test('無関係な Error は false', () => {
+    expect(isObsBackendIpcLost(new Error('some other error'))).toBe(false);
+  });
+
+  test('message プロパティのない値は false', () => {
+    expect(isObsBackendIpcLost(42)).toBe(false);
+  });
+});

--- a/app/util/obs-ipc-error.ts
+++ b/app/util/obs-ipc-error.ts
@@ -1,0 +1,35 @@
+import { IpcRequestError } from './ipc-request-error';
+
+// obs-studio-node が OBS バックエンドプロセス(obs64.exe)と通信する独自ネイティブ IPC が
+// 切断された際のエラー文言（Electron の IPC とは無関係。詳細: n-air-app#1380）。
+//   - Failed to make IPC call, verify IPC status. : 書き込み側 (ipc::client_win)
+//   - Lost IPC Connection                        : 読み出し側 (deserialize 失敗)
+// いずれも obs64.exe 側のクラッシュに起因し、アプリ側に再接続手段は存在しない。
+const OBS_BACKEND_IPC_LOST_PATTERNS = [
+  /Failed to make IPC call, verify IPC status\./,
+  /Lost IPC Connection/,
+];
+
+export function isObsBackendIpcLostMessage(message: string | undefined | null): boolean {
+  if (!message) return false;
+  return OBS_BACKEND_IPC_LOST_PATTERNS.some((re) => re.test(message));
+}
+
+/**
+ * 生の Error（メインウィンドウでのネイティブ例外）、IpcRequestError（RPC 越し。
+ * 元のネイティブ文言は rpcError.message に入る）、string のいずれでも
+ * OBS バックエンドIPC切断エラーかどうかを判定する。
+ */
+export function isObsBackendIpcLost(err: unknown): boolean {
+  if (err == null) return false;
+  if (typeof err === 'string') return isObsBackendIpcLostMessage(err);
+  if (err instanceof IpcRequestError) {
+    return (
+      isObsBackendIpcLostMessage(err.rpcError?.message) ||
+      isObsBackendIpcLostMessage(err.message)
+    );
+  }
+  if (err instanceof Error) return isObsBackendIpcLostMessage(err.message);
+  const message = (err as { message?: unknown }).message;
+  return typeof message === 'string' && isObsBackendIpcLostMessage(message);
+}

--- a/app/util/sentry-ipc-request.ts
+++ b/app/util/sentry-ipc-request.ts
@@ -1,12 +1,8 @@
 import * as Sentry from '@sentry/vue';
 
 import { IpcRequestError } from './ipc-request-error';
+import { isObsBackendIpcLostMessage } from './obs-ipc-error';
 import { SentryReport } from './sentry-report';
-
-// obs-studio-node が OBS バックエンドプロセスと通信する独自ネイティブ IPC が切断された際の
-// main プロセス側エラー文言（Electron の IPC とは無関係。詳細: n-air-app#1380）。
-// アプリ側に再接続機構がなく既知の未解決issueのため、原因不明の他エラーとは分離・降格する。
-const OBS_BACKEND_IPC_LOST_RE = /Failed to make IPC call, verify IPC status\./;
 
 export function captureIpcRequestError(
   serviceName: string,
@@ -17,7 +13,9 @@ export function captureIpcRequestError(
 ): IpcRequestError {
   const method = String(methodName);
   const err = new IpcRequestError(serviceName, method, rpcError);
-  const isObsBackendIpcLost = OBS_BACKEND_IPC_LOST_RE.test(rpcError.message ?? '');
+  // OBS バックエンドIPC切断（既知の未解決issue: n-air-app#1380）は原因不明の他エラーとは
+  // 分離・降格する。アプリ側に再接続機構がない
+  const isObsBackendIpcLost = isObsBackendIpcLostMessage(rpcError.message);
 
   Sentry.addBreadcrumb({
     category: 'ipc.request',


### PR DESCRIPTION
## このpull requestが解決する内容

obs-studio-node の独自ネイティブIPC（obs64.exeとの通信）が切断されたとき、**ユーザーが設定画面を開くまで何も気づけない**問題を修正します。切断を2秒以内に検知し、その場で再起動を促すダイアログを表示するようにします。

## 背景

#1380 の調査で、既存の唯一の通知導線が実際には一度も発火していないことが判明しました。

`app/services/settings/settings.ts` の `getSettingsFormData()` は `e instanceof IpcRequestError` で切断を判定していましたが、実行経路を追うとどのケースでもこれは false になります:

1. 子ウィンドウが `getSettingsFormData()` を呼ぶ → IPC で main へ転送
2. **main ウィンドウ内で** 実行され、**生のネイティブ Error**（`Failed to make IPC call, verify IPC status.`）が throw される
3. main の catch は `instanceof IpcRequestError` が false → rethrow
4. main→子の応答変換で初めて `IpcRequestError` が生成される（が、子側には catch がなく uncaught になる）

つまり `offerRestart()` のダイアログは誰も見たことがありませんでした。加えて、最速で切断を検知できる `PerformanceService` の2秒ポーリングは Sentry に1件送るだけでユーザーには何も伝えず、切断後もポーリングを止めずに回し続けていました（2秒ごとに uncaught error を出す箇所もありました）。

## 変更内容

- `app/util/obs-ipc-error.ts`（新規）
  - OBSバックエンドIPC切断の判定を集約。`Failed to make IPC call, verify IPC status.`（書き込み側）に加え `Lost IPC Connection`（読み出し側）も判定対象に追加
  - 生の `Error` / `IpcRequestError` / `string` のいずれでも判定できる `isObsBackendIpcLost()` を提供
- `app/util/sentry-ipc-request.ts`
  - 判定ロジックを上記ユーティリティに委譲（#1378 で追加した正規表現を移設）
- `app/services/obs-ipc-health/`（新規）
  - `ObsIpcHealthService` を新設し、切断の検知・通知を一本化
  - 2回目以降の呼び出しは無視（ダイアログの多重表示を防止）
  - モーダル親の選定を修正: 従来は非表示の子ウィンドウを常に親にしていたが、子ウィンドウが表示中の場合のみ子、それ以外はメインウィンドウを親にする
  - 再起動ダイアログで「いいえ」を選んだ場合、再接続手段がないため再通知・ポーリング再開はしない
- `app/services/settings/settings.ts`
  - catch 判定を `isObsBackendIpcLost(e) || e instanceof IpcRequestError` に広げ、`ObsIpcHealthService.notifyIpcLost()` を呼ぶように変更
  - 従来の `offerRestart()` は `ObsIpcHealthService` に移設
- `app/services/performance/performance.ts`
  - `getState()` が切断エラーで失敗した場合に `notifyIpcLost()` を呼ぶ
  - フレーム統計取得（`obs.Global.laggedFrames` 等）を try/catch で保護し、取得に失敗しても前回値で処理を継続する（従来は無防備で2秒ごとに uncaught error になり得た）
  - 切断が検知されたらポーリングを停止する（従来は `stop()` の呼び出し元が存在せず、無限に失敗し続けていた）
- `app/app-services.ts`
  - `ObsIpcHealthService` を登録

## 設計上の注意

libobs 内部のクラッシュ自体（真因）はアプリ側から直せないため、本PRは「切断を早く検知してユーザーに伝える」ことに専念します。再接続機構の実装可否や死活監視の追加は #1380 に残しています。

## テスト

- `app/util/obs-ipc-error.test.ts`（新規）
- `app/services/obs-ipc-health/obs-ipc-health.test.ts`（新規）: 通知の重複防止、モーダル親の選定、ダイアログの選択結果に応じた再起動
- `app/services/settings/settings.ipc-error.test.ts`（更新）: 生のネイティブ Error でも通知されることを追加
- `app/services/performance/performance.test.ts`（更新）: IPC切断検知時の通知、フレーム統計失敗時のフォールバック、ポーリング停止
- `pnpm run test:unit:app` / `pnpm run typecheck` で確認済み（全73スイート・1074テスト成功）

関連: #1380

### 手動確認（要人手）
- [x] devtools で `sm.getService('ObsIpcHealthService').instance().notifyIpcLost('manual')` を実行し、メインウィンドウを親にしたダイアログが出ることを確認
- [x] ダイアログで「はい」を選ぶとアプリが再起動することを確認
- [x] 「いいえ」を選んだ後は再度実行してもダイアログが出ないこと、PerformanceMetrics の CPU 表示が更新されなくなること（ポーリング停止）を確認
