### PR TITLE
追加: アップデート後の起動時、パッチノートが長いときにスクロールバーを表示

### DIFF
--- a/app/components/pages/PatchNotes.vue
+++ b/app/components/pages/PatchNotes.vue
@@ -69,7 +69,7 @@
   box-sizing: border-box;
   width: 100%;
   max-height: 160px;
-  padding: 0 32px;
+  padding: 0 48px 0 32px;
   margin-bottom: 32px;
   overflow-x: hidden;
   overflow-y: auto;

--- a/app/components/pages/PatchNotes.vue
+++ b/app/components/pages/PatchNotes.vue
@@ -38,7 +38,6 @@
 .patch-notes-container {
   position: absolute;
   width: 480px;
-  overflow: auto;
 }
 
 .patch-notes-content {
@@ -64,22 +63,32 @@
 
 .patch-notes-wrap {
   width: 100%;
-  overflow: hidden;
 }
 
 .patch-notes-list {
   box-sizing: border-box;
-  //lessなので　width: calc(100% + 8px) ではなく↓で記述
-  width: calc(~'100% + 8px');
+  width: 100%;
   max-height: 160px;
   padding: 0 32px;
-  //foundation対応
-  margin-right: 1.25rem;
   margin-bottom: 32px;
   overflow-x: hidden;
   overflow-y: auto;
   color: @text-secondary;
   text-align: left;
+}
+
+.patch-notes-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.patch-notes-list::-webkit-scrollbar-track {
+  background: fade(@grey, 15%);
+  border-radius: 4px;
+}
+
+.patch-notes-list::-webkit-scrollbar-thumb {
+  background: @text-secondary;
+  border-radius: 4px;
 }
 
 .patch-notes-item {


### PR DESCRIPTION
## 概要

パッチノートの内容が表示領域に収まらない場合に、スクロールできることが分かるようスクロールバーを表示します。

## 変更内容

- パッチノート一覧の最大高さを 160px とし、内容が収まらない場合のみ縦スクロールバーを表示
- スクロールバーのトラックとつまみを、画面の配色に合わせて装飾
- 本文とスクロールバーが重ならないよう、本文の右余白を調整
- スクロール領域をパッチノート一覧に限定するよう、周辺要素のレイアウトを整理

## 画面

<img width="648" height="481" alt="パッチノートにスクロールバーが表示された画面" src="https://github.com/user-attachments/assets/53b807de-b534-45e7-9835-a09e1ddf1a96" />

## 動作確認

- 内容が多い場合にスクロールバーが表示され、最後の項目までスクロールできること
- 内容が少ない場合にスクロールバーが表示されないこと