### PR TITLE
開発: 終了時の映像コンテキスト破棄警告を明確化

### DIFF
--- a/app/services/settings-v2/video.test.ts
+++ b/app/services/settings-v2/video.test.ts
@@ -296,7 +296,7 @@ describe('VideoSettingsService.shutdown', () => {
     instance.DESTROY_VIDEO_CONTEXT = jest.fn((display: 'horizontal') => {
       mockState[display] = null;
     });
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -350,8 +350,8 @@ describe('VideoSettingsService.shutdown', () => {
         error: 'IPC received error code 1',
       }),
     );
-    expect(console.error).toHaveBeenCalledWith(
-      '[VideoSettingsService] shutdown(horizontal): destroyContext failed:',
+    expect(console.warn).toHaveBeenCalledWith(
+      '[VideoSettingsService] shutdown(horizontal): video context was already unavailable; destroyContext cleanup failure ignored:',
       error,
     );
   });

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -383,7 +383,10 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
       operation,
       error: error instanceof Error ? error.message : String(error),
     });
-    console.error(`[VideoSettingsService] shutdown(${display}): ${operation} failed:`, error);
+    console.warn(
+      `[VideoSettingsService] shutdown(${display}): video context was already unavailable; ${operation} cleanup failure ignored:`,
+      error,
+    );
   }
 
   @mutation()


### PR DESCRIPTION
## このpull requestが解決する内容
配信中にアプリを終了した際、映像コンテキストがすでに利用できないことで発生するクリーンアップ失敗を、終了処理中に無視できる警告として明確に記録します。

## 背景
`VideoSettingsService.shutdown()` はOBS IPCの失敗を捕捉して終了処理を継続していますが、従来は汎用的なエラーメッセージを `console.error` で出力していました。そのため、正常に継続可能な終了時の競合がSentry上でエラーとして記録され、影響の判断が困難でした。

## 変更内容
- 映像コンテキストが利用できない終了時のクリーンアップ失敗であることをメッセージに明記
- ログレベルを `error` から `warn` に変更
- ユニットテストの期待値を新しい警告メッセージに更新

## 影響範囲
- アプリ終了時の診断ログのみ
- OBS操作のbreadcrumbには従来どおり操作名とIPCエラー詳細を記録
- コンテキスト破棄および後続の終了処理には変更なし

## Sentry
- Sentry-Resolves: N-AIR-APP-GGF
