### PR TITLE
修正: アプリ終了処理が完了しない状態で設定画面を開くとクラッシュする問題を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -940,7 +940,10 @@ function initialize(crashHandler) {
     // The child window is never closed, it just hides in the
     // background until it is needed.
     childWindow.on('close', (e) => {
-      if (!shutdownStarted) {
+      // shutdownStarted で判定すると、mainWindow の close が
+      // renderer 側でキャンセルされてアプリが継続する場合でも
+      // childWindow だけ実際に破棄されてしまう(N-AIR-APP-G8Y)。
+      if (!allowMainWindowClose) {
         safeSend(childWindow, 'closeWindow');
 
         // Prevent the window from actually closing
@@ -1126,7 +1129,9 @@ function initialize(crashHandler) {
         }
       }
 
-      childWindow.focus();
+      if (!childWindow.isDestroyed()) {
+        childWindow.focus();
+      }
     }
   });
 


### PR DESCRIPTION
## このpull requestが解決する内容
アプリ終了(または再起動)を試みた後、その終了処理が完了しないまま動作を続けている状態で設定画面などを開こうとすると、アプリ全体がクラッシュする問題を修正します。

## 背景
Sentry で `TypeError: Object has been destroyed` という fatal (unhandled) のクラッシュが継続的に発生していました(初出 2026/6/28、直近まで発生、40 events / 12 users)。

実際のイベントでは、終了処理が開始されてから1分半以上、アプリは通常通り操作可能な状態で動作し続けていました。終了確認応答(`acknowledgeShutdown`)を受け取った時点で強制終了タイマーは解除されるため、その後の終了完了通知(`shutdownComplete`)が何らかの理由(rendererのクラッシュ/リロード等)で送られてこなければ、理論上はこの「終了未完了だが動作は継続する」状態が無期限に続きます。ユーザーがこの間に設定画面を開こうとすると、アプリ全体がクラッシュします。

調査したところ、以下の2段階のバグが根本原因でした。

1. `childWindow.on('close', ...)` は `shutdownStarted` フラグを見て、false のときだけ `preventDefault()` して実際のクローズを防いでいました。しかし `shutdownStarted` は `mainWindow.on('close', ...)` の**最初の close 試行時点**で true になり、二度と false に戻りません。実際にアプリ終了が許可されたかどうかを表すのは別の `allowMainWindowClose` フラグです。
   `app.quit()`/`before-quit` は mainWindow と childWindow の両方に close イベントをカスケードするため、mainWindow 側の close は `allowMainWindowClose=false` で保留(アプリは終了しない)されているにもかかわらず、childWindow だけ `shutdownStarted=true` を理由に実際に破棄されてしまっていました。
2. その後ユーザーが再度「設定」などを開こうとすると `window-showChildWindow` ハンドラが実行されますが、破棄済み `childWindow` に対する `catch` 内の復旧処理は `isDestroyed()` でガードされていたものの、直後の `childWindow.focus()` にはガードがなく、未捕捉例外としてクラッシュしていました。

## 変更内容

- `main.js`
  - `childWindow.on('close', ...)` の判定を `shutdownStarted` から `allowMainWindowClose` に変更し、アプリ終了が実際に許可されていない限り childWindow を破棄しないようにする
  - `window-showChildWindow` ハンドラ内の `childWindow.focus()` を `isDestroyed()` チェックでガードし、想定外の状態でも未捕捉例外でクラッシュしないようにする(既存の他箇所と同様の防御的パターン)

## Sentry
Sentry-Resolves: N-AIR-APP-G8Y

## テスト
- [x] 公開版(修正前)で再現を確認: 設定画面の「拡張機能」タブ →「キャッシュを削除して再起動」→ OK → 即座に設定アイコンをクリック → `TypeError: Object has been destroyed` でクラッシュ
- [x] 修正版(このブランチ、開発ビルド)で解消を確認: 設定画面を開いた状態で DevTools コンソールから `ipcRenderer.removeAllListeners('shutdown')` → `remote.app.quit()` を実行し(rendererのshutdown応答を止めてmainWindowの終了待機を10秒に伸ばして再現条件を作った上で)、その間に設定アイコンをクリック → クラッシュせず正常に設定画面が開くことを確認
