### PR TITLE
開発: セキュリティアラート344/346のjs-yaml脆弱性をbin/lockfile更新で解消

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -19,7 +19,7 @@
     "@inquirer/prompts": "^7.3.2",
     "colors": "^1.4.0",
     "iconv-lite": "^0.7.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.2",
     "progress": "^2.0.0",
     "semver": "^7.6.3",
     "shelljs": "^0.8.5",

--- a/bin/pnpm-lock.yaml
+++ b/bin/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       js-yaml:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.2
+        version: 4.3.2
       progress:
         specifier: ^2.0.0
         version: 2.0.3
@@ -987,12 +987,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-parse-better-errors@1.0.2:
@@ -2562,7 +2562,7 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.15.0
+      js-yaml: 3.15.2
       parse-json: 4.0.0
 
   cubic2quad@1.2.1: {}
@@ -2710,12 +2710,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## 影響範囲: bin/ の開発用スクリプトのみ、アプリ本体への影響なし

`bin/` は `pnpm-lock.yaml` とは独立したパッケージで、パッチノート生成やリリーススクリプトなど開発用ツールが対象です。配布物には含まれません。

## このpull requestが解決する内容

| Alert | パッケージ | CVE | 重大度 | 内容 |
|-------|-----------|-----|--------|------|
| [Alert 346](https://github.com/n-air-app/n-air-app/security/dependabot/346) | js-yaml (4.x, bin/) | CVE-2026-59870（未バックポート） | High | `!!omap`解決における二次関数的CPU消費 |
| [Alert 344](https://github.com/n-air-app/n-air-app/security/dependabot/344) | js-yaml (3.x, bin/) | CVE-2026-59870（未バックポート） | High | 同上（3.x系） |

## 変更内容

| package | before | after |
|---------|--------|-------|
| js-yaml (bin/) | 3.15.0 / 4.3.0 | 3.15.2 / 4.3.2 |

### ファイル変更
- `bin/package.json`: js-yaml のバージョン指定を `^4.3.0` → `^4.3.2` に更新
- `bin/pnpm-lock.yaml`: 依存関係を更新

## テスト
- [x] `pnpm run test:unit:bin` がパス

関連: #1073
