### PR TITLE
変更: TCP APIをデフォルトで無効化し、設定画面から有効化できるように

### DIFF
--- a/app/components/settings/ExtraSettings.vue
+++ b/app/components/settings/ExtraSettings.vue
@@ -44,6 +44,13 @@
 
     <div>
       <div class="section">
+        <ObsBoolInput :value="enableTcpApiModel" @input="setEnableTcpApi" />
+        <p>{{ $t('settings.enableTcpApiDescription') }}</p>
+      </div>
+    </div>
+
+    <div>
+      <div class="section">
         <div class="input-label">
           <label>{{ $t('settings.cacheManagement') }}</label>
         </div>

--- a/app/components/settings/ExtraSettings.vue.ts
+++ b/app/components/settings/ExtraSettings.vue.ts
@@ -3,6 +3,7 @@ import ObsBoolInput from 'components/obs/inputs/ObsBoolInput.vue';
 import { IObsInput } from 'components/obs/inputs/ObsInput';
 import TocSection from 'components/shared/TocSection.vue';
 import electron from 'electron';
+import { TcpServerService } from 'services/api/tcp-server';
 import { AppService } from 'services/app';
 import { CustomizationService } from 'services/customization';
 import { $t } from 'services/i18n';
@@ -66,6 +67,13 @@ export default defineComponent({
         value: CustomizationService.instance().pollingPerformanceStatistics ?? false,
       };
     },
+    enableTcpApiModel(): IObsInput<boolean> {
+      return {
+        name: 'enable_tcp_api',
+        description: $t('settings.enableTcpApi'),
+        value: TcpServerService.instance().state.tcp.enabled ?? false,
+      };
+    },
     autoCompactModel(): IObsInput<boolean> {
       return {
         name: 'auto_compact',
@@ -103,6 +111,9 @@ export default defineComponent({
     },
     setPollingPerformanceStatistics(model: IObsInput<boolean>) {
       CustomizationService.instance().setPollingPerformanceStatistics(model.value ?? false);
+    },
+    setEnableTcpApi(model: IObsInput<boolean>) {
+      TcpServerService.instance().setTcpEnabled(model.value ?? false);
     },
     setAutoCompact(model: IObsInput<boolean>) {
       CustomizationService.instance().setAutoCompatMode(model.value ?? false);

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -715,6 +715,8 @@
   "encoderPreset": "Encoder Preset",
   "pollingPerformanceStatistics": "Activate performance statistics(bitrate, FPS, dropped frames)",
   "pollingPerformanceStatisticsDescription": "If the streaming is unstable, try disabling this option.",
+  "enableTcpApi": "Enable TCP API",
+  "enableTcpApiDescription": "Allows external tools to control N Air via 127.0.0.1:28194. This also makes it accessible from untrusted local processes, so keep this off unless you use an external tool integration.",
   "compactMode": "Compact Mode",
   "autoCompact": {
     "title": "Compact Mode Automation Settings",

--- a/app/i18n/ja-JP/settings.json
+++ b/app/i18n/ja-JP/settings.json
@@ -715,6 +715,8 @@
   "encoderPreset": "エンコーダープリセット",
   "pollingPerformanceStatistics": "パフォーマンス統計情報（ビットレート・FPS・ドロップフレーム数）を取得する",
   "pollingPerformanceStatisticsDescription": "配信が不安定な場合は無効にしてみてください。",
+  "enableTcpApi": "TCP API を有効にする",
+  "enableTcpApiDescription": "外部ツールが 127.0.0.1:28194 経由でN Airを操作できるようにします。信頼できないローカルプロセスからもアクセス可能になるため、外部ツール連携を使わない場合はオフのままにしてください。",
   "compactMode": "コンパクトモード",
   "autoCompact": {
     "title": "コンパクトモード自動化",

--- a/app/services/api/tcp-server/tcp-server-api.ts
+++ b/app/services/api/tcp-server/tcp-server-api.ts
@@ -1,5 +1,8 @@
 export interface ITcpServersSettings {
   token: string;
+  tcp: {
+    enabled: boolean;
+  };
   namedPipe: {
     enabled: boolean;
     pipeName: string;

--- a/app/services/api/tcp-server/tcp-server-api.ts
+++ b/app/services/api/tcp-server/tcp-server-api.ts
@@ -21,6 +21,7 @@ export interface ITcpServerServiceApi {
   listen(): void;
   stopListening(): void;
   enableWebsoketsRemoteConnections(): void;
+  setTcpEnabled(enabled: boolean): void;
   getIPAddresses(): IIPAddressDescription[];
   generateToken(): string;
   state: ITcpServersSettings;

--- a/app/services/api/tcp-server/tcp-server.test.ts
+++ b/app/services/api/tcp-server/tcp-server.test.ts
@@ -1,0 +1,212 @@
+jest.mock('services/core/stateful-service', () => ({
+  StatefulService: class {
+    static initialState: any = {};
+    static store: any = { watch: jest.fn() };
+    static getState() {
+      return {};
+    }
+  },
+  mutation: () => (_target: any, _key: string, descriptor: any) => descriptor,
+}));
+jest.mock('services/core/injector', () => ({
+  Inject: () => (_target: any, _key: string) => {},
+}));
+jest.mock('services/core', () => ({
+  PersistentStatefulService: class {
+    static defaultState: any = {};
+  },
+  mutation: () => (_target: any, _key: string, descriptor: any) => descriptor,
+  Inject: () => (_target: any, _key: string) => {},
+}));
+jest.mock('services/scene-collections', () => ({ SceneCollectionsService: class {} }));
+jest.mock('services/usage-statistics', () => ({ UsageStatisticsService: class {} }));
+jest.mock('../internal-api', () => ({ InternalApiService: class {} }));
+
+describe('TcpServerService', () => {
+  let TcpServerService: any;
+  let instance: any;
+  let remoteEnv: Record<string, string | undefined>;
+  let isDevMode: boolean;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    remoteEnv = {};
+    isDevMode = false;
+
+    jest.doMock('@electron/remote', () => ({
+      process: { env: remoteEnv },
+    }));
+    jest.doMock('services/utils', () => ({
+      __esModule: true,
+      default: { isDevMode: () => isDevMode },
+    }));
+
+    ({ TcpServerService } = require('./tcp-server'));
+
+    instance = Object.create(TcpServerService.prototype);
+    instance.jsonrpcService = {
+      createError: (request: any, error: any) => ({
+        jsonrpc: '2.0',
+        id: request?.id ?? null,
+        error,
+      }),
+    };
+    instance.internalApiService = {
+      executeServiceRequest: jest.fn().mockReturnValue({ jsonrpc: '2.0', id: '1', result: true }),
+      subscriptions: {},
+    };
+    instance.clients = {};
+    instance.nextClientId = 1;
+    instance.servers = [];
+    instance.isRequestsHandlingStopped = false;
+    instance.enableLogs = false;
+    // namedPipe/websockets はデフォルトで無効にしておく。実際の named pipe に
+    // listen してしまうと開発中に起動している n-air-app と衝突するため、
+    // listen() を呼ぶテストでは createNamedPipeServer/createWebsoketsServer を
+    // 個別にモックすること。
+    instance.state = {
+      ...TcpServerService.defaultState,
+      namedPipe: { ...TcpServerService.defaultState.namedPipe, enabled: false },
+    };
+  });
+
+  describe('shouldEnableTcp', () => {
+    test('本番ビルド・環境変数なし・明示設定なしでは false', () => {
+      expect(instance.shouldEnableTcp()).toBe(false);
+    });
+
+    test('dev モードでは true', () => {
+      isDevMode = true;
+      expect(instance.shouldEnableTcp()).toBe(true);
+    });
+
+    test('NAIR_ENABLE_TCP_API が設定されていれば true', () => {
+      remoteEnv.NAIR_ENABLE_TCP_API = '1';
+      expect(instance.shouldEnableTcp()).toBe(true);
+    });
+
+    test('state.tcp.enabled が true であれば true', () => {
+      instance.state = { ...instance.state, tcp: { enabled: true } };
+      expect(instance.shouldEnableTcp()).toBe(true);
+    });
+  });
+
+  describe('listen', () => {
+    test('shouldEnableTcp が false のとき TCP サーバーを起動しない', () => {
+      jest.spyOn(instance, 'shouldEnableTcp').mockReturnValue(false);
+      jest.spyOn(instance, 'createTcpServer');
+      jest.spyOn(instance, 'listenConnections').mockImplementation(() => {});
+
+      instance.listen();
+
+      expect(instance.createTcpServer).not.toHaveBeenCalled();
+    });
+
+    test('shouldEnableTcp が true のとき TCP サーバーを起動する', () => {
+      jest.spyOn(instance, 'shouldEnableTcp').mockReturnValue(true);
+      const fakeServer = { type: 'tcp', nativeServer: { on: jest.fn() }, close: jest.fn() };
+      jest.spyOn(instance, 'createTcpServer').mockReturnValue(fakeServer);
+      jest.spyOn(instance, 'listenConnections').mockImplementation(() => {});
+
+      instance.listen();
+
+      expect(instance.createTcpServer).toHaveBeenCalled();
+      expect(instance.listenConnections).toHaveBeenCalledWith(fakeServer);
+    });
+
+    test('namedPipe/websockets は state.enabled のみで起動判定される（既存動作を変えない）', () => {
+      jest.spyOn(instance, 'shouldEnableTcp').mockReturnValue(false);
+      jest.spyOn(instance, 'listenConnections').mockImplementation(() => {});
+      jest.spyOn(instance, 'createNamedPipeServer').mockReturnValue({});
+      jest.spyOn(instance, 'createWebsoketsServer').mockReturnValue({});
+      instance.state = {
+        ...TcpServerService.defaultState,
+        namedPipe: { enabled: true, pipeName: 'n-air-app' },
+        websockets: { enabled: true, port: 59650, allowRemote: false },
+      };
+
+      instance.listen();
+
+      expect(instance.createNamedPipeServer).toHaveBeenCalled();
+      expect(instance.createWebsoketsServer).toHaveBeenCalled();
+    });
+  });
+
+  describe('onConnectionHandler / クロスプロトコル攻撃の遮断', () => {
+    function createSocket() {
+      const handlers: Record<string, Function> = {};
+      return {
+        writable: true,
+        remoteAddress: '127.0.0.1',
+        on: jest.fn((event: string, cb: Function) => {
+          handlers[event] = cb;
+        }),
+        write: jest.fn(),
+        destroy: jest.fn(),
+        end: jest.fn(),
+        emit(event: string, ...args: any[]) {
+          handlers[event]?.(...args);
+        },
+      };
+    }
+
+    test('HTTP メソッド行で始まるデータを受けたら即座に socket を破棄し、以降処理しない', () => {
+      const socket = createSocket();
+      jest.spyOn(instance, 'isLocalClient').mockReturnValue(true);
+      const onRequestHandlerSpy = jest.spyOn(instance, 'onRequestHandler');
+
+      instance.onConnectionHandler(socket, { type: 'tcp' });
+      socket.emit(
+        'data',
+        Buffer.from(
+          'POST / HTTP/1.1\r\nHost: 127.0.0.1:28194\r\n\r\n' +
+            '{"jsonrpc":"2.0","id":1,"method":"write","params":{"resource":"FileManagerService","args":[]}}',
+        ),
+      );
+
+      expect(socket.destroy).toHaveBeenCalled();
+      expect(onRequestHandlerSpy).not.toHaveBeenCalled();
+      expect(instance.internalApiService.executeServiceRequest).not.toHaveBeenCalled();
+    });
+
+    test('不正な JSON の行を受けたら socket を破棄し、以降の行は処理しない', () => {
+      const socket = createSocket();
+      jest.spyOn(instance, 'isLocalClient').mockReturnValue(true);
+
+      instance.onConnectionHandler(socket, { type: 'tcp' });
+      socket.emit(
+        'data',
+        Buffer.from(
+          'not json\n{"jsonrpc":"2.0","id":1,"method":"write","params":{"resource":"FileManagerService","args":[]}}',
+        ),
+      );
+
+      expect(socket.destroy).toHaveBeenCalled();
+      expect(instance.internalApiService.executeServiceRequest).not.toHaveBeenCalled();
+    });
+
+    test('正規の JSON-RPC リクエストは従来どおり処理される', () => {
+      const socket = createSocket();
+      jest.spyOn(instance, 'isLocalClient').mockReturnValue(true);
+
+      instance.onConnectionHandler(socket, { type: 'tcp' });
+      socket.emit(
+        'data',
+        Buffer.from(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: '1',
+            method: 'getScenes',
+            params: { resource: 'ScenesService', args: [] },
+          }) + '\n',
+        ),
+      );
+
+      expect(socket.destroy).not.toHaveBeenCalled();
+      expect(instance.internalApiService.executeServiceRequest).toHaveBeenCalledTimes(1);
+      expect(socket.write).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/services/api/tcp-server/tcp-server.test.ts
+++ b/app/services/api/tcp-server/tcp-server.test.ts
@@ -82,9 +82,19 @@ describe('TcpServerService', () => {
       expect(instance.shouldEnableTcp()).toBe(true);
     });
 
-    test('NAIR_ENABLE_TCP_API が設定されていれば true', () => {
+    test('NAIR_ENABLE_TCP_API=1 であれば true', () => {
       remoteEnv.NAIR_ENABLE_TCP_API = '1';
       expect(instance.shouldEnableTcp()).toBe(true);
+    });
+
+    test('NAIR_ENABLE_TCP_API=true であれば true', () => {
+      remoteEnv.NAIR_ENABLE_TCP_API = 'true';
+      expect(instance.shouldEnableTcp()).toBe(true);
+    });
+
+    test('NAIR_ENABLE_TCP_API=0 (無効化の意図と読める値) では false', () => {
+      remoteEnv.NAIR_ENABLE_TCP_API = '0';
+      expect(instance.shouldEnableTcp()).toBe(false);
     });
 
     test('state.tcp.enabled が true であれば true', () => {
@@ -207,6 +217,33 @@ describe('TcpServerService', () => {
       expect(socket.destroy).not.toHaveBeenCalled();
       expect(instance.internalApiService.executeServiceRequest).toHaveBeenCalledTimes(1);
       expect(socket.write).toHaveBeenCalled();
+    });
+
+    test('サービス呼び出しが例外を投げた場合、詳細を露出せず id を保持したエラーを返す', () => {
+      const socket = createSocket();
+      jest.spyOn(instance, 'isLocalClient').mockReturnValue(true);
+      instance.internalApiService.executeServiceRequest.mockImplementation(() => {
+        throw new Error('sensitive internal detail');
+      });
+
+      instance.onConnectionHandler(socket, { type: 'tcp' });
+      socket.emit(
+        'data',
+        Buffer.from(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: '42',
+            method: 'getScenes',
+            params: { resource: 'ScenesService', args: [] },
+          }) + '\n',
+        ),
+      );
+
+      expect(socket.destroy).not.toHaveBeenCalled();
+      expect(socket.write).toHaveBeenCalledTimes(1);
+      const sent = JSON.parse((socket.write.mock.calls[0][0] as string).trim());
+      expect(sent.id).toBe('42');
+      expect(JSON.stringify(sent.error)).not.toContain('sensitive internal detail');
     });
   });
 });

--- a/app/services/api/tcp-server/tcp-server.test.ts
+++ b/app/services/api/tcp-server/tcp-server.test.ts
@@ -144,6 +144,34 @@ describe('TcpServerService', () => {
     });
   });
 
+  describe('setTcpEnabled', () => {
+    test('stopListening → setSettings({tcp:{enabled}}) → listen の順で呼ばれる', () => {
+      const callOrder: string[] = [];
+      jest.spyOn(instance, 'stopListening').mockImplementation(() => callOrder.push('stopListening'));
+      jest.spyOn(instance, 'setSettings').mockImplementation((settings: any) => {
+        callOrder.push('setSettings');
+        expect(settings).toEqual({ tcp: { enabled: true } });
+      });
+      jest.spyOn(instance, 'listen').mockImplementation(() => callOrder.push('listen'));
+
+      instance.setTcpEnabled(true);
+
+      expect(callOrder).toEqual(['stopListening', 'setSettings', 'listen']);
+    });
+
+    test('false を渡すと state.tcp.enabled が false になり listen が再実行される', () => {
+      instance.state = { ...instance.state, tcp: { enabled: true } };
+      jest.spyOn(instance, 'stopListening').mockImplementation(() => {});
+      jest.spyOn(instance, 'listen').mockImplementation(() => {});
+
+      instance.setTcpEnabled(false);
+
+      expect(instance.state.tcp.enabled).toBe(false);
+      expect(instance.stopListening).toHaveBeenCalled();
+      expect(instance.listen).toHaveBeenCalled();
+    });
+  });
+
   describe('onConnectionHandler / クロスプロトコル攻撃の遮断', () => {
     function createSocket() {
       const handlers: Record<string, Function> = {};

--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -136,6 +136,17 @@ export class TcpServerService
     this.listen();
   }
 
+  /**
+   * Enables/disables the TCP transport and applies the change immediately,
+   * so a user toggling this in the settings window doesn't need to restart
+   * the app for it to take effect.
+   */
+  setTcpEnabled(enabled: boolean) {
+    this.stopListening();
+    this.setSettings({ tcp: { enabled } });
+    this.listen();
+  }
+
   getDefaultSettings(): ITcpServersSettings {
     return TcpServerService.defaultState;
   }

--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -98,7 +98,7 @@ export class TcpServerService
     return (
       this.state.tcp.enabled ||
       Utils.isDevMode() ||
-      !!remote.process.env.NAIR_ENABLE_TCP_API
+      ['1', 'true'].includes(remote.process.env.NAIR_ENABLE_TCP_API ?? '')
     );
   }
 
@@ -376,11 +376,11 @@ export class TcpServerService
 
         this.sendResponse(client, response);
       } catch (e) {
+        console.error('TCP Server: error while processing the request', e);
         this.sendResponse(
           client,
-          this.jsonrpcService.createError(null, {
-            code: E_JSON_RPC_ERROR.INVALID_REQUEST,
-            message: `Error while processing the request: ${e}`,
+          this.jsonrpcService.createError(request, {
+            code: E_JSON_RPC_ERROR.INTERNAL_SERVER_ERROR,
           }),
         );
       }

--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -2,6 +2,7 @@ import WritableStream = NodeJS.WritableStream;
 import crypto from 'crypto';
 import os from 'os';
 
+import * as remote from '@electron/remote';
 import {
   E_JSON_RPC_ERROR,
   IJsonRpcEvent,
@@ -12,6 +13,7 @@ import {
 import { Inject, mutation, PersistentStatefulService } from 'services/core';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { UsageStatisticsService } from 'services/usage-statistics';
+import Utils from 'services/utils';
 
 import { InternalApiService } from '../internal-api';
 
@@ -53,6 +55,9 @@ export class TcpServerService
   implements ITcpServerServiceApi {
   static defaultState: ITcpServersSettings = {
     token: '',
+    tcp: {
+      enabled: false,
+    },
     namedPipe: {
       enabled: true,
       pipeName: 'n-air-app',
@@ -81,9 +86,20 @@ export class TcpServerService
   }
 
   listen() {
-    this.listenConnections(this.createTcpServer());
+    // TCP (127.0.0.1:28194) は認証なしでローカルの任意のプロセス・ブラウザから
+    // 到達可能なため、本番ビルドではデフォルトで listen しない。
+    // 開発時のデバッグ用途や、明示的な設定・環境変数による opt-in は維持する。
+    if (this.shouldEnableTcp()) this.listenConnections(this.createTcpServer());
     if (this.state.namedPipe.enabled) this.listenConnections(this.createNamedPipeServer());
     if (this.state.websockets.enabled) this.listenConnections(this.createWebsoketsServer());
+  }
+
+  private shouldEnableTcp(): boolean {
+    return (
+      this.state.tcp.enabled ||
+      Utils.isDevMode() ||
+      !!remote.process.env.NAIR_ENABLE_TCP_API
+    );
   }
 
   /**
@@ -236,7 +252,21 @@ export class TcpServerService
     }
 
     socket.on('data', (data: any) => {
-      this.onRequestHandler(client, data.toString());
+      const dataString = data.toString();
+
+      // Defend against cross-protocol attacks: a webpage can send an HTTP
+      // request to this TCP socket (e.g. via fetch()/XHR to 127.0.0.1). Its
+      // request line/headers fail JSON-RPC parsing and are ignored by
+      // onRequestHandler, but nothing prevented a JSON-RPC line hidden in the
+      // request body from being executed. Detect the HTTP request line up
+      // front and destroy the connection before any parsing happens.
+      if (this.looksLikeHttpRequest(dataString)) {
+        console.debug('TCP Server: received an HTTP request, disconnecting client');
+        this.destroyClient(client);
+        return;
+      }
+
+      this.onRequestHandler(client, dataString);
     });
 
     socket.on('end', () => {
@@ -262,6 +292,22 @@ export class TcpServerService
     client.isAuthorized = true;
   }
 
+  private static readonly HTTP_METHOD_PREFIXES = [
+    'GET ',
+    'POST ',
+    'PUT ',
+    'HEAD ',
+    'DELETE ',
+    'OPTIONS ',
+    'PATCH ',
+    'CONNECT ',
+    'TRACE ',
+  ];
+
+  private looksLikeHttpRequest(data: string): boolean {
+    return TcpServerService.HTTP_METHOD_PREFIXES.some((prefix) => data.startsWith(prefix));
+  }
+
   private isLocalClient(client: IClient) {
     const localAddresses = this.getIPAddresses()
       .filter((addressDescr) => addressDescr.internal)
@@ -285,11 +331,25 @@ export class TcpServerService
     }
 
     const requests = data.split('\n');
-    requests.forEach((requestString) => {
-      if (!requestString) return;
-      try {
-        const request: IJsonRpcRequest = JSON.parse(requestString);
+    for (const requestString of requests) {
+      if (!requestString) continue;
 
+      let request: IJsonRpcRequest;
+      try {
+        request = JSON.parse(requestString);
+      } catch (e) {
+        // The received line isn't valid JSON-RPC. This happens when a raw HTTP
+        // request reaches this socket (e.g. a malicious webpage doing a
+        // cross-protocol attack via fetch()/XHR against 127.0.0.1). Disconnect
+        // immediately instead of responding with an error: continuing to parse
+        // the remaining lines would let an HTTP request body that happens to
+        // look like JSON-RPC get executed.
+        console.debug('TCP Server: received a non-JSON-RPC request, disconnecting client', e);
+        this.destroyClient(client);
+        return;
+      }
+
+      try {
         const errorMessage = this.validateRequest(request);
 
         if (errorMessage) {
@@ -298,11 +358,11 @@ export class TcpServerService
             message: errorMessage,
           });
           this.sendResponse(client, errorResponse);
-          return;
+          continue;
         }
 
         // some requests have to be handled by TcpServerService
-        if (this.hadleTcpServerDirectives(client, request)) return;
+        if (this.hadleTcpServerDirectives(client, request)) continue;
 
         const response = this.internalApiService.executeServiceRequest(request);
 
@@ -320,14 +380,11 @@ export class TcpServerService
           client,
           this.jsonrpcService.createError(null, {
             code: E_JSON_RPC_ERROR.INVALID_REQUEST,
-            message:
-              'Make sure that the request is valid json. ' +
-              'If request string contains multiple requests, ensure requests are separated ' +
-              'by a single newline character LF ( ASCII code 10)',
+            message: `Error while processing the request: ${e}`,
           }),
         );
       }
-    });
+    }
   }
 
   private onServiceEventHandler(event: IJsonRpcResponse<IJsonRpcEvent>) {
@@ -454,6 +511,17 @@ export class TcpServerService
     const client = this.clients[clientId];
     client.socket.end();
     delete this.clients[clientId];
+  }
+
+  /**
+   * Immediately terminates the connection without sending any response.
+   * Used when the client sent data that isn't a valid JSON-RPC request
+   * (see onRequestHandler), so no assumption about the protocol being spoken
+   * on this socket can be made anymore.
+   */
+  private destroyClient(client: IClient) {
+    (client.socket as any).destroy();
+    delete this.clients[client.id];
   }
 
   private log(...messages: any[]) {

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,7 @@
 | `NAIR_DEBUG_CRASH_HANDLER`        | `DEV_SERVER` 時にもクラッシュハンドラを有効化                                                                                                                            |
 | `NAIR_FORCE_AUTO_UPDATE`          | 非本番ビルドで自動更新を強制有効化                                                                                                                                       |
 | `NAIR_FAKE_PROGRAM`               | フェイク番組モードを有効化（`DEV_SERVER` と組み合わせて使用）                                                                                                            |
+| `NAIR_ENABLE_TCP_API`             | 本番ビルドで TCP API (`127.0.0.1:28194`) を有効化（`1`/`true` のみ有効）。開発ビルドでは常に有効。一般ユーザー向けには設定画面「一般」タブの「TCP API を有効にする」トグルを使用 |
 | `NAIR_UPDATE_I18N_NOT_FOUND_KEYS` | 未翻訳キーを `i18n-not-found-keys.txt` に出力                                                                                                                            |
 | `NDGR_SERVER`                     | モデレーター表示サーバー URL のオーバーライド                                                                                                                            |
 


### PR DESCRIPTION
## このpull requestが解決する内容

issue #1380 の調査中に判明した、ローカル RPC サーバ（`app/services/api/tcp-server/`）のセキュリティ問題のうち、影響が大きく低リスクに対応できる2点を修正・軽減しました。

- **修正**: 受信データが JSON-RPC としてパースできない場合でもソケットを閉じずエラー応答を返すだけだったため、悪意あるウェブページからの `fetch()` によるクロスプロトコル攻撃（HTTP リクエストのボディに紛れ込ませた JSON-RPC 行が実行される）が可能だった脆弱性を閉じた
- **軽減**: TCP `127.0.0.1:28194` が本番ビルドでも認証なしに常時 listen していたため、ローカルの任意のプロセスから到達できる露出経路になっていた。本番ビルドではデフォルトで listen しないようにし、露出経路そのものを塞いだ。また、外部ツール連携で実際に使っているユーザーがいる可能性を踏まえ、環境変数だけでなく設定画面から明示的にON/OFFできる永続化トグルを追加した

なお、許可リストが無く到達可能な全サービス・全メソッドを呼べてしまう問題自体は今回のスコープには含まれておらず、別途対応が必要。

## 変更内容

### `tcp-server.ts`
- `onConnectionHandler`: 接続直後のデータが HTTP メソッド行（`GET `/`POST ` 等）で始まる場合、即座に `socket.destroy()` して以降の処理を行わないようにした
- `onRequestHandler`: 各行のパースを2段階に分離し、`JSON.parse` に失敗した行を受けた場合はエラー応答を返さず `socket.destroy()` するようにした(不正な行以降の行も処理しない)。正規のJSON-RPCリクエストの処理は変更していない
- `shouldEnableTcp()` を追加し、`listen()` でTCPサーバーの起動をこの判定でガードするようにした(namedPipe/websocketsと同様の条件分岐に統一)。判定は `state.tcp.enabled` (設定画面のトグル/明示設定) / `Utils.isDevMode()` (開発ビルド) / `NAIR_ENABLE_TCP_API` 環境変数(本番の開発者向けopt-in、`1`/`true` のみ有効) のいずれか
- `onRequestHandler` の catch: サービス呼び出しが例外を投げた場合、詳細をクライアントに露出せず(サーバ側にログするのみ)、`id` を保持したエラーを返すようにした
- `setTcpEnabled(enabled)` を追加。`stopListening() → setSettings() → listen()` の順で呼び、設定変更を再起動不要で即時反映する

### `tcp-server-api.ts`
- `ITcpServersSettings` に `tcp: { enabled: boolean }` を追加(デフォルト `false`)
- `ITcpServerServiceApi` に `setTcpEnabled(enabled: boolean): void` を追加

### `ExtraSettings.vue` / `ExtraSettings.vue.ts`
- 設定画面「一般」タブに「TCP API を有効にする」トグルを追加(既存の`pollingPerformanceStatistics`と同じ`ObsBoolInput`+説明文パターン)

### `app/i18n/ja-JP/settings.json` / `app/i18n/en-US/settings.json`
- `enableTcpApi` / `enableTcpApiDescription` を日英両方に追加

## 影響範囲

- 名前付きパイプ (`\\.\pipe\n-air-app`) は変更なし。テスト用APIクライアント (`test/helpers/api-client.ts`) はこちらを使用しているため影響を受けない
- TCP :28194 を利用するコードはリポジトリ内に存在しないため、本番ビルドでのデフォルト無効化による後方互換の懸念はない
- 開発ビルド (`pnpm start`/`pnpm dev`) では従来通りTCPが有効なため、デバッグ用途は継続可能
- 本番ビルドで外部ツール連携を使っていたユーザーは、設定画面「一般」タブから「TCP API を有効にする」をONにすることで従来と同じ挙動に戻せる

## テスト

- [x] `app/services/api/tcp-server/tcp-server.test.ts` に `setTcpEnabled()` のテストを追加し、`pnpm run test:unit:app` で全1114件がpassすることを確認
- [x] `pnpm typecheck` が通ることを確認
- [x] 開発ビルド (`pnpm compile && pnpm start`) で起動後、`netstat -ano | findstr 28194` で `LISTENING` を確認。ソケットに直接正規の JSON-RPC (`{"jsonrpc":"2.0","id":"1","method":"getScenes","params":{"resource":"ScenesService","args":[]}}\n`) を送信し、従来通りレスポンスが返ることを確認。また `POST / HTTP/1.1\r\n...\r\n\r\n{JSON-RPC}` およびHTTPを伴わない不正JSON行を送信し、いずれも即座に切断されJSON-RPCが実行されないことを確認
- [x] `pnpm run compile:production && pnpm package:local` でビルドしたインストーラ (`dist/n-air-app-setup.*.exe`) をインストールして起動し、`netstat -ano | findstr 28194` で**何も表示されない**(listenしていない)ことを確認
- [x] 上記インストール版を環境変数 `NAIR_ENABLE_TCP_API=1` を設定して起動し、`netstat -ano | findstr 28194` で `LISTENING` が表示される(opt-inで有効化される)ことを確認
- [x] 開発ビルドで設定画面「一般」タブに「TCP API を有効にする」トグルが表示されることを確認。トグルON操作でJSON-RPC (`TcpServerService.getSettings`) から `state.tcp.enabled: true` が永続化されていること、`netstat`でLISTENが維持されることを確認。トグルOFF操作で `state.tcp.enabled: false` に戻ることを確認(devモードのため`isDevMode()`により28194は開いたままになるのは仕様通り)

Closes #1390
関連: #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
