### PR TITLE
開発: シーンアイテム並べ替え時のindex範囲外例外によるSentryノイズを削減

### DIFF
--- a/app/services/scenes/scene.test.ts
+++ b/app/services/scenes/scene.test.ts
@@ -141,4 +141,23 @@ describe('Scene.reconcileNodeOrderWithObs (via moveNodes)', () => {
     expect(() => scene.moveNodes(['item1'])).not.toThrow();
     expect(obsScene.moveItem).not.toHaveBeenCalled();
   });
+
+  test('OBS側のアイテム数がstate側より少ないと、対応アイテムが見つかっても移動先indexが範囲外ならスキップする (N-AIR-APP-GGY)', () => {
+    const { scene, obsScene, Sentry } = prepare({
+      itemIds: [
+        { sceneItemId: 'item1', sourceId: 'source1', obsSceneItemId: 1 }, // OBS側に存在しない
+        { sceneItemId: 'item2', sourceId: 'source2', obsSceneItemId: 2 }, // OBS側に存在するがindex(1)が範囲外(length=1)
+      ],
+      obsItemIds: [2],
+    });
+
+    expect(() => scene.moveNodes(['item1'], '', 'item2')).not.toThrow();
+    expect(obsScene.moveItem).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'OBS scene item not found for obsSceneItemId, skipping moveItem',
+    );
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Target index out of range for OBS scene items, skipping moveItem',
+    );
+  });
 });

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -348,10 +348,8 @@ export class Scene {
     const obsScene = this.getObsScene();
     this.getItems().forEach((item, index) => {
       // moveItem実行後はOBS側の並びが変わるため、都度取り直す必要がある。
-      const currentIndex = obsScene
-        .getItems()
-        .reverse()
-        .findIndex((obsItem) => obsItem.id === item.obsSceneItemId);
+      const obsItems = obsScene.getItems().reverse();
+      const currentIndex = obsItems.findIndex((obsItem) => obsItem.id === item.obsSceneItemId);
       // stateとOBS側のアイテム集合が一時的にズレている(ドラッグ操作中の削除・
       // シーン切替との競合など)と対応するOBS側アイテムが見つからないことがある。
       // その場合はこのアイテムの並び替えのみスキップして処理を継続する。
@@ -359,6 +357,15 @@ export class Scene {
         SentryReport.message('Scene', 'reconcileNodeOrderWithObs', 'OBS scene item not found for obsSceneItemId, skipping moveItem', {
           level: 'warning',
           extra: { sceneId: this.id, sceneItemId: item.id, obsSceneItemId: item.obsSceneItemId, index },
+        });
+        return;
+      }
+      // 同様の理由でOBS側のアイテム数がstate側より少ないと、移動先indexが範囲外になり
+      // ネイティブ側のmoveItemが例外を投げる。この場合も並び替えをスキップする。
+      if (index >= obsItems.length) {
+        SentryReport.message('Scene', 'reconcileNodeOrderWithObs', 'Target index out of range for OBS scene items, skipping moveItem', {
+          level: 'warning',
+          extra: { sceneId: this.id, sceneItemId: item.id, obsSceneItemId: item.obsSceneItemId, index, obsItemsLength: obsItems.length },
         });
         return;
       }


### PR DESCRIPTION
## Summary

- ドラッグ&ドロップでシーンアイテムを並べ替える際、シーン切替やアイテム削除が競合するとVuex state側とOBSネイティブ側のアイテム数が一時的にズレることがある。既存のガード(N-AIR-APP-FWY/G8M対応、PR #1365)は「対応するOBS側アイテムが見つからない」場合のみをスキップしていたが、「見つかったが移動先indexがOBS側アイテム数の範囲外」というケースは未対応で、ネイティブ側`moveItem`が「Index not found in Scene.」例外を投げて**それ以降の全アイテムの並び替え処理が中断**していた (Sentry N-AIR-APP-GGY, 4件/3人)
- 影響を受ける競合自体はまれで、かつ後続の別操作(削除完了・シーン切替完了など)で再同期される可能性が高く、ユーザーが明確に気づく体験変化とは言い切れないため、本PRはユーザー向け変更ではなく内部的なロバスト性向上・Sentryノイズ削減として扱う
- 修正内容: 移動先indexが範囲外の場合はそのアイテムのみ並び替えをスキップし、警告としてSentryへ報告して処理を継続する(他のアイテムの並び替えは巻き込まれずに正常に実行される)

## Sentry

Sentry-Resolves: N-AIR-APP-GGY

## Test plan

- [ ] シーンコレクションで複数アイテムを含むシーンを開き、ドラッグ&ドロップでの並べ替えが問題なく動作することを確認
