### PR TITLE
変更: ProgramDescriptionの色指定をCSS変数に統一

### DIFF
--- a/app/components/nicolive-area/ProgramDescription.vue
+++ b/app/components/nicolive-area/ProgramDescription.vue
@@ -16,6 +16,7 @@
   flex-grow: 1;
   flex-direction: column;
   width: 100%;
+  background-color: var(--color-bg-tertiary);
 }
 
 .program-description-header {
@@ -26,15 +27,13 @@
   width: 100%;
   height: 48px;
   padding: 4px 16px;
-  background-color: @bg-secondary;
-  border-bottom: 1px solid @bg-primary;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .program-description-body {
   flex-grow: 1;
   overflow-x: hidden;
   overflow-y: auto;
-  background-color: @white;
 
   &::-webkit-scrollbar-track {
     background-color: transparent;
@@ -42,14 +41,14 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: @grey;
-    border-color: @white;
+    background-color: var(--color-scroll-bar);
+    border-color: var(--color-bg-tertiary);
   }
 }
 
 .program-description-text {
   padding: 16px;
-  color: @black;
+  color: var(--color-text);
   overflow-wrap: break-word;
 }
 </style>


### PR DESCRIPTION
## 概要

`ProgramDescription.vue` の色指定が他コンポーネントと異なる固定色変数（Less変数）のままになっていたため、CSS カスタムプロパティに統一しました。

## スクリーンショット

before
<img width="522" height="250" alt="Monosnap work 2026-09-11 15-08-43" src="https://github.com/user-attachments/assets/dea72121-e3b3-4e7a-9405-5eab39f70a7f" />

after
<img width="507" height="287" alt="Monosnap work 2026-09-11 15-09-39" src="https://github.com/user-attachments/assets/1752d3d6-4a67-48b9-912f-6f42bd4a133e" />

