### PR TITLE
変更: ボイスチェンジャーのプロパティを閉じると、中で有効にしたプレビューは停止するという注意を表示

### DIFF
--- a/app/components/sources/RtvcSourceProperties.vue
+++ b/app/components/sources/RtvcSourceProperties.vue
@@ -312,6 +312,9 @@
             $t('source-props.nair-rtvc-source.nav.check_voice')
           }}</span>
           <input v-model="isMonitor" type="checkbox" class="toggle-button" />
+          <span v-if="isMonitor" class="preview-stop-notice">{{
+            $t('source-props.nair-rtvc-source.nav.preview_stop_notice')
+          }}</span>
         </div>
         <div v-else>{{ $t('source-props.nair-rtvc-source.nav.preview_audio_on') }}</div>
       </div>
@@ -678,6 +681,13 @@
 
 .toggle-wrapper {
   margin-right: auto;
+
+  .preview-stop-notice {
+    margin-top: 2px;
+    margin-left: 16px;
+    font-size: @font-size2;
+    color: var(--color-text);
+  }
 }
 
 .row {

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -458,7 +458,7 @@
       "original_voice": "Originals",
       "remove_voice": "Remove",
       "copy_voice": "Copy",
-      "check_voice": "Check Voice",
+      "check_voice": "Preview converted audio",
       "original_voice_add": "Add new voice",
       "remove_confirm": "Remove?",
       "add_voice": "Add voice",

--- a/app/i18n/en-US/source-props.json
+++ b/app/i18n/en-US/source-props.json
@@ -464,7 +464,8 @@
       "add_voice": "Add voice",
       "play_sample": "Play sample",
       "open_menu": "Open menu",
-      "preview_audio_on": "Preview audio is turned on in the mixer advanced settings"
+      "preview_audio_on": "Preview audio is turned on in the mixer advanced settings",
+      "preview_stop_notice": "Closing the properties window stops the preview"
     },
     "container": {
       "voice_name": "Name",

--- a/app/i18n/ja-JP/source-props.json
+++ b/app/i18n/ja-JP/source-props.json
@@ -458,13 +458,14 @@
       "original_voice": "オリジナルボイス",
       "remove_voice": "ボイスを削除",
       "copy_voice": "ボイスを複製",
-      "check_voice": "変換後音声を聞く",
+      "check_voice": "変換後音声をプレビュー",
       "original_voice_add": "オリジナルボイスを追加",
       "remove_confirm": "削除しますか？",
       "add_voice": "ボイス作成",
       "play_sample": "サンプルボイスを再生",
       "open_menu": "メニューを開く",
-      "preview_audio_on": "ミキサーの高度な設定でプレビュー音声がONになっています"
+      "preview_audio_on": "ミキサーの高度な設定でプレビュー音声がONになっています",
+      "preview_stop_notice": "プロパティを閉じるとプレビューを停止します"
     },
     "container": {
       "voice_name": "名前",


### PR DESCRIPTION
## 概要

「変換後音声をプレビュー」は一時的なモニタテストとしての機能ですが、これが設定なのか、一時的なテストかわかりにくく、ONにしてもプロパティを閉じると値が反映されていないと感じられるので表示まわりを改修しました。

ボイスチェンジャーの「変換後音声をプレビュー」をONにした際、プロパティを閉じるとプレビューが停止することをスイッチの右側に表示します。
あわせて、スイッチの文言を「変換後音声を聞く」では少々分かりにくいのと音声設定ではプレビューと表記しているので揃えて「変換後音声をプレビュー」に変更します。

## 変更内容

- プレビューがONの間だけ停止条件の注意書きを表示
- 注意書きの日本語・英語文言を追加
- プレビュー用スイッチの日本語表記を変更

## 影響範囲

ボイスチェンジャーのプロパティ画面の表示のみです。音声処理や設定保存の挙動は変更しません。

### 表示

OFF時
<img width="582" height="47" alt="Monosnap work 2026-09-08 12-59-44" src="https://github.com/user-attachments/assets/088f4050-f455-45c9-8ac0-c06b24e2bbdc" />

ON時
<img width="605" height="46" alt="Monosnap work 2026-09-08 12-59-57" src="https://github.com/user-attachments/assets/c09f2542-4049-4613-9590-b2890b44f899" />

