### PR TITLE
変更: 番組取得済みのときはチャンネル権限があっても配信種別選択を省略する

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -149,38 +149,46 @@ describe('非JSONレスポンスの安全な取り扱い', () => {
 
   test('fetchKonomiTagsはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {
     const client = new NicoliveClient({ niconicoSession: 'dummy' });
-    fetchMock.post(
-      `${NicoliveClient.live2ApiBaseURL}/api/v1/konomiTags/GetFollowing`,
-      { body: upstreamErrorBody, status: 200 },
-    );
+    fetchViaMainProcess.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: [],
+      text: upstreamErrorBody,
+    });
 
     let error: unknown;
     await client.fetchKonomiTags(String(userID)).catch((e) => { error = e; });
     expect(error).not.toBeInstanceOf(SyntaxError);
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(/fetchKonomiTags/);
+    expect((error as Error).cause).toBeInstanceOf(SyntaxError);
   });
 
   test('fetchUserFollowはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {
     const client = new NicoliveClient({ niconicoSession: 'dummy' });
-    fetchMock.get(
-      NicoliveClient.userFollowEndpoint(String(userID)),
-      { body: upstreamErrorBody, status: 200 },
-    );
+    fetchViaMainProcess.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: [],
+      text: upstreamErrorBody,
+    });
 
     let error: unknown;
     await client.fetchUserFollow(String(userID)).catch((e) => { error = e; });
     expect(error).not.toBeInstanceOf(SyntaxError);
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(/fetchUserFollow/);
+    expect((error as Error).cause).toBeInstanceOf(SyntaxError);
   });
 
   test('unFollowUserは失敗レスポンスがJSONでなくてもSyntaxErrorを投げず本来のエラーメッセージを返す', async () => {
     const client = new NicoliveClient({ niconicoSession: 'dummy' });
-    fetchMock.delete(
-      NicoliveClient.userFollowEndpoint(String(userID)),
-      { body: upstreamErrorBody, status: 502 },
-    );
+    fetchViaMainProcess.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      headers: [],
+      text: upstreamErrorBody,
+    });
 
     let error: unknown;
     await client.unFollowUser(String(userID)).catch((e) => { error = e; });

--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -132,17 +132,18 @@ const upstreamErrorBody = 'upstream connect error or disconnect/reset before hea
 describe('非JSONレスポンスの安全な取り扱い', () => {
   test('fetchOnairUserProgramはbodyがJSONでなければSyntaxErrorではなくErrorを投げる', async () => {
     const client = new NicoliveClient({ niconicoSession: 'dummy' });
-    fetchMock.get(
-      `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/user`,
-      { body: upstreamErrorBody, status: 200 },
-    );
+    fetchViaMainProcess.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: [],
+      text: upstreamErrorBody,
+    });
 
     let error: unknown;
     await client.fetchOnairUserProgram().catch((e) => { error = e; });
     expect(error).not.toBeInstanceOf(SyntaxError);
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(/fetchOnairUserProgram/);
-    // 元のSyntaxErrorがcauseとして保持され、調査時に読めること
     expect((error as Error).cause).toBeInstanceOf(SyntaxError);
   });
 
@@ -276,12 +277,18 @@ suites.forEach((suite: Suite) => {
       niconicoSession: 'dummy',
     });
 
-    fetchMock[suite.method](suite.base + suite.path, dummyBody);
+    // Cookie 明示付与のため requestAPI は renderer では main 経由になる
+    fetchViaMainProcess.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: [],
+      text: JSON.stringify(dummyBody),
+    });
     // @ts-expect-error 引数の型
     const result = await client[suite.name](...suite.args);
 
     expect(result).toEqual({ ok: true, value: dummyBody.data });
-    expect(fetchMock.callHistory.done()).toBe(true);
+    expect(fetchViaMainProcess).toHaveBeenCalled();
   });
 });
 

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -6,7 +6,6 @@ import { getCookieDomain, getPartitionConfig, getPartitionName, transformUrl } f
 import { FrontendIdHeader } from 'services/platforms/niconicoDefs';
 import { addClipboardMenu } from 'util/addClipboardMenu';
 import { fetchViaMainProcess, MainProcessFetchResponse } from 'util/fetchViaMainProcess';
-import { handleErrors } from 'util/requests';
 import { SentryReport } from 'util/sentry-report';
 
 import {
@@ -293,8 +292,12 @@ export class NicoliveClient {
       };
     }
 
-    // 正常成功
-    if (res.ok) {
+    // HTTP は成功でも API 側 meta.status がエラーのことがある（その場合は失敗扱い）
+    const metaStatus =
+      obj && typeof obj === 'object' && obj.meta && typeof obj.meta.status === 'number'
+        ? (obj.meta.status as number)
+        : undefined;
+    if (res.ok && (metaStatus === undefined || metaStatus === 200)) {
       return {
         ok: true,
         value: obj.data as ResultType,
@@ -302,11 +305,15 @@ export class NicoliveClient {
       };
     }
 
-    // 正常失敗
+    // 正常失敗（HTTP エラー、または HTTP 成功だが meta.status がエラー）
     return {
       ok: false,
       value: obj as CommonErrorResponse,
-      diag: { route, httpStatus: res.status, failureKind: 'http_error' },
+      diag: {
+        route,
+        httpStatus: res.status,
+        failureKind: 'http_error',
+      },
     };
   }
 
@@ -338,7 +345,8 @@ export class NicoliveClient {
 
   /**
    * ニコニコのセッションを読みだし
-   * rendererのdocument.cookieからはローカル扱いになって読めないので、mainプロセスで取る
+   * renderer の document.cookie からは読めないので Electron session から取る。
+   * domain フィルタを使い、SameSite 属性に依存せず jar 上の user_session を得る。
    */
   private async fetchSession(): Promise<string> {
     if (this.options.niconicoSession) {
@@ -346,31 +354,51 @@ export class NicoliveClient {
     }
 
     const { session } = remote.getCurrentWebContents();
-    return new Promise((resolve, reject) => {
-      session.cookies.get({ url: 'https://' + getCookieDomain(), name: 'user_session' }).then((cookies) => {
-        if (cookies.length < 1) return reject(new NotLoggedInError());
-        resolve(cookies[0].value);
-      });
+    const cookies = await session.cookies.get({
+      domain: getCookieDomain(),
+      name: 'user_session',
     });
+    if (cookies.length < 1) {
+      throw new NotLoggedInError();
+    }
+    return cookies[0].value;
   }
 
+  /**
+   * 認証付き API リクエスト。
+   * SameSite=Lax の user_session は app origin からのクロスサイト fetch では自動付与されない。
+   * Cookie は renderer では forbidden header のため、session 値を明示して main 経由で送る。
+   */
   private async requestAPI<T>(
     method: 'GET' | 'POST' | 'PUT' | 'DELETE',
     url: string,
     options: RequestInit = {},
   ): Promise<WrappedResult<T>> {
-    // Origin リクエストヘッダーを付けるには main process で fetch を使う必要がある
-    const viaMainProcess = options.headers && 'Origin' in options.headers;
+    const headers: Record<string, string> = {
+      ...(options.headers as Record<string, string> | undefined),
+    };
+
+    // renderer（および niconicoSession を渡すテスト）ではセッションを明示付与する
+    if (process.type === 'renderer' || this.options.niconicoSession) {
+      try {
+        const userSession = await this.fetchSession();
+        headers['X-Niconico-Session'] = userSession;
+        headers.Cookie = `user_session=${userSession}`;
+      } catch (err) {
+        return NicoliveClient.wrapFetchError(err as Error, 'renderer');
+      }
+    }
+
+    // Cookie / Origin は renderer では forbidden のため main 経由にする
+    const viaMainProcess =
+      process.type === 'renderer'
+      && (Object.prototype.hasOwnProperty.call(headers, 'Cookie')
+        || Object.prototype.hasOwnProperty.call(headers, 'Origin'));
     const route: RequestRoute = viaMainProcess ? 'main' : 'renderer';
 
-    const headers: HeadersInit = {};
-    // renderer process だと cookieが取れないので、main process で取ってきて付ける
-    if (process.type === 'renderer') {
-      headers['X-Niconico-Session'] = await this.fetchSession();
-    }
     const requestInit = NicoliveClient.createRequest(method, {
       ...options,
-      headers: { ...headers, ...options.headers },
+      headers,
     });
     try {
       const resp = await (viaMainProcess ? fetchViaMainProcess : fetch)(url, requestInit);
@@ -511,13 +539,26 @@ export class NicoliveClient {
    */
   async fetchOnairUserProgram(): Promise<OnairUserProgramData> {
     const url = `${NicoliveClient.live2BaseURL}/unama/tool/v2/onairs/user`;
-    const headers = new Headers();
-    const userSession = await this.fetchSession();
-    headers.append('X-niconico-session', userSession);
-    const request = new Request(url, { headers });
-    const response = await fetch(request).then(handleErrors);
-    const json = await NicoliveClient.parseJsonOrThrow(response, 'fetchOnairUserProgram');
-    return json.data;
+    // requestAPI と同様、Cookie + X-Niconico-Session を main 経由で送る
+    const result = await this.requestAPI<OnairUserProgramData>('GET', url);
+    if (!isOk(result)) {
+      if (result.diag?.failureKind === 'not_logged_in' || result.value instanceof NotLoggedInError) {
+        throw result.value instanceof NotLoggedInError ? result.value : new NotLoggedInError();
+      }
+      if (result.diag?.failureKind === 'json_parse') {
+        throw new Error(
+          `fetchOnairUserProgram: response is not valid JSON (status=${result.diag.httpStatus})`,
+          { cause: result.value },
+        );
+      }
+      if (result.value instanceof Error) {
+        throw result.value;
+      }
+      // handleErrors 相当: HTTP/API エラーは status 付き Error で呼び出し側に返す
+      const status = result.diag?.httpStatus ?? result.value?.meta?.status ?? 0;
+      throw new Error(`fetchOnairUserProgram failed: ${status}`);
+    }
+    return result.value ?? {};
   }
 
   /**

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -374,38 +374,84 @@ export class NicoliveClient {
     url: string,
     options: RequestInit = {},
   ): Promise<WrappedResult<T>> {
+    try {
+      const res = await this.requestWithSession(method, url, options);
+      // wrapResult が Response / MainProcessFetchResponse 両方を扱える形に合わせて渡す
+      return NicoliveClient.wrapResult<T>(
+        {
+          ok: res.ok,
+          status: res.status,
+          headers: res.headers,
+          text: res.body,
+        },
+        res.route,
+      );
+    } catch (err) {
+      return NicoliveClient.wrapFetchError(err as Error, process.type === 'renderer' ? 'main' : 'renderer');
+    }
+  }
+
+  /**
+   * Cookie + X-Niconico-Session を付与した HTTP リクエスト（レスポンス形状を問わない汎用）。
+   * follow / konomi など wrapResult 前提ではない API 用。
+   */
+  private async requestWithSession(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    url: string,
+    options: RequestInit = {},
+  ): Promise<{
+    ok: boolean;
+    status: number;
+    statusText: string;
+    body: string;
+    headers: [string, string][];
+    route: RequestRoute;
+  }> {
     const headers: Record<string, string> = {
       ...(options.headers as Record<string, string> | undefined),
     };
 
-    // renderer（および niconicoSession を渡すテスト）ではセッションを明示付与する
     if (process.type === 'renderer' || this.options.niconicoSession) {
-      try {
-        const userSession = await this.fetchSession();
-        headers['X-Niconico-Session'] = userSession;
-        headers.Cookie = `user_session=${userSession}`;
-      } catch (err) {
-        return NicoliveClient.wrapFetchError(err as Error, 'renderer');
-      }
+      const userSession = await this.fetchSession();
+      headers['X-Niconico-Session'] = userSession;
+      headers.Cookie = `user_session=${userSession}`;
     }
 
-    // Cookie / Origin は renderer では forbidden のため main 経由にする
     const viaMainProcess =
       process.type === 'renderer'
       && (Object.prototype.hasOwnProperty.call(headers, 'Cookie')
         || Object.prototype.hasOwnProperty.call(headers, 'Origin'));
     const route: RequestRoute = viaMainProcess ? 'main' : 'renderer';
-
     const requestInit = NicoliveClient.createRequest(method, {
       ...options,
       headers,
     });
-    try {
-      const resp = await (viaMainProcess ? fetchViaMainProcess : fetch)(url, requestInit);
-      return NicoliveClient.wrapResult<T>(resp, route);
-    } catch (err) {
-      return NicoliveClient.wrapFetchError(err as Error, route);
+
+    if (viaMainProcess) {
+      const res = await fetchViaMainProcess(url, requestInit);
+      return {
+        ok: res.ok,
+        status: res.status,
+        statusText: `${res.status}`,
+        body: res.text,
+        headers: res.headers,
+        route,
+      };
     }
+
+    const res = await fetch(url, requestInit);
+    const headerEntries: [string, string][] = [];
+    res.headers.forEach((value, key) => {
+      headerEntries.push([key, value]);
+    });
+    return {
+      ok: res.ok,
+      status: res.status,
+      statusText: res.statusText,
+      body: await res.text(),
+      headers: headerEntries,
+      route,
+    };
   }
 
   static jsonBody<T>(body: T, extraHeaders: HeadersInit = {}): RequestInit {
@@ -554,8 +600,12 @@ export class NicoliveClient {
       if (result.value instanceof Error) {
         throw result.value;
       }
-      // handleErrors 相当: HTTP/API エラーは status 付き Error で呼び出し側に返す
-      const status = result.diag?.httpStatus ?? result.value?.meta?.status ?? 0;
+      // handleErrors 相当: API エラーは meta.status があればそちらを優先して調査しやすくする
+      const metaStatus =
+        result.value && typeof result.value === 'object' && 'meta' in result.value
+          ? result.value.meta?.status
+          : undefined;
+      const status = metaStatus ?? result.diag?.httpStatus ?? 0;
       throw new Error(`fetchOnairUserProgram failed: ${status}`);
     }
     return result.value ?? {};
@@ -762,18 +812,25 @@ export class NicoliveClient {
    * @returns
    */
   async fetchKonomiTags(userId: string): Promise<KonomiTag[]> {
-    const res = await fetch(
+    const res = await this.requestWithSession(
+      'POST',
       `${NicoliveClient.live2ApiBaseURL}/api/v1/konomiTags/GetFollowing`,
-      NicoliveClient.createRequest(
-        'POST',
-        NicoliveClient.jsonBody(
-          { follower_id: { value: userId, type: 'USER' } },
-          { 'x-service-id': 'n-air-app' },
-        ),
+      NicoliveClient.jsonBody(
+        { follower_id: { value: userId, type: 'USER' } },
+        { 'x-service-id': 'n-air-app' },
       ),
     );
     if (res.ok) {
-      const json = (await NicoliveClient.parseJsonOrThrow(res, 'fetchKonomiTags')) as KonomiTags;
+      let json: KonomiTags;
+      try {
+        json = JSON.parse(res.body) as KonomiTags;
+      } catch (e) {
+        console.warn('fetchKonomiTags: non-json body', res.body.slice(0, 200));
+        throw new Error(
+          `fetchKonomiTags: response is not valid JSON (status=${res.status})`,
+          { cause: e },
+        );
+      }
       return json.konomi_tags;
     }
     throw new Error(`fetchKonomiTags failed: ${res.status} ${res.statusText}`);
@@ -789,14 +846,20 @@ export class NicoliveClient {
    * @returns フォロー中ならtrue
    */
   async fetchUserFollow(userId: string): Promise<boolean> {
-    const res = await fetch(
-      NicoliveClient.userFollowEndpoint(userId),
-      NicoliveClient.createRequest('GET', {
-        headers: FrontendIdHeader,
-      }),
-    );
+    const res = await this.requestWithSession('GET', NicoliveClient.userFollowEndpoint(userId), {
+      headers: FrontendIdHeader,
+    });
     if (res.ok) {
-      const json = await NicoliveClient.parseJsonOrThrow(res, 'fetchUserFollow');
+      let json: unknown;
+      try {
+        json = JSON.parse(res.body);
+      } catch (e) {
+        console.warn('fetchUserFollow: non-json body', res.body.slice(0, 200));
+        throw new Error(
+          `fetchUserFollow: response is not valid JSON (status=${res.status})`,
+          { cause: e },
+        );
+      }
       console.info('fetchUserFollow', json);
       if (isValidUserFollowStatusResponse(json)) {
         return json.data.following;
@@ -824,15 +887,12 @@ export class NicoliveClient {
    */
   async followUser(userId: string): Promise<void> {
     this.prepareUserFollowApi();
-    const res = await fetch(
-      NicoliveClient.userFollowEndpoint(userId),
-      NicoliveClient.createRequest('POST', {
-        headers: {
-          ...FrontendIdHeader,
-          'X-Request-With': 'N Air',
-        },
-      }),
-    );
+    const res = await this.requestWithSession('POST', NicoliveClient.userFollowEndpoint(userId), {
+      headers: {
+        ...FrontendIdHeader,
+        'X-Request-With': 'N Air',
+      },
+    });
     if (!res.ok) {
       throw new Error(`followUser failed: ${res.status} ${res.statusText}`);
     }
@@ -844,19 +904,15 @@ export class NicoliveClient {
    */
   async unFollowUser(userId: string): Promise<void> {
     this.prepareUserFollowApi();
-    const res = await fetch(
-      NicoliveClient.userFollowEndpoint(userId),
-      NicoliveClient.createRequest('DELETE', {
-        headers: {
-          ...FrontendIdHeader,
-          'X-Request-With': 'N Air',
-        },
-      }),
-    );
+    const res = await this.requestWithSession('DELETE', NicoliveClient.userFollowEndpoint(userId), {
+      headers: {
+        ...FrontendIdHeader,
+        'X-Request-With': 'N Air',
+      },
+    });
     if (!res.ok) {
-      // ログ目的なのでJSONパースは不要 — body がプレーンテキストの場合に
-      // res.json() が SyntaxError を投げて本来のエラーを潰してしまうのを避ける
-      console.info('unFollowUser', userId, res, await res.text());
+      // ログ目的で body テキストのみ（JSON 前提にしない）
+      console.info('unFollowUser', userId, res.status, res.body);
       throw new Error(`unFollowUser failed: ${res.status} ${res.statusText}`);
     }
   }

--- a/app/services/platforms/niconico.ts
+++ b/app/services/platforms/niconico.ts
@@ -81,8 +81,9 @@ export class NiconicoService extends Service implements IPlatformService {
     // renderer の fetch では app 起点がクロスサイト扱いとなり、SameSite=Lax の
     // user_session が自動付与されない。logout と同様に cookie を明示して main 経由で送る。
     const { session } = remote.getCurrentWebContents();
+    // domain フィルタで取得（url: https://.nicovideo.jp は無効で取れないことがある）
     const cookies = await session.cookies.get({
-      url: `https://${getCookieDomain()}`,
+      domain: getCookieDomain(),
       name: 'user_session',
     });
     if (cookies.length < 1) {
@@ -145,7 +146,7 @@ export class NiconicoService extends Service implements IPlatformService {
     }
     const { session } = remote.getCurrentWebContents();
     const cookies = await session.cookies.get({
-      url: `https://${getCookieDomain()}`,
+      domain: getCookieDomain(),
       name: 'user_session',
     });
     if (cookies.length < 1) {

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -70,6 +70,8 @@ const createInjectee = ({
   isNiconicoLoggedIn = false,
   updateStreamSettings = noop,
   optimizeForNiconico = false,
+  panelProgramID = '',
+  panelProgramStatus = 'end' as 'reserved' | 'test' | 'onAir' | 'end',
 } = {}) => ({
   SettingsService: {
     state: {
@@ -108,7 +110,8 @@ const createInjectee = ({
   NicoliveCommentSynthesizerService: {},
   NicoliveProgramService: {
     state: {
-      programID: '',
+      programID: panelProgramID,
+      status: panelProgramStatus,
     },
     fetchProgram: noop,
   },
@@ -593,10 +596,59 @@ test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログ�
   );
 
   instance.toggleStreaming = jest.fn();
+  showWindow.mockClear();
 
   await instance.toggleStreamingAsync();
 
+  // パネル未取得 + チャンネルあり → 種別選択ダイアログ
+  expect(showWindow).toHaveBeenCalled();
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
+});
+
+test('toggleStreamingAsync: パネルで番組取得済みならチャンネル権限があってもダイアログなしで配信開始する', async () => {
+  const updateStreamSettings = jest.fn(() => {
+    return { key: 'stream-key' };
+  });
+  setup({
+    injectee: createInjectee({
+      isNiconicoLoggedIn: true,
+      updateStreamSettings,
+      panelProgramID: 'lv-panel-1',
+      panelProgramStatus: 'test',
+    }),
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const instance = StreamingService.instance();
+  const channels = [
+    {
+      id: 'ch1',
+      name: 'channel',
+      ownerName: 'owner',
+      thumbnailUrl: '',
+      smallThumbnailUrl: '',
+    },
+  ];
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv-user-1' }));
+  instance.client.fetchOnairChannels = jest.fn(() =>
+    Promise.resolve({ ok: true, value: channels }),
+  );
+  instance.toggleStreaming = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
+  showWindow.mockClear();
+
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).not.toHaveBeenCalled();
+  // onairs/user があればそれを優先
+  expect(updateStreamSettings).toHaveBeenCalledWith('lv-user-1');
+  expect(instance.client.fetchOnairChannels).not.toHaveBeenCalled();
 });
 
 test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログインしていて、番組がなかった場合', async () => {

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -651,6 +651,53 @@ test('toggleStreamingAsync: パネルで番組取得済みならチャンネル�
   expect(instance.client.fetchOnairChannels).not.toHaveBeenCalled();
 });
 
+test('toggleStreamingAsync: onairs/user が空でもパネル番組があればダイアログなしで配信開始する', async () => {
+  const updateStreamSettings = jest.fn(() => {
+    return { key: 'stream-key' };
+  });
+  setup({
+    injectee: createInjectee({
+      isNiconicoLoggedIn: true,
+      updateStreamSettings,
+      panelProgramID: 'lv-panel-1',
+      panelProgramStatus: 'test',
+    }),
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const instance = StreamingService.instance();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({}));
+  instance.client.fetchOnairChannels = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      value: [
+        {
+          id: 'ch1',
+          name: 'channel',
+          ownerName: 'owner',
+          thumbnailUrl: '',
+          smallThumbnailUrl: '',
+        },
+      ],
+    }),
+  );
+  instance.toggleStreaming = jest.fn();
+  instance.optimizeForNiconicoAndStartStreaming = jest.fn();
+  showWindow.mockClear();
+
+  await instance.toggleStreamingAsync();
+
+  expect(showWindow).not.toHaveBeenCalled();
+  expect(updateStreamSettings).toHaveBeenCalledWith('lv-panel-1');
+  expect(instance.client.fetchOnairChannels).not.toHaveBeenCalled();
+});
+
 test('toggleStreamingAsyncでstreamingStatusがoffline、ニコニコにログインしていて、番組がなかった場合', async () => {
   setup({
     injectee: createInjectee({

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -179,7 +179,10 @@ export class StreamingService
   /**
    * 配信開始ボタンまたはショートカットキーによる配信開始(対話可能)
    *
-   * 現在ログインされているユーザーで、配信可能なチャンネルが存在する場合には、配信番組選択ウィンドウを開きます。
+   * ニコ生パネルで番組取得済み（test / onAir / reserved）のときは、その番組でそのまま配信開始する。
+   *
+   * パネル未取得かつ現在ログインされているユーザーで配信可能なチャンネルが存在する場合には、
+   * 配信番組選択ウィンドウを開きます。
    *
    * 配信番組選択ウィンドウで「配信開始」ボタンを押した時にもこのメソッドが呼ばれ、
    * options.nicoliveProgramSelectorResult に、ウィンドウで選ばれた配信種別と
@@ -215,37 +218,55 @@ export class StreamingService
         this.SET_PROGRAM_FETCHING(true);
         const broadcastableUserProgram = await this.client.fetchOnairUserProgram();
 
+        // ニコ生パネルで既に番組取得済みで、配信可能な状態ならそれを優先する
+        // （チャンネル配信権限がある場合でも種別ダイアログを挟まない）
+        const panelProgramId = this.nicoliveProgramService.state.programID;
+        const panelStatus = this.nicoliveProgramService.state.status;
+        const panelStreamable =
+          Boolean(panelProgramId)
+          && (panelStatus === 'test' || panelStatus === 'onAir' || panelStatus === 'reserved');
+
         // 配信番組選択ウィンドウ以外からの呼び出し時
         if (!opts.nicoliveProgramSelectorResult) {
-          const broadcastableChannelsResult = await this.client.fetchOnairChannels();
+          // パネル未取得のときだけチャンネル有無を見て選択 UI を出す
+          if (!panelStreamable) {
+            const broadcastableChannelsResult = await this.client.fetchOnairChannels();
 
-          // 配信可能チャンネルがある時
-          // エラー時は チャンネルがない時と同様の挙動とする
-          if (isOk(broadcastableChannelsResult) && broadcastableChannelsResult.value.length > 0) {
-            this.windowsService.showWindow({
-              title: $t('streaming.nicoliveProgramSelector.title'),
-              componentName: 'NicoliveProgramSelector',
-              size: {
-                width: 800,
-                height: 800,
-              },
-            });
-            return;
-          }
+            // 配信可能チャンネルがある時
+            // エラー時は チャンネルがない時と同様の挙動とする
+            // Array.isArray でガード: 認証失敗時などに data が配列以外でも length>0 になり得ないようにする
+            if (
+              isOk(broadcastableChannelsResult)
+              && Array.isArray(broadcastableChannelsResult.value)
+              && broadcastableChannelsResult.value.length > 0
+            ) {
+              this.windowsService.showWindow({
+                title: $t('streaming.nicoliveProgramSelector.title'),
+                componentName: 'NicoliveProgramSelector',
+                size: {
+                  width: 800,
+                  height: 800,
+                },
+              });
+              return;
+            }
 
-          // 配信可能チャンネルがなく、配信できるユーザー生放送もない場合
-          if (!broadcastableUserProgram.programId && !broadcastableUserProgram.nextProgramId) {
-            return this.showNotBroadcastingMessageBoxForNicolive('no_user_program');
+            // 配信可能チャンネルがなく、配信できるユーザー生放送もない場合
+            if (!broadcastableUserProgram.programId && !broadcastableUserProgram.nextProgramId) {
+              return this.showNotBroadcastingMessageBoxForNicolive('no_user_program');
+            }
           }
         }
 
-        // 配信番組選択ウィンドウでチャンネル番組が選ばれた時はそのチャンネル番組を, それ以外の場合は放送中のユーザー番組のIDを代入
-        // ユーザー番組については、即時番組があればそれを優先し、なければ予約番組の番組IDを採用する。
+        // 配信番組選択ウィンドウでチャンネル番組が選ばれた時はそのチャンネル番組を,
+        // それ以外は onairs/user → パネル取得済み番組の順で採用する
         const programId = opts.nicoliveProgramSelectorResult
             && opts.nicoliveProgramSelectorResult.providerType === 'channel'
             && opts.nicoliveProgramSelectorResult.channelProgramId
           ? opts.nicoliveProgramSelectorResult.channelProgramId
-          : broadcastableUserProgram.programId || broadcastableUserProgram.nextProgramId;
+          : broadcastableUserProgram.programId
+            || broadcastableUserProgram.nextProgramId
+            || (panelStreamable ? panelProgramId : undefined);
 
         // 配信番組選択ウィンドウでユーザー番組を選んだが、配信可能なユーザー番組がない場合
         if (!programId) {

--- a/main.js
+++ b/main.js
@@ -1316,7 +1316,8 @@ function initialize(crashHandler) {
         const text = await response.text();
         return {
           ok: response.ok,
-          headers: response.headers.entries(),
+          // iterator のままでは Electron IPC の構造化クローンで中身が失われるため配列化する
+          headers: [...response.headers.entries()],
           status: response.status,
           text,
         };


### PR DESCRIPTION
## このpull requestが解決する内容

チャンネル配信権限があるアカウントで、ニコ生パネルから**番組取得済み**の状態であっても配信開始時に「配信種別」選択ダイアログが出てしまう問題を修正します。番組取得済み（test / onAir / reserved）のときは選択 UI を挟まず、その番組（または onairs/user）で配信開始します。

## 背景

#1392（未リリース）で `user_session` を `SameSite=Lax` にした後、live API へのセッション付与が不十分な状態だと配信可能なチャンネル一覧・ユーザー番組情報の取得が不安定になり、想定と異なる分岐に入っていました。あわせて Cookie 明示送信などの API 認証まわりも整えています（ユーザー向け挙動の根は上記の種別選択です）。

## 変更内容

### 配信開始フロー（`streaming.ts`）
- パネルで番組取得済みかつ配信可能な状態（`test` / `onAir` / `reserved`）のときは、チャンネル権限があっても種別選択を出さない
- 番組 ID は「選択結果（チャンネル）」→ `onairs/user` → パネル取得済み の順で採用

### セッション送信（#1392 補完）
- `requestWithSession` を共通化し、認証付き API では `Cookie` + `X-Niconico-Session` を main 経由で明示送信（renderer では Cookie ヘッダが forbidden）
- 対象: `requestAPI`（番組・モデレーター等）/ `fetchOnairUserProgram` / **好みタグ**（`fetchKonomiTags`）/ **フォロー**（`fetchUserFollow` / `followUser` / `unFollowUser`）
- cookie 取得を `domain` フィルタに統一
- HTTP 200 でも `meta.status !== 200` は API 失敗として扱い、エラーメッセージは `meta.status` を優先して表示

### main 経由 fetch のレスポンスヘッダー（`main.js`）
- `fetch` IPC で `response.headers.entries()` を **配列に展開**して返すよう修正（iterator のままでは Electron IPC の構造化クローンで中身が失われる）
- renderer 側 `wrapResult` が `Date` ヘッダーを取得でき、`serverDateMs` によるサーバー時刻補正が効くようにする
- 認証付き API が main 経由に寄ったことで影響が出やすくなっていたため、あわせて修正

### テスト
- パネル取得済み・チャンネル権限ありでダイアログを出さない経路
- `onairs/user` が空でもパネルの `programID` で配信開始するフォールバック
- 好みタグ / フォローの非 JSON レスポンス時のエラー扱い（main 経由モック）

## 関連

- 関連: #1392 （SameSite=Lax / ログイン検証の Cookie 明示。未リリース）

## テスト
- [x] チャンネル権限**なし**アカウント: 番組取得 → 配信開始が通ること
- [x] チャンネル権限**あり**アカウント: 番組取得済みなら種別ダイアログなしで配信開始できること
- [x] チャンネル権限あり・パネル未取得: 従来どおり種別選択が出ること
- [x] 種別選択からユーザー番組を選んで配信開始できること
- [x] ログイン済みで好みタグ / フォローの取得・操作ができること
