### PR TITLE
修正: 自動文字起こしでシステム既定以外のマイクを選ぶと別のマイクが使われる問題を修正

### DIFF
--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -154,23 +154,23 @@ function setupTranscription(
     modelDownloaded?: boolean;
     audioDeviceId?: string;
     emptyDevices?: boolean;
+    // vosk-cli の `-l` が返すデバイス一覧を差し替える (emptyDevices より優先)
+    devices?: Array<{ id: string; name: string; index: number }>;
   } = {},
 ) {
   const downloadedStatus = { state: 'downloaded' as const };
   const notDownloadedStatus = { state: 'not_downloaded' as const };
 
-  const prepareOptions = options.emptyDevices
-    ? {
-      mockOverrides: {
-        listAudioDevices: emptyDeviceList,
-        voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
-      },
-    }
-    : {
-      mockOverrides: {
-        voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
-      },
-    };
+  const explicitDeviceList = options.devices
+    ? { version: '1', devices: options.devices }
+    : undefined;
+  const deviceList = explicitDeviceList ?? (options.emptyDevices ? emptyDeviceList : undefined);
+  const prepareOptions = {
+    mockOverrides: {
+      ...(deviceList ? { listAudioDevices: deviceList } : {}),
+      voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
+    },
+  };
 
   const { instance, ...rest } = prepare(prepareOptions);
 
@@ -844,6 +844,87 @@ describe('TranscriptionService', () => {
       expect(instance.getAudioDeviceIndex('test-device', -1)).toBe(0);
       expect(instance.getAudioDeviceIndex('nonexistent', -1)).toBe(-1);
       expect(instance.getAudioDeviceIndex(null, -1)).toBe(-1);
+    });
+
+    describe('getRawAudioDeviceIndex (vosk-cli device index workaround, issue #1394)', () => {
+      // 実機で再現した構成: 既定デバイス (Realtek) が vosk-cli の `-l` で先頭に差し込まれるため、
+      // `-l` の並びと ID 辞書順 (= WASAPI の生の列挙順) が食い違う
+      const REALTEK = '{0.0.1.00000000}.{4dcb28e3-2fef-48b6-b9d6-176a8fabaa53}';
+      const LOGICOOL = '{0.0.1.00000000}.{0966b276-c28c-4c1b-88eb-85519f7d7a4a}';
+      const defaultReorderedDevices = [
+        { id: REALTEK, name: 'マイク (Realtek(R) Audio)', index: 0 },
+        { id: LOGICOOL, name: 'マイク (Logicool Wireless Headset)', index: 1 },
+      ];
+
+      it('recovers the raw enumeration order by sorting device ids', () => {
+        const { instance } = setupTranscription({ devices: defaultReorderedDevices });
+
+        // `-l` の並びはそのまま (既定が先頭)
+        expect(instance.getAudioDeviceList().map((d) => d.id)).toEqual([REALTEK, LOGICOOL]);
+        // `-l` 内の位置は従来通り
+        expect(instance.getAudioDeviceIndex(REALTEK, -1)).toBe(0);
+        expect(instance.getAudioDeviceIndex(LOGICOOL, -1)).toBe(1);
+        // `-d` に渡す添字は ID 辞書順 = 生の列挙順
+        expect(instance.getRawAudioDeviceIndex(LOGICOOL, -1)).toBe(0);
+        expect(instance.getRawAudioDeviceIndex(REALTEK, -1)).toBe(1);
+      });
+
+      it('returns notFoundValue for unknown or null id', () => {
+        const { instance } = setupTranscription({ devices: defaultReorderedDevices });
+        expect(instance.getRawAudioDeviceIndex('nonexistent', -1)).toBe(-1);
+        expect(instance.getRawAudioDeviceIndex(null, -1)).toBe(-1);
+      });
+
+      it('agrees with getAudioDeviceIndex when the default device is already first in raw order', () => {
+        // 既定が生の列挙順でも先頭 (k=0) の正常系。既に動いている環境を壊さないことの確認
+        const { instance } = setupTranscription({
+          devices: [
+            { id: LOGICOOL, name: 'マイク (Logicool Wireless Headset)', index: 0 },
+            { id: REALTEK, name: 'マイク (Realtek(R) Audio)', index: 1 },
+          ],
+        });
+        expect(instance.getRawAudioDeviceIndex(LOGICOOL, -1)).toBe(0);
+        expect(instance.getRawAudioDeviceIndex(REALTEK, -1)).toBe(1);
+      });
+
+      it('handles a single device', () => {
+        const { instance } = setupTranscription();
+        expect(instance.getRawAudioDeviceIndex('test-device', -1)).toBe(0);
+      });
+
+      it('falls back to the list position when the raw-order assumption does not hold', () => {
+        // devices[1..] が ID 辞書順に並んでいない = 前提が崩れている環境。
+        // 生の列挙順を復元できないので、従来の挙動 (`-l` 内の位置) に落とす
+        const OTHER = '{0.0.1.00000000}.{9999ffff-0000-0000-0000-000000000000}';
+        const { instance } = setupTranscription({
+          devices: [
+            { id: REALTEK, name: 'Default Mic', index: 0 },
+            { id: OTHER, name: 'Mic B', index: 1 },
+            { id: LOGICOOL, name: 'Mic A', index: 2 },
+          ],
+        });
+        expect(instance.getRawAudioDeviceIndex(REALTEK, -1)).toBe(0);
+        expect(instance.getRawAudioDeviceIndex(OTHER, -1)).toBe(1);
+        expect(instance.getRawAudioDeviceIndex(LOGICOOL, -1)).toBe(2);
+      });
+
+      it('passes the raw index to the vosk client', () => {
+        const { instance, client } = setupTranscription({
+          modelDownloaded: true,
+          devices: defaultReorderedDevices,
+        });
+
+        instance.setAudioDeviceId(REALTEK);
+        instance.setEnabled(true);
+
+        // 既定 (Realtek) は `-l` では index 0 だが、生の列挙順では 1
+        expect(instance.state.audioDeviceId).toBe(REALTEK);
+        expect(client.audioDeviceIndex).toBe(1);
+
+        instance.setAudioDeviceId(LOGICOOL);
+        expect(instance.state.audioDeviceId).toBe(LOGICOOL);
+        expect(client.audioDeviceIndex).toBe(0);
+      });
     });
 
     it('should set and correct audio device ID', () => {

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -103,6 +103,29 @@ export type ActiveStatus =
 
 export type VoskError = 'launchError' | 'error';
 
+/** デバイスID 文字列の ordinal 比較 (WASAPI の生の列挙順に相当する。getRawAudioDeviceIndex 参照) */
+function compareDeviceId(a: { id: string }, b: { id: string }): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+/**
+ * 「生の列挙順 == デバイスID 辞書順」の前提が成立しているかを検証する。
+ *
+ * vosk-cli は既定デバイスだけを一覧の先頭に差し込むので、残り (devices[1..]) は生の列挙順を
+ * 保っているはずである。したがって devices[1..] が ID 辞書順に並んでいれば前提が成立して
+ * いると判断できる。
+ */
+function isRawOrderRecoverable(devices: { id: string }[]): boolean {
+  for (let i = 2; i < devices.length; i += 1) {
+    if (compareDeviceId(devices[i - 1], devices[i]) > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export class TranscriptionService extends PersistentStatefulService<ITranscriptionServiceState> {
   @Inject() transcriptionSourceUsageService: TranscriptionSourceUsageService;
   @Inject() transcriptionSourceService: TranscriptionSourceService;
@@ -301,7 +324,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       )
       .subscribe((audioDeviceId) => {
         if (this.client) {
-          this.client.audioDeviceIndex = this.getAudioDeviceIndex(audioDeviceId, 0);
+          this.client.audioDeviceIndex = this.getRawAudioDeviceIndex(audioDeviceId, 0);
         }
       });
 
@@ -514,7 +537,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
         voskCliPath: this.voskCliPath,
         modelPath: this.getModelPath(this.state.voskModelName!),
       });
-      this.client!.audioDeviceIndex = this.getAudioDeviceIndex(this.state.audioDeviceId ?? null, 0);
+      this.client!.audioDeviceIndex = this.getRawAudioDeviceIndex(this.state.audioDeviceId ?? null, 0);
     } catch (err) {
       SentryReport.error('TranscriptionService', 'createClient', err, {
         tags: { voskModelName: this.state.voskModelName },
@@ -623,7 +646,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     }
     if (this.client) {
       // デバイスリストを更新したので、audioDeviceIndex も更新する(見つかるようになったかもしれない)
-      this.client.audioDeviceIndex = this.getAudioDeviceIndex(this.state.audioDeviceId ?? null, 0);
+      this.client.audioDeviceIndex = this.getRawAudioDeviceIndex(this.state.audioDeviceId ?? null, 0);
     }
     // audioDeviceId が未設定なら存在する値で更新する
     if (!this.state.audioDeviceId && this.audioDevices$.value.length > 0) {
@@ -653,6 +676,10 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     }
   }
 
+  /**
+   * vosk-cli の `-l` が返すデバイス一覧 (audioDevices$) の中での位置を返す。
+   * `-d` に渡す添字ではない点に注意 (そちらは getRawAudioDeviceIndex() を使う)。
+   */
   getAudioDeviceIndex<T>(id: string | null, notFoundValue: T): number | T {
     if (!id) {
       return notFoundValue;
@@ -664,13 +691,49 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     return index;
   }
 
+  /**
+   * vosk-cli の `-d` に渡すためのデバイス添字を返す。
+   *
+   * vosk-cli v1.0.2 には、`-l`(一覧出力)と `-d`(デバイス選択)でデバイス番号の数え方が
+   * 食い違う不具合がある (issue #1394)。
+   * - `-l` はシステム既定デバイスを配列先頭に差し込んでソートした後の添字を返す
+   * - `-d` は WASAPI の生の列挙順 (EnumAudioEndpoints の順) に対する添字として解釈する
+   *
+   * 実機調査で、生の列挙順は「デバイスID 文字列の ordinal ソート順」と一致することが分かって
+   * いる (レジストリ MMDevices\Audio\Capture のサブキー順に由来する)。これを利用し、`-l` の
+   * 一覧を ID 順にソートして生の列挙順を復元し、その位置を添字として返す。
+   *
+   * ただしこれは Windows の文書化された仕様ではなく実装依存の観測事実なので、前提が成立して
+   * いるかを検証してから採用する。成立しない環境では現状の挙動 (= 一覧内の位置) に落とす。
+   *
+   * vosk-cli 側が ID 指定に対応したら、この workaround は撤去できる。
+   */
+  getRawAudioDeviceIndex<T>(id: string | null, notFoundValue: T): number | T {
+    if (!id) {
+      return notFoundValue;
+    }
+    const devices = this.audioDevices$.value;
+    if (!isRawOrderRecoverable(devices)) {
+      // 前提が崩れているので安全側 (現状の挙動) に落とす
+      return this.getAudioDeviceIndex(id, notFoundValue);
+    }
+    const rawIndex = [...devices].sort(compareDeviceId).findIndex((device) => device.id === id);
+    if (rawIndex === -1) {
+      return notFoundValue;
+    }
+    return rawIndex;
+  }
+
   getAudioDeviceList(): { id: string; name: string }[] {
     return this.audioDevices$.value;
   }
 
   setAudioDeviceId(audioDeviceId: string | null) {
-    const index = this.getAudioDeviceIndex(audioDeviceId, 0);
-    const actualDeviceId = this.audioDevices$.value.length > 0 ? this.audioDevices$.value[index].id : null;
+    const devices = this.audioDevices$.value;
+    const found = audioDeviceId !== null && devices.some((device) => device.id === audioDeviceId);
+    // 見つからない場合は一覧の先頭にフォールバックする (デバイスが無ければ null)
+    const fallbackDeviceId = devices.length > 0 ? devices[0].id : null;
+    const actualDeviceId = found ? audioDeviceId : fallbackDeviceId;
     if (audioDeviceId !== actualDeviceId) {
       console.warn(
         `Audio device with id ${audioDeviceId} not found. Using ${actualDeviceId} instead.`,


### PR DESCRIPTION
## このpull requestが解決する内容

自動文字起こしの音声ソースで、**システム既定以外のマイクを選ぶと別のマイクが使われてしまう**問題を修正します。

ユーザーさんからのフィードバック:

> マイクA / マイクB / マイクC と並んでいる状況下で、「マイクA」を選択すると実際には「マイクB」が使用されるようである

関連: #1394

## 背景

`vosk-cli` v1.0.2 内部で、`-l`(デバイス一覧)と `-d N`(デバイス選択)が**別の順序**でデバイス番号を数えています。

| 経路 | 並び順 |
|---|---|
| `-l`(一覧出力) | システム既定デバイスを**先頭に差し込んだ後**の添字を返す |
| `-d N`(デバイス選択) | WASAPI の**生の列挙順**(`EnumAudioEndpoints` の順)に対する添字として解釈する |

両者が一致するのは既定デバイスが生の列挙順でたまたま先頭にある場合だけなので、**既定の録音デバイスが先頭ではない環境**で off-by-one のズレが発生します。既定デバイスを変更したりマイク/ヘッドセットを着脱したタイミングから突然発生し始めるため、環境依存で再現しにくい不具合でした。

**修正の本筋は vosk-cli 側**(添字ではなくデバイスID で指定できるようにする)ですが、それを待たずに直せるよう N Air 側の短期 workaround を入れます。

## 変更内容

### 生の列挙順を復元して `-d` に渡す

実機調査で、WASAPI の生の列挙順が**デバイスID 文字列の ordinal ソート順と一致する**ことを確認しました(レジストリ `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Capture` のサブキー順に由来します)。これを使うと `-l` の出力だけから生の列挙順を復元できるため、外部のデバイスリストは不要です。

### 自己検証ガードを併せて入れた

上記は Windows の文書化された仕様ではなく**実装依存の観測事実**なので、前提が成立しているかを検証してから採用します。

vosk-cli は既定デバイスだけを一覧の先頭に差し込むので、残り(`devices[1..]`)は生の列挙順を保っているはずです。したがって `devices[1..]` が ID 辞書順に並んでいるかを確認すればよく、

- **並んでいる** → 前提成立。ソートで生の列挙順を復元して採用
- **並んでいない** → 前提が崩れているので**従来の挙動にフォールバック**

とすることで、前提が崩れた環境でも今より悪くなることはありません。

### `getAudioDeviceIndex()` を2つに分離した

この関数は意味の異なる2用途で呼ばれていたため分離しました。

| 関数 | 意味 | 呼び出し元 |
|---|---|---|
| `getAudioDeviceIndex()` | `-l` の一覧内の位置(**変更なし**) | `setAudioDeviceId()` |
| `getRawAudioDeviceIndex()` | 生の列挙順の添字(**新規**) | `client.audioDeviceIndex` (3箇所) |

`setAudioDeviceId()` は返り値を `audioDevices$`(= `-l` の並び)の添字として使い、ID の存在確認とフォールバックに用いています。ここに生の列挙順の添字を返すと `audioDevices$[rawIndex]` が別デバイスを指し、**保存される `audioDeviceId` 自体が壊れる**ため、この分離は必須です。

あわせて `setAudioDeviceId()` の存在確認を `findIndex` の結果を使う形から `some((d) => d.id === id)` に整理し、意図を明確にしました(挙動は同じ)。

### ファイル変更

- `app/services/transcription/transcription.ts`: 上記2関数と3箇所の呼び出し。モジュールレベルに `compareDeviceId()` / `isRawOrderRecoverable()` を追加
- `app/services/transcription/transcription.test.ts`: 実機で再現した実デバイスID を使ったテストを6件追加

UI は `id` ベースのままなので変更していません。

## 影響範囲

- 自動文字起こしのデバイス選択のみ。配信/録画の音声や認識精度そのものには影響しません
- 既定デバイスが生の列挙順で先頭にある環境では `-l` の並びと生の列挙順が一致するため、**今正常に動いている環境の挙動は変わりません**(テストで担保)
- vosk-cli が ID 指定に対応したら、この workaround は撤去できます(`getRawAudioDeviceIndex()` の doc comment に明記)。vosk-cli 側の修正は n-air-app/vosk-cli#2 で扱います

## テスト

- [x] システム既定以外のマイクを自動文字起こしに設定し、**旧バージョンでは別のマイクが認識される / 本ブランチでは選んだマイクが正しく使われる**ことを実機で確認
- [x] 既定デバイスが列挙順の先頭にある環境で、従来どおり正しいマイクが使われること(リグレッション確認)

## 補足

- 追加したユニットテストは、実機で再現した構成(既定 = Realtek が `-l` で先頭に差し込まれ、ID 辞書順では Logicool が先)の実デバイスID をそのまま使っています。3箇所の呼び出しを元に戻すとテストが失敗することを確認済みです
- デバイス**名は一意にならない**(同一デバイスの複数エンドポイントや同型 USB 機器2台で衝突する)ため、名前ベースの照合は使えません。照合は ID で行っています
- vosk-cli 側の根本修正は n-air-app/vosk-cli#2、`setAudioDeviceId()` の無言フォールバックの見直しは #1399 に切り出しました(#1394 にも残しています)
- マイク着脱時に文字起こしが停止する問題は本 PR とは別件です(デバイス添字の計算のみを変更しており、デバイスの開き直しやエラー処理には触れていません)。#1399 と n-air-app/vosk-cli#1 で扱います

🤖 Generated with [Claude Code](https://claude.com/claude-code)

