### PR TITLE
修正: 配信開始直後に番組URL・合い言葉のコピーが反応しない問題を修正

### DIFF
--- a/app/components/nicolive-area/ProgramInfo.vue.test.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.test.ts
@@ -1,0 +1,59 @@
+/**
+ * ProgramInfo.copyProgramURL / copyProgramPassword の unit test
+ *
+ * 番組情報の自動更新中 (isFetching中) でもコピーが実行できることを確認する (N-AIR-APP-GD5)。
+ * 以前は isFetching 中は例外を投げてコピーを中断していたが、ユーザーからは
+ * 「クリックしても反応しない」ように見えるだけで、例外はどこにも捕捉・表示されていなかった。
+ */
+import { clipboard } from 'electron';
+
+jest.mock('electron', () => ({
+  clipboard: { writeText: jest.fn() },
+}));
+
+jest.mock('components/shared/Popper.vue', () => ({}));
+jest.mock('services/streaming', () => ({ StreamingService: { instance: () => ({}) } }));
+jest.mock('services/user', () => ({ UserService: { instance: () => ({}) } }));
+
+const getWatchPageURLMock = jest.fn((programID: string) => `https://live.nicovideo.jp/watch/${programID}`);
+jest.mock('services/hosts', () => ({
+  HostsService: { instance: () => ({ getWatchPageURL: getWatchPageURLMock }) },
+}));
+
+let nicoliveProgramState: { programID: string; password?: string; isFetching: boolean };
+jest.mock('services/nicolive-program/nicolive-program', () => ({
+  NicoliveProgramService: { instance: () => ({ state: nicoliveProgramState }) },
+}));
+
+const ProgramInfo = require('./ProgramInfo.vue.ts').default;
+
+describe('ProgramInfo.copyProgramURL / copyProgramPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nicoliveProgramState = { programID: 'lv12345', password: 'pass1234', isFetching: false };
+  });
+
+  test('isFetching中でも copyProgramURL は現在のprogramIDをコピーする (N-AIR-APP-GD5)', () => {
+    nicoliveProgramState.isFetching = true;
+
+    expect(() => ProgramInfo.methods.copyProgramURL.call({})).not.toThrow();
+
+    expect(clipboard.writeText).toHaveBeenCalledWith('https://live.nicovideo.jp/watch/lv12345');
+  });
+
+  test('isFetching中でも copyProgramPassword は現在のpasswordをコピーする (N-AIR-APP-GD5)', () => {
+    nicoliveProgramState.isFetching = true;
+
+    expect(() => ProgramInfo.methods.copyProgramPassword.call({})).not.toThrow();
+
+    expect(clipboard.writeText).toHaveBeenCalledWith('pass1234');
+  });
+
+  test('passwordが未設定の場合は空文字をコピーする', () => {
+    nicoliveProgramState.password = undefined;
+
+    ProgramInfo.methods.copyProgramPassword.call({});
+
+    expect(clipboard.writeText).toHaveBeenCalledWith('');
+  });
+});

--- a/app/components/nicolive-area/ProgramInfo.vue.ts
+++ b/app/components/nicolive-area/ProgramInfo.vue.ts
@@ -87,10 +87,6 @@ export default defineComponent({
       return url.toString();
     },
 
-    isFetching(): boolean {
-      return NicoliveProgramService.instance().state.isFetching;
-    },
-
     existsProgramPassword(): boolean {
       return !!NicoliveProgramService.instance().state.password;
     },
@@ -149,14 +145,12 @@ export default defineComponent({
     },
 
     copyProgramURL() {
-      if (this.isFetching) throw new Error('fetchProgram is running');
       clipboard.writeText(
         HostsService.instance().getWatchPageURL(NicoliveProgramService.instance().state.programID),
       );
     },
 
     copyProgramPassword() {
-      if (this.isFetching) throw new Error('fetchProgram is running');
       clipboard.writeText(NicoliveProgramService.instance().state.password ?? '');
     },
   },


### PR DESCRIPTION
## 概要

番組情報エリアの「番組URLをコピーする」「番組の合い言葉をコピーする」メニュー項目が、配信開始直後にクリックしても反応しないバグを修正しました。

## 原因

このメニュー項目のコピー処理に対して、`ProgramInfo` の `isFetching` プロパティがtrueのとき(`fetchProgram()` 実行中)には実行しないガードがかかっていました。
しかし、このコピー元は事前取得済みのstateであり、いつでもコピーして良いので、ガードがそもそも不要でした。

## 修正内容

`ProgramInfo` の `isFetching` はこの用途のためだけのプロパティだったため、削除しました。

## 実際の発生シーケンス

Sentryのbreadcrumbsで実際の発生シーケンスを確認したところ、6件中サンプルした4件すべてで
**「配信開始」ボタンをクリックした直後(1〜7秒後)に番組パネルのメニューを開き、番組URL/合い言葉をコピーしようとして失敗**、という同一の操作パターンでした。
配信開始と同時にURLをシェアしようとする自然な動線で実際に踏まれていた不具合です。

なお、番組状態が自動的に「終了」になるタイマー処理は別経路 `refreshProgram()` を使っており、`NicoliveProgramService.state.isFetching` には影響しません。

## Sentry

Sentry-Resolves: N-AIR-APP-GD5

## テスト

- `app/components/nicolive-area/ProgramInfo.vue.test.ts` を新規追加し、`isFetching` 中でも `copyProgramURL` / `copyProgramPassword` が正しくコピーを実行することを確認

### Test plan

- [x] 配信開始直後、番組情報取得中に右上メニューから「番組URLをコピーする」をクリックし、正しくコピーされることを確認
- [x] 同様に「番組の合い言葉をコピーする」も確認(合い言葉が設定されている番組)

