### PR TITLE
修正: ソース削除後もプロパティ・フィルタ画面が閉じずに残る問題を修正

### DIFF
--- a/app/components/sources/BrowserSourceInteraction.vue
+++ b/app/components/sources/BrowserSourceInteraction.vue
@@ -12,7 +12,7 @@
         style="height: 100%; outline: none"
         ref="eventDiv"
       >
-        <Display :sourceId="sourceId" @outputResize="onOutputResize" />
+        <Display v-if="source" :sourceId="sourceId" @outputResize="onOutputResize" />
       </div>
     </template>
   </ModalLayout>

--- a/app/components/sources/BrowserSourceInteraction.vue.ts
+++ b/app/components/sources/BrowserSourceInteraction.vue.ts
@@ -1,5 +1,6 @@
 import Display from 'components/shared/Display.vue';
 import ModalLayout from 'components/shared/ModalLayout.vue';
+import { Subscription } from 'rxjs';
 import { SourcesService } from 'services/sources';
 import Utils from 'services/utils';
 import { WindowsService } from 'services/windows';
@@ -13,6 +14,7 @@ export default defineComponent({
   data() {
     return {
       currentRegion: { x: 0, y: 0, width: 1, height: 1 } as IRectangle,
+      sourceRemovedSub: null as Subscription | null,
     };
   },
 
@@ -29,6 +31,17 @@ export default defineComponent({
 
   mounted(): void {
     (this.$refs.eventDiv as HTMLDivElement).focus();
+
+    // ソースが削除されたら display の500msポーリングを止めるため window を閉じる（#1380）
+    this.sourceRemovedSub = SourcesService.instance().sourceRemoved.subscribe((source) => {
+      if (source.sourceId === this.sourceId) {
+        WindowsService.instance().closeChildWindow();
+      }
+    });
+  },
+
+  unmounted(): void {
+    this.sourceRemovedSub?.unsubscribe();
   },
 
   methods: {

--- a/app/components/sources/BrowserSourceInteraction.vue.ts
+++ b/app/components/sources/BrowserSourceInteraction.vue.ts
@@ -62,6 +62,8 @@ export default defineComponent({
     },
 
     onWheel(e: WheelEvent): void {
+      // ソース削除直後、windowが閉じるまでの短い間 source が undefined になりうる（#1380）
+      if (!this.source) return;
       this.source.mouseWheel(this.eventLocationInSourceSpace(e), {
         x: e.deltaX,
         y: e.deltaY,
@@ -69,25 +71,30 @@ export default defineComponent({
     },
 
     onMousedown(e: MouseEvent): void {
+      if (!this.source) return;
       this.source.mouseClick(e.button, this.eventLocationInSourceSpace(e), false);
     },
 
     onMouseup(e: MouseEvent): void {
+      if (!this.source) return;
       this.source.mouseClick(e.button, this.eventLocationInSourceSpace(e), true);
     },
 
     onMousemove(e: MouseEvent): void {
+      if (!this.source) return;
       const pos = this.eventLocationInSourceSpace(e);
       if (pos.x < 0 || pos.y < 0) return;
       this.source.mouseMove(pos);
     },
 
     onKeydown(e: KeyboardEvent): void {
+      if (!this.source) return;
       if (this.isModifierPress(e)) return;
       this.source.keyInput(e.key, e.keyCode, false, this.getModifiers(e));
     },
 
     onKeyup(e: KeyboardEvent): void {
+      if (!this.source) return;
       if (this.isModifierPress(e)) return;
       this.source.keyInput(e.key, e.keyCode, true, this.getModifiers(e));
     },

--- a/app/components/sources/SourceFilters.vue
+++ b/app/components/sources/SourceFilters.vue
@@ -1,6 +1,6 @@
 <template>
   <modal-layout :show-cancel="false" :done-handler="done" :fixedSectionHeight="250" bare-content>
-    <template #fixed><display :sourceId="sourceId" /></template>
+    <template #fixed><display v-if="source" :sourceId="sourceId" /></template>
 
     <template #content>
       <div class="container" data-test="SourceFilters">

--- a/app/components/sources/SourceFilters.vue.ts
+++ b/app/components/sources/SourceFilters.vue.ts
@@ -3,6 +3,7 @@ import Display from 'components/shared/Display.vue';
 import ModalLayout from 'components/shared/ModalLayout.vue';
 import NavItem from 'components/shared/NavItem.vue';
 import NavMenu from 'components/shared/NavMenu.vue';
+import { Subscription } from 'rxjs';
 import { ISourceFilter, SourceFiltersService } from 'services/source-filters';
 import { SourcesService } from 'services/sources';
 import { WindowsService } from 'services/windows';
@@ -45,10 +46,15 @@ export default defineComponent({
       filters,
       selectedFilterName,
       properties,
+      sourceRemovedSub: null as Subscription | null,
     };
   },
 
   computed: {
+    source() {
+      return SourcesService.instance().getSource(this.sourceId);
+    },
+
     sourceDisplayName(): string {
       return SourcesService.instance().getSource(this.sourceId).name;
     },
@@ -76,6 +82,19 @@ export default defineComponent({
         );
       },
     },
+  },
+
+  mounted(): void {
+    // ソースが削除されたら display の500msポーリングを止めるため window を閉じる（#1380）
+    this.sourceRemovedSub = SourcesService.instance().sourceRemoved.subscribe((source) => {
+      if (source.sourceId === this.sourceId) {
+        WindowsService.instance().closeChildWindow();
+      }
+    });
+  },
+
+  unmounted(): void {
+    this.sourceRemovedSub?.unsubscribe();
   },
 
   methods: {

--- a/app/services/sources/sources.test.ts
+++ b/app/services/sources/sources.test.ts
@@ -230,6 +230,18 @@ describe('removeSource', () => {
     expect(instance.sourceRemoved.next).toHaveBeenCalledWith(fakeSource.state);
   });
 
+  test('sourceRemoved.next には REMOVE_SOURCE 前のスナップショットが渡される（state delete 後の評価順バグ回避）', () => {
+    const { instance } = setupRemoveSourceInstance({ audio: true });
+
+    instance.removeSource('test-source-id');
+
+    // REMOVE_SOURCE で state.sources から削除された後でも、
+    // next に渡された値には削除前の内容（sourceId / audio）が正しく残っていること
+    expect(instance.sourceRemoved.next).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'test-source-id', audio: true }),
+    );
+  });
+
   test('存在しない id では Source not found を throw する', () => {
     const { instance } = setupRemoveSourceInstance();
     instance.getSource = jest.fn().mockReturnValue(undefined);

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -228,6 +228,11 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
     if (!source) throw new Error(`Source ${id} not found`);
 
+    // REMOVE_SOURCE で state からキーが delete された後に source.state を評価すると、
+    // Vuex の reactive proxy 越しの delete で invalidate される可能性があるため、
+    // 削除前にスナップショットを取っておく（#1380）
+    const removedState = { ...source.state };
+
     /* When we release sources, we need to make
      * sure we reset the channel it's set to,
      * otherwise OBS thinks it's still attached
@@ -264,7 +269,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     // OBS 側の解放に失敗しても state からは必ず外す。
     // 残すと同じソースを二度と削除できなくなる（#1380）
     this.REMOVE_SOURCE(id);
-    this.sourceRemoved.next(source.state);
+    this.sourceRemoved.next(removedState);
   }
 
   /**

--- a/app/services/video.test.ts
+++ b/app/services/video.test.ts
@@ -149,19 +149,20 @@ describe('Display ライフサイクルガード', () => {
 });
 
 describe('VideoService OBSラッパー エラー格下げ', () => {
-  function setupVideoService() {
+  function setupVideoService(obsIpcHealthService = { notifyIpcLost: jest.fn() }) {
     const { __setup } = require('services/core/injector');
     __setup({
       SettingsService: { loadSettingsIntoStore: jest.fn() },
       VideoSettingsService: {},
+      ObsIpcHealthService: obsIpcHealthService,
     });
     const { VideoService } = require('./video');
-    return VideoService.instance();
+    return { instance: VideoService.instance(), obsIpcHealthService };
   }
 
   test('moveOBSDisplayが"Invalid key"エラーを投げてもwarnとして格下げされ伝播しない', () => {
     const obsApi = require('../../obs-api');
-    const instance = setupVideoService();
+    const { instance } = setupVideoService();
 
     obsApi.NodeObs.OBS_content_moveDisplay.mockImplementation(() => {
       throw new Error('Invalid key provided to moveDisplay: some-uuid');
@@ -178,7 +179,7 @@ describe('VideoService OBSラッパー エラー格下げ', () => {
 
   test('destroyOBSDisplayが"Failed to find key"エラーを投げてもwarnとして格下げされ伝播しない', () => {
     const obsApi = require('../../obs-api');
-    const instance = setupVideoService();
+    const { instance } = setupVideoService();
 
     obsApi.NodeObs.OBS_content_destroyDisplay.mockImplementation(() => {
       throw new Error('Failed to find key for destruction: some-uuid');
@@ -193,14 +194,92 @@ describe('VideoService OBSラッパー エラー格下げ', () => {
     warnSpy.mockRestore();
   });
 
+  test('setOBSDisplayShouldDrawUIが"Invalid key"エラーを投げてもwarnとして格下げされ伝播しない（一般化した正規表現の確認）', () => {
+    const obsApi = require('../../obs-api');
+    const { instance } = setupVideoService();
+
+    obsApi.NodeObs.OBS_content_setShouldDrawUI.mockImplementation(() => {
+      throw new Error('Invalid key provided to setShouldDrawUI: some-uuid');
+    });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => instance.setOBSDisplayShouldDrawUI('some-uuid', true)).not.toThrow();
+    warnSpy.mockRestore();
+  });
+
   test('既知でないエラーはmoveOBSDisplayから再スローされる', () => {
     const obsApi = require('../../obs-api');
-    const instance = setupVideoService();
+    const { instance } = setupVideoService();
 
     obsApi.NodeObs.OBS_content_moveDisplay.mockImplementation(() => {
       throw new Error('OOM: out of memory');
     });
 
     expect(() => instance.moveOBSDisplay('some-uuid', 0, 0)).toThrow('OOM: out of memory');
+  });
+});
+
+describe('VideoService OBSラッパー IPC切断検知（#1380）', () => {
+  function setupVideoService(obsIpcHealthService = { notifyIpcLost: jest.fn() }) {
+    const { __setup } = require('services/core/injector');
+    __setup({
+      SettingsService: { loadSettingsIntoStore: jest.fn() },
+      VideoSettingsService: {},
+      ObsIpcHealthService: obsIpcHealthService,
+    });
+    const { VideoService } = require('./video');
+    return { instance: VideoService.instance(), obsIpcHealthService };
+  }
+
+  test('moveOBSDisplayがIPC切断エラーを投げるとnotifyIpcLostが呼ばれ再スローされない', () => {
+    const obsApi = require('../../obs-api');
+    const { instance, obsIpcHealthService } = setupVideoService();
+
+    obsApi.NodeObs.OBS_content_moveDisplay.mockImplementation(() => {
+      throw new Error('Failed to make IPC call, verify IPC status.');
+    });
+
+    expect(() => instance.moveOBSDisplay('some-uuid', 0, 0)).not.toThrow();
+    expect(obsIpcHealthService.notifyIpcLost).toHaveBeenCalledWith('VideoService.moveOBSDisplay');
+  });
+
+  test('destroyOBSDisplayが"Lost IPC Connection"を投げるとnotifyIpcLostが呼ばれる', () => {
+    const obsApi = require('../../obs-api');
+    const { instance, obsIpcHealthService } = setupVideoService();
+
+    obsApi.NodeObs.OBS_content_destroyDisplay.mockImplementation(() => {
+      throw new Error('Lost IPC Connection');
+    });
+
+    expect(() => instance.destroyOBSDisplay('some-uuid')).not.toThrow();
+    expect(obsIpcHealthService.notifyIpcLost).toHaveBeenCalledWith('VideoService.destroyOBSDisplay');
+  });
+
+  test('getOBSDisplayPreviewOffsetがIPC切断エラーを投げるとfallback値が返る', () => {
+    const obsApi = require('../../obs-api');
+    const { instance, obsIpcHealthService } = setupVideoService();
+
+    obsApi.NodeObs.OBS_content_getDisplayPreviewOffset.mockImplementation(() => {
+      throw new Error('Failed to make IPC call, verify IPC status.');
+    });
+
+    expect(instance.getOBSDisplayPreviewOffset('some-uuid')).toEqual({ x: 0, y: 0 });
+    expect(obsIpcHealthService.notifyIpcLost).toHaveBeenCalledWith(
+      'VideoService.getOBSDisplayPreviewOffset',
+    );
+  });
+
+  test('setOBSDisplayDrawGuideLinesがIPC切断エラーを投げるとnotifyIpcLostが呼ばれる', () => {
+    const obsApi = require('../../obs-api');
+    const { instance, obsIpcHealthService } = setupVideoService();
+
+    obsApi.NodeObs.OBS_content_setDrawGuideLines.mockImplementation(() => {
+      throw new Error('Failed to make IPC call, verify IPC status.');
+    });
+
+    expect(() => instance.setOBSDisplayDrawGuideLines('some-uuid', true)).not.toThrow();
+    expect(obsIpcHealthService.notifyIpcLost).toHaveBeenCalledWith(
+      'VideoService.setOBSDisplayDrawGuideLines',
+    );
   });
 });

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -1,7 +1,10 @@
 import * as remote from '@electron/remote';
+import * as Sentry from '@sentry/vue';
 import { Subscription } from 'rxjs';
 import { InitAfter } from 'services/core';
+import { ObsIpcHealthService } from 'services/obs-ipc-health';
 import { SelectionService } from 'services/selection';
+import { isObsBackendIpcLost } from 'util/obs-ipc-error';
 
 import * as obs from '../../obs-api';
 import { ScalableRectangle } from '../util/ScalableRectangle';
@@ -30,7 +33,6 @@ export class Display {
 
   outputRegionCallbacks: Function[];
   outputRegion: IRectangle;
-  isDestroyed = false;
 
   trackingInitialTimeout: ReturnType<typeof setTimeout>;
   trackingInterval: number;
@@ -216,6 +218,7 @@ export class Display {
 export class VideoService extends Service {
   @Inject() settingsService: SettingsService;
   @Inject() videoSettingsService: VideoSettingsService;
+  @Inject() private obsIpcHealthService: ObsIpcHealthService;
 
   init() {
     this.settingsService.loadSettingsIntoStore();
@@ -302,71 +305,82 @@ export class VideoService extends Service {
   }
 
   moveOBSDisplay(name: string, x: number, y: number) {
-    try {
-      obs.NodeObs.OBS_content_moveDisplay(name, x, y);
-    } catch (e) {
-      if (isKnownDisplayRaceError(e)) {
-        console.warn('[VideoService] moveOBSDisplay:', e.message);
-        return;
-      }
-      throw e;
-    }
+    this.tryDisplayOp('moveOBSDisplay', () => obs.NodeObs.OBS_content_moveDisplay(name, x, y), undefined);
   }
 
   resizeOBSDisplay(name: string, width: number, height: number) {
-    try {
-      obs.NodeObs.OBS_content_resizeDisplay(name, width, height);
-    } catch (e) {
-      if (isKnownDisplayRaceError(e)) {
-        console.warn('[VideoService] resizeOBSDisplay:', e.message);
-        return;
-      }
-      throw e;
-    }
+    this.tryDisplayOp(
+      'resizeOBSDisplay',
+      () => obs.NodeObs.OBS_content_resizeDisplay(name, width, height),
+      undefined,
+    );
   }
 
   destroyOBSDisplay(name: string) {
-    try {
-      obs.NodeObs.OBS_content_destroyDisplay(name);
-    } catch (e) {
-      if (isKnownDisplayRaceError(e)) {
-        console.warn('[VideoService] destroyOBSDisplay:', e.message);
-        return;
-      }
-      throw e;
-    }
+    this.tryDisplayOp('destroyOBSDisplay', () => obs.NodeObs.OBS_content_destroyDisplay(name), undefined);
   }
 
   getOBSDisplayPreviewOffset(name: string): IVec2 {
-    try {
-      return obs.NodeObs.OBS_content_getDisplayPreviewOffset(name);
-    } catch (e) {
-      if (isKnownDisplayRaceError(e)) {
-        console.warn('[VideoService] getOBSDisplayPreviewOffset:', e.message);
-        return { x: 0, y: 0 };
-      }
-      throw e;
-    }
+    return this.tryDisplayOp(
+      'getOBSDisplayPreviewOffset',
+      () => obs.NodeObs.OBS_content_getDisplayPreviewOffset(name),
+      { x: 0, y: 0 },
+    );
   }
 
   getOBSDisplayPreviewSize(name: string): { width: number; height: number } {
-    try {
-      return obs.NodeObs.OBS_content_getDisplayPreviewSize(name);
-    } catch (e) {
-      if (isKnownDisplayRaceError(e)) {
-        console.warn('[VideoService] getOBSDisplayPreviewSize:', e.message);
-        return { width: 0, height: 0 };
-      }
-      throw e;
-    }
+    return this.tryDisplayOp(
+      'getOBSDisplayPreviewSize',
+      () => obs.NodeObs.OBS_content_getDisplayPreviewSize(name),
+      { width: 0, height: 0 },
+    );
   }
 
   setOBSDisplayShouldDrawUI(name: string, drawUI: boolean) {
-    obs.NodeObs.OBS_content_setShouldDrawUI(name, drawUI);
+    this.tryDisplayOp(
+      'setOBSDisplayShouldDrawUI',
+      () => obs.NodeObs.OBS_content_setShouldDrawUI(name, drawUI),
+      undefined,
+    );
   }
 
   setOBSDisplayDrawGuideLines(name: string, drawGuideLines: boolean) {
-    obs.NodeObs.OBS_content_setDrawGuideLines(name, drawGuideLines);
+    this.tryDisplayOp(
+      'setOBSDisplayDrawGuideLines',
+      () => obs.NodeObs.OBS_content_setDrawGuideLines(name, drawGuideLines),
+      undefined,
+    );
+  }
+
+  /**
+   * display 系のネイティブ呼び出しを共通のエラーハンドリングで包む。
+   * - OBS バックエンドIPC切断（n-air-app#1380）: ObsIpcHealthService に通知して fallback を返す。
+   *   display のトラッキングは500ms間隔（PerformanceServiceの2秒より速い）なので、早期検知の入口になる。
+   * - 既知のdisplayレース（ウィンドウ破棄と操作のタイミング競合）: 従来通りwarnに格下げしてfallbackを返す。
+   * - それ以外は再スローする。
+   */
+  private tryDisplayOp<T>(method: string, fn: () => T, fallback: T): T {
+    try {
+      return fn();
+    } catch (e) {
+      if (isObsBackendIpcLost(e)) {
+        // 復旧不能な切断。ObsIpcHealthService 側で1度だけ Sentry 報告＋ダイアログを出すので、
+        // ここでは個別の SentryReport / breadcrumb を積まない
+        this.obsIpcHealthService.notifyIpcLost(`VideoService.${method}`);
+        return fallback;
+      }
+      if (isKnownDisplayRaceError(e)) {
+        console.warn(`[VideoService] ${method}:`, e.message);
+        // 正規表現で汎用的に拾っているため、本物のバグが握り潰されていないか観測可能にする
+        Sentry.addBreadcrumb({
+          category: 'video.displayRace',
+          message: `${method}: ${e.message}`,
+          level: 'info',
+        });
+        return fallback;
+      }
+      throw e;
+    }
   }
 }
 
@@ -376,8 +390,5 @@ export class VideoService extends Service {
  */
 function isKnownDisplayRaceError(e: unknown): e is Error {
   if (!(e instanceof Error)) return false;
-  return (
-    e.message.startsWith('Invalid key provided to moveDisplay:') ||
-    e.message.startsWith('Failed to find key for destruction:')
-  );
+  return /^(Invalid key provided to \w+:|Failed to find key for destruction:)/.test(e.message);
 }


### PR DESCRIPTION
## このpull requestが解決する内容

`VideoService` の display 系ネイティブ呼び出し（500msポーリング）がOBSバックエンドIPC切断エラーを検知せず、`PerformanceService` の2秒ポーリングより早く検知できるはずの経路が活かされていなかった問題を修正します。あわせて `removeSource()` の評価順バグと、ソース削除後もdisplayのポーリングが続く問題も修正します。

## 背景

`#1380` の調査で、当初 issue に書いた「`release()` を `sourceRemoved.next()` の後に移す」対応案は効果が無いことが判明しました。`sourceId` 付き Display はすべて子ウィンドウ/one-offウィンドウにあり、`sourceRemoved` はローカルの rxjs Subject でプロセス境界を越えて同期的に伝播しないため、`release()` の位置を変えても display の破棄タイミングには影響しません（かつ `REMOVE_SOURCE` で state から消えた後に `getObsInput()` を呼ぶ新たなバグを生みます）。

代わりに、display のトラッキングが500ms間隔（`PerformanceService` の2秒より速い）であることを活かし、display 系呼び出しの中で直接IPC切断を検知する方式に変更しました。

## 変更内容

- `app/services/video.ts`
  - `VideoService` に `ObsIpcHealthService` を注入し、display 系7メソッド（`moveOBSDisplay` 等）を共通ヘルパー `tryDisplayOp()` で保護
  - IPC切断エラー（`isObsBackendIpcLost()`）を検知したら `ObsIpcHealthService.notifyIpcLost()` を呼んでfallbackを返す（従来は未捕捉例外として500msごとに漏れていた）
  - 既知の display レースエラー判定（`isKnownDisplayRaceError`）を正規表現で汎用化し、`setOBSDisplayShouldDrawUI` / `setOBSDisplayDrawGuideLines`（従来ガード無し）にも同じ保護を追加。汎用化した分は breadcrumb（`level: info`）で観測可能にした
  - 未使用の `Display.isDestroyed` フィールドを削除
- `app/services/sources/sources.ts`
  - `removeSource()` が `REMOVE_SOURCE`（state からの delete）の**後**に `source.state` を評価していた評価順バグを修正。削除前にスナップショットを取得してから `sourceRemoved.next()` に渡すようにした
- `app/components/sources/SourceFilters.vue` / `.vue.ts`, `app/components/sources/BrowserSourceInteraction.vue` / `.vue.ts`
  - `sourceRemoved` を購読して該当ソースが削除されたらウィンドウを閉じるようにし、テンプレートに `v-if="source"` を追加。従来はソース削除後もdisplayの500msポーリングが継続していた（`SourceProperties.vue` の既存パターンを移植）

## テスト

- `app/services/video.test.ts` に IPC切断検知（4テスト）、既存レースエラー処理の一般化確認を追加
- `app/services/sources/sources.test.ts` に評価順バグの回帰テストを追加
- `pnpm run test:unit:app` / `pnpm run typecheck` で確認済み（全74スイート成功）

関連: #1380

### 手動確認（要人手）
- [x] ソースプロパティ / ソースフィルタ / ブラウザソースのインタラクトウィンドウを開いた状態で、main側からそのソースを削除 → ウィンドウが閉じ、コンソールに `Invalid key provided to` 系のエラーが出ないこと
