### PR TITLE
開発: APIエラーダイアログの表示の並びを調整

### DIFF
--- a/app/services/nicolive-program/NicoliveFailure.test.ts
+++ b/app/services/nicolive-program/NicoliveFailure.test.ts
@@ -90,6 +90,21 @@ test('追加文言をAPIメッセージ（エラーコード）の順にする',
   expect(failure.additionalMessage).toBe('APIのエラーメッセージ (ERROR_CODE)');
 });
 
+test('エラーコードがなくAPIメッセージだけの場合は区切り文字を付けない', () => {
+  const { NicoliveFailure } = prepare('400');
+  const failure = NicoliveFailure.fromClientError('method', {
+    ok: false,
+    value: {
+      meta: {
+        status: 400,
+        errorMessage: 'APIのエラーメッセージ',
+      },
+    },
+  });
+
+  expect(failure.additionalMessage).toBe('APIのエラーメッセージ');
+});
+
 test('errorCodeがなかったらstatusCodeを使う', async () => {
   const { showMessageBox, NicoliveFailure, openErrorDialogFromFailure } = prepare('403');
   const failure = NicoliveFailure.fromClientError('method', {

--- a/app/services/nicolive-program/NicoliveFailure.test.ts
+++ b/app/services/nicolive-program/NicoliveFailure.test.ts
@@ -74,6 +74,22 @@ test('errorCodeがあったらそれを使う', async () => {
   expect(showMessageBox.mock.calls[0][1].message).toBe('message');
 });
 
+test('追加文言をAPIメッセージ（エラーコード）の順にする', () => {
+  const { NicoliveFailure } = prepare('ERROR_CODE');
+  const failure = NicoliveFailure.fromClientError('method', {
+    ok: false,
+    value: {
+      meta: {
+        status: 400,
+        errorCode: 'ERROR_CODE',
+        errorMessage: 'APIのエラーメッセージ',
+      },
+    },
+  });
+
+  expect(failure.additionalMessage).toBe('APIのエラーメッセージ (ERROR_CODE)');
+});
+
 test('errorCodeがなかったらstatusCodeを使う', async () => {
   const { showMessageBox, NicoliveFailure, openErrorDialogFromFailure } = prepare('403');
   const failure = NicoliveFailure.fromClientError('method', {

--- a/app/services/nicolive-program/NicoliveFailure.ts
+++ b/app/services/nicolive-program/NicoliveFailure.ts
@@ -45,7 +45,9 @@ export class NicoliveFailure {
       return new this('network_error', method, kind, '', diagCode ?? '', route, kind);
     }
     const { errorCode, errorMessage } = res.value.meta;
-    const additionalMessage = `${errorCode ?? ''}${errorMessage ? `: ${errorMessage}` : ''}`;
+    const additionalMessage = errorMessage
+      ? `${errorMessage}${errorCode ? ` (${errorCode})` : ''}`
+      : (errorCode ?? '');
     return new this(
       'http_error',
       method,

--- a/app/services/nicolive-program/nicolive-comment-filter.test.ts
+++ b/app/services/nicolive-program/nicolive-comment-filter.test.ts
@@ -72,7 +72,7 @@ test('fetchFilters/失敗', async () => {
 
   await expect(instance.fetchFilters()).rejects.toMatchInlineSnapshot(`
 NicoliveFailure {
-  "additionalMessage": "ERROR_CODE: simple description",
+  "additionalMessage": "simple description (ERROR_CODE)",
   "errorCode": "ERROR_CODE",
   "failureKind": undefined,
   "method": "fetchFilters",
@@ -142,7 +142,7 @@ test('addFilters/失敗', async () => {
 
   await expect(instance.addFilter({ type: 'word', body: '810' })).rejects.toMatchInlineSnapshot(`
 NicoliveFailure {
-  "additionalMessage": "ERROR_CODE: simple description",
+  "additionalMessage": "simple description (ERROR_CODE)",
   "errorCode": "ERROR_CODE",
   "failureKind": undefined,
   "method": "addFilters",
@@ -196,7 +196,7 @@ test('deleteFilters/失敗', async () => {
 
   await expect(instance.deleteFilters([114514])).rejects.toMatchInlineSnapshot(`
 NicoliveFailure {
-  "additionalMessage": "ERROR_CODE: simple description",
+  "additionalMessage": "simple description (ERROR_CODE)",
   "errorCode": "ERROR_CODE",
   "failureKind": undefined,
   "method": "deleteFilters",


### PR DESCRIPTION
## 概要

APIエラー発生時の詳細を、エラーコードよりメッセージを先に表示する形式へ変更します。

- 変更前: `ERROR_CODE: APIメッセージ`
- 変更後: `APIメッセージ (ERROR_CODE)`
- メッセージまたはエラーコードの片方しかない場合も不要な区切り文字を表示しません

## 影響範囲

ニコニコ生放送APIのエラーダイアログに表示される追加文言が対象です。エラー種別の判定やフォールバック処理は変更しません。

before 
<img width="368" height="134" alt="Monosnap work 2026-08-31 13-02-33" src="https://github.com/user-attachments/assets/bede02cb-1516-4ff9-b0b5-f0a7eb45bf8b" />

after
<img width="374" height="137" alt="Monosnap work 2026-08-31 13-09-46" src="https://github.com/user-attachments/assets/15107a3c-9056-408c-9676-1c3fc686f100" />
