### PR TITLE
開発: 起動時OBS IPC失敗時のmainWindow破棄後アクセス例外を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -812,7 +812,10 @@ function initialize(crashHandler) {
     mainWindow.webContents.once('did-finish-load', () => {
       // Give Vue a moment to render before showing
       setTimeout(() => {
-        mainWindow.show();
+        // OBS IPC接続失敗等でシャットダウンが先行し、mainWindowが破棄済みの場合がある
+        if (!mainWindow.isDestroyed()) {
+          mainWindow.show();
+        }
         closeSplashWindow();
       }, 100);
     });


### PR DESCRIPTION
## このpull requestが解決する内容

Sentry issue [N-AIR-APP-GFD](https://n-air-app2.sentry.io/issues/7680366512/) で報告されている、起動シーケンス中に発生する未処理例外 `TypeError: Object has been destroyed` を解消します。

## スコープについて(重要)

この修正は **Sentryへの二次的なクラッシュレポートを解消するのみ** で、ユーザーが実際に体験する「アプリが起動しない」問題そのものを修正するものではありません。

- `obs.IPC.host()` が失敗すると、`app.ts` は既に「初期化エラー」ダイアログを表示してアプリを終了する処理が入っています(この修正以前から存在する挙動)
- その終了処理の最中、`did-finish-load` から100ms後に予約されていた `mainWindow.show()` が、既に破棄済みの `mainWindow` に対して呼ばれ、別の未処理例外(fatal, unhandled)としてSentryに送信されていました
- `obs.IPC.host()` がなぜ失敗するか(根本原因)は本PRの範囲外です。過去に調査した [OBS IPC切断問題](issue #1380) と同系統で、obs64.exe側の問題である可能性が高く、アプリ側での特定・対処が難しい領域です

## 変更内容

`main.js` の `did-finish-load` ハンドラ内で、`mainWindow.show()` の前に `isDestroyed()` チェックを追加しました。同ファイル内の他の箇所(`closeSplashWindow()` 含む)では一貫してこのガードが入っており、この箇所だけ抜けていました。

## テスト

手動での再現・検証は困難(OBS IPC接続失敗を意図的に再現する必要がある)のため省略しました。

## Sentry

Sentry-Investigates: N-AIR-APP-GFD
