### PR TITLE
開発: CIのlintジョブがNode.jsバージョン設定漏れで失敗する問題を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version-file: '.node-version'
 
       - name: Install pnpm
         run: corepack enable pnpm
@@ -197,7 +197,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'additional/additional.json', 'additional/main.mjs') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('.node-version', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'additional/additional.json', 'additional/main.mjs') }}
 
       - name: Run lint
         run: pnpm run lint


### PR DESCRIPTION
## 概要

CIの `lint` ジョブが Node.js バージョンの一元化(`.node-version`)から取り残されていた問題を修正します。

## 背景

- #1467 で `lint` ジョブを追加した時点では `node-version: 22`(ハードコード)を使用していた
- #1465 で `.node-version` への一元化を行い、他ジョブの `node_modules` キャッシュキーは `hashFiles('.node-version', 'pnpm-lock.yaml', ...)` の形式に変わった
- この2つのPRは並行して開発・別々にマージされたため、`lint` ジョブだけがNode.js 22ハードコード + 旧形式のキャッシュキーのまま残ってしまっていた
- 結果、`lint` ジョブの `node_modules` キャッシュキーが `setup-app` ジョブの新しいキーと一致せず毎回キャッシュミスになり、`node_modules` がインストールされない状態で `eslint` を実行してしまい `'eslint' is not recognized...` で失敗していた
- #1468 のCIで発覚([該当ログ](https://github.com/n-air-app/n-air-app/pull/1468))

## 変更内容

- `.github/workflows/test.yml` の `lint` ジョブを他ジョブと同じ形式に修正
  - `node-version: 22` → `node-version-file: '.node-version'`
  - キャッシュキーに `hashFiles('.node-version', ...)` を含める

## テスト

- CIで `lint` ジョブが正常に実行されることを確認
