### PR TITLE
修正: 配信開始時に最適化処理が失敗するとエラーダイアログが表示されず配信できないことがある問題を修正

### DIFF
--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -1187,7 +1187,7 @@ test('optimizeForNiconicoAndStartStreaming: diffOptimizedSettingsが例外を投
     'optimizeForNiconicoAndStartStreaming',
     expect.any(Error),
     expect.objectContaining({
-      fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'exception'],
+      fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'niconico', 'exception'],
     }),
   );
   expect(currentRemote.dialog.showMessageBox).toHaveBeenCalledWith(
@@ -1229,7 +1229,7 @@ test('optimizeForNiconicoAndStartStreaming: optimizeForNiconico(即時適用)が
     'optimizeForNiconicoAndStartStreaming',
     expect.any(Error),
     expect.objectContaining({
-      fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'exception'],
+      fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'niconico', 'exception'],
     }),
   );
   expect(currentRemote.dialog.showMessageBox).toHaveBeenCalledWith(

--- a/app/services/streaming/streaming.test.ts
+++ b/app/services/streaming/streaming.test.ts
@@ -1152,6 +1152,92 @@ test('optimizeForNiconicoAndStartStreaming: 差分なし・canvasResolutionWarni
   expect(instance.toggleStreaming).not.toHaveBeenCalled();
 });
 
+test('optimizeForNiconicoAndStartStreaming: diffOptimizedSettingsが例外を投げてもtoggleStreamingAsyncがハングせず、エラーダイアログを表示する', async () => {
+  const injectee = createInjecteeForOptimizeTest();
+  injectee.SettingsService.diffOptimizedSettings = jest.fn(() => {
+    throw new Error('boom');
+  });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const { SentryReport } = require('util/sentry-report');
+  const currentRemote = require('@electron/remote') as typeof remote;
+  const errorSpy = jest.spyOn(SentryReport, 'error');
+  const instance = StreamingService.instance();
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  // return await していないと、この await は解決しても例外は握り込まれず
+  // unhandled rejection になり、テストの評価より後に発火してしまう。
+  await instance.toggleStreamingAsync();
+
+  expect(instance.toggleStreaming).not.toHaveBeenCalled();
+  expect(errorSpy).toHaveBeenCalledWith(
+    'StreamingService',
+    'optimizeForNiconicoAndStartStreaming',
+    expect.any(Error),
+    expect.objectContaining({
+      fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'exception'],
+    }),
+  );
+  expect(currentRemote.dialog.showMessageBox).toHaveBeenCalledWith(
+    currentRemote.getCurrentWindow(),
+    expect.objectContaining({ title: 'streaming.streamingError', message: 'streaming.startFailedError' }),
+  );
+});
+
+test('optimizeForNiconicoAndStartStreaming: optimizeForNiconico(即時適用)が例外を投げてもエラーダイアログを表示する', async () => {
+  const injectee = createInjecteeForOptimizeTest({ showOptimizationDialogForNiconico: false });
+  injectee.SettingsService.optimizeForNiconico = jest.fn(() => {
+    throw new Error('boom');
+  });
+  setup({
+    injectee,
+    state: {
+      StreamingService: {
+        streamingStatus: EStreamingState.Offline,
+        recordingStatus: ERecordingState.Offline,
+      },
+    },
+  });
+
+  const { StreamingService } = require('./streaming');
+  const { SentryReport } = require('util/sentry-report');
+  const currentRemote = require('@electron/remote') as typeof remote;
+  const errorSpy = jest.spyOn(SentryReport, 'error');
+  const instance = StreamingService.instance();
+  instance.toggleStreaming = jest.fn();
+
+  instance.client.fetchOnairUserProgram = jest.fn(() => Promise.resolve({ programId: 'lv12345' }));
+  instance.client.fetchOnairChannels = jest.fn(() => Promise.resolve({ ok: true, value: [] }));
+
+  await instance.toggleStreamingAsync();
+
+  expect(instance.toggleStreaming).not.toHaveBeenCalled();
+  expect(errorSpy).toHaveBeenCalledWith(
+    'StreamingService',
+    'optimizeForNiconicoAndStartStreaming',
+    expect.any(Error),
+    expect.objectContaining({
+      fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'exception'],
+    }),
+  );
+  expect(currentRemote.dialog.showMessageBox).toHaveBeenCalledWith(
+    currentRemote.getCurrentWindow(),
+    expect.objectContaining({ title: 'streaming.streamingError', message: 'streaming.startFailedError' }),
+  );
+});
+
 test('logStreamEndがstreamingTrackIdが設定されている場合にstream_endを送信する', () => {
   const recordEvent = jest.fn();
   setup({

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -555,10 +555,10 @@ export class StreamingService
         this.toggleStreaming();
       }
     } catch (e) {
-      // ここで捕まえないと、呼び出し元(toggleStreamingAsync)の catch にも届かず
-      // unhandled rejection になり、ユーザーには何も表示されずに配信開始が失敗する。
+      // 呼び出し元(toggleStreamingAsync)でも catch するが、二重の安全策としてここでも捕捉し
+      // ユーザーに必ずエラーダイアログを表示する。
       SentryReport.error('StreamingService', 'optimizeForNiconicoAndStartStreaming', e, {
-        fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'exception'],
+        fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'niconico', 'exception'],
       });
       await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
         buttons: ['OK'],

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -345,7 +345,10 @@ export class StreamingService
         }
 
         if (this.customizationService.optimizeForNiconico) {
-          return this.optimizeForNiconicoAndStartStreaming(
+          // await しないと、この catch では拾えず unhandled rejection になる
+          // (optimizeForNiconicoAndStartStreaming 自身も内部で例外を処理するが、
+          // 二重の安全策として await する)
+          return await this.optimizeForNiconicoAndStartStreaming(
             setting,
             opts.mustShowOptimizationDialog,
           );
@@ -521,34 +524,48 @@ export class StreamingService
           .then(({ response: done }) => resolve(done));
       });
     }
-    const settings = this.settingsService.diffOptimizedSettings({
-      bitrate: streamingSetting.quality.bitrate,
-      height: streamingSetting.quality.height,
-      fps: streamingSetting.quality.fps,
-      useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
-    });
-    if (Object.keys(settings.delta).length > 0 || mustShowDialog || settings.canvasResolutionWarning) {
-      if (
-        this.customizationService.showOptimizationDialogForNiconico
-        || mustShowDialog
-        || this.isRecording
-        || settings.canvasResolutionWarning
-      ) {
-        this.windowsService.showWindow({
-          componentName: 'OptimizeForNiconico',
-          title: $t('streaming.optimizationForNiconico.title'),
-          queryParams: settings,
-          size: {
-            width: 600,
-            height: 594, // なぜ {@link this.calculateOptimizeWindowSize()} を使っていない?
-          },
-        });
+    try {
+      const settings = this.settingsService.diffOptimizedSettings({
+        bitrate: streamingSetting.quality.bitrate,
+        height: streamingSetting.quality.height,
+        fps: streamingSetting.quality.fps,
+        useHardwareEncoder: this.customizationService.optimizeWithHardwareEncoder,
+      });
+      if (Object.keys(settings.delta).length > 0 || mustShowDialog || settings.canvasResolutionWarning) {
+        if (
+          this.customizationService.showOptimizationDialogForNiconico
+          || mustShowDialog
+          || this.isRecording
+          || settings.canvasResolutionWarning
+        ) {
+          this.windowsService.showWindow({
+            componentName: 'OptimizeForNiconico',
+            title: $t('streaming.optimizationForNiconico.title'),
+            queryParams: settings,
+            size: {
+              width: 600,
+              height: 594, // なぜ {@link this.calculateOptimizeWindowSize()} を使っていない?
+            },
+          });
+        } else {
+          this.settingsService.optimizeForNiconico(settings.best);
+          this.toggleStreaming();
+        }
       } else {
-        this.settingsService.optimizeForNiconico(settings.best);
         this.toggleStreaming();
       }
-    } else {
-      this.toggleStreaming();
+    } catch (e) {
+      // ここで捕まえないと、呼び出し元(toggleStreamingAsync)の catch にも届かず
+      // unhandled rejection になり、ユーザーには何も表示されずに配信開始が失敗する。
+      SentryReport.error('StreamingService', 'optimizeForNiconicoAndStartStreaming', e, {
+        fingerprint: ['StreamingService', 'optimizeForNiconicoAndStartStreaming', 'exception'],
+      });
+      await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
+        buttons: ['OK'],
+        title: $t('streaming.streamingError'),
+        type: 'error',
+        message: $t('streaming.startFailedError'),
+      });
     }
   }
 


### PR DESCRIPTION
## このpull requestが解決する内容

配信開始ボタンを押した後、ボタンが「番組取得中」表示になり、その後**エラーダイアログが一切出ずにサイレントに配信開始前の状態へ戻る**問題を修正します。

SNS上で複数のユーザーから同様の症状(配信開始ボタンを押しても配信されない、エラーは出ていない)の報告があり、実際にユーザーから提供された画面キャプチャで「N Airの画面を見ている状態で、番組取得中→ダイアログ無しでサイレントに配信開始前へ戻る」ことを確認しました(番組はニコ生パネルで既に認識済み・取得済み)。

## 原因

`app/services/streaming/streaming.ts` の `toggleStreamingAsync()` に、JavaScriptの以下の既知の落とし穴がありました。

```ts
try {
  // ...
  if (this.customizationService.optimizeForNiconico) {
    return this.optimizeForNiconicoAndStartStreaming(setting, opts.mustShowOptimizationDialog);
  }
} catch (e) {
  // ここでダイアログを表示する処理があるが…
} finally {
  this.SET_PROGRAM_FETCHING(false);
}
```

`return <Promise>` は `await` していないため、`optimizeForNiconicoAndStartStreaming()` が返すPromiseは **tryブロックの制御フローが完了した後に** async関数自身の返り値として解決されます。つまり:

1. `return` した時点で `finally` が実行され、`SET_PROGRAM_FETCHING(false)` でボタン表示が元に戻る(これが「番組取得中→サイレントに戻る」の部分)
2. その後 `optimizeForNiconicoAndStartStreaming()` が例外を投げても、**すでに完了した `catch` には届かない**
3. `unhandledrejection` として `app.ts:84-86` のグローバルハンドラに流れるが、そこはログ送信のみでダイアログは出さない

`optimizeForNiconico`(「配信のたびに設定を最適化する」)はデフォルトで有効(`customization.ts:26`)のため、多くのユーザーがこの経路を通ります。`optimizeForNiconicoAndStartStreaming()` 自身にも try/catch がなく、内部の `settingsService.diffOptimizedSettings()` / `settingsService.optimizeForNiconico()` / `toggleStreaming()` のいずれかが例外を投げると同様に握り潰されていました。

## 変更内容

- `toggleStreamingAsync()`: `return this.optimizeForNiconicoAndStartStreaming(...)` を `return await ...` に修正し、呼び出し元の `catch` に届くようにした
- `optimizeForNiconicoAndStartStreaming()`: 設定適用〜配信開始までを try/catch で保護し、失敗時に `SentryReport.error` で報告した上で `streaming.startFailedError` のエラーダイアログを表示するようにした(二重の安全策。呼び出し元だけに頼らず、ここ単体でも堅牢にした)

## スコープについて

これはニコ生パネルで番組が既に認識されている場合など、**単発の失敗で最初のダイアログすら出ない**ケースに対する修正です。別PR #1423 (診断情報追加＋複数エラー同時発生時の握り潰し修正)とは独立した、別の原因・別の修正です。

`optimizeForNiconicoAndStartStreaming()` 内で実際に何が例外を投げていたか(OBS31関連の設定非互換の可能性が高いと推測していますが)は未確認です。今回のSentry報告追加により、次回発生時に原因を特定できるようになります。

## テスト

- [x] `pnpm run test:unit:app` (新規テスト2件を含め全件成功)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] 実機での挙動確認(OBS31環境での再現検証と合わせて別途実施予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
