### PR TITLE
開発: セキュリティアラート281のbrace-expansion脆弱性をbin/lockfile更新で解消

### DIFF
--- a/bin/pnpm-lock.yaml
+++ b/bin/pnpm-lock.yaml
@@ -758,8 +758,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2504,7 +2504,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -2773,7 +2773,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.18
 
   minimist-options@4.1.0:
     dependencies:


### PR DESCRIPTION
## 影響範囲: bin/ の開発用スクリプトのみ、アプリ本体への影響なし

`bin/` は `pnpm-lock.yaml` とは独立したパッケージで、パッチノート生成やリリーススクリプトなど開発用ツールが対象です。配布物には含まれません。

## このpull requestが解決する内容

| Alert | パッケージ | CVE | 重大度 | 内容 |
|-------|-----------|-----|--------|------|
| [Alert 281](https://github.com/n-air-app/n-air-app/security/dependabot/281) | brace-expansion (bin/) | CVE-2026-13149 | High | 連続する非展開`{}`グループの指数時間展開によるDoS |

## 変更内容

| package | before | after |
|---------|--------|-------|
| brace-expansion (bin/, minimatch経由) | 1.1.13 | 1.1.18 |

### ファイル変更
- `bin/pnpm-lock.yaml`: `minimatch`経由のbrace-expansionを更新（`bin/package.json`の変更なし）

## テスト
- [x] `pnpm run test:unit:bin` がパス

関連: #1073
