### PR TITLE
修正: ソースの並べ替え操作が重くなる問題を修正

### DIFF
--- a/app/components/shared/tree-view/TreeView.vue
+++ b/app/components/shared/tree-view/TreeView.vue
@@ -2,7 +2,7 @@
   <div ref="root" class="tree-view tree-view-root" @contextmenu.self="$emit('contextmenu', $event)" @dragover="onRootDragOver" @drop="onDrop">
     <div class="tree-view-nodes-list">
       <div v-for="node in visibleNodes" :key="node.pathStr" class="tree-view-node" :class="{ 'tree-view-selected': node.isSelected }">
-        <div class="tree-view-cursor tree-view-cursor_before" :style="cursorStyle(node, 'before')" />
+        <div class="tree-view-cursor tree-view-cursor_before" />
         <div
           class="tree-view-node-item"
           :class="nodeClasses(node)"
@@ -26,7 +26,7 @@
           </div>
           <div class="tree-view-sidebar"><slot name="sidebar" :node="node" /></div>
         </div>
-        <div class="tree-view-cursor tree-view-cursor_after" :style="cursorStyle(node, 'after')" />
+        <div class="tree-view-cursor tree-view-cursor_after" />
       </div>
     </div>
   </div>
@@ -129,6 +129,7 @@
   right: 0;
   left: calc(var(--depth) * 24px + 12px);
   z-index: 1;
+  visibility: hidden;
   height: 1px;
   pointer-events: none;
 

--- a/app/components/shared/tree-view/TreeView.vue.ts
+++ b/app/components/shared/tree-view/TreeView.vue.ts
@@ -1,7 +1,21 @@
-import { CSSProperties, defineComponent, PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
+import { clearTreeCursor, updateTreeCursor } from './tree-cursor';
 import { buildTreeNodes, flattenTree, getDropPlacement, isSameOrDescendant, resolveDropPosition, selectNodes } from './tree-utils';
-import { ITreeCursorPosition, ITreeNode, ITreeNodeModel, TDropPlacement } from './types';
+import { ITreeCursorPosition, ITreeNode, ITreeNodeModel } from './types';
+
+function cursorPositionKey(position: ITreeCursorPosition<unknown> | null): string {
+  if (!position) return '';
+  return [
+    position.node.pathStr,
+    position.placement,
+    position.parentNode?.pathStr || '',
+    position.beforeNode?.pathStr || '',
+    position.lineNode?.pathStr || '',
+    position.linePlacement || '',
+    position.lineLevel || '',
+  ].join('|');
+}
 
 export default defineComponent({
   name: 'TreeView',
@@ -29,21 +43,11 @@ export default defineComponent({
   beforeUnmount() { this.stopScroll(); },
   methods: {
     nodeClasses(node: ITreeNode<unknown>) {
-      const cursor = this.cursorPosition?.node.pathStr === node.pathStr;
       return {
-        'tree-view-cursor-hover': cursor,
-        'tree-view-cursor-inside': cursor && this.cursorPosition?.placement === 'inside',
         'tree-view-dragging': this.draggingNodes.some((candidate: ITreeNode<unknown>) => candidate.pathStr === node.pathStr),
         'tree-view-node-is-leaf': node.isLeaf,
         'tree-view-node-is-folder': !node.isLeaf,
       };
-    },
-    cursorStyle(node: ITreeNode<unknown>, placement: TDropPlacement): CSSProperties {
-      const lineNode = this.cursorPosition?.lineNode || this.cursorPosition?.node;
-      const linePlacement = this.cursorPosition?.linePlacement || this.cursorPosition?.placement;
-      const visible = lineNode?.pathStr === node.pathStr && linePlacement === placement;
-      const level = this.cursorPosition?.lineLevel || node.level;
-      return { visibility: visible ? 'visible' : 'hidden', '--depth': level - 1 } as CSSProperties;
     },
     emitSelection(node: ITreeNode<unknown>, event: MouseEvent, additive: boolean, anchor?: string) {
       this.lastSelectedPath = node.pathStr;
@@ -62,6 +66,18 @@ export default defineComponent({
       }
     },
     toggle(node: ITreeNode<unknown>, event: MouseEvent) { this.$emit('toggle', node, event); },
+    clearCursorDisplay() {
+      clearTreeCursor(this.$refs.root as HTMLElement);
+    },
+    updateCursorDisplay(position: ITreeCursorPosition<unknown>) {
+      updateTreeCursor(this.$refs.root as HTMLElement, position);
+    },
+    updateCursorPosition(position: ITreeCursorPosition<unknown>): boolean {
+      if (cursorPositionKey(this.cursorPosition) === cursorPositionKey(position)) return false;
+      this.cursorPosition = position;
+      this.updateCursorDisplay(position);
+      return true;
+    },
     onDragStart(node: ITreeNode<unknown>, event: DragEvent) {
       if (!node.isDraggable) { event.preventDefault(); return; }
       this.dragStarted = true;
@@ -77,7 +93,9 @@ export default defineComponent({
       const placement = getDropPlacement(!!node.isLeaf, event.clientY - rect.top, rect.height, this.edgeSize);
       const rootRect = (this.$refs.root as HTMLElement).getBoundingClientRect();
       const desiredLevel = Math.max(1, Math.floor((event.clientX - rootRect.left - 12) / 24) + 1);
-      this.cursorPosition = resolveDropPosition(this.allNodes, this.visibleNodes, node, placement, desiredLevel);
+      this.updateCursorPosition(
+        resolveDropPosition(this.allNodes, this.visibleNodes, node, placement, desiredLevel),
+      );
       this.updateAutoScroll(event.clientY);
     },
     onRootDragOver(event: DragEvent) {
@@ -88,7 +106,9 @@ export default defineComponent({
       const node = before ? this.visibleNodes[0] : this.visibleNodes[this.visibleNodes.length - 1];
       if (node) {
         const placement = before ? 'before' : 'after';
-        this.cursorPosition = resolveDropPosition(this.allNodes, this.visibleNodes, node, placement, 1);
+        this.updateCursorPosition(
+          resolveDropPosition(this.allNodes, this.visibleNodes, node, placement, 1),
+        );
       }
       this.updateAutoScroll(event.clientY);
     },
@@ -120,6 +140,7 @@ export default defineComponent({
     },
     stopScroll() { cancelAnimationFrame(this.scrollFrame); this.scrollFrame = 0; this.scrollSpeed = 0; },
     stopDrag() {
+      this.clearCursorDisplay();
       this.draggingNodes = [];
       this.cursorPosition = null;
       this.stopScroll();

--- a/app/components/shared/tree-view/tree-cursor.test.ts
+++ b/app/components/shared/tree-view/tree-cursor.test.ts
@@ -86,4 +86,17 @@ describe('TreeViewのドラッグカーソル', () => {
     clearTreeCursor(root);
     expect(root.querySelector('.tree-view-cursor[style*="visible"]')).toBeNull();
   });
+
+  it('複数残ったカーソル表示をすべて消す', () => {
+    const root = createTreeRoot();
+    root.querySelectorAll<HTMLElement>('.tree-view-cursor')
+      .forEach((cursor) => { cursor.style.visibility = 'visible'; });
+    root.querySelectorAll<HTMLElement>('[data-tree-path]')
+      .forEach((item) => item.classList.add('tree-view-cursor-inside'));
+
+    clearTreeCursor(root);
+
+    expect(root.querySelectorAll('.tree-view-cursor[style*="visible"]')).toHaveLength(0);
+    expect(root.querySelectorAll('.tree-view-cursor-inside')).toHaveLength(0);
+  });
 });

--- a/app/components/shared/tree-view/tree-cursor.test.ts
+++ b/app/components/shared/tree-view/tree-cursor.test.ts
@@ -1,0 +1,89 @@
+/** @jest-environment jsdom */
+
+import { clearTreeCursor, updateTreeCursor } from './tree-cursor';
+import { buildTreeNodes } from './tree-utils';
+
+function createTreeRoot() {
+  const root = document.createElement('div');
+  root.innerHTML = `
+    <div class="tree-view-node">
+      <div class="tree-view-cursor tree-view-cursor_before"></div>
+      <div class="tree-view-node-item" data-tree-path="[0]"></div>
+      <div class="tree-view-cursor tree-view-cursor_after"></div>
+    </div>
+    <div class="tree-view-node">
+      <div class="tree-view-cursor tree-view-cursor_before"></div>
+      <div class="tree-view-node-item" data-tree-path="[1]"></div>
+      <div class="tree-view-cursor tree-view-cursor_after"></div>
+    </div>
+  `;
+  return root;
+}
+
+function getNodeItem(root: HTMLElement, path: string) {
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-tree-path]'))
+    .find((item) => item.dataset.treePath === path)!;
+}
+
+describe('TreeViewのドラッグカーソル', () => {
+  const nodes = buildTreeNodes([
+    { title: 'folder', children: [] },
+    { title: 'item', isLeaf: true },
+  ]);
+
+  it('指定した行の境界にカーソルを表示する', () => {
+    const root = createTreeRoot();
+    updateTreeCursor(root, {
+      node: nodes[1],
+      placement: 'before',
+      parentNode: null,
+      beforeNode: nodes[1],
+      lineNode: nodes[1],
+      linePlacement: 'before',
+      lineLevel: 1,
+    });
+
+    const cursor = getNodeItem(root, nodes[1].pathStr).parentElement!
+      .querySelector<HTMLElement>('.tree-view-cursor_before')!;
+    expect(cursor.style.visibility).toBe('visible');
+    expect(cursor.style.getPropertyValue('--depth')).toBe('0');
+  });
+
+  it('フォルダー内へのドロップ対象だけを強調する', () => {
+    const root = createTreeRoot();
+    updateTreeCursor(root, {
+      node: nodes[0],
+      placement: 'inside',
+      parentNode: nodes[0],
+      beforeNode: null,
+    });
+
+    expect(getNodeItem(root, nodes[0].pathStr).classList.contains('tree-view-cursor-inside')).toBe(true);
+    expect(root.querySelector('.tree-view-cursor[style*="visible"]')).toBeNull();
+  });
+
+  it('移動前の表示を消して新しい位置だけを表示する', () => {
+    const root = createTreeRoot();
+    updateTreeCursor(root, {
+      node: nodes[0],
+      placement: 'inside',
+      parentNode: nodes[0],
+      beforeNode: null,
+    });
+    updateTreeCursor(root, {
+      node: nodes[1],
+      placement: 'after',
+      parentNode: null,
+      beforeNode: null,
+      lineNode: nodes[1],
+      linePlacement: 'after',
+      lineLevel: 1,
+    });
+
+    expect(getNodeItem(root, nodes[0].pathStr).classList.contains('tree-view-cursor-inside')).toBe(false);
+    expect(root.querySelectorAll('.tree-view-cursor[style*="visible"]')).toHaveLength(1);
+
+    clearTreeCursor(root);
+    expect(root.querySelector('.tree-view-cursor[style*="visible"]')).toBeNull();
+  });
+});

--- a/app/components/shared/tree-view/tree-cursor.ts
+++ b/app/components/shared/tree-view/tree-cursor.ts
@@ -1,0 +1,25 @@
+import { ITreeCursorPosition } from './types';
+
+const visibleCursorSelector = '.tree-view-cursor[style*="visible"]';
+const insideCursorSelector = '.tree-view-cursor-inside';
+
+export function clearTreeCursor(root: HTMLElement) {
+  root.querySelector<HTMLElement>(visibleCursorSelector)?.style.removeProperty('visibility');
+  root.querySelector<HTMLElement>(insideCursorSelector)?.classList.remove('tree-view-cursor-inside');
+}
+
+export function updateTreeCursor<TData>(root: HTMLElement, position: ITreeCursorPosition<TData>) {
+  clearTreeCursor(root);
+  const nodeItems = Array.from(root.querySelectorAll<HTMLElement>('[data-tree-path]'));
+  const targetItem = nodeItems.find((item) => item.dataset.treePath === position.node.pathStr);
+  if (position.placement === 'inside') targetItem?.classList.add('tree-view-cursor-inside');
+
+  const lineNode = position.lineNode || position.node;
+  const linePlacement = position.linePlacement || position.placement;
+  if (linePlacement === 'inside') return;
+  const lineItem = nodeItems.find((item) => item.dataset.treePath === lineNode.pathStr);
+  const cursor = lineItem?.parentElement?.querySelector<HTMLElement>(`.tree-view-cursor_${linePlacement}`);
+  if (!cursor) return;
+  cursor.style.visibility = 'visible';
+  cursor.style.setProperty('--depth', String((position.lineLevel || lineNode.level) - 1));
+}

--- a/app/components/shared/tree-view/tree-cursor.ts
+++ b/app/components/shared/tree-view/tree-cursor.ts
@@ -4,8 +4,10 @@ const visibleCursorSelector = '.tree-view-cursor[style*="visible"]';
 const insideCursorSelector = '.tree-view-cursor-inside';
 
 export function clearTreeCursor(root: HTMLElement) {
-  root.querySelector<HTMLElement>(visibleCursorSelector)?.style.removeProperty('visibility');
-  root.querySelector<HTMLElement>(insideCursorSelector)?.classList.remove('tree-view-cursor-inside');
+  root.querySelectorAll<HTMLElement>(visibleCursorSelector)
+    .forEach((cursor) => cursor.style.removeProperty('visibility'));
+  root.querySelectorAll<HTMLElement>(insideCursorSelector)
+    .forEach((item) => item.classList.remove('tree-view-cursor-inside'));
 }
 
 export function updateTreeCursor<TData>(root: HTMLElement, position: ITreeCursorPosition<TData>) {


### PR DESCRIPTION
## 概要

ソース一覧で項目をドラッグして並べ替える際、ドロップ位置を示すカーソルの移動ごとに、表示中のソース行全体が再描画されていました。

カーソル表示をVueのリアクティブな行描画から分離し、変更対象のDOM要素のみを更新することで、ドラッグ操作の負荷を軽減します。

## 変更内容

- 同じドロップ位置への重複したカーソル更新を抑制
- ドラッグカーソルの表示をソース行全体の再描画から分離
- カーソル線またはドロップ対象行のみを更新
- カーソル表示処理を `tree-cursor.ts` へ分離
- 境界カーソル、フォルダー内ドロップ、表示解除のユニットテストを追加

## 計測結果

18項目のソース一覧でドラッグ操作を計測しました。

| 指標 | 変更前 | 変更後 |
|---|---:|---:|
| Vue更新時間（平均） | 27.66ms | 0.67ms |
| Vue更新時間（最大） | 31ms | 2.1ms |
| 行クラスの評価回数 | 308回 | 14回 |
| カーソルスタイルの評価回数 | 616回 | 0回 |

Vue更新時間は平均で約98%短縮され、カーソル移動に伴うソース行全体の再描画が解消されました。

## 影響範囲

- ソース一覧のドラッグ並べ替え
- ドロップ位置を示すカーソル線
- フォルダー内へドロップする際の行強調表示

ソースの並べ替え位置の計算や、ドロップ後の並べ替え処理には変更ありません。
