### PR TITLE
変更: ウィンドウをより小さいサイズで使えるように最小幅を削減

### DIFF
--- a/app/components/shared/Popper.vue
+++ b/app/components/shared/Popper.vue
@@ -92,5 +92,25 @@
       margin-right: 16px;
     }
   }
+
+  .popup-menu-item__button {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 6px 12px;
+    font-size: @font-size2;
+    line-height: normal;
+    color: var(--color-text);
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+
+    i {
+      flex-shrink: 0;
+      width: 16px;
+      margin-right: 0;
+      text-align: center;
+    }
+  }
 }
 </style>

--- a/app/components/studio/MixerItem.vue
+++ b/app/components/studio/MixerItem.vue
@@ -30,14 +30,14 @@
         <template v-if="!narrowControls">
           <i
             class="icon-btn icon-speaker"
-            title="click to switch off"
+            :title="$t('audio.mute')"
             v-if="!audioSource.muted"
             @click="setMuted(true)"
           >
           </i>
           <i
             class="icon-btn icon-mute"
-            title="click to switch on"
+            :title="$t('audio.unmute')"
             v-if="audioSource.muted"
             @click="setMuted(false)"
           >
@@ -54,13 +54,13 @@
             <div class="popper mixer-actions-menu">
               <ul class="popup-menu-list">
                 <li class="popup-menu-item">
-                  <button class="source-actions-menu__item" @click="setMuted(!audioSource.muted)">
+                  <button class="popup-menu-item__button" @click="setMuted(!audioSource.muted)">
                     <i :class="audioSource.muted ? 'icon-mute' : 'icon-speaker'" />
                     {{ audioSource.muted ? $t('audio.unmute') : $t('audio.mute') }}
                   </button>
                 </li>
                 <li class="popup-menu-item" v-if="!isCompactMode">
-                  <button class="source-actions-menu__item" @click="showSourceMenu(audioSource.sourceId)">
+                  <button class="popup-menu-item__button" @click="showSourceMenu(audioSource.sourceId)">
                     <i class="icon-settings" />
                     {{ $t('audio.advancedAudioSettings') }}
                   </button>

--- a/app/components/studio/MixerItem.vue
+++ b/app/components/studio/MixerItem.vue
@@ -27,26 +27,51 @@
         tooltip="false"
       />
       <div class="controls">
-        <i
-          class="icon-btn icon-speaker"
-          title="click to switch off"
-          v-if="!audioSource.muted"
-          @click="setMuted(true)"
-        >
-        </i>
-        <i
-          class="icon-btn icon-mute"
-          title="click to switch on"
-          v-if="audioSource.muted"
-          @click="setMuted(false)"
-        >
-        </i>
-        <i
-          class="icon-btn icon-settings"
-          @click="showSourceMenu(audioSource.sourceId)"
-          v-if="!isCompactMode"
-        >
-        </i>
+        <template v-if="!narrowControls">
+          <i
+            class="icon-btn icon-speaker"
+            title="click to switch off"
+            v-if="!audioSource.muted"
+            @click="setMuted(true)"
+          >
+          </i>
+          <i
+            class="icon-btn icon-mute"
+            title="click to switch on"
+            v-if="audioSource.muted"
+            @click="setMuted(false)"
+          >
+          </i>
+          <i
+            class="icon-btn icon-settings"
+            @click="showSourceMenu(audioSource.sourceId)"
+            v-if="!isCompactMode"
+          >
+          </i>
+        </template>
+        <template v-else>
+          <popper placement="bottom-end">
+            <div class="popper mixer-actions-menu">
+              <ul class="popup-menu-list">
+                <li class="popup-menu-item">
+                  <button class="source-actions-menu__item" @click="setMuted(!audioSource.muted)">
+                    <i :class="audioSource.muted ? 'icon-mute' : 'icon-speaker'" />
+                    {{ audioSource.muted ? $t('audio.unmute') : $t('audio.mute') }}
+                  </button>
+                </li>
+                <li class="popup-menu-item" v-if="!isCompactMode">
+                  <button class="source-actions-menu__item" @click="showSourceMenu(audioSource.sourceId)">
+                    <i class="icon-settings" />
+                    {{ $t('audio.advancedAudioSettings') }}
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <template #reference>
+              <i class="icon-btn icon-ellipsis-vertical" />
+            </template>
+          </popper>
+        </template>
       </div>
     </div>
   </div>

--- a/app/components/studio/MixerItem.vue.ts
+++ b/app/components/studio/MixerItem.vue.ts
@@ -22,22 +22,23 @@ export default defineComponent({
   data() {
     return {
       narrowControls: false,
+      resizeObserver: null as ResizeObserver | null,
     };
   },
 
   mounted() {
     const el = this.$el as HTMLElement;
-    (this as any)._resizeObserver = new ResizeObserver((entries) => {
+    this.resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         this.narrowControls = entry.contentRect.width < NARROW_MIXER_THRESHOLD;
       }
     });
-    (this as any)._resizeObserver.observe(el);
+    this.resizeObserver.observe(el);
     this.narrowControls = el.offsetWidth < NARROW_MIXER_THRESHOLD;
   },
 
   beforeUnmount() {
-    (this as any)._resizeObserver?.disconnect();
+    this.resizeObserver?.disconnect();
   },
 
   computed: {

--- a/app/components/studio/MixerItem.vue.ts
+++ b/app/components/studio/MixerItem.vue.ts
@@ -1,3 +1,4 @@
+import Popper from 'components/shared/Popper.vue';
 import Slider from 'components/shared/Slider.vue';
 import MixerVolmeter from 'components/studio/MixerVolmeter.vue';
 import { AudioSource } from 'services/audio';
@@ -6,13 +7,37 @@ import { CustomizationService } from 'services/customization';
 import { EditMenu } from 'util/menus/EditMenu';
 import { defineComponent, PropType } from 'vue';
 
+// コントロールをまとめるかどうかの幅の閾値
+const NARROW_MIXER_THRESHOLD = 200;
+
 export default defineComponent({
   name: 'MixerItem',
 
-  components: { Slider, MixerVolmeter },
+  components: { Slider, MixerVolmeter, Popper },
 
   props: {
     audioSource: { type: Object as PropType<AudioSource>, required: true as const },
+  },
+
+  data() {
+    return {
+      narrowControls: false,
+    };
+  },
+
+  mounted() {
+    const el = this.$el as HTMLElement;
+    (this as any)._resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        this.narrowControls = entry.contentRect.width < NARROW_MIXER_THRESHOLD;
+      }
+    });
+    (this as any)._resizeObserver.observe(el);
+    this.narrowControls = el.offsetWidth < NARROW_MIXER_THRESHOLD;
+  },
+
+  beforeUnmount() {
+    (this as any)._resizeObserver?.disconnect();
   },
 
   computed: {

--- a/app/components/studio/SceneSelector.vue
+++ b/app/components/studio/SceneSelector.vue
@@ -85,9 +85,9 @@
 .scene-collections-wrapper {
   position: relative;
   display: flex;
-  flex-grow: 1;
+  flex: 1 1 0;
   align-items: center;
-  width: 160px;
+  min-width: 0;
   margin-right: 16px;
 }
 

--- a/app/components/studio/SourceSelector.vue
+++ b/app/components/studio/SourceSelector.vue
@@ -83,7 +83,7 @@
                 <ul class="popup-menu-list">
                   <li class="popup-menu-item">
                     <button
-                      class="source-actions-menu__item"
+                      class="popup-menu-item__button"
                       @click.stop="toggleLock(node.data.id)"
                     >
                       <i :class="lockClassesForSource(node.data.id)" />
@@ -92,7 +92,7 @@
                   </li>
                   <li class="popup-menu-item">
                     <button
-                      class="source-actions-menu__item"
+                      class="popup-menu-item__button"
                       @click.stop="toggleVisibility(node.data.id)"
                     >
                       <i :class="visibilityClassesForSource(node.data.id)" />
@@ -101,7 +101,7 @@
                   </li>
                   <li class="popup-menu-item">
                     <button
-                      class="source-actions-menu__item"
+                      class="popup-menu-item__button"
                       @click.stop="removeItems"
                     >
                       <i class="icon-delete" />
@@ -110,7 +110,7 @@
                   </li>
                   <li class="popup-menu-item">
                     <button
-                      class="source-actions-menu__item"
+                      class="popup-menu-item__button"
                       @click.stop="sourceProperties"
                     >
                       <i class="icon-settings" />
@@ -148,30 +148,6 @@
 
 .source-actions-menu {
   min-width: 140px;
-}
-
-.source-actions-menu__item {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  width: 100%;
-  padding: 6px 12px;
-  font-size: @font-size2;
-  color: var(--color-text);
-  text-align: left;
-  white-space: nowrap;
-  cursor: pointer;
-
-  i {
-    flex-shrink: 0;
-    width: 16px;
-    text-align: center;
-  }
-
-  &:hover {
-    color: var(--color-text-light);
-    background-color: var(--color-bg-active);
-  }
 }
 
 .source-selector-action {

--- a/app/components/studio/SourceSelector.vue
+++ b/app/components/studio/SourceSelector.vue
@@ -49,32 +49,81 @@
 
       <template #sidebar="{ node }">
         <template v-if="canShowActions(node.data.id)">
-          <i
-            class="source-selector-action"
-            :class="lockClassesForSource(node.data.id)"
-            v-tooltip.bottom="lockTooltipForSource(node.data.id, node.isLeaf)"
-            @click.stop="toggleLock(node.data.id)"
-            @dblclick.stop
-          />
-          <i
-            class="source-selector-action"
-            :class="visibilityClassesForSource(node.data.id)"
-            v-tooltip.bottom="visibilityTooltip"
-            @click.stop="toggleVisibility(node.data.id)"
-            @dblclick.stop
-          />
-          <i
-            class="source-selector-action icon-delete"
-            @click="removeItems"
-            v-tooltip.bottom="removeSourcesTooltip"
-            :data-test="`Remove` + node.title"
-          />
-          <i
-            class="source-selector-action icon-settings"
-            @click="sourceProperties"
-            v-tooltip.bottom="openSourcePropertiesTooltip"
-            data-test="Edit"
-          />
+          <template v-if="!narrowSidebar">
+            <i
+              class="source-selector-action"
+              :class="lockClassesForSource(node.data.id)"
+              v-tooltip.bottom="lockTooltipForSource(node.data.id, node.isLeaf)"
+              @click.stop="toggleLock(node.data.id)"
+              @dblclick.stop
+            />
+            <i
+              class="source-selector-action"
+              :class="visibilityClassesForSource(node.data.id)"
+              v-tooltip.bottom="visibilityTooltip"
+              @click.stop="toggleVisibility(node.data.id)"
+              @dblclick.stop
+            />
+            <i
+              class="source-selector-action icon-delete"
+              @click="removeItems"
+              v-tooltip.bottom="removeSourcesTooltip"
+              :data-test="`Remove` + node.title"
+            />
+            <i
+              class="source-selector-action icon-settings"
+              @click="sourceProperties"
+              v-tooltip.bottom="openSourcePropertiesTooltip"
+              data-test="Edit"
+            />
+          </template>
+          <template v-else>
+            <popper placement="bottom-end" class="source-actions-popper">
+              <div class="popper source-actions-menu">
+                <ul class="popup-menu-list">
+                  <li class="popup-menu-item">
+                    <button
+                      class="source-actions-menu__item"
+                      @click.stop="toggleLock(node.data.id)"
+                    >
+                      <i :class="lockClassesForSource(node.data.id)" />
+                      {{ lockClassesForSource(node.data.id)['icon-lock'] ? $t('scenes.unlockLabel') : $t('scenes.lockLabel') }}
+                    </button>
+                  </li>
+                  <li class="popup-menu-item">
+                    <button
+                      class="source-actions-menu__item"
+                      @click.stop="toggleVisibility(node.data.id)"
+                    >
+                      <i :class="visibilityClassesForSource(node.data.id)" />
+                      {{ $t('scenes.visibilityLabel') }}
+                    </button>
+                  </li>
+                  <li class="popup-menu-item">
+                    <button
+                      class="source-actions-menu__item"
+                      @click.stop="removeItems"
+                    >
+                      <i class="icon-delete" />
+                      {{ $t('scenes.removeLabel') }}
+                    </button>
+                  </li>
+                  <li class="popup-menu-item">
+                    <button
+                      class="source-actions-menu__item"
+                      @click.stop="sourceProperties"
+                    >
+                      <i class="icon-settings" />
+                      {{ $t('scenes.propertiesLabel') }}
+                    </button>
+                  </li>
+                </ul>
+              </div>
+              <template #reference>
+                <i class="source-selector-action source-selector-action--more icon-ellipsis-vertical" @click.stop @dblclick.stop />
+              </template>
+            </popper>
+          </template>
         </template>
       </template>
     </tree-view>
@@ -88,7 +137,41 @@
 
 .studio-controls-top-sidebar {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
+}
+
+.source-selector-action--more {
+  cursor: pointer;
+  opacity: 1;
+}
+
+.source-actions-menu {
+  min-width: 140px;
+}
+
+.source-actions-menu__item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  padding: 6px 12px;
+  font-size: @font-size2;
+  color: var(--color-text);
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+
+  i {
+    flex-shrink: 0;
+    width: 16px;
+    text-align: center;
+  }
+
+  &:hover {
+    color: var(--color-text-light);
+    background-color: var(--color-bg-active);
+  }
 }
 
 .source-selector-action {

--- a/app/components/studio/SourceSelector.vue.ts
+++ b/app/components/studio/SourceSelector.vue.ts
@@ -6,8 +6,12 @@ import { SourcesService } from 'services/sources';
 import { EditMenu } from 'util/menus/EditMenu';
 import { defineComponent } from 'vue';
 
+import Popper from '../shared/Popper.vue';
 import TreeView from '../shared/tree-view/TreeView.vue';
 import { ITreeCursorPosition, ITreeNode, ITreeNodeModel } from '../shared/tree-view/types';
+
+// サイドバーアイコンをまとめるかどうかの幅の閾値
+const NARROW_SIDEBAR_THRESHOLD = 240;
 
 const sourceIconMap = {
   ffmpeg_source: 'icon-media',
@@ -38,7 +42,7 @@ const sourceIconMap = {
 export default defineComponent({
   name: 'SourceSelector',
 
-  components: { TreeView },
+  components: { TreeView, Popper },
 
   data() {
     return {
@@ -53,7 +57,23 @@ export default defineComponent({
       unlockFolderTooltip: $t('scenes.unlockFolderTooltip'),
       visibilityTooltip: $t('scenes.visibilityTooltip'),
       expandedFoldersIds: [] as string[],
+      narrowSidebar: false,
     };
+  },
+
+  mounted() {
+    const el = this.$el as HTMLElement;
+    (this as any)._resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        this.narrowSidebar = entry.contentRect.width < NARROW_SIDEBAR_THRESHOLD;
+      }
+    });
+    (this as any)._resizeObserver.observe(el);
+    this.narrowSidebar = el.offsetWidth < NARROW_SIDEBAR_THRESHOLD;
+  },
+
+  beforeUnmount() {
+    (this as any)._resizeObserver?.disconnect();
   },
 
   computed: {

--- a/app/components/studio/SourceSelector.vue.ts
+++ b/app/components/studio/SourceSelector.vue.ts
@@ -58,22 +58,23 @@ export default defineComponent({
       visibilityTooltip: $t('scenes.visibilityTooltip'),
       expandedFoldersIds: [] as string[],
       narrowSidebar: false,
+      resizeObserver: null as ResizeObserver | null,
     };
   },
 
   mounted() {
     const el = this.$el as HTMLElement;
-    (this as any)._resizeObserver = new ResizeObserver((entries) => {
+    this.resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         this.narrowSidebar = entry.contentRect.width < NARROW_SIDEBAR_THRESHOLD;
       }
     });
-    (this as any)._resizeObserver.observe(el);
+    this.resizeObserver.observe(el);
     this.narrowSidebar = el.offsetWidth < NARROW_SIDEBAR_THRESHOLD;
   },
 
   beforeUnmount() {
-    (this as any)._resizeObserver?.disconnect();
+    this.resizeObserver?.disconnect();
   },
 
   computed: {

--- a/app/components/studio/StudioControls.vue
+++ b/app/components/studio/StudioControls.vue
@@ -145,9 +145,14 @@
 }
 
 .studio-controls__label {
+  flex: 1 1 0;
+  min-width: 0;
   margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: @font-size4;
   color: var(--color-text-light);
+  white-space: nowrap;
   .semibold();
 }
 

--- a/app/components/studio/StudioFooter.vue
+++ b/app/components/studio/StudioFooter.vue
@@ -10,7 +10,7 @@
     </div>
   </div>
   <div class="footer" v-else>
-    <div class="flex flex--center flex--grow flex--justify-start">
+    <div class="flex flex--center flex--grow flex--justify-start footer__metrics">
       <performance-metrics />
     </div>
     <streaming-controller :locked="locked" />
@@ -44,5 +44,10 @@
     height: 32px;
     background-color: var(--color-bg-secondary);
   }
+}
+
+.footer__metrics {
+  max-height: 40px;
+  overflow: hidden;
 }
 </style>

--- a/app/components/studio/StudioFooter.vue
+++ b/app/components/studio/StudioFooter.vue
@@ -47,7 +47,9 @@
 }
 
 .footer__metrics {
+  align-items: flex-start;
   max-height: 40px;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 </style>

--- a/app/i18n/en-US/audio.json
+++ b/app/i18n/en-US/audio.json
@@ -10,5 +10,7 @@
   "tracks": "Tracks",
   "advancedAudioSettings": "Advanced Audio Settings",
   "mixer": "Mixer",
+  "mute": "Mute",
+  "unmute": "Unmute",
   "mixerTooltip": "Monitor audio levels. If the bars are moving you are outputting audio."
 }

--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -60,6 +60,11 @@
   "lockFolderTooltip": "Lock the position and size of sources in the folder.",
   "unlockFolderTooltip": "Unlock the position and size of sources in the folder.",
   "visibilityTooltip": "Toggle the visibility of the source.",
+  "lockLabel": "Lock",
+  "unlockLabel": "Unlock",
+  "visibilityLabel": "Visibility",
+  "removeLabel": "Remove",
+  "propertiesLabel": "Properties",
   "addSceneTooltip": "Add a new scene.",
   "removeSceneTooltip": "Remove the scene.",
   "openSceneSwitcherTooltip": "Open the scene switcher properties."

--- a/app/i18n/ja-JP/audio.json
+++ b/app/i18n/ja-JP/audio.json
@@ -10,5 +10,7 @@
   "tracks": "トラック",
   "advancedAudioSettings": "高度な音声設定",
   "mixer": "ミキサー",
+  "mute": "ミュート",
+  "unmute": "ミュート解除",
   "mixerTooltip": "各ソースの音量を確認できます。バーが動いている場合、音声が出力されています。"
 }

--- a/app/i18n/ja-JP/scenes.json
+++ b/app/i18n/ja-JP/scenes.json
@@ -60,6 +60,11 @@
   "lockFolderTooltip": "フォルダー内のソースの位置とサイズを固定します。",
   "unlockFolderTooltip": "フォルダー内のソースの位置とサイズの固定を解除します。",
   "visibilityTooltip": "ソースの表示/非表示を切り替えます。",
+  "lockLabel": "固定",
+  "unlockLabel": "固定解除",
+  "visibilityLabel": "表示切替",
+  "removeLabel": "削除",
+  "propertiesLabel": "プロパティ",
   "removeSceneTooltip": "シーンを削除します。",
   "addSceneTooltip": "新しいシーンを追加します。",
   "openSceneSwitcherTooltip": "シーン切り替えのプロパティを開きます。"

--- a/app/services/window-size.test.ts
+++ b/app/services/window-size.test.ts
@@ -247,8 +247,8 @@ describe('updateWindowSize', () => {
     COMPACT: 'コンパクトモード',
   };
   const BASE_HEIGHT = 600;
-  const BASE_WIDTH = 800;
-  const SMALL_WIDTH = BASE_WIDTH - 1; // 800より小さくしておくと便利
+  const BASE_WIDTH = 1000;
+  const SMALL_WIDTH = 400; // 最小幅(INACTIVE=548, CLOSED=572)より小さい値
 
   const initSuites: {
     prev: PanelState | null;

--- a/app/services/window-size.ts
+++ b/app/services/window-size.ts
@@ -17,7 +17,7 @@ interface IWindowSizeState {
   isReady: boolean; // 初期化が完了したかどうか
 }
 
-const STUDIO_WIDTH = 800;
+const STUDIO_WIDTH = 500;
 const SIDENAV_WIDTH = 48;
 const NICOLIVE_PANEL_WIDTH = 400;
 const PANEL_DIVIDER_WIDTH = 24;


### PR DESCRIPTION
## 概要

ウィンドウの最小幅を全状態で 300px 削減しました。
あわせて、狭い幅でパネルのタイトルやアイコンが崩れる問題を修正しています。

## 最小幅の変化

| 状態 | 変更前 | 変更後 |
|------|--------|--------|
| OPENED（パネル展開中） | 1272px | 972px |
| CLOSED（パネル折りたたみ） | 872px | 572px |
| INACTIVE（未ログイン） | 848px | 548px |
| COMPACT（コンパクトモード） | 448px | 448px（変化なし） |

`STUDIO_WIDTH` を 800px → 500px に変更したことによる削減です。

## UI修正内容

- **パネルタイトル**: 幅が狭い場合に省略記号（…）で切り捨て表示
- **シーンコレクション選択欄**: 固定幅 160px を廃止し、flex で伸縮するよう変更
- **ソースセレクター**: パネル幅が 240px 未満になるとアイコン4つを「…」ポップアップメニューに折りたたむ
- **ミキサー**: パネル幅が 200px 未満になるとスピーカー・設定アイコンを「…」ポップアップメニューに折りたたむ
- **フッターのパフォーマンス指標**: 3行以上に折り返さないよう `max-height` で制限

## i18n

ポップアップメニュー用の短いラベルを追加しました（ja-JP / en-US）。
- `scenes`: `lockLabel`, `unlockLabel`, `visibilityLabel`, `removeLabel`, `propertiesLabel`
- `audio`: `mute`, `unmute`



## 最小にした際の表示

サイズが大きいのでここでは動的に縮小表示されますが、パネル展開中により 1272 -> 972

before 
<img width="1536" height="969" alt="Snapzy_2026-09-04_14-36-52_241" src="https://github.com/user-attachments/assets/e04f495c-76db-4966-a91c-2c2623b38e12" />

after
<img width="1175" height="974" alt="Snapzy_2026-09-04_14-38-55_236" src="https://github.com/user-attachments/assets/37529f14-cd13-4243-88eb-371933ca6f1a" />
