### PR TITLE
修正: OBS終了時にN Airを再起動できないことがある問題を修正

### DIFF
--- a/app/services/settings-v2/video.test.ts
+++ b/app/services/settings-v2/video.test.ts
@@ -272,3 +272,82 @@ describe('VideoSettingsService.refrectLegacy', () => {
     });
   });
 });
+
+describe('VideoSettingsService.shutdown', () => {
+  let VideoSettingsService: any;
+  let markObsOpMock: jest.Mock;
+  let instance: any;
+  let mockState: { horizontal: IVideoInfo | null };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    ({ VideoSettingsService } = require('./video'));
+    ({ markObsOp: markObsOpMock } = require('util/sentry-obs-breadcrumb'));
+
+    instance = Object.create(VideoSettingsService.prototype);
+    instance.debouncedUpdateObsSettings = { cancel: jest.fn() };
+    mockState = { horizontal: makeVideoInfo() };
+    Object.defineProperty(instance, 'state', {
+      get: () => mockState,
+      configurable: true,
+    });
+    instance.DESTROY_VIDEO_CONTEXT = jest.fn((display: 'horizontal') => {
+      mockState[display] = null;
+    });
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('legacySettings の保存に失敗しても context を destroy してローカル状態を破棄する', () => {
+    const destroy = jest.fn();
+    const context = { destroy } as any;
+    Object.defineProperty(context, 'legacySettings', {
+      set: () => { throw new Error('IPC received error code 1'); },
+    });
+    instance.contexts = { horizontal: context };
+
+    expect(() => instance.shutdown()).not.toThrow();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(instance.contexts.horizontal).toBeNull();
+    expect(instance.DESTROY_VIDEO_CONTEXT).toHaveBeenCalledWith('horizontal');
+    expect(markObsOpMock).toHaveBeenCalledWith(
+      'VideoSettingsService',
+      'shutdown',
+      expect.objectContaining({
+        display: 'horizontal',
+        operation: 'saveLegacySettings',
+        error: 'IPC received error code 1',
+      }),
+    );
+  });
+
+  test('context の destroy に失敗してもローカル状態を破棄する', () => {
+    const expectedLegacySettings = mockState.horizontal;
+    const context = {
+      legacySettings: null,
+      destroy: jest.fn(() => { throw new Error('IPC received error code 1'); }),
+    } as any;
+    instance.contexts = { horizontal: context };
+
+    expect(() => instance.shutdown()).not.toThrow();
+
+    expect(context.legacySettings).toEqual(expectedLegacySettings);
+    expect(instance.contexts.horizontal).toBeNull();
+    expect(instance.DESTROY_VIDEO_CONTEXT).toHaveBeenCalledWith('horizontal');
+    expect(markObsOpMock).toHaveBeenCalledWith(
+      'VideoSettingsService',
+      'shutdown',
+      expect.objectContaining({
+        display: 'horizontal',
+        operation: 'destroyContext',
+        error: 'IPC received error code 1',
+      }),
+    );
+  });
+});

--- a/app/services/settings-v2/video.test.ts
+++ b/app/services/settings-v2/video.test.ts
@@ -329,9 +329,10 @@ describe('VideoSettingsService.shutdown', () => {
 
   test('context の destroy に失敗してもローカル状態を破棄する', () => {
     const expectedLegacySettings = mockState.horizontal;
+    const error = new Error('IPC received error code 1');
     const context = {
       legacySettings: null,
-      destroy: jest.fn(() => { throw new Error('IPC received error code 1'); }),
+      destroy: jest.fn(() => { throw error; }),
     } as any;
     instance.contexts = { horizontal: context };
 
@@ -348,6 +349,10 @@ describe('VideoSettingsService.shutdown', () => {
         operation: 'destroyContext',
         error: 'IPC received error code 1',
       }),
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      '[VideoSettingsService] shutdown(horizontal): destroyContext failed:',
+      error,
     );
   });
 });

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -373,13 +373,17 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     });
   }
 
-  private reportShutdownError(display: TDisplayType, operation: string, error: unknown) {
+  private reportShutdownError(
+    display: TDisplayType,
+    operation: 'saveLegacySettings' | 'destroyContext',
+    error: unknown,
+  ) {
     markObsOp('VideoSettingsService', 'shutdown', {
       display,
       operation,
       error: error instanceof Error ? error.message : String(error),
     });
-    console.error(`[VideoSettingsService] shutdown: ${operation} failed:`, error);
+    console.error(`[VideoSettingsService] shutdown(${display}): ${operation} failed:`, error);
   }
 
   @mutation()

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -350,16 +350,36 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     this.debouncedUpdateObsSettings.cancel();
 
     displays.forEach((display) => {
-      if (this.contexts[display]) {
-        // save settings as legacy settings
-        this.contexts[display].legacySettings = this.state[display]!;
+      const context = this.contexts[display];
+      if (!context) return;
 
-        // destroy context
-        this.contexts[display].destroy();
+      // OBS IPC が切断済みでも、1つのネイティブ呼び出しの失敗で残りの
+      // シャットダウン処理を中断しない。各処理を独立して試行し、フロント側の
+      // コンテキストは必ず破棄する。
+      try {
+        context.legacySettings = this.state[display]!;
+      } catch (e) {
+        this.reportShutdownError(display, 'saveLegacySettings', e);
+      }
+
+      try {
+        context.destroy();
+      } catch (e) {
+        this.reportShutdownError(display, 'destroyContext', e);
+      } finally {
         this.contexts[display] = null;
         this.DESTROY_VIDEO_CONTEXT(display);
       }
     });
+  }
+
+  private reportShutdownError(display: TDisplayType, operation: string, error: unknown) {
+    markObsOp('VideoSettingsService', 'shutdown', {
+      display,
+      operation,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    console.error(`[VideoSettingsService] shutdown: ${operation} failed:`, error);
   }
 
   @mutation()


### PR DESCRIPTION
## このpull requestが解決する内容
OBSの終了処理中にIPCエラーが発生しても、残りの終了処理を継続してN Airを終了・再起動できるようにします。

## 背景
Sentry `N-AIR-APP-FGN` では、`VideoSettingsService.shutdown()` がOBSのvideo contextを保存・破棄する際に `IPC received error code 1` が発生し、後続の終了処理が中断していました。

特にobs-studio-node 0.26.28を含むリリースで発生が増えており、OBSとの通信切断後に再起動を選んだ際、終了処理が完了しない一因になる可能性があります。

## 変更内容
- video contextのlegacy設定保存とcontext破棄を個別にエラーハンドリング
- ネイティブ呼び出しが失敗してもフロント側のcontext状態を必ず破棄
- 失敗した終了操作とエラー内容をOBS breadcrumbへ記録
- IPCエラー発生時も終了処理を継続するユニットテストを追加

## 影響範囲
- アプリ終了時のvideo context解放処理のみ
- 通常終了時の処理順序と動作は変更なし
- 破壊的変更なし

## Sentry
Sentry-Investigates: N-AIR-APP-FGN
