### PR TITLE
修正: 配信状態に設定項目の有効・無効表示が追従しない問題を修正

### DIFF
--- a/app/components/settings/Settings.vue.ts
+++ b/app/components/settings/Settings.vue.ts
@@ -118,12 +118,15 @@ export default defineComponent({
     streamingStatus() {
       if (this.settingsRefreshTimer) clearTimeout(this.settingsRefreshTimer);
 
-      // OBS does not expose a signal for completion of the settings unlock. The streaming
-      // stop signal can arrive before it, so retry briefly after returning to Offline.
+      // OBS には設定ロック解除の完了通知がなく、配信停止シグナルが先に届くことがあるため、
+      // Offline に戻った後は短時間再取得を繰り返す
       const delays = this.streamingStatus === EStreamingState.Offline ? [0, 100, 500, 1000] : [0];
       const refresh = (index: number) => {
         this.settingsRefreshTimer = setTimeout(() => {
-          if (!this.categoryName) return;
+          if (!this.categoryName) {
+            this.settingsRefreshTimer = null;
+            return;
+          }
           this.settingsData = SettingsService.instance().getSettingsFormData(this.categoryName);
           if (index + 1 < delays.length) {
             refresh(index + 1);

--- a/app/components/settings/Settings.vue.ts
+++ b/app/components/settings/Settings.vue.ts
@@ -114,7 +114,7 @@ export default defineComponent({
     },
   },
   watch: {
-    isStreaming() {
+    streamingStatus() {
       if (!this.categoryName) return;
       this.settingsData = SettingsService.instance().getSettingsFormData(this.categoryName);
     },

--- a/app/components/settings/Settings.vue.ts
+++ b/app/components/settings/Settings.vue.ts
@@ -92,6 +92,7 @@ export default defineComponent({
       isTocOpen: true,
       currentActiveTocId: null as string | null,
       tocManager: new TocManager(),
+      settingsRefreshTimer: null as ReturnType<typeof setTimeout> | null,
     };
   },
   computed: {
@@ -115,8 +116,23 @@ export default defineComponent({
   },
   watch: {
     streamingStatus() {
-      if (!this.categoryName) return;
-      this.settingsData = SettingsService.instance().getSettingsFormData(this.categoryName);
+      if (this.settingsRefreshTimer) clearTimeout(this.settingsRefreshTimer);
+
+      // OBS does not expose a signal for completion of the settings unlock. The streaming
+      // stop signal can arrive before it, so retry briefly after returning to Offline.
+      const delays = this.streamingStatus === EStreamingState.Offline ? [0, 100, 500, 1000] : [0];
+      const refresh = (index: number) => {
+        this.settingsRefreshTimer = setTimeout(() => {
+          if (!this.categoryName) return;
+          this.settingsData = SettingsService.instance().getSettingsFormData(this.categoryName);
+          if (index + 1 < delays.length) {
+            refresh(index + 1);
+          } else {
+            this.settingsRefreshTimer = null;
+          }
+        }, delays[index]);
+      };
+      refresh(0);
     },
     categoryName(categoryName: SettingsCategory) {
       this.settingsData = SettingsService.instance().getSettingsFormData(categoryName);
@@ -159,6 +175,7 @@ export default defineComponent({
     }
   },
   beforeUnmount() {
+    if (this.settingsRefreshTimer) clearTimeout(this.settingsRefreshTimer);
     if (this.userSubscription) {
       this.userSubscription.unsubscribe();
     }


### PR DESCRIPTION
## このpull requestが解決する内容
設定ウィンドウを開いたまま配信を開始・終了した際に、各設定項目の有効・無効状態が配信状態に追従しない問題を修正します。

## 背景
設定フォームの再取得条件が「配信中か否か」の変化だけになっていたため、`Starting` から `Live` への遷移時には再取得されませんでした。また、配信終了時は OBS の `Stop` シグナルより後に設定ロックが解除されるため、シグナル直後の再取得だけでは無効状態が残ることがありました。

## 変更内容
- 設定フォームの再取得を、配信中フラグではなく配信ステータスの変化ごとに行うよう変更
- `Starting`、`Live`、`Ending`、`Offline` の遷移に合わせて表示中の設定項目を更新
- `Offline` への遷移後は、OBS の設定ロック解除を反映するため短時間の段階的な再取得を実施
- ウィンドウ終了時や次の状態変化時に、保留中の再取得タイマーを解除

## 影響範囲
- 設定ウィンドウで現在表示しているカテゴリのフォーム更新のみ
- 設定値や配信処理自体への変更はありません

## テスト
- [x] 出力タブを開いたまま配信を開始・終了し、各項目のグレー表示が配信状態に追従することを確認

## Sentry
なし
