### PR TITLE
開発: user_session を SameSite=Lax にしログイン検証で cookie を明示送信する

### DIFF
--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -103,8 +103,9 @@ export class NiconicoService extends Service implements IPlatformService {
     try {
       json = JSON.parse(response.text);
     } catch (e) {
+      // 200 だが HTML 等の場合は未ログインではなく一時エラー扱い（validateLogin で LOGOUT しない）
       console.error('NiconicoService.getUserId: invalid JSON response', response.text);
-      return '';
+      throw new Error('NiconicoService.getUserId: invalid JSON response');
     }
     if (isSessionsMeResponse(json)) {
       if ('user' in json) {

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -78,13 +78,34 @@ export class NiconicoService extends Service implements IPlatformService {
     if (isFakeMode()) {
       return FakeUserAuth.platform.id; // dummy user ID
     }
-    const { url, init } = this.sessionsMeParams();
-    const response = await fetch(url, init);
+    // renderer の fetch では app 起点がクロスサイト扱いとなり、SameSite=Lax の
+    // user_session が自動付与されない。logout と同様に cookie を明示して main 経由で送る。
+    const { session } = remote.getCurrentWebContents();
+    const cookies = await session.cookies.get({
+      url: `https://${getCookieDomain()}`,
+      name: 'user_session',
+    });
+    if (cookies.length < 1) {
+      return '';
+    }
+    const { url, init } = this.sessionsMeParams('GET', {
+      Cookie: `user_session=${cookies[0].value}`,
+    });
+    const response = await fetchViaMainProcess(url, init);
     if (response.status === 400 || response.status === 401) {
       return '';
     }
-    const response_1 = await handleErrors(response); // !response.ok を例外にする
-    const json = await response_1.json();
+    if (!response.ok) {
+      // オフライン等は例外にし、validateLogin 側で LOGOUT しない
+      throw new RequestError(response.status, url, 'GET');
+    }
+    let json: unknown;
+    try {
+      json = JSON.parse(response.text);
+    } catch (e) {
+      console.error('NiconicoService.getUserId: invalid JSON response', response.text);
+      return '';
+    }
     if (isSessionsMeResponse(json)) {
       if ('user' in json) {
         return json.user.id.toString();

--- a/main.js
+++ b/main.js
@@ -244,10 +244,10 @@ async function showRequiredSystemComponentInstallGuideDialog() {
 }
 
 async function recollectUserSessionCookie() {
-  // electron14->15でcookieがつかない
-  // 設定されるcookieのSameSite指定がないため unspecified となり
-  // 設定が無いためchromeがcookieをつけない(通信ログを見るとフィルタされている)
-  // cookieを直せば通るようなのでそのパッチ処理
+  // electron14->15 で SameSite 未指定 (unspecified) の cookie がフィルタされる問題へのパッチ。
+  // API 呼び出しは session.cookies から読み取った値を X-Niconico-Session / Cookie ヘッダで
+  // 明示送信するため、クロスサイト自動付与用の SameSite=None は不要。
+  // SameSite=None; Secure; not Partitioned は Chromium の third-party cookie 警告の対象になるため Lax にする。
   console.log('recollectUserSessionCookie');
   try {
     const cookies = await getAppSession().cookies.get({
@@ -257,7 +257,8 @@ async function recollectUserSessionCookie() {
     if (!cookies || !cookies.length) return;
 
     for (const cookie of cookies) {
-      if (cookie.sameSite === 'no_restriction') {
+      // 既に目的の属性なら何もしない（過去に no_restriction にした cookie は Lax へ移行する）
+      if (cookie.sameSite === 'lax' && cookie.httpOnly && cookie.secure) {
         console.log(`no-need change cookie ${cookie.name}`);
         continue;
       }
@@ -266,7 +267,7 @@ async function recollectUserSessionCookie() {
       if (d[0] === '.') d = d.substring(1);
 
       cookie.url = `https://${d}`; //nicovideo.jp';
-      cookie.sameSite = 'no_restriction';
+      cookie.sameSite = 'lax';
       cookie.httpOnly = true;
       cookie.secure = true;
 

--- a/main.js
+++ b/main.js
@@ -272,7 +272,10 @@ async function recollectUserSessionCookie() {
       cookie.secure = true;
 
       await getAppSession().cookies.set(cookie);
-      console.log(`cookie changed ${JSON.stringify(cookie)}`);
+      // value（セッショントークン）はログに出さない
+      console.log(
+        `cookie changed name=${cookie.name} domain=${cookie.domain} sameSite=${cookie.sameSite} httpOnly=${cookie.httpOnly} secure=${cookie.secure}`,
+      );
     }
   } catch (e) {
     console.log(`cookie error ${e.toString()}`);


### PR DESCRIPTION
## このpull requestが解決する内容

Electron アプリの origin と `.nicovideo.jp` はクロスサイト扱いのため、`user_session` を `SameSite=None` のまま cookie 自動付与に頼ると Chromium の third-party cookie 制限（現在は DevTools 警告として顕在化）の影響を受けやすい。将来の Electron/Chromium 更新で制限が強化されると、起動時のログイン検証などが先に壊れうる。

本 PR は次の2点でこの問題を解消する。

1. `user_session` を `SameSite=Lax` に正規化し、警告対象の `SameSite=None; Secure; not Partitioned` から外す
2. ログイン検証（`getUserId`）を cookie 自動付与に依存せず、`session.cookies` + 明示 `Cookie` ヘッダ + main 経由に寄せる

## 背景

- Chromium DevTools に出る third-party cookie 警告（`SameSite=None; Secure` かつ `Partitioned` なし）の原因のひとつが、`recollectUserSessionCookie` による `SameSite=None` 強制だった
- ニコ生 API 側はすでに `X-Niconico-Session` / 明示 `Cookie` で session を送っているため、クロスサイト自動付与用の `SameSite=None` は不要
- 一方、起動時の `validateLogin` → `getUserId` は renderer の `fetch` に cookie 自動付与を頼っており、Lax だけにすると 401 扱いで `LOGOUT` してしまう

## 変更内容

### `main.js`
- `recollectUserSessionCookie` で `user_session` を `sameSite: 'lax'` / `httpOnly` / `secure` に正規化
- 過去に `no_restriction` だった cookie も起動時・ログイン時に Lax へ移行
- cookie 変更ログに `value`（セッショントークン）を含めない

### `app/services/platforms/niconico.ts`
- `getUserId` を `logout` と同様に `session.cookies.get` + 明示 `Cookie` ヘッダ + `fetchViaMainProcess` に変更
- SameSite に依存せずログイン状態を検証できるようにする
- 200 だが JSON でない応答などは未ログインではなく一時エラーとして例外化し、`validateLogin` の誤 `LOGOUT` を避ける

## テスト
- [x] 再起動後に起動時ログアウトされないこと
- [x] ログアウト → ログインが成功すること
- [x] DevTools の `SameSite=None; Secure and not Partitioned` 警告が `user_session` 起因で出ない／減ること
