### PR TITLE
開発: ファイル選択ダイアログ応答時のnull参照例外によるSentryノイズを削減

### DIFF
--- a/app/components/obs/inputs/ObsPathInput.vue.test.ts
+++ b/app/components/obs/inputs/ObsPathInput.vue.test.ts
@@ -1,0 +1,67 @@
+/**
+ * ObsPathInput.showFileDialog の unit test
+ *
+ * ダイアログの応答待ち中にコンポーネントが破棄されるなどして
+ * $refs.input が null になっても例外を投げないことを確認する (N-AIR-APP-GCR)。
+ */
+import * as remote from '@electron/remote';
+
+jest.mock('@electron/remote', () => ({
+  dialog: { showOpenDialog: jest.fn() },
+  getCurrentWindow: jest.fn(),
+}));
+
+const ObsPathInput = require('./ObsPathInput.vue.ts').default;
+
+function makeContext(refsInput: HTMLInputElement | undefined) {
+  return {
+    value: { name: 'test', type: 'OBS_PROPERTY_FILE', value: '', filters: [] },
+    $refs: { input: refsInput },
+    $emit: jest.fn(),
+    handleChange: ObsPathInput.methods.handleChange,
+    emitInput: ObsPathInput.methods.emitInput,
+  };
+}
+
+describe('ObsPathInput.showFileDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('$refs.input が null ならクラッシュせず何もしない (N-AIR-APP-GCR)', async () => {
+    (remote.dialog.showOpenDialog as jest.Mock).mockResolvedValue({
+      filePaths: ['C:/selected.txt'],
+    });
+    const ctx = makeContext(undefined);
+
+    await expect(ObsPathInput.methods.showFileDialog.call(ctx)).resolves.toBeUndefined();
+    expect(ctx.$emit).not.toHaveBeenCalled();
+  });
+
+  test('$refs.input が存在する場合は value を設定して input イベントを emit する', async () => {
+    (remote.dialog.showOpenDialog as jest.Mock).mockResolvedValue({
+      filePaths: ['C:/selected.txt'],
+    });
+    const input = { value: '' } as HTMLInputElement;
+    const ctx = makeContext(input);
+
+    await ObsPathInput.methods.showFileDialog.call(ctx);
+
+    expect(input.value).toBe('C:/selected.txt');
+    expect(ctx.$emit).toHaveBeenCalledWith(
+      'input',
+      expect.objectContaining({ value: 'C:/selected.txt' }),
+    );
+  });
+
+  test('ファイルが選択されなかった場合は何もしない', async () => {
+    (remote.dialog.showOpenDialog as jest.Mock).mockResolvedValue({ filePaths: [] });
+    const input = { value: '' } as HTMLInputElement;
+    const ctx = makeContext(input);
+
+    await ObsPathInput.methods.showFileDialog.call(ctx);
+
+    expect(input.value).toBe('');
+    expect(ctx.$emit).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/obs/inputs/ObsPathInput.vue.test.ts
+++ b/app/components/obs/inputs/ObsPathInput.vue.test.ts
@@ -13,7 +13,7 @@ jest.mock('@electron/remote', () => ({
 
 const ObsPathInput = require('./ObsPathInput.vue.ts').default;
 
-function makeContext(refsInput: HTMLInputElement | undefined) {
+function makeContext(refsInput: HTMLInputElement | null) {
   return {
     value: { name: 'test', type: 'OBS_PROPERTY_FILE', value: '', filters: [] },
     $refs: { input: refsInput },
@@ -32,7 +32,7 @@ describe('ObsPathInput.showFileDialog', () => {
     (remote.dialog.showOpenDialog as jest.Mock).mockResolvedValue({
       filePaths: ['C:/selected.txt'],
     });
-    const ctx = makeContext(undefined);
+    const ctx = makeContext(null);
 
     await expect(ObsPathInput.methods.showFileDialog.call(ctx)).resolves.toBeUndefined();
     expect(ctx.$emit).not.toHaveBeenCalled();

--- a/app/components/obs/inputs/ObsPathInput.vue.ts
+++ b/app/components/obs/inputs/ObsPathInput.vue.ts
@@ -35,8 +35,9 @@ const ObsPathInput = defineComponent({
         options.properties!.push('openDirectory');
       }
       const { filePaths } = await remote.dialog.showOpenDialog(remote.getCurrentWindow(), options);
-      if (filePaths[0]) {
-        (this.$refs.input as HTMLInputElement).value = filePaths[0];
+      const input = this.$refs.input as HTMLInputElement | undefined;
+      if (filePaths[0] && input) {
+        input.value = filePaths[0];
         this.handleChange();
       }
     },

--- a/app/components/obs/inputs/ObsPathInput.vue.ts
+++ b/app/components/obs/inputs/ObsPathInput.vue.ts
@@ -35,7 +35,7 @@ const ObsPathInput = defineComponent({
         options.properties!.push('openDirectory');
       }
       const { filePaths } = await remote.dialog.showOpenDialog(remote.getCurrentWindow(), options);
-      const input = this.$refs.input as HTMLInputElement | undefined;
+      const input = this.$refs.input as HTMLInputElement | null;
       if (filePaths[0] && input) {
         input.value = filePaths[0];
         this.handleChange();


### PR DESCRIPTION
## 概要

`ObsPathInput.showFileDialog` は `remote.dialog.showOpenDialog` の応答を `await` する間にコンポーネントが破棄されると、`this.$refs.input` が `null` になった状態で `.value =` への代入を行い例外を投げていた。

この例外は `window.addEventListener('unhandledrejection'/'error')` でログ送信・Sentry送信されるのみで、ユーザー向けのダイアログ等は表示されない。ユーザーが操作中に画面上で気づく症状はなく、Sentry上のノイズ削減のみを目的とした内部的な修正。

## 変更内容

- `app/components/obs/inputs/ObsPathInput.vue.ts`: ダイアログ応答後に `this.$refs.input` の存在を確認し、`null` の場合は何もせずスキップするよう変更
- `app/components/obs/inputs/ObsPathInput.vue.test.ts`: 上記ガードのテストを追加(null時にクラッシュしない・値がある場合はvalueを設定してinputイベントをemitする・ファイル未選択時は何もしない)

## Sentry

Sentry-Resolves: N-AIR-APP-GCR (TypeError: Cannot set properties of null (setting 'value'))
