### PR TITLE
開発: N Voiceの音声処理の性能と安定性を改善

### DIFF
--- a/app/services/nicolive-program/PhonemeServer.ts
+++ b/app/services/nicolive-program/PhonemeServer.ts
@@ -8,7 +8,7 @@ export class PhonemeServer {
   constructor({ onPortAssigned }: { onPortAssigned: (port: number) => void }) {
     try {
       const server = createServer();
-      server.listen(() => {
+      server.listen(0, '127.0.0.1', () => {
         const address = server.address();
         if (address !== null && typeof address === 'object') {
           console.log('PhonemeServer: socket.io listening on', address.port);
@@ -16,10 +16,8 @@ export class PhonemeServer {
         }
       });
       this.io = new Server(server, {
-        transports: ['polling'],
-        cors: {
-          origin: '*',
-        },
+        // 音素ごとの HTTP polling を避け、ローカル接続だけを WebSocket で維持する
+        transports: ['websocket'],
       });
     } catch (e) {
       console.error('socket.io constructor error', e);

--- a/app/services/nicolive-program/speech/NVoiceClient.test.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { join } from 'path';
 
 import { getNVoicePath } from '@n-air-app/n-voice-package';
+import { access } from 'fs/promises';
 
 import { NVoiceClient } from './NVoiceClient';
 
@@ -34,6 +35,19 @@ describe('NVoiceClient', () => {
     const filename = join(dir, `test-${randomUUID()}.wav`);
     const { wave, labels } = await client.talk(1.0, 'テスト', filename);
     expect(wave).not.toBeNull();
-    expect(labels.map((l) => l.phoneme)).toEqual(['silB', 't', 'e', 's', 'U', 't', 'o', 'silE']);
+    expect(labels.map((l) => l.phoneme)).toEqual([
+      'silB',
+      't',
+      'e',
+      's',
+      'U',
+      't',
+      'o',
+      'silE',
+    ]);
+    await expect(access(filename)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(access(filename + '.txt')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   }, 20000 /* longer timeout */);
 });

--- a/app/services/nicolive-program/speech/NVoiceClient.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.ts
@@ -1,5 +1,5 @@
 import { ChildProcess, spawn } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { readdir, readFile, unlink } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { createInterface } from 'node:readline';
 
@@ -94,7 +94,9 @@ export class CommandLineClient {
   onTerminate(callback: () => void): () => void {
     this.terminateCallbacks.push(callback);
     return () => {
-      this.terminateCallbacks = this.terminateCallbacks.filter((c) => c !== callback);
+      this.terminateCallbacks = this.terminateCallbacks.filter(
+        (c) => c !== callback,
+      );
     };
   }
 
@@ -183,10 +185,14 @@ async function StartNVoice(
   };
 
   const client = new CommandLineClient(
-    spawn(enginePath, [dictionaryPath, userDictionary, modelPath, extraVoicesPath], {
-      stdio: 'pipe',
-      cwd,
-    }),
+    spawn(
+      enginePath,
+      [dictionaryPath, userDictionary, modelPath, extraVoicesPath],
+      {
+        stdio: 'pipe',
+        cwd,
+      },
+    ),
     log,
     true, // options.showStdout,
   );
@@ -229,8 +235,7 @@ export type Label = {
   phoneme: string;
 };
 
-function loadLabelFile(filename: string): Label[] {
-  const labels = readFileSync(filename, 'utf8');
+function parseLabels(labels: string): Label[] {
   const lines = labels.split(/\r?\n/).filter((line) => line.length > 0);
   const result: Label[] = [];
   for (const line of lines) {
@@ -242,6 +247,34 @@ function loadLabelFile(filename: string): Label[] {
     });
   }
   return result;
+}
+
+function isFileNotFoundError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err && err.code === 'ENOENT';
+}
+
+async function readFileIfExists(filename: string): Promise<Buffer | null> {
+  try {
+    return await readFile(filename);
+  } catch (err) {
+    if (isFileNotFoundError(err)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function cleanupFiles(filenames: string[]): Promise<void> {
+  const results = await Promise.allSettled(
+    filenames.map((filename) => unlink(filename)),
+  );
+  const failed = results.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === 'rejected' && !isFileNotFoundError(result.reason),
+  );
+  if (failed) {
+    throw failed.reason;
+  }
 }
 
 class NVoiceEngineError extends Error {
@@ -288,7 +321,7 @@ export class NVoiceClient {
       const dictionaryPath = 'open_jtalk_dic_shift_jis-1.11';
       const userDictionary = 'user.dic';
 
-      const models = readdirSync(baseDir).filter((s) => /.*\.pt$/.test(s));
+      const models = (await readdir(baseDir)).filter((s) => /.*\.pt$/.test(s));
       if (models.length !== 1) {
         throw new Error('model file found: ' + models.join(', '));
       }
@@ -305,7 +338,9 @@ export class NVoiceClient {
       let started = false;
       client.waitExit().then((code) => {
         if (!started) {
-          this.options.onError(new Error(`n-voice-engine start failed! ${code}`));
+          this.options.onError(
+            new Error(`n-voice-engine start failed! ${code}`),
+          );
         }
         this.commandLineClient = undefined; // 落ちたときは次回、起動を試みる
       });
@@ -383,7 +418,9 @@ export class NVoiceClient {
     } catch (err) {
       const opts: SentryReportOpts = {};
       if (err instanceof NVoiceEngineError) {
-        const tags: Record<string, string> = { 'NVoiceEngineError.code': err.code };
+        const tags: Record<string, string> = {
+          'NVoiceEngineError.code': err.code,
+        };
         const extra: Record<string, unknown> = {};
         for (const a of args) {
           if (a.sentryExtra) {
@@ -418,41 +455,52 @@ export class NVoiceClient {
       // ignore empty text
       return { wave: null, labels: [] };
     }
-    try {
-      await this._command(
-        'talk',
-        {
-          label: 'speed',
-          value: speed.toString(),
-        },
-        {
-          label: 'text',
-          value: text,
-          encoder: toShiftJisBase64,
-        },
-        {
-          label: 'filename',
-          value: filename,
-          encoder: toShiftJisBase64,
-          sentryExtra: true,
-        },
-      );
-    } catch (err) {
-      // TODO エラー内容によってはユーザーに伝えるか?
-      return { wave: null, labels: [] };
-    }
-
-    const wave = existsSync(filename) ? readFileSync(filename) : null;
-    if (wave) {
-      unlinkSync(filename);
-    }
     const labelFilename = filename + '.txt';
-    let labels: Label[] = [];
-    if (existsSync(labelFilename)) {
-      labels = loadLabelFile(labelFilename);
-      unlinkSync(labelFilename);
+    const outputFilenames = [filename, labelFilename];
+
+    // 前回異常終了時のファイルを今回の合成結果として使用しないように削除する
+    await cleanupFiles(outputFilenames);
+    try {
+      try {
+        await this._command(
+          'talk',
+          {
+            label: 'speed',
+            value: speed.toString(),
+          },
+          {
+            label: 'text',
+            value: text,
+            encoder: toShiftJisBase64,
+          },
+          {
+            label: 'filename',
+            value: filename,
+            encoder: toShiftJisBase64,
+            sentryExtra: true,
+          },
+        );
+      } catch (err) {
+        // TODO エラー内容によってはユーザーに伝えるか?
+        return { wave: null, labels: [] };
+      }
+
+      const [wave, labelFile] = await Promise.all([
+        readFileIfExists(filename),
+        readFileIfExists(labelFilename),
+      ]);
+      const labels = labelFile ? parseLabels(labelFile.toString('utf8')) : [];
+      return { wave, labels };
+    } finally {
+      // 読み込みやコマンドが失敗しても、生成途中のファイルを残さない
+      try {
+        await cleanupFiles(outputFilenames);
+      } catch (err) {
+        SentryReport.error('NVoiceClient', 'cleanupTalkFiles', err, {
+          fingerprint: ['talk', 'cleanupFiles'],
+        });
+      }
     }
-    return { wave, labels };
   }
 
   async set_max_time(seconds: number): Promise<void> {

--- a/app/services/nicolive-program/speech/NVoiceClient.ts
+++ b/app/services/nicolive-program/speech/NVoiceClient.ts
@@ -459,7 +459,14 @@ export class NVoiceClient {
     const outputFilenames = [filename, labelFilename];
 
     // 前回異常終了時のファイルを今回の合成結果として使用しないように削除する
-    await cleanupFiles(outputFilenames);
+    try {
+      await cleanupFiles(outputFilenames);
+    } catch (err) {
+      SentryReport.error('NVoiceClient', 'cleanupTalkFiles', err, {
+        fingerprint: ['talk', 'cleanupFiles'],
+      });
+      throw err;
+    }
     try {
       try {
         await this._command(

--- a/nvoice/near/src/index.ts
+++ b/nvoice/near/src/index.ts
@@ -6,8 +6,10 @@ let socket: Socket | undefined;
 try {
   const port = params.get('port');
   if (port && parseInt(port, 10) !== 0) {
-    const host = `http://localhost:${port}`;
-    socket = io(host);
+    const host = `http://127.0.0.1:${port}`;
+    socket = io(host, {
+      transports: ['websocket'],
+    });
   } else {
     console.log('offline mode.');
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,6 +197,9 @@ module.exports = function (env, argv) {
         'font-manager': 'require("font-manager")',
         'color-picker': 'require("color-picker")',
         'node-fontinfo': 'require("node-fontinfo")',
+        // Socket.IO server depends on the Node.js implementation of ws.
+        // Bundling it for the renderer resolves ws to its browser-only shim.
+        'socket.io': 'require("socket.io")',
       },
 
       module: {


### PR DESCRIPTION
## 概要

N Voiceの音声ファイル処理を非同期化し、読み上げ完了時にレンダラースレッドをブロックしないよう改善します。

あわせて、口パク用Socket.IO通信をHTTP pollingからWebSocketへ変更します。

## 変更内容

- WAV・ラベルファイルの読み込みと削除を非同期化
- WAVとラベルを並行して読み込み
- 合成前後に一時ファイルを削除
  - 異常終了時に残ったファイルの再利用を防止
  - コマンドや読み込みの失敗時にも生成途中のファイルを削除
- 一時ファイルの削除失敗をSentryへ記録
- 口パク用Socket.IO通信をWebSocketへ変更
- 口パクサーバーの待受を`127.0.0.1`へ限定
- 合成後に一時ファイルが削除されることをテストへ追加

## 性能計測

口パク相当の音素イベント100件を送信する簡易計測では、次の改善を確認しました。

| 項目 | HTTP polling | WebSocket |
|---|---:|---:|
| HTTPリクエスト | 103回 | 0回（Upgrade 1回） |
| 通信量 | 36,463 B | 2,330 B |
| CPU時間 | 203 ms | 31 ms |

WAV・ラベルの非同期化については、合成時間の短縮ではなく、ファイル操作中のレンダラースレッド停止を避けることを目的としています。

## 手動確認

- N Voiceでコメントを正常に読み上げられること
- N Voiceキャラクターの口パクが読み上げに追従すること
- 読み上げ後に一時ファイルが残らないこと
