### PR TITLE
開発: Electronネットワークフォールバック警告のSentryグルーピングを統一

### DIFF
--- a/app/services/nicolive-program/NicoliveClient.ts
+++ b/app/services/nicolive-program/NicoliveClient.ts
@@ -450,7 +450,7 @@ export class NicoliveClient {
             'Electron network request failed; Node.js fallback succeeded',
             {
               level: 'warning',
-              fingerprint: ['NicoliveClient', 'electron-net-fallback', res.electronNetErrorCode],
+              fingerprint: ['NicoliveClient', 'electron-net-fallback'],
               tags: {
                 transport: 'electron-net',
                 errorCode: res.electronNetErrorCode,


### PR DESCRIPTION
## 概要

Sentryのrelease `1.1.20260826-1` で、`Electron network request failed; Node.js fallback succeeded` という同一タイトルの警告が、複数の異なるissueに分かれて表示されており一覧性が悪化していました。

## 原因

`NicoliveClient.requestWithSession()` でこの警告をSentryへ送る際、`fingerprint`に`res.electronNetErrorCode`(例: `ERR_CONNECTION_RESET`など)を含めていたため、発生したネットワークエラーコードごとに別issueとしてグルーピングされていました。エラーコードは`tags.errorCode`にも既に設定されているため、fingerprintに含める必要はありませんでした。

## 変更内容

- `app/services/nicolive-program/NicoliveClient.ts`: `fingerprint`から`res.electronNetErrorCode`を除去し、`['NicoliveClient', 'electron-net-fallback']`で統一
- エラーコード別の内訳はSentry上で`tags.errorCode`によるフィルタ/集計で確認可能

ユーザーの操作結果や画面表示は変わりません。Sentryのissueグルーピングのみに影響する変更です。

## テスト

- [x] `pnpm run test:unit:app`
- [x] `pnpm run typecheck`
- [x] `pnpm lint`
