### PR TITLE
開発: Jest 30の不要な依存ビルドを明示的に無視

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,15 +167,6 @@
     "yarn": "please-use-pnpm"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@sentry/cli",
-      "electron",
-      "electron-chromedriver",
-      "electron-winstaller",
-      "husky",
-      "less",
-      "protobufjs"
-    ],
     "overrides": {
       "nth-check": "^2.0.1",
       "tar-fs": "^2.1.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,7 @@ onlyBuiltDependencies:
   - husky
   - protobufjs
   - vue-popperjs
+
+ignoredBuiltDependencies:
+  - '@parcel/watcher'
+  - unrs-resolver


### PR DESCRIPTION
## このpull requestが解決する内容

Jest 30で追加されたネイティブ依存パッケージの不要なビルドスクリプトを明示的に無視し、`pnpm install`時の警告を解消します。

## 背景

PR #1437 のJest 30移行後、`@parcel/watcher`と`unrs-resolver`のビルドスクリプトがpnpmに自動で無視されたことを示す警告が出ていました。

N Airのローカル開発環境とGitHub ActionsはいずれもWindows x64を使用し、lockfileで完全性ハッシュが固定されたプラットフォーム別のビルド済みバイナリを利用します。PR #1437 のCIではスクリプトを実行しない状態でunit、e2e、production build、インストーラー作成まで成功しているため、これらのスクリプトを許可せず、意図的に無視する設定とします。

## 変更内容

| package | version | before | after |
|---------|---------|--------|-------|
| @parcel/watcher | 2.6.0 | build script automatically ignored with warning | build script explicitly ignored |
| unrs-resolver | 1.12.2 | build script automatically ignored with warning | build script explicitly ignored |

- `pnpm-workspace.yaml`の`ignoredBuiltDependencies`へ2パッケージを追加
- `package.json`に重複していた`onlyBuiltDependencies`を削除し、workspace設定へ一本化

## Breaking Changes の影響分析

依存バージョンやアプリケーションコードは変更しません。従来から実行されていなかったビルドスクリプトを明示的に無視する設定へ変えるだけなので、ランタイム動作やCI成果物への破壊的変更はありません。

## 影響範囲

- ローカル開発環境およびGitHub Actionsの`pnpm install`警告
- Jestのファイル監視とモジュール解決に使われる開発依存
- N Air本体の実行および配布物には影響なし

## テスト

- [x] `pnpm install --frozen-lockfile`で対象スクリプトが実行されず、従来のignored build警告も出ないことを確認
- [x] Node.jsから両パッケージをロードできることを確認

## Sentry

なし
