### PR TITLE
改善: 設定ウィンドウを配信状態の変化にリアルタイムに追従

### DIFF
--- a/app/components/settings/ExtraSettings.vue.ts
+++ b/app/components/settings/ExtraSettings.vue.ts
@@ -7,7 +7,7 @@ import { AppService } from 'services/app';
 import { CustomizationService } from 'services/customization';
 import { $t } from 'services/i18n';
 import { OnboardingService } from 'services/onboarding';
-import { StreamingService } from 'services/streaming';
+import { EStreamingState, StreamingService } from 'services/streaming';
 import { UserService } from 'services/user';
 import { UuidService } from 'services/uuid';
 import { WindowsService } from 'services/windows';
@@ -29,6 +29,9 @@ export default defineComponent({
     };
   },
   computed: {
+    isStreaming(): boolean {
+      return StreamingService.instance().state.streamingStatus !== EStreamingState.Offline;
+    },
     cacheId(): string {
       return UuidService.instance().uuid;
     },
@@ -37,7 +40,7 @@ export default defineComponent({
         name: 'optimize_for_niconico',
         description: $t('settings.optimizeForNiconico'),
         value: CustomizationService.instance().state.optimizeForNiconico,
-        enabled: StreamingService.instance().isStreaming === false,
+        enabled: !this.isStreaming,
       };
     },
     showOptimizationDialogForNiconicoModel(): IObsInput<boolean> {
@@ -45,7 +48,7 @@ export default defineComponent({
         name: 'show_optimization_dialog_for_niconico',
         description: $t('settings.showOptimizationDialogForNiconico'),
         value: CustomizationService.instance().state.showOptimizationDialogForNiconico,
-        enabled: StreamingService.instance().isStreaming === false,
+        enabled: !this.isStreaming,
       };
     },
     optimizeWithHardwareEncoderModel(): IObsInput<boolean> {
@@ -53,7 +56,7 @@ export default defineComponent({
         name: 'optimize_with_hardware_encoder',
         description: $t('settings.optimizeWithHardwareEncoder'),
         value: CustomizationService.instance().state.optimizeWithHardwareEncoder,
-        enabled: StreamingService.instance().isStreaming === false,
+        enabled: !this.isStreaming,
       };
     },
     pollingPerformanceStatisticsModel(): IObsInput<boolean> {
@@ -137,4 +140,3 @@ export default defineComponent({
     },
   },
 });
-

--- a/app/components/settings/Settings.vue.ts
+++ b/app/components/settings/Settings.vue.ts
@@ -18,12 +18,8 @@ import TocSection from 'components/shared/TocSection.vue';
 import { Subscription } from 'rxjs';
 import { $t } from 'services/i18n';
 import { ScenesService } from 'services/scenes';
-import {
-  ISettingsSubCategory,
-  SettingsCategory,
-  SettingsService,
-} from 'services/settings';
-import { StreamingService } from 'services/streaming';
+import { ISettingsSubCategory, SettingsCategory, SettingsService } from 'services/settings';
+import { EStreamingState, StreamingService } from 'services/streaming';
 import { UserService } from 'services/user';
 import { WindowsService } from 'services/windows';
 import { defineComponent, toRaw } from 'vue';
@@ -99,8 +95,11 @@ export default defineComponent({
     };
   },
   computed: {
+    streamingStatus(): EStreamingState {
+      return StreamingService.instance().state.streamingStatus;
+    },
     isStreaming(): boolean {
-      return StreamingService.instance().isStreaming;
+      return this.streamingStatus !== EStreamingState.Offline;
     },
     showLoginRequiredNotice(): boolean {
       return (
@@ -114,6 +113,10 @@ export default defineComponent({
     },
   },
   watch: {
+    streamingStatus() {
+      if (!this.categoryName) return;
+      this.settingsData = SettingsService.instance().getSettingsFormData(this.categoryName);
+    },
     categoryName(categoryName: SettingsCategory) {
       this.settingsData = SettingsService.instance().getSettingsFormData(categoryName);
       (this.$refs.settingsContainer as HTMLElement).scrollTop = 0;

--- a/app/components/settings/Settings.vue.ts
+++ b/app/components/settings/Settings.vue.ts
@@ -113,7 +113,7 @@ export default defineComponent({
     },
   },
   watch: {
-    streamingStatus() {
+    isStreaming() {
       if (!this.categoryName) return;
       this.settingsData = SettingsService.instance().getSettingsFormData(this.categoryName);
     },


### PR DESCRIPTION
## このpull requestが解決する内容
設定ウィンドウを開いた状態のまま配信を開始・終了しても、警告表示や各設定項目の有効・無効状態が更新されず、ウィンドウを再度開き直すまで反映されないという問題を修正しました。

## 変更内容

### `Settings.vue.ts`
- `isStreaming` を `streamingStatus` computed 経由に変更し、`streamingStatus` を watch するようにした
- `streamingStatus` の変化時に現在カテゴリの `settingsData` を再取得し、警告表示・各フィールドの有効/無効が即時反映されるようにした

### `ExtraSettings.vue.ts`
- `isStreaming` を `StreamingService` の `streamingStatus` state を直接参照する computed に変更(computed のリアクティブ依存関係に載るようにするため)
- 「ニコニコ向け最適化」関連3項目(`optimizeForNiconicoModel` / `showOptimizationDialogForNiconicoModel` / `optimizeWithHardwareEncoderModel`)の `enabled` を `!this.isStreaming` から算出するように変更し、配信状態変化に追従するようにした

## テスト
- [x] 設定ウィンドウを開いたまま配信を開始・終了し、警告表示が即時に切り替わることを確認
- [x] 設定ウィンドウを開いたまま配信を開始・終了し、「ニコニコ向け最適化」関連項目のチェックボックスが即時に無効/有効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
