### PR TITLE
修正: 一部の環境で配信を開始できない問題を修正

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.test.ts
+++ b/app/services/nicolive-program/NicoliveClient.test.ts
@@ -578,6 +578,22 @@ describe('NicoliveClient.deleteComment', () => {
       expect(fetchViaMainProcess).toHaveBeenCalledWith(expect.anything(), expect.anything());
     }
   });
+
+  test('Origin ヘッダーはパスを含まない scheme://host のみで main 経由リクエストに載る', async () => {
+    fetchViaMainProcess.mockResolvedValueOnce(
+      Promise.resolve<MainProcessFetchResponse>({ ok: true, headers: [], status: 204, text: '' }),
+    );
+
+    const client = new NicoliveClient({ niconicoSession: 'dummy' });
+    await client.deleteComment('lv1', '1');
+
+    expect(fetchViaMainProcess).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Origin: 'https://live.nicovideo.jp' }),
+      }),
+    );
+  });
 });
 
 describe('NicoliveClient.wrapFetchError', () => {

--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -643,7 +643,7 @@ export class NicoliveClient {
       'PUT',
       `${NicoliveClient.live2BaseURL}/unama/api/v4/ingest_info?nicoliveProgramId=${programId}`,
       {
-        headers: NicoliveClient.v4ApiHeaders(programId),
+        headers: NicoliveClient.v4ApiHeaders(),
       },
     );
   }
@@ -961,10 +961,10 @@ export class NicoliveClient {
     );
   }
 
-  static v4ApiHeaders(programId: string): HeadersInit {
+  static v4ApiHeaders(): HeadersInit {
     return {
-      // v4 APIは Origin headerが必要
-      Origin: `${NicoliveClient.liveBaseURL}/watch/${programId}`,
+      // v4 APIは Origin headerが必要。Origin はパスを含まない scheme://host[:port] のみ
+      Origin: NicoliveClient.liveBaseURL,
     };
   }
 
@@ -977,7 +977,7 @@ export class NicoliveClient {
       `${NicoliveClient.live2BaseURL
       }/unama/api/v4/programs/${programId}/comments?${params.toString()}`,
       {
-        headers: NicoliveClient.v4ApiHeaders(programId),
+        headers: NicoliveClient.v4ApiHeaders(),
       },
     );
   }
@@ -986,7 +986,7 @@ export class NicoliveClient {
     const requestInit = NicoliveClient.jsonBody('');
     requestInit.headers = {
       ...requestInit.headers,
-      ...NicoliveClient.v4ApiHeaders(programId),
+      ...NicoliveClient.v4ApiHeaders(),
     };
 
     return this.requestAPI<void>(

--- a/main-process/fetch.d.ts
+++ b/main-process/fetch.d.ts
@@ -1,0 +1,9 @@
+import type { Net } from 'electron';
+
+import type { MainProcessFetchResponse } from '../app/util/fetchViaMainProcess';
+
+export function fetchViaElectronNet(
+  net: Pick<Net, 'fetch'>,
+  url: string,
+  options: RequestInit,
+): Promise<MainProcessFetchResponse>;

--- a/main-process/fetch.js
+++ b/main-process/fetch.js
@@ -1,0 +1,34 @@
+/**
+ * Electron のネットワークスタックを使ってリクエストし、IPC で転送可能な値へ変換する。
+ *
+ * @param {Pick<import('electron').Net, 'fetch'>} net
+ * @param {string} url
+ * @param {RequestInit} options
+ * @returns {Promise<import('../app/util/fetchViaMainProcess.ts').MainProcessFetchResponse>}
+ */
+async function fetchViaElectronNet(net, url, options) {
+  try {
+    const response = await net.fetch(url, options);
+    const text = await response.text();
+    return {
+      ok: response.ok,
+      // iterator のままでは Electron IPC の構造化クローンで中身が失われるため配列化する
+      headers: [...response.headers.entries()],
+      status: response.status,
+      text,
+    };
+  } catch (e) {
+    // cause チェーンとURLを文字列化してrendererに伝搬する
+    // (Electron の IPC シリアライズでは cause が失われるため)
+    // [MAIN_FETCH_FAIL code=...] 接頭辞は renderer 側 wrapFetchError が機械可読に経路を判別するために使用する
+    const causeCode = e.cause?.code ?? '';
+    const cause = e.cause
+      ? `${e.cause.name}: ${e.cause.message} (code: ${e.cause.code})`
+      : undefined;
+    throw new Error(
+      `[MAIN_FETCH_FAIL code=${causeCode}] ${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`,
+    );
+  }
+}
+
+module.exports = { fetchViaElectronNet };

--- a/main-process/fetch.test.ts
+++ b/main-process/fetch.test.ts
@@ -1,0 +1,44 @@
+import { fetchViaElectronNet } from './fetch';
+
+describe('fetchViaElectronNet', () => {
+  test('net.fetch にリクエストをそのまま渡し、IPC で転送可能なレスポンスを返す', async () => {
+    const options: RequestInit = {
+      method: 'POST',
+      headers: { Cookie: 'user_session=abc', Origin: 'https://www.nicovideo.jp' },
+      body: JSON.stringify({ test: true }),
+    };
+    const response = {
+      ok: true,
+      headers: new Headers([
+        ['content-type', 'application/json'],
+        ['set-cookie', 'user_session=updated'],
+      ]),
+      status: 200,
+      text: jest.fn().mockResolvedValue('{"result":"ok"}'),
+    };
+    const net = { fetch: jest.fn().mockResolvedValue(response) };
+
+    await expect(fetchViaElectronNet(net, 'https://example.com/ingest', options)).resolves.toEqual({
+      ok: true,
+      headers: [
+        ['content-type', 'application/json'],
+        ['set-cookie', 'user_session=updated'],
+      ],
+      status: 200,
+      text: '{"result":"ok"}',
+    });
+    expect(net.fetch).toHaveBeenCalledWith('https://example.com/ingest', options);
+  });
+
+  test('fetch 失敗時に cause の診断情報とURLを MAIN_FETCH_FAIL として返す', async () => {
+    const cause = Object.assign(new Error('self signed certificate in certificate chain'), {
+      code: 'SELF_SIGNED_CERT_IN_CHAIN',
+    });
+    const error = new Error('fetch failed', { cause });
+    const net = { fetch: jest.fn().mockRejectedValue(error) };
+
+    await expect(fetchViaElectronNet(net, 'https://example.com/ingest', {})).rejects.toThrow(
+      '[MAIN_FETCH_FAIL code=SELF_SIGNED_CERT_IN_CHAIN] fetch failed [url: https://example.com/ingest, cause: Error: self signed certificate in certificate chain (code: SELF_SIGNED_CERT_IN_CHAIN)]',
+    );
+  });
+});

--- a/main.js
+++ b/main.js
@@ -40,11 +40,12 @@ const osnVersion = getObsStudioNodeVersion();
 ////////////////////////////////////////////////////////////////////////////////
 const electron = require('electron');
 
-const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell, crashReporter } =
+const { app, BrowserWindow, ipcMain, session, dialog, webContents, shell, crashReporter, net } =
   electron;
 const path = require('node:path');
 const fs = require('node:fs');
 const remote = require('@electron/remote/main');
+const { fetchViaElectronNet } = require('./main-process/fetch');
 
 ////////////////////////////////////////////////////////////////////////////////
 // Dev Hosts Configuration
@@ -657,6 +658,11 @@ function initialize(crashHandler) {
     SentryElectron.init({
       dsn: sentryDefs.DSN,
       release: process.env.NAIR_VERSION,
+      // sentry-trace/baggage ヘッダーの自動付与を無効化。
+      // 無指定だと electronNetIntegration が net.request 経由の全リクエストに
+      // ヘッダーを付与し、ニコニコ生放送APIのCORSプリフライトが
+      // sentry-trace ヘッダーで拒否される(Access-Control-Allow-Headersに含まれないため)。
+      tracePropagationTargets: [],
     });
     if (osnVersion) {
       SentryElectron.getCurrentScope().setTag('obs-studio-node', osnVersion);
@@ -1311,26 +1317,7 @@ function initialize(crashHandler) {
      * @returns {Promise<import('./app/util/fetchViaMainProcess.ts').MainProcessFetchResponse>}
      * */
     async (_e, url, options) => {
-      try {
-        const response = await fetch(url, options);
-        const text = await response.text();
-        return {
-          ok: response.ok,
-          // iterator のままでは Electron IPC の構造化クローンで中身が失われるため配列化する
-          headers: [...response.headers.entries()],
-          status: response.status,
-          text,
-        };
-      } catch (e) {
-        // cause チェーンとURLを文字列化してrendererに伝搬する
-        // (Electron の IPC シリアライズでは cause が失われるため)
-        // [MAIN_FETCH_FAIL code=...] 接頭辞は renderer 側 wrapFetchError が機械可読に経路を判別するために使用する
-        const causeCode = e.cause?.code ?? '';
-        const cause = e.cause
-          ? `${e.cause.name}: ${e.cause.message} (code: ${e.cause.code})`
-          : undefined;
-        throw new Error(`[MAIN_FETCH_FAIL code=${causeCode}] ${e.message} [url: ${url}, cause: ${cause ?? 'no cause'}]`);
-      }
+      return fetchViaElectronNet(net, url, options);
     },
   );
 }


### PR DESCRIPTION
## このpull requestが解決する内容
main process の fetch を Node のグローバル `fetch`（undici）から Electron の `net.fetch` に切り替え、OS の証明書ストアを利用できるようにします。特定ユーザー環境で発生していた TLS 証明書エラー（N-AIR-APP-G9M / N-AIR-APP-G9K）への対処です。

以前 #1396 で同じ修正を導入しましたが、配信開始が全ユーザーで失敗する回帰を起こし #1406 で revert していました。本PRは根本原因を修正した上での再挑戦です。

## 背景（前回失敗した理由と今回の対処）

`net.fetch` は Chromium の実ネットワークスタックであり、Node の `fetch` と異なり実際に CORS 検証を行います。`NicoliveClient.fetchIngestInfo()` が呼ぶ `PUT /unama/api/v4/ingest_info` は非単純メソッド(`PUT`)＋カスタムヘッダー(`X-Niconico-Session`)を伴うため CORS プリフライト(OPTIONS)が発生します。

`--log-net-log`（Chromiumのネットワーク内部ログ）で dev実行時と前回のパッケージ版実行時を比較し、以下を確認しました:

- `@sentry/electron/main` の `electronNetIntegration`（`net-breadcrumbs.js`）が `electron.net.request` をモンキーパッチしており、`tracePropagationTargets` が未設定の場合は**無条件に全リクエストへ `sentry-trace` / `baggage` ヘッダーを付与する**実装になっている
- `net.fetch` は内部的に `net.request` を使うため、このパッチの影響を受ける
- ニコニコ生放送APIサーバーの `Access-Control-Allow-Headers` には `sentry-trace` / `baggage` が含まれていないため、CORSプリフライトが `failed-parameter: "sentry-trace"` で拒否され、`ingest_info` への PUT が一切送信できなくなっていた
- dev実行（`pnpm start`）では `NODE_ENV=production` でない限り Sentry が初期化されないため問題が再現せず、パッケージ版（常にSentry有効）でのみ発生していた

対照実験として、dev環境で `NAIR_REPORT_TO_SENTRY=1` を付けて `pnpm start` すると、パッケージ版と同一の CORS 失敗が再現することを確認済みです。

## 変更内容

### `main.js` — Sentry初期化に `tracePropagationTargets: []` を追加
`sentry-trace` / `baggage` ヘッダーの自動付与を無効化します。`tracePropagationTargets` を空配列にすると `stringMatchesSomePattern(url, [])` が常に `false` を返すため、どのリクエストにもトレース伝播ヘッダーが付与されなくなります（breadcrumb記録やspan計測自体には影響しません）。

### `main-process/fetch.js` / `fetch.d.ts` / `fetch.test.ts` — net.fetch実装を再導入
#1396 と同内容です。`net.fetch(url, options)` を呼び、IPC で転送可能な形にレスポンスを変換し、失敗時は診断情報を `[MAIN_FETCH_FAIL code=...]` 形式で伝搬します。

### `app/services/nicolive-program/NicoliveClient.ts` — `Origin` ヘッダーの構文修正
調査中に見つけた既存バグです。`v4ApiHeaders()` が返す `Origin` ヘッダーの値がパスを含んでおり仕様上不正でした（`Origin` は `scheme://host[:port]` のみが正しい）。今回の失敗の直接原因ではありませんでしたが、正しい記法に修正しました。`programId` 引数も不要になったため削除しています。

## テスト
- [x] `pnpm run test:unit:app` で既存ユニットテスト（`main-process/fetch.test.ts`, `NicoliveClient.test.ts`）が通ることを確認
- [x] `pnpm typecheck` で型エラーがないことを確認
- [x] `NAIR_REPORT_TO_SENTRY=1` を付けて `pnpm start`（Sentry有効なdev環境）で配信開始が成功することを確認
- [x] 通常の `pnpm start`（Sentry無効）でも配信開始が成功することを確認（回帰なし）
- [x] `pnpm run compile:production` → `pnpm run package:local` でパッケージ版を作成し、実際に配信開始が成功することを確認

## Sentry
Sentry-Resolves: N-AIR-APP-G9M
Sentry-Resolves: N-AIR-APP-G9K

## 関連
- #1396（前回の修正、同内容の再導入）
- #1406（前回の revert）
- 調査issue: #1407（根本原因判明・対処済み）

Closes #1407

