### PR TITLE
修正: 複数ソース選択時にフォルダ/シーンへまとめる操作ができない問題を修正

### DIFF
--- a/app/services/core/stateful-service.test.ts
+++ b/app/services/core/stateful-service.test.ts
@@ -1,0 +1,42 @@
+import { reactive } from 'vue';
+
+import { deepToRaw } from './stateful-service';
+
+describe('deepToRaw', () => {
+  it('プリミティブ・nullはそのまま返す', () => {
+    expect(deepToRaw(1)).toBe(1);
+    expect(deepToRaw('a')).toBe('a');
+    expect(deepToRaw(null)).toBeNull();
+    expect(deepToRaw(undefined)).toBeUndefined();
+  });
+
+  it('非reactiveな配列・オブジェクトはそのまま構造化クローン可能', () => {
+    const plain = { itemsToGroup: ['a', 'b'], parentId: 'p' };
+    expect(structuredClone(deepToRaw(plain))).toEqual(plain);
+  });
+
+  // N-AIR-APP-GDJ: SelectionService.getIds() は Vuex(reactive)の state 配下の
+  // 配列をそのまま返すため、Proxy化された配列が ipcRenderer.send に渡ると
+  // structuredClone (V8 ValueSerializer) が「An object could not be cloned.」で失敗する。
+  it('reactiveなstate直下の配列はProxyのままだとstructuredCloneに失敗し、deepToRaw後は成功する', () => {
+    const state = reactive({ selectedIds: ['a', 'b'] });
+    const proxiedArray = state.selectedIds;
+
+    expect(() => structuredClone(proxiedArray)).toThrow();
+    expect(structuredClone(deepToRaw(proxiedArray))).toEqual(['a', 'b']);
+  });
+
+  it('queryParamsにネストしたreactive配列を含む形でもstructuredClone可能になる', () => {
+    const state = reactive({ selectedIds: ['a', 'b'] });
+    const options = {
+      componentName: 'NameFolder',
+      queryParams: { itemsToGroup: state.selectedIds, parentId: undefined },
+    };
+
+    expect(() => structuredClone(options)).toThrow();
+    expect(structuredClone(deepToRaw(options))).toEqual({
+      componentName: 'NameFolder',
+      queryParams: { itemsToGroup: ['a', 'b'] },
+    });
+  });
+});

--- a/app/services/core/stateful-service.test.ts
+++ b/app/services/core/stateful-service.test.ts
@@ -30,13 +30,13 @@ describe('deepToRaw', () => {
     const state = reactive({ selectedIds: ['a', 'b'] });
     const options = {
       componentName: 'NameFolder',
-      queryParams: { itemsToGroup: state.selectedIds, parentId: undefined },
+      queryParams: { itemsToGroup: state.selectedIds, parentId: 'p' },
     };
 
     expect(() => structuredClone(options)).toThrow();
     expect(structuredClone(deepToRaw(options))).toEqual({
       componentName: 'NameFolder',
-      queryParams: { itemsToGroup: ['a', 'b'] },
+      queryParams: { itemsToGroup: ['a', 'b'], parentId: 'p' },
     });
   });
 });

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -30,7 +30,7 @@ import electron from 'electron';
 // for spawning various child windows.
 import cloneDeep from 'lodash/cloneDeep';
 import { Subject } from 'rxjs';
-import { mutation, StatefulService } from 'services/core/stateful-service';
+import { deepToRaw, mutation, StatefulService } from 'services/core/stateful-service';
 import { getPartitionConfig } from 'services/dev-hosts';
 import Util, { uuidv4 } from 'services/utils';
 import { SentryReport } from 'util/sentry-report';
@@ -202,7 +202,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
       this.requireWaitWindowCleanup('child', false);
     }
 
-    ipcRenderer.send('window-showChildWindow', options);
+    ipcRenderer.send('window-showChildWindow', deepToRaw(options));
     this.updateChildWindowOptions(options);
   }
 
@@ -232,7 +232,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
         isPreserved: true,
       };
 
-      ipcRenderer.send('window-showChildWindow', options);
+      ipcRenderer.send('window-showChildWindow', deepToRaw(options));
       this.updateChildWindowOptions(options);
       return Promise.resolve();
     }


### PR DESCRIPTION
## 概要

複数のソースを選択して「フォルダにまとめる」「シーンにまとめる」操作を行うと、名前入力ダイアログが開かずコンソールに `An object could not be cloned.` エラーが発生する不具合を修正します(Sentry: N-AIR-APP-GDJ)。

## 原因

Vue3移行に伴うリグレッションです。`SelectionService.getIds()` は `Utils.applyMixins` により `Selection.prototype.getIds` を借用していますが、実行時の `this.state` は `StatefulService` 経由でVuexのreactive stateに解決されるため、**Vuexのreactive Proxyでラップされた配列**を返します。

この配列が `ScenesService.showNameFolder` / `showNameScene` の `queryParams` を経由して `WindowsService.showWindow()` に渡り、`ipcRenderer.send('window-showChildWindow', options)` で構造化クローン(V8 ValueSerializer)に失敗していました。

同種の問題は `app/services/api/internal-api-client.ts` の子ウィンドウ向けIPCで既に対策済み(`deepToRaw`)でしたが、`WindowsService.showWindow` の直接送信経路には適用されていませんでした。

- **初出バージョン(コード上のリグレッション発生点)**: `v1.1.20260617-1`(PR #1296「開発: Vue3に移行」マージ後の最初のリリース。`this.state` がVuexのreactive stateに解決されるようになった)
- **初観測バージョン(Sentryで最初にイベントが記録されたリリース)**: `1.1.20260722-1`(初回イベント2026-08-02)。同一親を持つ複数ソースの選択+フォルダ/シーンへまとめる、という操作自体が発生頻度の低いアクションのため、コード上の発生から実際の初観測までに約5週間のギャップがある

## 変更内容

- `app/services/windows.ts`: `ipcRenderer.send('window-showChildWindow', ...)` の2箇所(`showWindow`、`closeChildWindow`の`preservePrevWindow`分岐)で、既存の共有ユーティリティ `deepToRaw`(`services/core/stateful-service.ts`)を適用してVue reactiveプロキシを剥がすようにしました
- `app/services/core/stateful-service.test.ts`: `deepToRaw` の契約テストを追加(reactive配列がProxyのままだと`structuredClone`に失敗すること、`deepToRaw`後は成功することを検証)

## Sentry

Sentry-Resolves: N-AIR-APP-GDJ

## Test plan

- [x] `pnpm dev` で起動し、Sourcesパネルで同じ階層のソースを2つ以上Ctrl+クリックで複数選択し、フォルダアイコンをクリック
  - 修正前: ダイアログが開かず `An object could not be cloned.` エラー
  - 修正後: 名前入力ダイアログが正常に開き、フォルダ作成まで完了することを確認
