### PR TITLE
開発: project rootのnpm系Dependabotのバージョン更新PR作成を停止

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,12 @@ updates:
       prefix: '開発:'
 
   # Root npm dependencies
+  # 依存更新を追いかけられる状況になるまで新規PR作成を停止中 (open-pull-requests-limit: 0)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: increase
     ignore:
       # @n-air-app/* パッケージは内製なので即座に更新可能


### PR DESCRIPTION
## このpull requestが解決する内容

project root の npm 系 Dependabot 設定 (`.github/dependabot.yml`) について、新規のバージョン更新PR作成を停止します。

## 背景

以前のPR #1064 で誤って project root の npm 系 Dependabot 更新を有効化してしまい、今になって動き出しました。まだ依存更新を最新に追いかけられない事情があるため、一時的に停止します。

## 変更内容

- `.github/dependabot.yml`: project root の npm エコシステムエントリの `open-pull-requests-limit` を `10` から `0` に変更
  - `open-pull-requests-limit: 0` は新規のバージョン更新PR作成のみを停止する公式にサポートされた方法
  - `ignore` / `groups` などの既存設定は維持しているため、事情が解消したら数値を戻すだけで再開できる
  - `bin/` 側の npm エントリ、および Dependabot のセキュリティアラート/セキュリティ更新PRには影響しない（別枠の設定のため）

## テスト

- [x] `.github/dependabot.yml` の YAML構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
