### PR TITLE
開発: パッケージ版が起動できない問題を修正

### DIFF
--- a/electron-builder/stable.config.js
+++ b/electron-builder/stable.config.js
@@ -19,7 +19,7 @@ const config = {
     'splash/splash-window.js',
     'index.html',
     'main.js',
-    'main-process/window-startup-state.js',
+    'main-process/*.js',
     'obs-api',
   ],
   extraFiles: [


### PR DESCRIPTION
## このpull requestが解決する内容
パッケージ版（リリースビルド）で起動時に `Cannot find module './main-process/fetch'` が発生し、アプリが起動できなくなる問題を修正します。

## 背景
#1396 で追加した `main-process/fetch.js` は electron-builder の `files` allowlist に含まれておらず、パッケージビルドの `app.asar` に同梱されていませんでした。

- `main.js:48` の `require('./main-process/fetch')` はトップレベルで実行されるため、起動直後に即クラッシュします。
- 開発環境（`pnpm start`）では実ファイルがディスク上に存在するため再現しませんでした。
- 導入時のコミット（`main processのfetchでOSの証明書設定を利用する`）で `main-process/fetch.js` を新規追加した際、`electron-builder/stable.config.js` の `files` への追加が漏れていました。
- ユニットテスト（`main-process/fetch.test.ts`）は元ファイルを直接 import するため、パッケージ内容の欠落は検出できませんでした。

`main.js` と `main-process/*.js` は webpack でバンドルされず、tsc の対象にもならず、素の JS として asar に同梱される設計です。そのため `files` に1ファイルずつ手書き列挙する必要があり、これが漏れの温床になっています。

## 変更内容
`electron-builder/stable.config.js` の `files` エントリを、個別ファイル列挙からグロブに変更しました。

```diff
     'main.js',
-    'main-process/window-startup-state.js',
+    'main-process/*.js',
     'obs-api',
```

`*.js` パターンのため `.d.ts` / `.test.ts` は自然に除外されます。派生config（unstable / local / internal-stable / internal-unstable）はすべて `stable.config.js` の `files` を継承するため、追加変更は不要です。

## テスト
- [x] `pnpm run compile:production` → `pnpm run package:public-unstable` でビルドし、`app.asar` 内に `main-process/fetch.js` と `main-process/window-startup-state.js` が両方含まれることを確認
- [ ] パッケージ版アプリを起動し、`Cannot find module` エラーが出ずに正常起動することを確認
- [ ] ニコニコ生放送関連の通信（main process 経由の fetch を使う操作）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
