### PR TITLE
修正: 一部の環境で配信を開始できない問題を修正

### DIFF
--- a/main-process/fetch.d.ts
+++ b/main-process/fetch.d.ts
@@ -1,0 +1,9 @@
+import type { Net } from 'electron';
+
+import type { MainProcessFetchResponse } from '../app/util/fetchViaMainProcess';
+
+export function fetchViaElectronNet(
+  net: Pick<Net, 'fetch'>,
+  url: string,
+  options: RequestInit,
+): Promise<MainProcessFetchResponse>;

--- a/main-process/fetch.js
+++ b/main-process/fetch.js
@@ -1,0 +1,34 @@
+/**
+ * Electron のネットワークスタックを使ってリクエストし、IPC で転送可能な値へ変換する。
+ *
+ * @param {Pick<import('electron').Net, 'fetch'>} net
+ * @param {string} url
+ * @param {RequestInit} options
+ * @returns {Promise<import('../app/util/fetchViaMainProcess.ts').MainProcessFetchResponse>}
+ */
+async function fetchViaElectronNet(net, url, options) {
+  try {
+    const response = await net.fetch(url, options);
+    const text = await response.text();
+    return {
+      ok: response.ok,
+      // iterator のままでは Electron IPC の構造化クローンで中身が失われるため配列化する
+      headers: [...response.headers.entries()],
+      status: response.status,
+      text,
+    };
+  } catch (e) {
+    // cause チェーンとURLを文字列化してrendererに伝搬する
+    // (Electron の IPC シリアライズでは cause が失われるため)
+    // [MAIN_FETCH_FAIL code=...] 接頭辞は renderer 側 wrapFetchError が機械可読に経路を判別するために使用する
+    const causeCode = e.cause?.code ?? '';
+    const cause = e.cause
+      ? `${e.cause.name}: ${e.cause.message} (code: ${e.cause.code})`
+      : undefined;
+    throw new Error(
+      `[MAIN_FETCH_FAIL code=${causeCode}] ${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`,
+    );
+  }
+}
+
+module.exports = { fetchViaElectronNet };

--- a/main-process/fetch.test.ts
+++ b/main-process/fetch.test.ts
@@ -1,0 +1,44 @@
+import { fetchViaElectronNet } from './fetch';
+
+describe('fetchViaElectronNet', () => {
+  test('net.fetch にリクエストをそのまま渡し、IPC で転送可能なレスポンスを返す', async () => {
+    const options: RequestInit = {
+      method: 'POST',
+      headers: { Cookie: 'user_session=abc', Origin: 'https://www.nicovideo.jp' },
+      body: JSON.stringify({ test: true }),
+    };
+    const response = {
+      ok: true,
+      headers: new Headers([
+        ['content-type', 'application/json'],
+        ['set-cookie', 'user_session=updated'],
+      ]),
+      status: 200,
+      text: jest.fn().mockResolvedValue('{"result":"ok"}'),
+    };
+    const net = { fetch: jest.fn().mockResolvedValue(response) };
+
+    await expect(fetchViaElectronNet(net, 'https://example.com/ingest', options)).resolves.toEqual({
+      ok: true,
+      headers: [
+        ['content-type', 'application/json'],
+        ['set-cookie', 'user_session=updated'],
+      ],
+      status: 200,
+      text: '{"result":"ok"}',
+    });
+    expect(net.fetch).toHaveBeenCalledWith('https://example.com/ingest', options);
+  });
+
+  test('fetch 失敗時に cause の診断情報とURLを MAIN_FETCH_FAIL として返す', async () => {
+    const cause = Object.assign(new Error('self signed certificate in certificate chain'), {
+      code: 'SELF_SIGNED_CERT_IN_CHAIN',
+    });
+    const error = new Error('fetch failed', { cause });
+    const net = { fetch: jest.fn().mockRejectedValue(error) };
+
+    await expect(fetchViaElectronNet(net, 'https://example.com/ingest', {})).rejects.toThrow(
+      '[MAIN_FETCH_FAIL code=SELF_SIGNED_CERT_IN_CHAIN] fetch failed [url: https://example.com/ingest, cause: Error: self signed certificate in certificate chain (code: SELF_SIGNED_CERT_IN_CHAIN)]',
+    );
+  });
+});

--- a/main.js
+++ b/main.js
@@ -40,11 +40,12 @@ const osnVersion = getObsStudioNodeVersion();
 ////////////////////////////////////////////////////////////////////////////////
 const electron = require('electron');
 
-const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell, crashReporter } =
+const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell, crashReporter, net } =
   electron;
 const path = require('node:path');
 const fs = require('node:fs');
 const remote = require('@electron/remote/main');
+const { fetchViaElectronNet } = require('./main-process/fetch');
 
 ////////////////////////////////////////////////////////////////////////////////
 // Dev Hosts Configuration
@@ -1311,26 +1312,7 @@ function initialize(crashHandler) {
      * @returns {Promise<import('./app/util/fetchViaMainProcess.ts').MainProcessFetchResponse>}
      * */
     async (_e, url, options) => {
-      try {
-        const response = await fetch(url, options);
-        const text = await response.text();
-        return {
-          ok: response.ok,
-          // iterator のままでは Electron IPC の構造化クローンで中身が失われるため配列化する
-          headers: [...response.headers.entries()],
-          status: response.status,
-          text,
-        };
-      } catch (e) {
-        // cause チェーンとURLを文字列化してrendererに伝搬する
-        // (Electron の IPC シリアライズでは cause が失われるため)
-        // [MAIN_FETCH_FAIL code=...] 接頭辞は renderer 側 wrapFetchError が機械可読に経路を判別するために使用する
-        const causeCode = e.cause?.code ?? '';
-        const cause = e.cause
-          ? `${e.cause.name}: ${e.cause.message} (code: ${e.cause.code})`
-          : undefined;
-        throw new Error(`[MAIN_FETCH_FAIL code=${causeCode}] ${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`);
-      }
+      return fetchViaElectronNet(net, url, options);
     },
   );
 }


### PR DESCRIPTION
## このpull requestが解決する内容
main process 経由の HTTP リクエストを Node のグローバル `fetch` から Electron `net.fetch` へ変更します。

これにより Chromium のネットワークスタックを使用し、OS の証明書ストアやプロキシ設定を利用できるようにします。

Fixes #1395

## 背景
HTTPS 検査を行うウイルス対策ソフトや組織プロキシの環境では、OS／Chromium が信頼する証明書を Node／Undici が信頼できず、main process 経由の Niconico API だけ `SELF_SIGNED_CERT_IN_CHAIN` で失敗することがありました。

## 変更内容
- IPC `fetch` handler から Electron `net.fetch` を使用
- method、body、headers を含むリクエストオプションを従来どおり転送
- status、response headers、response body を IPC で転送可能な形式へ変換
- `MAIN_FETCH_FAIL` の cause code、URL、cause 情報を維持
- リクエスト転送、レスポンス変換、失敗時診断の単体テストを追加

## 影響範囲
- main process 経由で実行する Niconico API リクエスト
- 証明書検証は無効化せず、Electron／Chromium の通常の検証を使用

## Sentry
Sentry-Resolves: N-AIR-APP-G9M
Sentry-Resolves: N-AIR-APP-G9K
