### PR TITLE
開発: nth-check の pnpm.overrides を削除（依存元が既に 2.x を使用）

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
   },
   "pnpm": {
     "overrides": {
-      "nth-check": "^2.0.1",
       "tar-fs": "^2.1.4"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nth-check: ^2.0.1
   tar-fs: ^2.1.4
 
 importers:


### PR DESCRIPTION
## 概要

`pnpm.overrides` から不要になった `nth-check` の上書き指定を削除します。

## 変更内容

- `nth-check: ^2.0.1` の override を削除
  - `eslint-plugin-vue@9` が既に `nth-check@2.1.1` を使用しており、上書きが不要になっていた
  - `tar-fs` の override は `puppeteer-core@13` が `2.1.1` 固定指定のため引き続き必要

## テスト計画

- `pnpm install` が正常に完了すること
- `pnpm lint` が通ること
