### PR TITLE
開発: 未使用のESLint Jestプラグインを削除

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'url';
 
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
-import jest from 'eslint-plugin-jest';
 import jsoncPlugin from 'eslint-plugin-jsonc';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import unusedImports from 'eslint-plugin-unused-imports';
@@ -233,7 +232,6 @@ export default [
 
     plugins: {
       '@typescript-eslint': tseslint.plugin,
-      jest,
       'simple-import-sort': simpleImportSort,
       'unused-imports': unusedImports,
     },
@@ -281,7 +279,6 @@ export default [
     plugins: {
       vue,
       '@typescript-eslint': tseslint.plugin,
-      jest,
       'simple-import-sort': simpleImportSort,
       'unused-imports': unusedImports,
     },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "eslint": "^9.39.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jest": "^29.16.6",
     "eslint-plugin-jsonc": "^3.4.2",
     "eslint-plugin-simple-import-sort": "13.0.0",
     "eslint-plugin-unused-imports": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.1
         version: 2.32.0(@typescript-eslint/parser@8.69.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-jest:
-        specifier: ^29.16.6
-        version: 29.16.6(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(jest@30.5.1(@types/node@20.19.27))(typescript@5.9.3)
       eslint-plugin-jsonc:
         specifier: ^3.4.2
         version: 3.4.2(eslint@9.39.2(jiti@2.7.0))
@@ -3703,22 +3700,6 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     peerDependenciesMeta:
       '@typescript-eslint/parser':
-        optional: true
-
-  eslint-plugin-jest@29.16.6:
-    resolution: {integrity: sha512-q8TVr0rlNvUD0XnafGWkwtPeX+tTl2llP86EDl3sJtwWrQA/JT9SIu2hLLZbhhX6fT5SDE4O0gIKyZUujKnkYA==}
-    engines: {node: ^20.12.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^8.0.0
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      jest: '*'
-      typescript: '>=4.8.4 <8.0.0'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-      typescript:
         optional: true
 
   eslint-plugin-jsonc@3.4.2:
@@ -11483,17 +11464,6 @@ snapshots:
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-jest@29.16.6(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(jest@30.5.1(@types/node@20.19.27))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.69.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.7.0)
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      jest: 30.5.1(@types/node@20.19.27)
-      typescript: 5.9.3
-    transitivePeerDependencies:
       - supports-color
 
   eslint-plugin-jsonc@3.4.2(eslint@9.39.2(jiti@2.7.0)):


### PR DESCRIPTION
## 概要

未使用になっていた `eslint-plugin-jest` を削除します。

## 背景

ESLint 9のFlat Config移行後は、Jestのグローバル変数を `eslint.config.mjs` で明示的に定義しています。`eslint-plugin-jest` はプラグインとして登録されているものの、Jest固有のルールやpresetは利用されておらず、役割が重複していました。

## 変更内容

- `eslint.config.mjs` から `eslint-plugin-jest` のimportとplugin登録を削除
- `package.json` と `pnpm-lock.yaml` から依存を削除
