### PR TITLE
修正: 自動文字起こしでシステム既定以外のマイクを選ぶと別のマイクが使われる問題を修正 (vosk-cli 1.1.0)

### DIFF
--- a/app/services/transcription/VoskClient.test.ts
+++ b/app/services/transcription/VoskClient.test.ts
@@ -1,0 +1,130 @@
+import type { spawn as spawnType, spawnSync as spawnSyncType } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import { jest_fn } from 'util/jest_fn';
+
+// spawn したプロセスの最小限のモック。stdout/stderr を持つ EventEmitter として振る舞う。
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+
+  kill() {
+    this.killed = true;
+  }
+}
+
+jest.mock('node:child_process', () => ({
+  spawn: jest_fn<typeof spawnType>().mockName('spawn'),
+  spawnSync: jest_fn<typeof spawnSyncType>().mockName('spawnSync'),
+}));
+jest.mock('node:fs', () => ({
+  existsSync: jest_fn<() => boolean>().mockName('existsSync').mockReturnValue(true),
+  statSync: jest_fn<() => { isDirectory(): boolean }>()
+    .mockName('statSync')
+    .mockReturnValue({ isDirectory: () => true }),
+}));
+
+describe('VoskClient', () => {
+  let spawnMock: jest.Mock;
+  let fakeProcesses: FakeChildProcess[];
+
+  beforeEach(() => {
+    jest.resetModules();
+    const { spawn } = require('node:child_process');
+    spawnMock = spawn;
+    fakeProcesses = [];
+    spawnMock.mockImplementation(() => {
+      const proc = new FakeChildProcess();
+      fakeProcesses.push(proc);
+      return proc;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createClient(audioDeviceId?: string | null) {
+    const { VoskClient } = require('./VoskClient');
+    return new VoskClient({
+      voskCliPath: '/fake/vosk-cli.exe',
+      modelPath: '/fake/model',
+      audioDeviceId,
+    });
+  }
+
+  it('does not pass a device flag when audioDeviceId is not specified', () => {
+    const client = createClient();
+    client.startTranscription();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const args = spawnMock.mock.calls[0][1] as string[];
+    expect(args).not.toContain('-D');
+    expect(args).not.toContain('-d');
+  });
+
+  it('does not pass a device flag when audioDeviceId is null', () => {
+    const client = createClient(null);
+    client.startTranscription();
+
+    const args = spawnMock.mock.calls[0][1] as string[];
+    expect(args).not.toContain('-D');
+    expect(args).not.toContain('-d');
+  });
+
+  it('passes -D <id> and never -d when audioDeviceId is specified', () => {
+    const DEVICE_ID = '{0.0.1.00000000}.{0966b276-c28c-4c1b-88eb-85519f7d7a4a}';
+    const client = createClient(DEVICE_ID);
+    client.startTranscription();
+
+    const args = spawnMock.mock.calls[0][1] as string[];
+    const dIndex = args.indexOf('-D');
+    expect(dIndex).toBeGreaterThanOrEqual(0);
+    expect(args[dIndex + 1]).toBe(DEVICE_ID);
+    expect(args).not.toContain('-d');
+  });
+
+  it('spawns exactly once even if startTranscription is called multiple times', () => {
+    const client = createClient('some-id');
+    client.startTranscription();
+    client.startTranscription();
+    client.startTranscription();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts the process when audioDeviceId changes while running', () => {
+    const DEVICE_A = 'device-a';
+    const DEVICE_B = 'device-b';
+    const client = createClient(DEVICE_A);
+    client.startTranscription();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const firstProcess = fakeProcesses[0];
+
+    client.audioDeviceId = DEVICE_B;
+
+    expect(firstProcess.killed).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const secondArgs = spawnMock.mock.calls[1][1] as string[];
+    expect(secondArgs[secondArgs.indexOf('-D') + 1]).toBe(DEVICE_B);
+  });
+
+  it('does not spawn when audioDeviceId is set before the process is started', () => {
+    const client = createClient(null);
+    client.audioDeviceId = 'device-a';
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(client.audioDeviceId).toBe('device-a');
+  });
+
+  it('does not restart when the same audioDeviceId is assigned again', () => {
+    const client = createClient('device-a');
+    client.startTranscription();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    client.audioDeviceId = 'device-a';
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/services/transcription/VoskClient.ts
+++ b/app/services/transcription/VoskClient.ts
@@ -4,7 +4,6 @@ import { ChildProcess, spawn, spawnSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
 
 import { Observable, Subject } from 'rxjs';
-import { CommandLineClient } from 'services/nicolive-program/speech/NVoiceClient';
 
 export function getVoskCliPath(): string {
   // import/require構文を使うとビルド時に展開してしまうが、
@@ -16,14 +15,14 @@ export function getVoskCliPath(): string {
 }
 
 export type AudioDeviceInfo = {
-  index: number;
+  index: number; // vosk-cli の `-l` 一覧内の位置。N Air は `-D` でID指定するため参照しない
   id: string;
   name: string;
 };
 
 export type AudioDeviceList = {
   devices: AudioDeviceInfo[];
-  version: string; // vosk-cli version
+  version: string; // vosk-cli version。1.0.2 でも出力されるため能力判定には使えない
 };
 
 type VoskCliMessage =
@@ -48,7 +47,7 @@ export type TranscriptionMessage =
     };
 
 export interface ITranscriber {
-  audioDeviceIndex: number;
+  audioDeviceId: string | null;
   startTranscription(): Observable<TranscriptionMessage>;
   stopTranscription(): void;
 }
@@ -108,19 +107,15 @@ function isVoskCliMessage(obj: any): obj is TranscriptionMessage {
   );
 }
 
-function isTranscriptionMessage(obj: any): obj is TranscriptionMessage {
-  return obj && (isVoskCliMessage(obj) || isProcessExitedMessage(obj));
-}
-
 // Transcriber implementation using vosk-cli
 export class VoskClient implements ITranscriber {
   private _voskCliPath: string;
   private _modelPath: string;
-  private _audioDeviceIndex: number = 0;
+  private _audioDeviceId: string | null = null;
   private _voskCliProcess: ChildProcess | null = null;
   private transcribe$: Subject<TranscriptionMessage> | null = null;
 
-  constructor(options: { voskCliPath: string; modelPath: string }) {
+  constructor(options: { voskCliPath: string; modelPath: string; audioDeviceId?: string | null }) {
     // validate options
     if (!options.voskCliPath) {
       throw new Error('voskCliPath is required');
@@ -138,6 +133,7 @@ export class VoskClient implements ITranscriber {
     }
     this._voskCliPath = options.voskCliPath;
     this._modelPath = options.modelPath;
+    this._audioDeviceId = options.audioDeviceId ?? null;
     this.transcribe$ = new Subject<TranscriptionMessage>();
   }
 
@@ -162,9 +158,11 @@ export class VoskClient implements ITranscriber {
       return; // Process is already running
     }
     const args = ['-m', this._modelPath];
-    if (this._audioDeviceIndex !== null) {
-      args.push('-d', this._audioDeviceIndex.toString());
+    if (this._audioDeviceId) {
+      // vosk-cli 1.1.0 以降はデバイスIDで直接指定できる (-d は使わない。両方渡すとエラーになる)
+      args.push('-D', this._audioDeviceId);
     }
+    // ID が未指定/一覧に無い場合はフラグを付けない。vosk-cli がシステム既定の入力デバイスを使う
     this._voskCliProcess = spawn(this._voskCliPath, args, {
       stdio: 'pipe',
     });
@@ -225,43 +223,25 @@ export class VoskClient implements ITranscriber {
     }
   }
 
-  set audioDeviceIndex(index: number) {
-    if (this._audioDeviceIndex === index) {
+  set audioDeviceId(id: string | null) {
+    if (this._audioDeviceId === id) {
       return; // No change needed
     }
-    this._audioDeviceIndex = index;
-    this.shutdownVoskCliProcess(); // Restart the process with the new device
-    this.activateVoskCliProcess();
+    this._audioDeviceId = id;
+    if (this._voskCliProcess) {
+      // プロセスが走っている時だけ新しいデバイスで再起動する。
+      // 未起動時に再起動すると、activate() 前の代入で二重起動してしまう。
+      this.shutdownVoskCliProcess();
+      this.activateVoskCliProcess();
+    }
   }
-  get audioDeviceIndex(): number {
-    return this._audioDeviceIndex;
+  get audioDeviceId(): string | null {
+    return this._audioDeviceId;
   }
 
   startTranscription(): Observable<TranscriptionMessage> {
     if (!this._voskCliProcess || this._voskCliProcess.killed) {
       this.activateVoskCliProcess();
-
-      const client = new CommandLineClient(
-        this._voskCliProcess!,
-        (...args: unknown[]) => {
-          console.log(...args);
-        },
-        true,
-      );
-      client.waitLine((line: string) => {
-        try {
-          const message: TranscriptionMessage = JSON.parse(line);
-          if (isTranscriptionMessage(message)) {
-            this.transcribe$?.next(message);
-          } else {
-            console.warn(`Invalid message format: ${line}`);
-          }
-        } catch (e) {
-          console.error(`Failed to parse message: ${line}`, e);
-          this.transcribe$?.next({ info: `Error parsing message: ${JSON.stringify(line)}` });
-        }
-        return false; // Continue listening for more lines
-      });
     }
 
     return this.transcribe$!.asObservable();
@@ -275,11 +255,13 @@ export class VoskClient implements ITranscriber {
 export function CreateVoskCliClient(options: {
   voskCliPath: string;
   modelPath: string;
+  audioDeviceId?: string | null;
 }): ITranscriber {
-  const { voskCliPath, modelPath } = options;
+  const { voskCliPath, modelPath, audioDeviceId } = options;
 
   return new VoskClient({
     voskCliPath,
     modelPath,
+    audioDeviceId,
   });
 }

--- a/app/services/transcription/VoskClient.ts
+++ b/app/services/transcription/VoskClient.ts
@@ -15,14 +15,14 @@ export function getVoskCliPath(): string {
 }
 
 export type AudioDeviceInfo = {
-  index: number; // vosk-cli の `-l` 一覧内の位置。N Air は `-D` でID指定するため参照しない
+  index: number;
   id: string;
   name: string;
 };
 
 export type AudioDeviceList = {
   devices: AudioDeviceInfo[];
-  version: string; // vosk-cli version。1.0.2 でも出力されるため能力判定には使えない
+  version: string;
 };
 
 type VoskCliMessage =
@@ -115,7 +115,7 @@ export class VoskClient implements ITranscriber {
   private _voskCliProcess: ChildProcess | null = null;
   private transcribe$: Subject<TranscriptionMessage> | null = null;
 
-  constructor(options: { voskCliPath: string; modelPath: string; audioDeviceId?: string | null }) {
+  constructor(options: { voskCliPath: string; modelPath: string; audioDeviceId: string | null }) {
     // validate options
     if (!options.voskCliPath) {
       throw new Error('voskCliPath is required');
@@ -133,7 +133,7 @@ export class VoskClient implements ITranscriber {
     }
     this._voskCliPath = options.voskCliPath;
     this._modelPath = options.modelPath;
-    this._audioDeviceId = options.audioDeviceId ?? null;
+    this._audioDeviceId = options.audioDeviceId;
     this.transcribe$ = new Subject<TranscriptionMessage>();
   }
 
@@ -255,7 +255,7 @@ export class VoskClient implements ITranscriber {
 export function CreateVoskCliClient(options: {
   voskCliPath: string;
   modelPath: string;
-  audioDeviceId?: string | null;
+  audioDeviceId: string | null;
 }): ITranscriber {
   const { voskCliPath, modelPath, audioDeviceId } = options;
 

--- a/app/services/transcription/transcription.test.ts
+++ b/app/services/transcription/transcription.test.ts
@@ -154,23 +154,23 @@ function setupTranscription(
     modelDownloaded?: boolean;
     audioDeviceId?: string;
     emptyDevices?: boolean;
+    // vosk-cli の `-l` が返すデバイス一覧を差し替える (emptyDevices より優先)
+    devices?: Array<{ id: string; name: string; index: number }>;
   } = {},
 ) {
   const downloadedStatus = { state: 'downloaded' as const };
   const notDownloadedStatus = { state: 'not_downloaded' as const };
 
-  const prepareOptions = options.emptyDevices
-    ? {
-      mockOverrides: {
-        listAudioDevices: emptyDeviceList,
-        voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
-      },
-    }
-    : {
-      mockOverrides: {
-        voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
-      },
-    };
+  const explicitDeviceList = options.devices
+    ? { version: '1', devices: options.devices }
+    : undefined;
+  const deviceList = explicitDeviceList ?? (options.emptyDevices ? emptyDeviceList : undefined);
+  const prepareOptions = {
+    mockOverrides: {
+      ...(deviceList ? { listAudioDevices: deviceList } : {}),
+      voskModelStatus: options.modelDownloaded ? downloadedStatus : notDownloadedStatus,
+    },
+  };
 
   const { instance, ...rest } = prepare(prepareOptions);
 
@@ -195,6 +195,7 @@ function prepare(options: PrepareOptions = {}): {
   transcriptionMessages$: Subject<TranscriptionMessage>;
   stopTranscription: jest.Mock;
   audioSourceUpdated: Subject<unknown>;
+  restartCalls: (string | null)[];
 } {
   const obsAudioDevicesOverride = options.mockOverrides?.obsAudioDevices;
   const audioServiceOverride = options.mockOverrides?.audioServiceOverride;
@@ -232,18 +233,37 @@ function prepare(options: PrepareOptions = {}): {
 
   const transcriptionMessages$ = new Subject<TranscriptionMessage>();
   const stopTranscription = jest_fn<VoskClientType['stopTranscription']>().mockName('stopTranscription');
+  // audioDeviceId は実際の getter/setter として実装し、デバイス変更時の再起動挙動
+  // (実装と同じ no-op セマンティクス) をテストで観測できるようにする
+  const restartCalls: (string | null)[] = [];
+  let currentAudioDeviceId: string | null = null;
   const client = {
     startTranscription: jest_fn<VoskClientType['startTranscription']>()
       .mockName('startTranscription')
       .mockReturnValue(transcriptionMessages$),
     stopTranscription,
-    audioDeviceIndex: -1,
+    get audioDeviceId() {
+      return currentAudioDeviceId;
+    },
+    set audioDeviceId(id: string | null) {
+      if (currentAudioDeviceId === id) {
+        return;
+      }
+      currentAudioDeviceId = id;
+      restartCalls.push(id);
+    },
   } as unknown as VoskClientType;
   const {
     CreateVoskCliClient: mockedCreateVoskCliClient,
     VoskClient: mockedVoskClient,
   } = require('./VoskClient');
-  mockedCreateVoskCliClient.mockReturnValue(client);
+  mockedCreateVoskCliClient.mockImplementation(
+    (createOptions: { audioDeviceId?: string | null }) => {
+      // 実装と同じく、生成時に渡された audioDeviceId をコンストラクタ引数として反映する
+      currentAudioDeviceId = createOptions.audioDeviceId ?? null;
+      return client;
+    },
+  );
 
   // Apply mock overrides for listAudioDevices
   if (options.mockOverrides?.listAudioDevices) {
@@ -271,6 +291,7 @@ function prepare(options: PrepareOptions = {}): {
     transcriptionMessages$: transcriptionMessages$!,
     setVoskModelStatus: setVoskModelStatus!,
     audioSourceUpdated,
+    restartCalls,
   };
 }
 
@@ -839,13 +860,6 @@ describe('TranscriptionService', () => {
       expect(setupTranscription({ emptyDevices: true }).instance.getAudioDeviceList()).toEqual([]);
     });
 
-    it('should get audio device index correctly', () => {
-      const { instance } = setupTranscription();
-      expect(instance.getAudioDeviceIndex('test-device', -1)).toBe(0);
-      expect(instance.getAudioDeviceIndex('nonexistent', -1)).toBe(-1);
-      expect(instance.getAudioDeviceIndex(null, -1)).toBe(-1);
-    });
-
     it('should set and correct audio device ID', () => {
       const { instance } = setupTranscription();
 
@@ -967,6 +981,112 @@ describe('TranscriptionService', () => {
       );
       consoleSpy.mockRestore();
     });
+  });
+
+  describe('audio device selection (ID based, vosk-cli 1.1.0)', () => {
+    // 実機で再現した #1394 の構成: 既定デバイス (Realtek) が `-l` で先頭に来るが、
+    // Logicool は非既定。vosk-cli 1.1.0 の `-D` は列挙順に依存しないので、
+    // どちらを選んでも選んだ ID がそのまま vosk-cli に渡ることを確認する
+    const REALTEK = '{0.0.1.00000000}.{4dcb28e3-2fef-48b6-b9d6-176a8fabaa53}';
+    const LOGICOOL = '{0.0.1.00000000}.{0966b276-c28c-4c1b-88eb-85519f7d7a4a}';
+    const twoDevices = [
+      { id: REALTEK, name: 'マイク (Realtek(R) Audio)', index: 0 },
+      { id: LOGICOOL, name: 'マイク (Logicool Wireless Headset)', index: 1 },
+    ];
+
+    it(
+      'passes the selected (non-default) device id to CreateVoskCliClient',
+      withClock(async (clock) => {
+        const { instance, client } = setupTranscription({
+          modelDownloaded: true,
+          devices: twoDevices,
+        });
+
+        instance.setAudioDeviceId(LOGICOOL);
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+
+        expect(instance.state.audioDeviceId).toBe(LOGICOOL);
+        expect(client.audioDeviceId).toBe(LOGICOOL);
+      }),
+    );
+
+    it(
+      'restarts the client with the new device id when the selection changes',
+      withClock(async (clock) => {
+        const { instance, client, restartCalls } = setupTranscription({
+          modelDownloaded: true,
+          devices: twoDevices,
+        });
+
+        instance.setAudioDeviceId(REALTEK);
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+        restartCalls.length = 0; // activate() 時点のコンストラクタ渡しはカウントしない
+
+        instance.setAudioDeviceId(LOGICOOL);
+        await clock.tickAsync(0);
+
+        expect(client.audioDeviceId).toBe(LOGICOOL);
+        expect(restartCalls).toEqual([LOGICOOL]);
+      }),
+    );
+
+    it(
+      'passes null when the selected device is not in the current list',
+      withClock(async (clock) => {
+        const { instance, client } = setupTranscription({
+          modelDownloaded: true,
+          devices: twoDevices,
+        });
+
+        instance.setAudioDeviceId(LOGICOOL);
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+
+        // デバイスが着脱されて一覧から消えたケースを模す
+        // (updateAudioDevices() は state.audioDeviceId 自体は書き換えない)
+        const { VoskClient: mockedVoskClient } = require('./VoskClient');
+        mockedVoskClient.listAudioDevices.mockReturnValue({
+          version: '1',
+          devices: [twoDevices[0]],
+        });
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        instance.updateAudioDevices();
+        await clock.tickAsync(0);
+
+        expect(instance.state.audioDeviceId).toBe(LOGICOOL); // 選択自体は保持される
+        expect(client.audioDeviceId).toBeNull(); // クライアントには渡さず既定デバイスに委ねる
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining('is not in the current device list'),
+        );
+        consoleSpy.mockRestore();
+      }),
+    );
+
+    it(
+      'ignores device_reconnecting / device_reconnected info messages',
+      withClock(async (clock) => {
+        const { instance, transcriptionMessages$, stopTranscription } = setupTranscription({
+          modelDownloaded: true,
+          devices: twoDevices,
+          audioDeviceId: LOGICOOL,
+        });
+        instance.setEnabled(true);
+        await clock.tickAsync(0);
+
+        transcriptionMessages$.next({ info: 'device_reconnecting' });
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('active');
+        expect(stopTranscription).not.toHaveBeenCalled();
+
+        transcriptionMessages$.next({ info: 'device_reconnected' });
+        await clock.tickAsync(0);
+        expect(instance.activeStatus()).toBe('active');
+        expect(stopTranscription).not.toHaveBeenCalled();
+      }),
+    );
   });
 
   describe('audio device muted stream', () => {
@@ -1252,6 +1372,7 @@ describe('TranscriptionService', () => {
         expect(mockedCreateVoskCliClient).toHaveBeenCalledWith({
           voskCliPath: '/fake/vosk-cli',
           modelPath: `/fake/path/vosk-model/${VOSK_MODEL_NAME}`,
+          audioDeviceId: 'test-device',
         });
 
         // Clear mock to track new calls
@@ -1270,6 +1391,7 @@ describe('TranscriptionService', () => {
         expect(mockedCreateVoskCliClient).toHaveBeenCalledWith({
           voskCliPath: '/fake/vosk-cli',
           modelPath: `/fake/path/vosk-model/${VOSK_MODEL_NAME_2}`,
+          audioDeviceId: 'test-device',
         });
 
         // Verify new client's startTranscription was called

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -670,7 +670,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     );
     Sentry.addBreadcrumb({
       category: 'transcription',
-      message: 'audioDeviceId not found in device list; falling back to system default',
+      message: `Audio device ${audioDeviceId} not found in device list; falling back to system default`,
     });
     return null;
   }

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -53,7 +53,7 @@ const getVoskModelURL = (name: string): string =>
 export interface ITranscriptionServiceState {
   enabled?: boolean;
   voskModelName: string;
-  audioDeviceId?: string | null;
+  audioDeviceId: string | null;
   commentEnabled: boolean;
   commentPosition: CommentPosition;
   commentSize: CommentSize;
@@ -111,6 +111,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
 
   static defaultState: ITranscriptionServiceState = {
     voskModelName: VOSK_MODEL_NAMES[0],
+    audioDeviceId: null,
     commentEnabled: false,
     commentPosition: 'shita',
     commentFont: 'gothic',
@@ -296,7 +297,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     // audioDeviceId 状態を監視して、状態が変わったらクライアントの audioDeviceId を更新する
     this.state$
       .pipe(
-        map((state) => state.audioDeviceId ?? null),
+        map((state) => state.audioDeviceId),
         distinctUntilChanged(),
       )
       .subscribe((audioDeviceId) => {
@@ -315,7 +316,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
   private createAudioDeviceMutedStream() {
     merge(
       this.state$.pipe(
-        map((state) => state.audioDeviceId ?? null),
+        map((state) => state.audioDeviceId),
         distinctUntilChanged(),
       ),
       this.audioService.audioSourceUpdated,
@@ -513,7 +514,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       this.client = CreateVoskCliClient({
         voskCliPath: this.voskCliPath,
         modelPath: this.getModelPath(this.state.voskModelName!),
-        audioDeviceId: this.resolveClientAudioDeviceId(this.state.audioDeviceId ?? null),
+        audioDeviceId: this.resolveClientAudioDeviceId(this.state.audioDeviceId),
       });
     } catch (err) {
       SentryReport.error('TranscriptionService', 'createClient', err, {
@@ -528,7 +529,6 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
 
     this.subscription = this.client!.startTranscription().subscribe({
       next: (message) => {
-        console.log('Transcribe message:', message);
         if (isTextTranscriptionMessage(message)) {
           const text = filterNoiseText(message.text);
           if (text) {
@@ -623,7 +623,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     }
     if (this.client) {
       // デバイスリストを更新したので、クライアントの audioDeviceId も更新する(見つかるようになったかもしれない)
-      this.client.audioDeviceId = this.resolveClientAudioDeviceId(this.state.audioDeviceId ?? null);
+      this.client.audioDeviceId = this.resolveClientAudioDeviceId(this.state.audioDeviceId);
     }
     // audioDeviceId が未設定なら存在する値で更新する
     if (!this.state.audioDeviceId && this.audioDevices$.value.length > 0) {

--- a/app/services/transcription/transcription.ts
+++ b/app/services/transcription/transcription.ts
@@ -293,7 +293,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
         }
       });
 
-    // audioDeviceId 状態を監視して、状態が変わったら audioDeviceIndex を更新する
+    // audioDeviceId 状態を監視して、状態が変わったらクライアントの audioDeviceId を更新する
     this.state$
       .pipe(
         map((state) => state.audioDeviceId ?? null),
@@ -301,7 +301,7 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       )
       .subscribe((audioDeviceId) => {
         if (this.client) {
-          this.client.audioDeviceIndex = this.getAudioDeviceIndex(audioDeviceId, 0);
+          this.client.audioDeviceId = this.resolveClientAudioDeviceId(audioDeviceId);
         }
       });
 
@@ -513,8 +513,8 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       this.client = CreateVoskCliClient({
         voskCliPath: this.voskCliPath,
         modelPath: this.getModelPath(this.state.voskModelName!),
+        audioDeviceId: this.resolveClientAudioDeviceId(this.state.audioDeviceId ?? null),
       });
-      this.client!.audioDeviceIndex = this.getAudioDeviceIndex(this.state.audioDeviceId ?? null, 0);
     } catch (err) {
       SentryReport.error('TranscriptionService', 'createClient', err, {
         tags: { voskModelName: this.state.voskModelName },
@@ -622,8 +622,8 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
       return;
     }
     if (this.client) {
-      // デバイスリストを更新したので、audioDeviceIndex も更新する(見つかるようになったかもしれない)
-      this.client.audioDeviceIndex = this.getAudioDeviceIndex(this.state.audioDeviceId ?? null, 0);
+      // デバイスリストを更新したので、クライアントの audioDeviceId も更新する(見つかるようになったかもしれない)
+      this.client.audioDeviceId = this.resolveClientAudioDeviceId(this.state.audioDeviceId ?? null);
     }
     // audioDeviceId が未設定なら存在する値で更新する
     if (!this.state.audioDeviceId && this.audioDevices$.value.length > 0) {
@@ -653,15 +653,26 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
     }
   }
 
-  getAudioDeviceIndex<T>(id: string | null, notFoundValue: T): number | T {
-    if (!id) {
-      return notFoundValue;
+  /**
+   * vosk-cli の `-D` に渡すデバイスIDを決める。
+   * 一覧に無い/未選択なら null を返し、VoskClient はデバイス指定フラグを付けない
+   * (vosk-cli はシステム既定の入力デバイスを使う)。
+   */
+  private resolveClientAudioDeviceId(audioDeviceId: string | null): string | null {
+    if (!audioDeviceId) {
+      return null;
     }
-    const index = this.audioDevices$.value.findIndex((device) => device.id === id);
-    if (index === -1) {
-      return notFoundValue;
+    if (this.audioDevices$.value.some((device) => device.id === audioDeviceId)) {
+      return audioDeviceId;
     }
-    return index;
+    console.warn(
+      `Audio device ${audioDeviceId} is not in the current device list. Falling back to the system default device.`,
+    );
+    Sentry.addBreadcrumb({
+      category: 'transcription',
+      message: 'audioDeviceId not found in device list; falling back to system default',
+    });
+    return null;
   }
 
   getAudioDeviceList(): { id: string; name: string }[] {
@@ -669,8 +680,11 @@ export class TranscriptionService extends PersistentStatefulService<ITranscripti
   }
 
   setAudioDeviceId(audioDeviceId: string | null) {
-    const index = this.getAudioDeviceIndex(audioDeviceId, 0);
-    const actualDeviceId = this.audioDevices$.value.length > 0 ? this.audioDevices$.value[index].id : null;
+    const devices = this.audioDevices$.value;
+    const found = audioDeviceId !== null && devices.some((device) => device.id === audioDeviceId);
+    // 見つからない場合は一覧の先頭にフォールバックする (デバイスが無ければ null)
+    const fallbackDeviceId = devices.length > 0 ? devices[0].id : null;
+    const actualDeviceId = found ? audioDeviceId : fallbackDeviceId;
     if (audioDeviceId !== actualDeviceId) {
       console.warn(
         `Audio device with id ${audioDeviceId} not found. Using ${actualDeviceId} instead.`,

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "sockjs": "~0.3.19",
     "traverse": "~0.6.7",
     "unzip-stream": "^0.3.4",
-    "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz",
+    "vosk-cli": "https://github.com/n-air-app/vosk-cli/releases/download/1.1.0/vosk-cli-v1.1.0-windows-x64.tar.gz",
     "vue": "^3.5.38",
     "vue-i18n": "11.4.6",
     "vuex": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4
       vosk-cli:
-        specifier: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz
-        version: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz
+        specifier: https://github.com/n-air-app/vosk-cli/releases/download/1.1.0/vosk-cli-v1.1.0-windows-x64.tar.gz
+        version: https://github.com/n-air-app/vosk-cli/releases/download/1.1.0/vosk-cli-v1.1.0-windows-x64.tar.gz
       vue:
         specifier: ^3.5.38
         version: 3.5.38(typescript@5.9.3)
@@ -6954,9 +6954,9 @@ packages:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
 
-  vosk-cli@https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz:
-    resolution: {tarball: https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz}
-    version: 1.0.2
+  vosk-cli@https://github.com/n-air-app/vosk-cli/releases/download/1.1.0/vosk-cli-v1.1.0-windows-x64.tar.gz:
+    resolution: {integrity: sha512-5XYk1ZzOa/Q2JM/gxDNETgAXVwqPajrz4PKNAOtbsW8QKemC7OWWbf4dXPR9kKKtPUiqDD05o5lAf/VhLiRCcQ==, tarball: https://github.com/n-air-app/vosk-cli/releases/download/1.1.0/vosk-cli-v1.1.0-windows-x64.tar.gz}
+    version: 1.1.0
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -15213,7 +15213,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vosk-cli@https://github.com/n-air-app/vosk-cli/releases/download/1.0.2/vosk-cli-v1.0.2-windows-x64.tar.gz: {}
+  vosk-cli@https://github.com/n-air-app/vosk-cli/releases/download/1.1.0/vosk-cli-v1.1.0-windows-x64.tar.gz: {}
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
## このpull requestが解決する内容

自動文字起こしの音声ソースで、**システム既定以外のマイクを選ぶと別のマイクが使われてしまう**問題を、vosk-cli 側の根本修正 (1.1.0) を使って解決します。

Fixes #1394

## 背景

`vosk-cli` v1.0.2 内部で、`-l`(デバイス一覧)と `-d N`(デバイス選択)が**別の順序**でデバイス番号を数えていました。

| 経路 | 並び順 |
|---|---|
| `-l`(一覧出力) | システム既定デバイスを**先頭に差し込んだ後**の添字を返す |
| `-d N`(デバイス選択) | WASAPI の**生の列挙順**に対する添字として解釈する |

両者が一致するのは既定デバイスが生の列挙順でたまたま先頭にある場合だけなので、既定の録音デバイスが先頭ではない環境で off-by-one のズレが発生していました。

これに対し #1398 で N Air 側の短期 workaround を入れましたが、それは「WASAPI の生の列挙順 == デバイスID 辞書順」という実装依存の観測事実に依存する暫定対応でした。

その後 vosk-cli 1.1.0 (https://github.com/n-air-app/vosk-cli/releases/tag/1.1.0) がリリースされ、**`-D <deviceId>` によるデバイスID 直接指定**が追加されました。これは列挙順に一切依存しない、本質的な解決方法です。本PRはこちらに移行します。

## 変更内容

### vosk-cli 1.1.0 への更新

- `package.json` の vosk-cli 依存を 1.1.0 に変更
- `-l` と `-d` の順序も 1.1.0 で修正済みですが、本PRでは添字ではなく ID 指定 (`-D`) に完全移行します

### `VoskClient.ts`: index から ID ベースへ

- `ITranscriber.audioDeviceIndex: number` → `audioDeviceId: string | null`
- `activateVoskCliProcess()`: `-d <index>` → `-D <deviceId>`(ID が無ければフラグ自体を付けない。`-d`/`-D` は相互排他のため両方渡すとエラーになります)
- デバイスは **コンストラクタ引数として生成時に確定**させ、setter は**プロセスが走っている時だけ**再起動するようガードしました。これにより `activate()` 内で「生成 → 代入」の順序に依存する不安定さを構造的に排除しています
- `startTranscription()` 内の `CommandLineClient` 配線を削除しました。調査の結果、この経路は `client.run()` を一度も呼んでおらず**実際には1行も配信していないデッドコード**でした(メッセージ配信は `activateVoskCliProcess()` 自身の `stdout` ハンドラが100%担っています)

### `transcription.ts`: ID 解決の一本化

- workaround だった (前バージョンでの) `getAudioDeviceIndex()` を削除し、`resolveClientAudioDeviceId()` に一本化
- 選択中のデバイスIDが一覧に無い場合は `null` を返し、`VoskClient` はデバイス指定フラグを付けません。vosk-cli が自動的にシステム既定デバイスを使います(起動時に不明なIDを渡すと復帰不能なエラーになるため、これが最も安全なフォールバックです)
- `setAudioDeviceId()` は `some()` による存在確認に整理(挙動は変えていません)

### 副産物: マイク着脱時の自動再接続

vosk-cli 1.1.0 は `AUDCLNT_E_DEVICE_INVALIDATED`(デバイス無効化)からの自動再接続を実装しています。既存コードは `info` メッセージを安全に無視する作りだったため、**追加実装なしでこの恩恵を受けられます**。実機で以下を確認しました:

- 60秒以内に接続が戻る場合: `device_reconnecting` → `device_reconnected` で継続
- 60秒を超えた場合: `Failed to reconnect audio device` でプロセス終了 → `activeStatus` が `voskError` に固着(既知の挙動。復帰には文字起こしの OFF→ON が必要。これは別 issue #1399 で追跡しています)

## 影響範囲

- 自動文字起こしのデバイス選択のみ。配信/録画の音声や認識精度そのものには影響しません
- UI は `id` ベースのままなので変更していません

## テスト

- [x] システム既定のマイク(Logicool)を選択し、正しく認識されること
- [x] システム既定以外のマイク(Realtek)に切り替え、spawn 引数が `-D {Realtek のID}` になり、Realtek に喋った内容が正しく認識されること(#1394 の回帰確認)
- [x] 使用中のマイクを抜いて `device_reconnecting` が出ること、60秒以内に挿し直すと復帰すること／60秒を超えると `Failed to reconnect audio device` で `voskError` になり、OFF→ON で復帰すること
- [x] `pnpm run test:unit:app` で新規テスト含め全件パス

## #1398 との関係

#1398 (短期 workaround) は**クローズしません**。本PRのスケジュールに間に合わない場合のフォールバックとして、オープンのまま維持します。

本PRは `n-air_development` から直接分岐しており、#1398 のブランチには依存していません。**#1398 が先にマージされた場合、本PRは rebase して workaround (旧 `getRawAudioDeviceIndex()` / `compareDeviceId()` / `isRawOrderRecoverable()` とそのテスト) を削除する必要があります。** `setAudioDeviceId()` の書き換えと `setupTranscription()` の `devices` テストオプションは両PRで同一の差分にしてあるため、その部分の衝突は自明に解決できます。

## 補足

- vosk-cli リポジトリ: https://github.com/n-air-app/vosk-cli
- vosk-cli 側の issue: n-air-app/vosk-cli#2 (本PRで解決)、n-air-app/vosk-cli#1 (着脱時の復旧。1.1.0 で対応済みのため実機確認結果を記載してクローズ予定)
- N Air 側で追跡中の関連issue: #1399 (`voskError` の固着とエラー表示の改善)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
