### PR TITLE
修正: ファイル保存に失敗した後に保存できなくなることがある問題を修正

### DIFF
--- a/app/services/file-manager.test.ts
+++ b/app/services/file-manager.test.ts
@@ -1,4 +1,49 @@
+import path from 'path';
+
+import { SentryReport } from 'util/sentry-report';
+
+import { FileManagerService } from './file-manager';
+
+interface IFileManagerInternals {
+  files: Record<string, {
+    data: string;
+    locked: boolean;
+    version: number;
+    dirty: boolean;
+  }>;
+  flush(filePath: string, tries?: number): Promise<void>;
+  writeFile(filePath: string, data: string): Promise<void>;
+}
+
 test('get instance', () => {
-  const { FileManagerService } = require('./file-manager');
   expect(FileManagerService.instance()).toBeInstanceOf(FileManagerService);
+});
+
+test('リトライ上限到達後も次回の保存を実行できる', async () => {
+  const instance = FileManagerService.instance();
+  const internals = instance as unknown as IFileManagerInternals;
+  const filePath = path.resolve('file-manager-retry-test.json');
+  internals.files[filePath] = {
+    data: '{}',
+    locked: false,
+    version: 0,
+    dirty: true,
+  };
+
+  const writeFile = jest.spyOn(internals, 'writeFile');
+  writeFile.mockRejectedValueOnce(Object.assign(new Error('write failed'), { code: 'EPERM' }));
+  jest.spyOn(SentryReport, 'message').mockImplementation();
+
+  await internals.flush(filePath, 0);
+
+  expect(internals.files[filePath]).toMatchObject({ locked: false, dirty: true });
+
+  writeFile.mockResolvedValueOnce();
+  await internals.flush(filePath);
+
+  expect(writeFile).toHaveBeenCalledTimes(2);
+  expect(internals.files[filePath]).toMatchObject({ locked: false, dirty: false });
+
+  delete internals.files[filePath];
+  jest.restoreAllMocks();
 });

--- a/app/services/file-manager.ts
+++ b/app/services/file-manager.ts
@@ -158,8 +158,9 @@ export class FileManagerService extends Service {
         level: 'debug',
       });
     } catch (e) {
+      // 失敗後も、再試行または次回の書き込みができるようロックを解除する。
+      file.locked = false;
       if (tries > 0) {
-        file.locked = false;
         await this.flush(filePath, tries - 1);
       } else {
         SentryReport.message('FileManagerService', 'flush', 'Ran out of retries writing file', {


### PR DESCRIPTION
## 概要

ファイル保存処理がリトライ上限まで失敗した場合、対象ファイルの書き込みロックが解除されず、以降の保存処理が実行されなくなる問題を修正します。

一時的なファイルシステムエラーが解消した後も、アプリを再起動するまで対象ファイルを保存できない可能性がありました。

## 原因

`FileManagerService.flush()` は、重複した書き込みを防ぐため、保存処理中のファイルをロックします。

従来はリトライが残っている場合にだけ失敗後のロックを解除していたため、最後のリトライに失敗するとロックされた状態が残っていました。以降の保存処理は、このロックによってスキップされていました。

## 変更内容

- 書き込み失敗時のロック解除処理を共通化
- リトライ上限到達後にも書き込みロックを解除
- 保存に失敗したファイルの `dirty` 状態を維持し、次回の書き込みで再度保存できるように変更
- 最終失敗後に次回の保存処理を実行できることを確認する回帰テストを追加

## 補足

この変更は、ディスク容量不足やファイル操作の拒否など、書き込み失敗そのものを解消するものではありません。

書き込み失敗後に内部ロックが残り、一時的なエラーが継続的な保存不能状態へ発展することを防ぐ修正です。
