### PR TITLE
修正: サブ配信で映像が送信されない問題を修正

### DIFF
--- a/additional/additional.json
+++ b/additional/additional.json
@@ -13,7 +13,7 @@
       "dest": "/node_modules/obs-studio-node/obs-plugins/64bit"
     },
     {
-      "url": "https://github.com/n-air-app/substream/releases/download/1.1.0/nair-substream.dll",
+      "url": "https://github.com/n-air-app/substream/releases/download/1.2.0/nair-substream.dll",
       "dest": "/node_modules/obs-studio-node/obs-plugins/64bit"
     }
   ]


### PR DESCRIPTION
## 概要

SubStreamプラグインを1.1.0から1.2.0へ更新します。

N Airが使用するLibOBSとの互換性を修復するとともに、サブ配信の映像エンコーダーが適切な映像ミックスを参照するように変更しました。

これにより、サブ配信のRTMP接続には成功するものの、配信先の映像が黒いままとなり、送信フレーム数も増加しない問題を修正します。

## N Air側の変更

`additional/additional.json`に指定されているSubStream DLLの取得先を、1.1.0から1.2.0へ更新します。

- 変更前:
  `https://github.com/n-air-app/substream/releases/download/1.1.0/nair-substream.dll`
- 変更後:
  `https://github.com/n-air-app/substream/releases/download/1.2.0/nair-substream.dll`

N Air側のSubStream設定形式、UI、名前付きパイプによる通信仕様に変更はありません。

## SubStream DLL 1.2.0の変更内容

### N AirのLibOBSに対応したSDKへ更新

SubStreamプラグインはOBSプラグインとしてN Airのプロセス内へ読み込まれ、N Airに同梱されているLibOBSのAPIを直接使用します。

従来のDLLは、N Airが使用しているLibOBSと異なるバージョンのSDKでビルドされていました。このため、プラグインと実行時LibOBSのAPIおよびABIに不整合があり、エンコーダーの列挙や映像処理が正常に動作しない状態になっていました。

1.2.0では、N Airの`obs-studio-node` 0.26.28に対応するLibOBS `31.1.2sl19`のヘッダーとインポートライブラリを使用してDLLを再ビルドしています。

SDKのヘッダーと`obs.lib`を同じバージョンで統一し、N Airに同梱されるLibOBSとの互換性を確保しました。

### 有効なレンダリングモードの映像を使用

従来のSubStream DLLは、映像エンコーダーを固定のストリーミング用レンダリングへ接続していました。

しかし、N Airの実行状態によってはそのレンダリングが駆動されていないため、映像ミックス自体を取得できてもフレームが生成されない場合がありました。この場合、以下の処理は成功します。

- RTMPサーバーへの接続
- 映像・音声エンコーダーの作成
- OBS出力の開始

一方で、映像エンコーダーへフレームが渡らないため、配信先には黒い映像が表示され、送信フレーム数と送信バイト数も増加しません。

1.2.0では、`obs_get_video_rendering_mode()`で現在有効なレンダリングモードを取得し、そのモードに対応する`obs_video_mix`を映像エンコーダーへ設定します。

これにより、N Airが実際に描画している映像ミックスからサブ配信用のフレームが生成されます。

### DLLのバージョン情報を更新

DLL内部のプラグインバージョンに加え、Windowsのファイルリソースに含まれるFileVersionとProductVersionも1.2.0へ統一しました。

## SubStream 1.2.0

https://github.com/n-air-app/substream/releases/tag/1.2.0

## 影響範囲

- 「サブ配信」機能を使用する場合にのみ影響します
- メイン配信のエンコーダーおよび送信処理に変更はありません
- SubStreamの設定値と保存形式に変更はありません
- 既存のSubStream設定はそのまま利用できます
