### PR TITLE
開発: ソースプロパティ操作時のOBS呼び出し回数を削減

### DIFF
--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -334,7 +334,6 @@ export function getPropertiesFormData(obsSource: obs.ISource): TObsFormData {
   const sourceType = obsSource.id;
   const formData: TObsFormData = [];
   const obsProps = obsSource.properties;
-  const obsSettings = obsSource.settings;
 
   if (!obsProps) return null;
   if (!obsProps.count()) return null;

--- a/app/services/audio/audio.test.ts
+++ b/app/services/audio/audio.test.ts
@@ -1,0 +1,153 @@
+/**
+ * AudioService: sourceUpdated 購読時の reroute_audio 判定のテスト
+ *
+ * 従来は getPropertiesFormData() の全プロパティ走査で reroute_audio を探していたが、
+ * settings の直接読みに変更した(#1380)。挙動が変わりうる箇所（nvoice-character の
+ * blacklist 差異、reroute_audio が undefined のケース）を中心に検証する。
+ */
+import { Subject } from 'rxjs';
+import { createSetupFunction } from 'util/test-setup';
+
+jest.mock('services/core/stateful-service');
+jest.mock('services/core/injector');
+jest.mock('services/core/service-initialization-observer', () => ({
+  InitAfter: () => () => {},
+}));
+jest.mock('services/core/service-helper', () => ({
+  ServiceHelper: () => () => {},
+}));
+
+jest.mock('services/i18n', () => ({ $t: (key: string) => key }));
+
+jest.mock('services/sources', () => {
+  const actual = jest.requireActual('services/sources/sources-api');
+  return {
+    isNoAudioPropertiesManagerType: actual.isNoAudioPropertiesManagerType,
+  };
+});
+
+jest.mock('../../../obs-api', () => ({
+  NodeObs: {
+    RegisterVolmeterCallback: jest.fn(),
+  },
+  ESourceFlags: { ForceMono: 1 },
+}));
+
+function makeSourcesServiceMock() {
+  return {
+    sourceAdded: new Subject<any>(),
+    sourceUpdated: new Subject<any>(),
+    sourceRemoved: new Subject<any>(),
+    getSource: jest.fn(),
+  };
+}
+
+function makeObsInput(settings: Dictionary<any> = {}) {
+  return { settings };
+}
+
+const setup = createSetupFunction({
+  injectee: {
+    ScenesService: { sceneSwitched: { subscribe: jest.fn() } },
+    WindowsService: {},
+  },
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe('AudioService: sourceUpdated での reroute_audio 判定', () => {
+  function setupInstance() {
+    const sourcesService = makeSourcesServiceMock();
+    setup({ injectee: { SourcesService: sourcesService } });
+
+    const { AudioService } = require('./audio');
+    const instance = AudioService.instance();
+    instance.state = { audioSources: { src1: { sourceId: 'src1' } } };
+    // AudioSource の生成には AudioService/SourcesService への @Inject が必要で
+    // このテストの主眼(reroute_audio 判定)には無関係なため、getSource をスタブして回避する
+    instance.getSource = jest.fn().mockReturnValue(undefined);
+    instance.init();
+
+    const updateSpy = jest.spyOn(instance, 'UPDATE_AUDIO_SOURCE' as any);
+    const changedSpy = jest.spyOn(instance.audioSourcesChanged, 'next');
+
+    return { instance, sourcesService, updateSpy, changedSpy };
+  }
+
+  test('getPropertiesFormData を呼ばずに settings.reroute_audio から isControlledViaObs を設定する', () => {
+    const { sourcesService, updateSpy, changedSpy } = setupInstance();
+
+    const getPropertiesFormData = jest.fn();
+    sourcesService.getSource.mockReturnValue({
+      getObsInput: () => makeObsInput({ reroute_audio: true }),
+      getPropertiesFormData,
+    });
+
+    sourcesService.sourceUpdated.next({
+      sourceId: 'src1',
+      audio: false,
+      muted: false,
+      propertiesManagerType: 'default',
+    });
+
+    expect(getPropertiesFormData).not.toHaveBeenCalled();
+    expect(updateSpy).toHaveBeenCalledWith('src1', { isControlledViaObs: true });
+    expect(changedSpy).toHaveBeenCalled();
+  });
+
+  test('reroute_audio が false でも isControlledViaObs が設定される', () => {
+    const { sourcesService, updateSpy } = setupInstance();
+
+    sourcesService.getSource.mockReturnValue({
+      getObsInput: () => makeObsInput({ reroute_audio: false }),
+    });
+
+    sourcesService.sourceUpdated.next({
+      sourceId: 'src1',
+      audio: false,
+      muted: false,
+      propertiesManagerType: 'default',
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith('src1', { isControlledViaObs: false });
+  });
+
+  test('reroute_audio が undefined（プロパティ自体を持たないソース）ならスキップする', () => {
+    const { sourcesService, updateSpy, changedSpy } = setupInstance();
+
+    sourcesService.getSource.mockReturnValue({
+      getObsInput: () => makeObsInput({}),
+    });
+
+    sourcesService.sourceUpdated.next({
+      sourceId: 'src1',
+      audio: false,
+      muted: false,
+      propertiesManagerType: 'default',
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(changedSpy).not.toHaveBeenCalled();
+  });
+
+  test('propertiesManagerType が nvoice-character の場合はスキップする（blacklist差異の維持）', () => {
+    const { sourcesService, updateSpy } = setupInstance();
+
+    sourcesService.getSource.mockReturnValue({
+      getObsInput: () => makeObsInput({ reroute_audio: true }),
+    });
+
+    sourcesService.sourceUpdated.next({
+      sourceId: 'src1',
+      audio: false,
+      muted: false,
+      propertiesManagerType: 'nvoice-character',
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(sourcesService.getSource).not.toHaveBeenCalled();
+  });
+});

--- a/app/services/audio/audio.test.ts
+++ b/app/services/audio/audio.test.ts
@@ -133,6 +133,24 @@ describe('AudioService: sourceUpdated での reroute_audio 判定', () => {
     expect(changedSpy).not.toHaveBeenCalled();
   });
 
+  test('reroute_audio が null でもスキップする（generateAudioSourceData の == null 判定と揃える）', () => {
+    const { sourcesService, updateSpy, changedSpy } = setupInstance();
+
+    sourcesService.getSource.mockReturnValue({
+      getObsInput: () => makeObsInput({ reroute_audio: null }),
+    });
+
+    sourcesService.sourceUpdated.next({
+      sourceId: 'src1',
+      audio: false,
+      muted: false,
+      propertiesManagerType: 'default',
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(changedSpy).not.toHaveBeenCalled();
+  });
+
   test('propertiesManagerType が nvoice-character の場合はスキップする（blacklist差異の維持）', () => {
     const { sourcesService, updateSpy } = setupInstance();
 

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -90,15 +90,19 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     this.sourcesService.sourceUpdated.subscribe((source) => {
       const audioSource = this.getSource(source.sourceId);
 
-      const obsSource = this.sourcesService.getSource(source.sourceId);
-      const formData = obsSource
-        .getPropertiesFormData()
-        .find((data) => data.name === 'reroute_audio');
-      if (formData) {
-        this.UPDATE_AUDIO_SOURCE(source.sourceId, {
-          isControlledViaObs: !!formData.value,
-        });
-        this.audioSourcesChanged.next();
+      // reroute_audio は browser_source 専用プロパティ。従来は getPropertiesFormData() の
+      // 全プロパティ走査(1操作あたり数百回のnative呼び出し)で探していたが、settings の直接読みで
+      // 十分なため置き換える(#1380)。nvoice-character は reroute_audio を blacklist に
+      // 入れて隠しているため、従来通りスキップする(generateAudioSourceData と同じ判定)。
+      if (!isNoAudioPropertiesManagerType(source.propertiesManagerType)) {
+        const obsSource = this.sourcesService.getSource(source.sourceId);
+        const rerouteAudio = obsSource.getObsInput().settings?.reroute_audio;
+        if (rerouteAudio !== undefined) {
+          this.UPDATE_AUDIO_SOURCE(source.sourceId, {
+            isControlledViaObs: !!rerouteAudio,
+          });
+          this.audioSourcesChanged.next();
+        }
       }
 
       const useAudio = source.audio && !isNoAudioPropertiesManagerType(source.propertiesManagerType);

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -97,7 +97,9 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
       if (!isNoAudioPropertiesManagerType(source.propertiesManagerType)) {
         const obsSource = this.sourcesService.getSource(source.sourceId);
         const rerouteAudio = obsSource.getObsInput().settings?.reroute_audio;
-        if (rerouteAudio !== undefined) {
+        // generateAudioSourceData() は null/undefined を「プロパティ未定義」として
+        // isControlledViaObs: true 扱いにしている(== null で判定)ため、ここも揃える
+        if (rerouteAudio != null) {
           this.UPDATE_AUDIO_SOURCE(source.sourceId, {
             isControlledViaObs: !!rerouteAudio,
           });


### PR DESCRIPTION
## このpull requestが解決する内容

`AudioService` がソースプロパティ変更ごとに `getPropertiesFormData()` の全プロパティ走査（1操作あたり数百回の同期native呼び出し）を行い、`reroute_audio` プロパティ1個を探していた問題を修正します。

## 背景

`#1380` の調査で、当初 issue に書いた「ソースプロパティのドロップダウンに debounce を入れる」対応案は効果が無いことが判明しました。debounce が効くのは連打時のみで、実際の操作（デバイスを1回選ぶ等）では1回しか発火しないため効果はゼロです。

真の問題は1操作あたりの native 呼び出し数でした。`getPropertiesFormData()` の全プロパティ走査は `ObsInput.setPropertiesFormData()` 内・`SourceProperties.vue.ts` の自己発火 `refresh()`・`AudioService` の `sourceUpdated` 購読の3箇所で走っており、dshow_input（20+プロパティ）では1操作あたり600〜800回の同期native呼び出しになっていました。このPRはそのうちの1箇所（`AudioService`）を修正します。

## 変更内容

- `app/services/audio/audio.ts`
  - `sourceUpdated` 購読内の `reroute_audio` 取得を `getPropertiesFormData()` の全走査から、既存の `generateAudioSourceData()` と同じ `settings` の直接読みに変更
  - `reroute_audio` は `browser_source` 専用プロパティで、`nvoice-character` は `blacklist` でこのプロパティを隠しているため、`isNoAudioPropertiesManagerType()` で従来と同じスキップ判定を維持
- `app/components/obs/inputs/ObsInput.ts`
  - 未使用の変数 `obsSettings`（native の `settings` getter を無駄に1回呼んでいた）を削除

## テスト

- `app/services/audio/audio.test.ts`（新規）: `getPropertiesFormData` を呼ばないこと、`settings.reroute_audio` からの判定、`undefined` 時のスキップ、`nvoice-character` の blacklist 差異維持
- `pnpm run test:unit:app` / `pnpm run typecheck` で確認済み（全74スイート成功）

`nvoice-character` の blacklist 差異、dshow のデバイス切替はユニットテストでカバーしている。実機（音声合成ライセンス・Webカメラ）を使った手動確認は環境が無ければスキップしてよい。

関連: #1380

### 手動確認（要人手・環境があれば）
- [x] ブラウザソースのプロパティで「N Airを介して音声を制御する」をON/OFF → ミキサーに現れる/消えることを確認
