### PR TITLE
開発: OBSネイティブIPC切断由来のconsole.errorをSentryノイズフィルタで捕捉

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -19,6 +19,7 @@ import tooltipDirective from 'directives/tooltip';
 import electron from 'electron';
 import { Settings } from 'luxon';
 import { setupGlobalContextMenuForEditableElement } from 'util/menus/GlobalMenu';
+import { filterNoiseErrorEvent } from 'util/sentry-noise-filter';
 import { markObsOp } from 'util/sentry-obs-breadcrumb';
 import { SentryReport } from 'util/sentry-report';
 import { createApp } from 'vue';
@@ -89,29 +90,7 @@ if ((isProduction || process.env.NAIR_REPORT_TO_SENTRY) && !remote.process.env.N
   Sentry.init(
     {
       sampleRate: /* isPreview ? */ 1.0 /* : 0.1 */,
-      beforeSend(event) {
-        // 診断目的で構造化して送るイベントは NOISE チェックより前に通す
-        // (tags.diagnostic が設定されているものは意図的に送っているので除外しない)
-        if ((event.tags as Record<string, unknown>)?.diagnostic) {
-          return event;
-        }
-
-        // quota 対策: ユーザー側ネット環境起因またはアプリバグに起因しないノイズを除外する
-        const NOISE_PATTERNS = [
-          /Failed to make IPC call/,
-          /ERR_ABORTED/,
-          /ERR_FAILED/,
-          /read ECONNRESET/,
-          /network error/i,
-          /Failed to fetch/,
-        ];
-        const messageText =
-          (event.exception?.values?.[0]?.value) ?? event.message ?? '';
-        if (NOISE_PATTERNS.some((re) => re.test(messageText))) {
-          return null;
-        }
-        return event;
-      },
+      beforeSend: filterNoiseErrorEvent,
     },
   );
 

--- a/app/util/sentry-noise-filter.test.ts
+++ b/app/util/sentry-noise-filter.test.ts
@@ -1,0 +1,44 @@
+import type { ErrorEvent } from '@sentry/electron/renderer';
+
+import { filterNoiseErrorEvent } from './sentry-noise-filter';
+
+function makeErrorEvent(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+  return { ...overrides } as ErrorEvent;
+}
+
+describe('filterNoiseErrorEvent', () => {
+  test('diagnostic タグ付きイベントは NOISE チェックより前に通す', () => {
+    const event = makeErrorEvent({
+      tags: { diagnostic: true },
+      message: 'Failed to make IPC call, verify IPC status.',
+    });
+    expect(filterNoiseErrorEvent(event)).toBe(event);
+  });
+
+  test('event.message が NOISE_PATTERNS に一致する場合は抑制する', () => {
+    const event = makeErrorEvent({ message: 'network error: connection lost' });
+    expect(filterNoiseErrorEvent(event)).toBeNull();
+  });
+
+  test('event.exception の value が NOISE_PATTERNS に一致する場合は抑制する', () => {
+    const event = makeErrorEvent({
+      exception: { values: [{ value: 'Failed to fetch' }] },
+    });
+    expect(filterNoiseErrorEvent(event)).toBeNull();
+  });
+
+  test('console.error(msg, err) 経由で extra.exception に IPC 切断エラーが入っている場合も抑制する (N-AIR-APP-E4F)', () => {
+    const event = makeErrorEvent({
+      message: 'Array node step failed',
+      extra: {
+        exception: 'Error: Failed to make IPC call, verify IPC status.\n    at ScenesService.createScene',
+      },
+    });
+    expect(filterNoiseErrorEvent(event)).toBeNull();
+  });
+
+  test('ノイズパターンに一致しない場合はそのまま通す', () => {
+    const event = makeErrorEvent({ message: 'Some genuine bug' });
+    expect(filterNoiseErrorEvent(event)).toBe(event);
+  });
+});

--- a/app/util/sentry-noise-filter.ts
+++ b/app/util/sentry-noise-filter.ts
@@ -1,0 +1,38 @@
+import type { ErrorEvent } from '@sentry/electron/renderer';
+
+// quota 対策: ユーザー側ネット環境起因またはアプリバグに起因しないノイズを除外する
+const NOISE_PATTERNS = [
+  /Failed to make IPC call/,
+  /ERR_ABORTED/,
+  /ERR_FAILED/,
+  /read ECONNRESET/,
+  /network error/i,
+  /Failed to fetch/,
+];
+
+function extractMessageText(event: ErrorEvent): string {
+  const extra = event.extra as Record<string, unknown> | undefined;
+  const candidates = [
+    event.exception?.values?.[0]?.value,
+    event.message,
+    // console.error(msg, err) 経由の captureMessage は元の err の内容が
+    // event.message には乗らず extra.exception (err.stack) 側に入るため、
+    // そちらも見ないと NOISE_PATTERNS をすり抜けてしまう
+    extra?.exception,
+  ];
+  return candidates.filter((v): v is string => typeof v === 'string').join('\n');
+}
+
+export function filterNoiseErrorEvent(event: ErrorEvent): ErrorEvent | null {
+  // 診断目的で構造化して送るイベントは NOISE チェックより前に通す
+  // (tags.diagnostic が設定されているものは意図的に送っているので除外しない)
+  if ((event.tags as Record<string, unknown>)?.diagnostic) {
+    return event;
+  }
+
+  const messageText = extractMessageText(event);
+  if (NOISE_PATTERNS.some((re) => re.test(messageText))) {
+    return null;
+  }
+  return event;
+}


### PR DESCRIPTION
## 概要

Sentryの`Array node step failed`(N-AIR-APP-E4F、377件/25ユーザー)を調査したところ、既知のOBSバックエンドIPC切断(n-air-app#1380と同系統、`Failed to make IPC call, verify IPC status.`)がノイズ除外フィルタをすり抜けて送信され続けていたことが判明しました。

- `app/services/scene-collections/nodes/array-node.ts`の`console.error('Array node step failed', e)`は、`app.ts`のグローバル`console.error`オーバーライド経由で`Sentry.captureMessage('Array node step failed', 'error')`として送信される
- このとき実際の例外内容(`e.stack`)は`event.message`ではなく`scope.setExtra('exception', ...)`側(`event.extra.exception`)に入る
- `beforeSend`の`NOISE_PATTERNS`(`/Failed to make IPC call/`等)は`event.message` / `event.exception.value`のみを見ており、`event.extra.exception`を見ていなかったため、E4Fの実体である「OBSネイティブIPC切断由来のエラー」が既存の除外意図に反してすり抜けていました

## 変更内容

- `beforeSend`のノイズ判定ロジックを`app/util/sentry-noise-filter.ts`に切り出し
- 判定対象のテキストに`event.extra.exception`も追加
- ユニットテストを追加(`app/util/sentry-noise-filter.test.ts`)

ユーザーの操作結果や画面表示は変わりません(このエラーは元々Sentryにのみ送られておりダイアログ等は出ていなかったため)。Sentryに送るイベント数を減らすだけの変更です。

## Sentry

Sentry-Resolves: N-AIR-APP-E4F

## テスト

- [x] `pnpm run test:unit:app` (既存テスト含め全て成功)
- [x] `pnpm run typecheck`
- [x] `pnpm lint`
