### PR TITLE
開発: サブ配信プラグインを1.1.1に更新

### DIFF
--- a/additional/additional.json
+++ b/additional/additional.json
@@ -13,7 +13,7 @@
       "dest": "/node_modules/obs-studio-node/obs-plugins/64bit"
     },
     {
-      "url": "https://github.com/n-air-app/substream/releases/download/1.1.0/nair-substream.dll",
+      "url": "https://github.com/n-air-app/substream/releases/download/1.1.1/nair-substream.dll",
       "dest": "/node_modules/obs-studio-node/obs-plugins/64bit"
     }
   ]


### PR DESCRIPTION
## 概要

`additional/additional.json` で取得するサブ配信プラグインを 1.1.0 から 1.1.1 に更新します。

substream 1.1.1 は、現在の N Air が使用する obs-studio-node 0.25.56 / LibOBS 30.2.4sl41 向けに再ビルドされたバージョンです。

## 主な更新内容

- LibOBS 30.2.4sl41 SDK との互換性を確保
- 再接続成功シグナル名を修正
- ログから配信設定の機密情報を除去
- 出力状態ログと実行環境の互換性情報を追加

## 影響範囲・回帰リスク

- 影響範囲はサブ配信機能で使用するネイティブプラグインのみです。
- DLL と obs-studio-node / LibOBS の組み合わせに依存するため、サブ配信の開始・停止・再接続が主な回帰確認対象です。

## 手動確認項目

- サブ配信を開始・停止できること
- サブ配信の再接続後に正常な状態へ復帰すること
