### PR TITLE
修正: OBSサーバーの起動に失敗した際にエラー内容を表示するよう修正

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -19,6 +19,8 @@ import tooltipDirective from 'directives/tooltip';
 import electron from 'electron';
 import { Settings } from 'luxon';
 import { setupGlobalContextMenuForEditableElement } from 'util/menus/GlobalMenu';
+import { markObsOp } from 'util/sentry-obs-breadcrumb';
+import { SentryReport } from 'util/sentry-report';
 import { createApp } from 'vue';
 import { createI18n, type Locale, type Path } from 'vue-i18n';
 
@@ -141,6 +143,32 @@ document.addEventListener('auxclick', (event) => event.preventDefault());
 
 const locale = remote.app.getLocale();
 
+// obs-studio-node の EIPCError (node_modules/obs-studio-node/module.d.ts) をローカルに複製したもの。
+// const enum のため実行時に値が存在せず、かつ obs-api/obs-api.d.ts の re-export にも無いので、
+// 直接 import せずここに数値を持つ。NORMAL_EXIT が成功値 (0)。
+const EIPC_NORMAL_EXIT = 0;
+const IPC_ERROR_NAMES: Record<number, string> = {
+  0: 'NORMAL_EXIT',
+  252: 'VERSION_MISMATCH',
+  253: 'OTHER_ERROR',
+  254: 'MISSING_DEPENDENCY',
+  259: 'STILL_RUNNING',
+};
+
+export const ipcHostErrorToMessage = (hostResult: number): string => {
+  // 前回起動の obs64.exe がまだ終了していないケース。実際に起こりうる最有力パターンなので専用文言にする
+  if (hostResult === 259 /* STILL_RUNNING */) {
+    if (locale === 'ja') {
+      return '前回の終了処理が完了していません。しばらく待ってから、もう一度起動してください。';
+    }
+    return 'The previous instance has not finished shutting down yet. Please wait a moment and try again.';
+  }
+  if (locale === 'ja') {
+    return 'OBSサーバーの起動に失敗しました。しばらく待ってから、もう一度起動してください。';
+  }
+  return 'Failed to start the OBS server. Please wait a moment and try again.';
+};
+
 export const apiInitErrorResultToMessage = (resultCode: obs.EVideoCodes) => {
   switch (resultCode) {
     case obs.EVideoCodes.NotSupported: {
@@ -181,7 +209,50 @@ document.addEventListener('DOMContentLoaded', () => {
       window['obs'] = obs;
 
       // Host a new OBS server instance
-      obs.IPC.host(remote.process.env.IPC_UUID);
+      markObsOp('AppStartup', 'ipcHost');
+      let hostResult: unknown;
+      let hostThrown: unknown;
+      try {
+        hostResult = obs.IPC.host(remote.process.env.IPC_UUID);
+      } catch (e) {
+        hostThrown = e;
+      }
+
+      if (hostThrown || (typeof hostResult === 'number' && hostResult !== EIPC_NORMAL_EXIT)) {
+        const hostResultName =
+          typeof hostResult === 'number'
+            ? IPC_ERROR_NAMES[hostResult] ?? String(hostResult)
+            : 'thrown';
+
+        SentryReport.error('AppStartup', 'ipcHost', hostThrown ?? new Error('obs.IPC.host() failed'), {
+          level: 'error',
+          // app.ts の beforeSend が /Failed to make IPC call/ を NOISE として捨てるため、
+          // 意図的に送るこのイベントには diagnostic タグが必須
+          tags: { diagnostic: 'obs-ipc-host-failed', 'ipc.hostResult': hostResultName },
+          fingerprint: ['AppStartup', 'ipcHostFailed'],
+          extra: { hostResult, hostThrown },
+        });
+
+        showDialog(ipcHostErrorToMessage(typeof hostResult === 'number' ? hostResult : -1));
+
+        electron.ipcRenderer.send('shutdownComplete');
+        return;
+      } else if (typeof hostResult !== 'number') {
+        // native の実装が number を返さないケースが実在するか実測するための情報収集。
+        // 起動不能リグレッションを避けるため成功扱いにフォールバックする
+        SentryReport.message(
+          'AppStartup',
+          'ipcHost',
+          'obs.IPC.host() returned a non-number value',
+          {
+            level: 'info',
+            tags: { diagnostic: 'obs-ipc-host-non-number-result' },
+            fingerprint: ['AppStartup', 'ipcHostNonNumberResult'],
+            extra: { hostResult },
+          },
+        );
+      }
+
       obs.NodeObs.SetWorkingDirectory(
         path.join(
           remote.app.getAppPath().replace('app.asar', 'app.asar.unpacked'),

--- a/app/app.ts
+++ b/app/app.ts
@@ -147,17 +147,18 @@ const locale = remote.app.getLocale();
 // const enum のため実行時に値が存在せず、かつ obs-api/obs-api.d.ts の re-export にも無いので、
 // 直接 import せずここに数値を持つ。NORMAL_EXIT が成功値 (0)。
 const EIPC_NORMAL_EXIT = 0;
+const EIPC_STILL_RUNNING = 259;
 const IPC_ERROR_NAMES: Record<number, string> = {
   0: 'NORMAL_EXIT',
   252: 'VERSION_MISMATCH',
   253: 'OTHER_ERROR',
   254: 'MISSING_DEPENDENCY',
-  259: 'STILL_RUNNING',
+  [EIPC_STILL_RUNNING]: 'STILL_RUNNING',
 };
 
 export const ipcHostErrorToMessage = (hostResult: number): string => {
   // 前回起動の obs64.exe がまだ終了していないケース。実際に起こりうる最有力パターンなので専用文言にする
-  if (hostResult === 259 /* STILL_RUNNING */) {
+  if (hostResult === EIPC_STILL_RUNNING) {
     if (locale === 'ja') {
       return '前回の終了処理が完了していません。しばらく待ってから、もう一度起動してください。';
     }
@@ -219,10 +220,11 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (hostThrown || (typeof hostResult === 'number' && hostResult !== EIPC_NORMAL_EXIT)) {
-        const hostResultName =
-          typeof hostResult === 'number'
-            ? IPC_ERROR_NAMES[hostResult] ?? String(hostResult)
-            : 'thrown';
+        // 例外が投げられた場合は、たとえ hostResult が number であっても
+        // その値は host() 呼び出しの結果を表していない可能性があるため 'thrown' を優先する
+        const hostResultName = hostThrown
+          ? 'thrown'
+          : IPC_ERROR_NAMES[hostResult as number] ?? String(hostResult);
 
         SentryReport.error('AppStartup', 'ipcHost', hostThrown ?? new Error('obs.IPC.host() failed'), {
           level: 'error',

--- a/app/app.ts
+++ b/app/app.ts
@@ -143,22 +143,17 @@ document.addEventListener('auxclick', (event) => event.preventDefault());
 
 const locale = remote.app.getLocale();
 
-// obs-studio-node の EIPCError (node_modules/obs-studio-node/module.d.ts) をローカルに複製したもの。
-// const enum のため実行時に値が存在せず、かつ obs-api/obs-api.d.ts の re-export にも無いので、
-// 直接 import せずここに数値を持つ。NORMAL_EXIT が成功値 (0)。
-const EIPC_NORMAL_EXIT = 0;
-const EIPC_STILL_RUNNING = 259;
 const IPC_ERROR_NAMES: Record<number, string> = {
-  0: 'NORMAL_EXIT',
-  252: 'VERSION_MISMATCH',
-  253: 'OTHER_ERROR',
-  254: 'MISSING_DEPENDENCY',
-  [EIPC_STILL_RUNNING]: 'STILL_RUNNING',
+  [obs.EIPCError.NORMAL_EXIT]: 'NORMAL_EXIT',
+  [obs.EIPCError.VERSION_MISMATCH]: 'VERSION_MISMATCH',
+  [obs.EIPCError.OTHER_ERROR]: 'OTHER_ERROR',
+  [obs.EIPCError.MISSING_DEPENDENCY]: 'MISSING_DEPENDENCY',
+  [obs.EIPCError.STILL_RUNNING]: 'STILL_RUNNING',
 };
 
 export const ipcHostErrorToMessage = (hostResult: number): string => {
   // 前回起動の obs64.exe がまだ終了していないケース。実際に起こりうる最有力パターンなので専用文言にする
-  if (hostResult === EIPC_STILL_RUNNING) {
+  if (hostResult === obs.EIPCError.STILL_RUNNING) {
     if (locale === 'ja') {
       return '前回の終了処理が完了していません。しばらく待ってから、もう一度起動してください。';
     }
@@ -219,7 +214,10 @@ document.addEventListener('DOMContentLoaded', () => {
         hostThrown = e;
       }
 
-      if (hostThrown || (typeof hostResult === 'number' && hostResult !== EIPC_NORMAL_EXIT)) {
+      if (
+        hostThrown ||
+        (typeof hostResult === 'number' && hostResult !== obs.EIPCError.NORMAL_EXIT)
+      ) {
         // 例外が投げられた場合は、たとえ hostResult が number であっても
         // その値は host() 呼び出しの結果を表していない可能性があるため 'thrown' を優先する
         const hostResultName = hostThrown

--- a/obs-api/obs-api.d.ts
+++ b/obs-api/obs-api.d.ts
@@ -13,6 +13,7 @@ export {
   EFontStyle,
   EFPSType,
   EInteractionFlags,
+  EIPCError,
   EMonitoringType,
   EMouseButtonType,
   ENumberType,


### PR DESCRIPTION
## このpull requestが解決する内容

`obs.IPC.host()` の戻り値・例外を検査せずに無視していたため、obs64.exe の起動に失敗しても検知できず、以降の全OBS呼び出しが原因不明の初期化エラーになる問題を修正します。

## 背景

`#1380` の調査で、`app/app.ts` の `obs.IPC.host(remote.process.env.IPC_UUID);` が起動時に1回呼ばれるだけで、戻り値（`EIPCError`）も例外も一切扱っていないことが分かりました。obs-studio-node の型定義（`module.d.ts`）によれば、`host()` は失敗すると `STILL_RUNNING`（前回の obs64.exe が終了していない）等のエラーコードを返すか、例外を throw します。

これを無視すると、obs64.exe が起動していないまま `OBS_API_initAPI` 以降の全OBS呼び出しが実行され、原因不明の初期化エラーに繋がっていました。

## 変更内容

- `app/app.ts`
  - `obs.IPC.host()` の戻り値・例外を検査するよう変更
  - 失敗時は Sentry へ診断情報（`diagnostic: 'obs-ipc-host-failed'` タグ、`obs.lastOp` breadcrumb）を送りつつ、`ipcHostErrorToMessage()`（新規、`apiInitErrorResultToMessage` と同じ locale 直分岐パターン）でエラーダイアログを表示して終了
  - `STILL_RUNNING`（前回起動の obs64.exe がまだ終了していないケース）には専用の文言を用意
  - `InitShutdownSequence()` / `IPC.disconnect()` は呼ばない（host が失敗＝接続が確立していないため未定義動作になりうる）
  - native 実装が `number` を返さないケースを起動不能リグレッションなく吸収するため、`typeof` チェックでフォールバックし、非number実測値も `level: 'info'` で Sentry に収集する

## 設計上の注意

`EIPCError` は obs-studio-node の `const enum` で、`obs-api/obs-api.d.ts` の re-export にも無く実行時に値が存在しないため、直接 import せずローカルに数値マップを複製しています（コメントに出典を明記）。

`STILL_RUNNING` 経路（前回の obs64.exe が終了していない状態での起動）は、意図的に安全に再現する手順が確立していないため未検証です。過去の調査で obs64.exe を `taskkill` すると開発ビルドではアプリ全体が即死する（本来想定している「obs64だけ生きていて再接続できない」状態と異なる）ことが分かっており、`STILL_RUNNING` を安全に再現する手段は今回の変更のスコープ外としています。`typeof` チェックによる正常系優先のフォールバックがあるため、想定外の戻り値が来ても起動不能にはなりません。

## テスト

- `pnpm run typecheck` / `pnpm exec eslint app/app.ts` で確認済み
- `app/app.ts` は `DOMContentLoaded` ハンドラ内のロジックのため既存も含めユニットテスト不可（`apiInitErrorResultToMessage` も同様に未テスト）

関連: #1380

### 手動確認（要人手）
- [x] 通常起動でリグレッションがないこと（`hostResult` が `0` を返す想定通りの正常系）
