### PR TITLE
修正: ソースの削除に失敗するとそのソースが二度と削除できなくなる問題を修正

### DIFF
--- a/app/services/sources/sources.test.ts
+++ b/app/services/sources/sources.test.ts
@@ -16,7 +16,16 @@ const mockMarkObsOp = jest.fn();
 jest.mock('util/sentry-obs-breadcrumb', () => ({
   markObsOp: mockMarkObsOp,
   setObsOpObserver: jest.fn(),
-  getLastObsOp: jest.fn(),
+  getLastObsOp: jest.fn(() => 'test'),
+}));
+
+const mockSentryReportError = jest.fn();
+const mockSentryReportMessage = jest.fn();
+jest.mock('util/sentry-report', () => ({
+  SentryReport: {
+    error: (...args: any[]) => mockSentryReportError(...args),
+    message: (...args: any[]) => mockSentryReportMessage(...args),
+  },
 }));
 
 // OBS ネイティブモジュールのモック（sources.ts は '../../../obs-api' で import している）
@@ -73,6 +82,7 @@ const setup = createSetupFunction({
     UserService: {},
     RtvcStateService: {
       didAddSource: jest.fn(),
+      didRemoveSource: jest.fn(),
     },
   },
 });
@@ -174,6 +184,191 @@ describe('createSource', () => {
     expect(() => {
       instance.createSource('テストソース', 'window_capture', {});
     }).toThrow('InputFactory.create returned no input for type=window_capture');
+  });
+});
+
+describe('removeSource', () => {
+  function setupRemoveSourceInstance(sourceOverrides: any = {}) {
+    setup();
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+    // SourcesService.init() は StatefulService.init() をオーバーライドしており、
+    // mock 環境では state が自動初期化されないため明示的に設定する
+    instance.state = { sources: {}, temporarySources: {} };
+
+    const releaseMock = jest.fn();
+    const fakeSourceState = {
+      sourceId: 'test-source-id',
+      name: 'test-source-id',
+      type: 'browser_source',
+      channel: undefined,
+      ...sourceOverrides,
+    };
+    const fakeSource = {
+      ...fakeSourceState,
+      state: fakeSourceState,
+      getObsInput: () => ({ release: releaseMock }),
+    };
+
+    instance.state.sources['test-source-id'] = fakeSourceState;
+    instance.getSource = jest.fn((id: string) => (id === 'test-source-id' ? fakeSource : undefined));
+    instance.propertiesManagers = {
+      'test-source-id': { manager: { destroy: jest.fn() }, type: 'default' },
+    };
+    instance.sourceRemoved = { next: jest.fn() };
+
+    return { instance, fakeSource, releaseMock };
+  }
+
+  test('正常時は propertiesManagers から削除され sourceRemoved が発火する', () => {
+    const { instance, fakeSource } = setupRemoveSourceInstance();
+
+    instance.removeSource('test-source-id');
+
+    expect(instance.propertiesManagers['test-source-id']).toBeUndefined();
+    expect(instance.state.sources['test-source-id']).toBeUndefined();
+    expect(instance.sourceRemoved.next).toHaveBeenCalledWith(fakeSource.state);
+  });
+
+  test('存在しない id では Source not found を throw する', () => {
+    const { instance } = setupRemoveSourceInstance();
+    instance.getSource = jest.fn().mockReturnValue(undefined);
+
+    expect(() => instance.removeSource('unknown-id')).toThrow('Source unknown-id not found');
+  });
+
+  test('nair-rtvc-source の場合 didRemoveSource が呼ばれる', () => {
+    const { instance } = setupRemoveSourceInstance({ type: 'nair-rtvc-source' });
+
+    instance.removeSource('test-source-id');
+
+    expect(instance.rtvcStateService.didRemoveSource).toHaveBeenCalled();
+  });
+
+  test('propertiesManagers にエントリが無くても REMOVE_SOURCE / sourceRemoved まで到達する', () => {
+    const { instance } = setupRemoveSourceInstance();
+    instance.propertiesManagers = {}; // エントリ欠落を再現
+
+    instance.removeSource('test-source-id');
+
+    expect(instance.state.sources['test-source-id']).toBeUndefined();
+    expect(instance.sourceRemoved.next).toHaveBeenCalled();
+  });
+
+  test('propertiesManagers 欠落時は SentryReport.message で警告する', () => {
+    const { instance } = setupRemoveSourceInstance();
+    instance.propertiesManagers = {};
+
+    instance.removeSource('test-source-id');
+
+    expect(mockSentryReportMessage).toHaveBeenCalledWith(
+      'SourcesService',
+      'removeSource',
+      'propertiesManager missing on removeSource',
+      expect.objectContaining({
+        fingerprint: ['SourcesService', 'removeSource', 'managerMissing'],
+      }),
+    );
+  });
+
+  test('manager.destroy() が throw しても REMOVE_SOURCE まで到達する', () => {
+    const { instance } = setupRemoveSourceInstance();
+    instance.propertiesManagers['test-source-id'].manager.destroy = jest.fn(() => {
+      throw new Error('destroy failed');
+    });
+
+    instance.removeSource('test-source-id');
+
+    expect(instance.state.sources['test-source-id']).toBeUndefined();
+    expect(instance.sourceRemoved.next).toHaveBeenCalled();
+  });
+
+  test('release() が throw しても REMOVE_SOURCE まで到達する', () => {
+    const { instance, releaseMock } = setupRemoveSourceInstance();
+    releaseMock.mockImplementation(() => {
+      throw new Error('release failed');
+    });
+
+    instance.removeSource('test-source-id');
+
+    expect(instance.state.sources['test-source-id']).toBeUndefined();
+    expect(instance.sourceRemoved.next).toHaveBeenCalled();
+  });
+
+  test('channel が設定されたソースで setOutputSource が throw しても REMOVE_SOURCE まで到達する', () => {
+    const { instance } = setupRemoveSourceInstance({ channel: 1 });
+    const obs = require('../../../obs-api');
+    obs.Global.setOutputSource.mockImplementation(() => {
+      throw new Error('Failed to make IPC call, verify IPC status.');
+    });
+
+    instance.removeSource('test-source-id');
+
+    expect(instance.state.sources['test-source-id']).toBeUndefined();
+    expect(instance.sourceRemoved.next).toHaveBeenCalled();
+
+    obs.Global.setOutputSource.mockReset();
+  });
+
+  test('各ステップの失敗は step ごとの fingerprint で SentryReport.error される', () => {
+    const { instance, releaseMock } = setupRemoveSourceInstance();
+    releaseMock.mockImplementation(() => {
+      throw new Error('release failed');
+    });
+
+    instance.removeSource('test-source-id');
+
+    expect(mockSentryReportError).toHaveBeenCalledWith(
+      'SourcesService',
+      'removeSource',
+      expect.anything(),
+      expect.objectContaining({
+        fingerprint: ['SourcesService', 'removeSource', 'release'],
+      }),
+    );
+  });
+});
+
+describe('reset', () => {
+  test('reset() で propertiesManagers が空になり各 manager の destroy が呼ばれる', () => {
+    setup();
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+    instance.state = { sources: {}, temporarySources: {} };
+
+    const destroyA = jest.fn();
+    const destroyB = jest.fn();
+    instance.propertiesManagers = {
+      a: { manager: { destroy: destroyA }, type: 'default' },
+      b: { manager: { destroy: destroyB }, type: 'default' },
+    };
+
+    instance.reset();
+
+    expect(destroyA).toHaveBeenCalled();
+    expect(destroyB).toHaveBeenCalled();
+    expect(instance.propertiesManagers).toEqual({});
+  });
+
+  test('manager.destroy() が throw しても propertiesManagers は空になる', () => {
+    setup();
+    const { SourcesService } = require('./sources');
+    const instance = SourcesService.instance();
+    instance.state = { sources: {}, temporarySources: {} };
+
+    instance.propertiesManagers = {
+      a: {
+        manager: {
+          destroy: jest.fn(() => {
+            throw new Error('destroy failed');
+          }),
+        },
+        type: 'default',
+      },
+    };
+
+    expect(() => instance.reset()).not.toThrow();
+    expect(instance.propertiesManagers).toEqual({});
   });
 });
 

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -16,7 +16,8 @@ import { uuidv4 } from 'services/utils';
 import { IWindowOptions, WindowsService } from 'services/windows';
 import { getKeys } from 'util/getKeys';
 import namingHelpers from 'util/NamingHelpers';
-import { markObsOp } from 'util/sentry-obs-breadcrumb';
+import { getLastObsOp, markObsOp } from 'util/sentry-obs-breadcrumb';
+import { SentryReport } from 'util/sentry-report';
 
 import * as obs from '../../../obs-api';
 import { RtvcStateService } from '../../services/rtvcStateService';
@@ -232,16 +233,55 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
      * otherwise OBS thinks it's still attached
      * and won't release it. */
     if (source.channel !== undefined) {
-      obs.Global.setOutputSource(source.channel, null);
+      this.tryObsStep('resetChannel', id, () => obs.Global.setOutputSource(source.channel, null));
     }
 
     if (source.type === 'nair-rtvc-source') this.rtvcStateService.didRemoveSource(source);
 
-    source.getObsInput().release();
-    this.propertiesManagers[id].manager.destroy();
+    this.tryObsStep('release', id, () => source.getObsInput().release());
+
+    const activeManager = this.propertiesManagers[id];
+    if (activeManager) {
+      this.tryObsStep('managerDestroy', id, () => activeManager.manager.destroy());
+    } else {
+      // propertiesManagers の欠落経路: addSource が ADD_SOURCE 後・propertiesManagers[id] 代入前で
+      // throw した場合、シーンコレクション読込の部分失敗、reset()/RESET_SOURCES() が
+      // propertiesManagers を掃除しないケースなど
+      SentryReport.message(
+        'SourcesService',
+        'removeSource',
+        'propertiesManager missing on removeSource',
+        {
+          level: 'warning',
+          fingerprint: ['SourcesService', 'removeSource', 'managerMissing'],
+          tags: { diagnostic: 'source-manager-missing', 'source.type': source.type },
+          extra: { sourceId: id, lastObsOp: getLastObsOp() },
+        },
+      );
+    }
     delete this.propertiesManagers[id];
+
+    // OBS 側の解放に失敗しても state からは必ず外す。
+    // 残すと同じソースを二度と削除できなくなる（#1380）
     this.REMOVE_SOURCE(id);
     this.sourceRemoved.next(source.state);
+  }
+
+  /**
+   * removeSource 内の OBS 呼び出しを個別に保護する。
+   * 失敗しても state 更新まで到達させるため、報告のうえ握りつぶす。
+   */
+  private tryObsStep(step: string, sourceId: string, fn: () => void): void {
+    try {
+      fn();
+    } catch (e) {
+      SentryReport.error('SourcesService', 'removeSource', e, {
+        level: 'warning',
+        fingerprint: ['SourcesService', 'removeSource', step],
+        tags: { 'removeSource.step': step },
+        extra: { sourceId, lastObsOp: getLastObsOp() },
+      });
+    }
   }
 
   addFile(path: string): Source | null {
@@ -579,6 +619,10 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   reset() {
+    for (const id of Object.keys(this.propertiesManagers)) {
+      this.tryObsStep('resetManagerDestroy', id, () => this.propertiesManagers[id].manager.destroy());
+    }
+    this.propertiesManagers = {};
     this.RESET_SOURCES();
   }
 

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -271,14 +271,20 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
    * removeSource 内の OBS 呼び出しを個別に保護する。
    * 失敗しても state 更新まで到達させるため、報告のうえ握りつぶす。
    */
-  private tryObsStep(step: string, sourceId: string, fn: () => void): void {
+  private tryObsStep(
+    step: string,
+    sourceId: string,
+    fn: () => void,
+    opts?: { methodName?: string },
+  ): void {
+    const methodName = opts?.methodName ?? 'removeSource';
     try {
       fn();
     } catch (e) {
-      SentryReport.error('SourcesService', 'removeSource', e, {
+      SentryReport.error('SourcesService', methodName, e, {
         level: 'warning',
-        fingerprint: ['SourcesService', 'removeSource', step],
-        tags: { 'removeSource.step': step },
+        fingerprint: ['SourcesService', methodName, step],
+        tags: { [`${methodName}.step`]: step },
         extra: { sourceId, lastObsOp: getLastObsOp() },
       });
     }
@@ -620,7 +626,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
   reset() {
     for (const id of Object.keys(this.propertiesManagers)) {
-      this.tryObsStep('resetManagerDestroy', id, () => this.propertiesManagers[id].manager.destroy());
+      this.tryObsStep('resetManagerDestroy', id, () => this.propertiesManagers[id].manager.destroy(), { methodName: 'reset' });
     }
     this.propertiesManagers = {};
     this.RESET_SOURCES();


### PR DESCRIPTION
## このpull requestが解決する内容

ソースの削除（`removeSource`）が OBS 側の処理に失敗した場合、そのソースがアプリの一覧から二度と削除できなくなる問題を修正します。

## 背景

`#1380` の調査で見つかった不具合です。`removeSource()` は以下の順で処理していますが、いずれかが失敗すると Vuex state の更新（`REMOVE_SOURCE` / `sourceRemoved`）まで到達しませんでした。

1. `obs.Global.setOutputSource()` でチャンネルを解除
2. `source.getObsInput().release()`
3. `propertiesManagers[id].manager.destroy()` — **未ガードで、`propertiesManagers[id]` が存在しないと TypeError**

3 が未ガードだったため、`propertiesManagers` にエントリが無い状態（`addSource` の途中失敗、シーンコレクション読込の部分失敗などで起こりうる）で `removeSource` を呼ぶと即座に TypeError で処理が止まります。すると OBS 側は解放済み（または一部未解放）なのに Vuex state にはソースが残り続け、**次に同じソースを削除しようとしても同じ場所で再び失敗する**ため、そのソースは恒久的に削除不能になります。

`#1380` で調査した OBS バックエンドIPC切断が発生している最中は 1・2 も失敗しうるため、同じ問題が起こる範囲はより広くなります。

## 変更内容

- `app/services/sources/sources.ts`
  - `removeSource()` の OBS 呼び出し（チャンネル解除・release・manager destroy）を `tryObsStep()` で個別に保護し、いずれが失敗しても `REMOVE_SOURCE` / `sourceRemoved` まで必ず到達するようにした
  - `propertiesManagers[id]` の存在を確認してから `destroy()` を呼ぶようにし、欠落時は Sentry に警告を記録する
  - `reset()` も同様に `propertiesManagers` の各エントリを保護しつつ破棄し、空にしてから `RESET_SOURCES()` を呼ぶようにした（従来は `propertiesManagers` がクリアされずリークしていた）

## テスト

- `app/services/sources/sources.test.ts` に `removeSource` / `reset` のテストを追加（従来テストは無し）
  - `propertiesManagers` にエントリが無くても `REMOVE_SOURCE` / `sourceRemoved` まで到達すること（回帰テスト）
  - `release()` / `manager.destroy()` / `setOutputSource()` のいずれが失敗しても state 更新まで到達すること
  - 失敗時は step ごとの fingerprint で Sentry に報告されること
  - 正常系・`nair-rtvc-source` の `didRemoveSource` 呼び出し・存在しない id での throw
- `pnpm run test:unit:app` / `pnpm run typecheck` で確認済み

関連: #1380

